### PR TITLE
refactor: replace inline abort_unless(canAccessProperty) with model p…

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+
 abstract class Controller
 {
-    //
+    use AuthorizesRequests;
 }

--- a/app/Http/Controllers/LeaseController.php
+++ b/app/Http/Controllers/LeaseController.php
@@ -18,7 +18,7 @@ class LeaseController extends Controller
 {
     public function index(Property $property, Room $room): Response
     {
-        abort_unless(request()->user()->canAccessProperty($property), 403);
+        $this->authorize('viewAny', [Lease::class, $property]);
 
         $room->load('property.city');
 
@@ -124,7 +124,7 @@ class LeaseController extends Controller
 
     public function store(StoreLeaseRequest $request, Property $property, Room $room): RedirectResponse
     {
-        abort_unless($request->user()->canAccessProperty($property), 403);
+        $this->authorize('create', [Lease::class, $property]);
 
         $request->ensureRoomAvailable($room);
 
@@ -151,7 +151,7 @@ class LeaseController extends Controller
 
     public function update(UpdateLeaseRequest $request, Property $property, Room $room, Lease $lease): RedirectResponse
     {
-        abort_unless($request->user()->canAccessProperty($property), 403);
+        $this->authorize('update', $lease);
 
         $lease->update($request->validated());
 
@@ -162,7 +162,7 @@ class LeaseController extends Controller
 
     public function destroy(Property $property, Room $room, Lease $lease): RedirectResponse
     {
-        abort_unless(request()->user()->canAccessProperty($property), 403);
+        $this->authorize('delete', $lease);
 
         $lease->update([
             'end_date' => now(),
@@ -178,8 +178,6 @@ class LeaseController extends Controller
 
     public function moveOut(Request $request, Lease $lease): RedirectResponse
     {
-        abort_unless($request->user()->canAccessProperty($lease->room->property), 403);
-
         $validated = $request->validate([
             'move_out_date' => ['required', 'date'],
             'reason' => ['nullable', 'string', 'max:255'],
@@ -190,11 +188,13 @@ class LeaseController extends Controller
             'target_room_id' => ['nullable', 'integer', 'exists:rooms,id'],
         ]);
 
+        $targetRoom = ($validated['move_to_another_room'] ?? false)
+            ? Room::findOrFail($validated['target_room_id'])
+            : null;
+
+        $this->authorize('moveOut', [$lease, $targetRoom]);
+
         if ($validated['move_to_another_room'] ?? false) {
-            $targetRoom = Room::findOrFail($validated['target_room_id']);
-
-            abort_unless($request->user()->canAccessProperty($targetRoom->property), 403);
-
             $hasActiveLease = Lease::query()
                 ->where('room_id', $targetRoom->id)
                 ->where('status', 'active')
@@ -250,15 +250,13 @@ class LeaseController extends Controller
 
     public function move(Request $request, Property $property, Room $room, Lease $lease): RedirectResponse
     {
-        abort_unless($request->user()->canAccessProperty($property), 403);
-
         $request->validate([
             'target_room_id' => ['required', 'integer', 'exists:rooms,id'],
         ]);
 
         $targetRoom = Room::findOrFail($request->target_room_id);
 
-        abort_unless($request->user()->canAccessProperty($targetRoom->property), 403);
+        $this->authorize('move', [$lease, $targetRoom]);
 
         $hasActiveLease = Lease::query()
             ->where('room_id', $targetRoom->id)

--- a/app/Http/Controllers/PropertyController.php
+++ b/app/Http/Controllers/PropertyController.php
@@ -93,7 +93,7 @@ class PropertyController extends Controller
 
     public function update(UpdatePropertyRequest $request, Property $property): RedirectResponse
     {
-        abort_unless($request->user()->canAccessProperty($property), 403);
+        $this->authorize('update', $property);
 
         $property->update($request->validated());
 
@@ -104,7 +104,7 @@ class PropertyController extends Controller
 
     public function destroy(Property $property): RedirectResponse
     {
-        abort_unless(request()->user()->canAccessProperty($property), 403);
+        $this->authorize('delete', $property);
 
         Property::query()->whereKey($property->id)->update(['is_active' => DB::raw('false')]);
 

--- a/app/Http/Controllers/RoomController.php
+++ b/app/Http/Controllers/RoomController.php
@@ -18,7 +18,7 @@ class RoomController extends Controller
 {
     public function index(Request $request, Property $property): Response
     {
-        abort_unless($request->user()->canAccessProperty($property), 403);
+        $this->authorize('viewAny', [Room::class, $property]);
 
         $sort = $request->query('sort', 'name');
         $direction = $request->query('direction', 'asc');
@@ -85,7 +85,7 @@ class RoomController extends Controller
 
     public function store(StoreRoomRequest $request, Property $property): RedirectResponse
     {
-        abort_unless($request->user()->canAccessProperty($property), 403);
+        $this->authorize('create', [Room::class, $property]);
 
         $property->rooms()->create($request->validated());
 
@@ -96,7 +96,7 @@ class RoomController extends Controller
 
     public function update(UpdateRoomRequest $request, Property $property, Room $room): RedirectResponse
     {
-        abort_unless($request->user()->canAccessProperty($property), 403);
+        $this->authorize('update', $room);
 
         $room->update($request->validated());
 
@@ -107,7 +107,7 @@ class RoomController extends Controller
 
     public function destroy(Property $property, Room $room): RedirectResponse
     {
-        abort_unless(request()->user()->canAccessProperty($property), 403);
+        $this->authorize('delete', $room);
 
         $room->delete();
 

--- a/app/Http/Controllers/TenantController.php
+++ b/app/Http/Controllers/TenantController.php
@@ -96,7 +96,7 @@ class TenantController extends Controller
 
         $room = Room::findOrFail($validated['room_id']);
 
-        abort_unless($request->user()->canAccessProperty($room->property), 403);
+        $this->authorize('assignRoom', [Tenant::class, $room]);
 
         $hasActiveLease = Lease::query()
             ->where('room_id', $room->id)
@@ -137,6 +137,8 @@ class TenantController extends Controller
 
     public function update(UpdateTenantRequest $request, Tenant $tenant): RedirectResponse
     {
+        $this->authorize('update', $tenant);
+
         $tenant->update($request->validated());
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Tenant updated.')]);
@@ -146,6 +148,8 @@ class TenantController extends Controller
 
     public function destroy(Tenant $tenant): RedirectResponse
     {
+        $this->authorize('delete', $tenant);
+
         $tenant->delete();
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Tenant archived.')]);

--- a/app/Policies/LeasePolicy.php
+++ b/app/Policies/LeasePolicy.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Lease;
+use App\Models\Property;
+use App\Models\Room;
+use App\Models\User;
+
+class LeasePolicy
+{
+    public function viewAny(User $user, Property $property): bool
+    {
+        return $user->properties->contains($property);
+    }
+
+    public function view(User $user, Lease $lease): bool
+    {
+        return $user->properties->contains($lease->room->property_id);
+    }
+
+    public function create(User $user, Property $property): bool
+    {
+        return $user->properties->contains($property);
+    }
+
+    public function update(User $user, Lease $lease): bool
+    {
+        return $user->properties->contains($lease->room->property_id);
+    }
+
+    public function delete(User $user, Lease $lease): bool
+    {
+        return $user->properties->contains($lease->room->property_id);
+    }
+
+    public function move(User $user, Lease $lease, Room $targetRoom): bool
+    {
+        return $user->properties->contains($lease->room->property_id)
+            && $user->properties->contains($targetRoom->property_id);
+    }
+
+    public function moveOut(User $user, Lease $lease, ?Room $targetRoom = null): bool
+    {
+        if (! $user->properties->contains($lease->room->property_id)) {
+            return false;
+        }
+
+        if ($targetRoom && ! $user->properties->contains($targetRoom->property_id)) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/app/Policies/MaintenanceTicketPolicy.php
+++ b/app/Policies/MaintenanceTicketPolicy.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\MaintenanceTicket;
+use App\Models\User;
+
+class MaintenanceTicketPolicy
+{
+    public function view(User $user, MaintenanceTicket $ticket): bool
+    {
+        return $user->properties->contains($ticket->room->property_id);
+    }
+}

--- a/app/Policies/PaymentPolicy.php
+++ b/app/Policies/PaymentPolicy.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Payment;
+use App\Models\User;
+
+class PaymentPolicy
+{
+    public function view(User $user, Payment $payment): bool
+    {
+        return $user->properties->contains($payment->lease->room->property_id);
+    }
+}

--- a/app/Policies/PropertyPolicy.php
+++ b/app/Policies/PropertyPolicy.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Property;
+use App\Models\User;
+
+class PropertyPolicy
+{
+    public function view(User $user, Property $property): bool
+    {
+        return $user->properties->contains($property);
+    }
+
+    public function create(User $user): bool
+    {
+        return true;
+    }
+
+    public function update(User $user, Property $property): bool
+    {
+        return $user->properties->contains($property);
+    }
+
+    public function delete(User $user, Property $property): bool
+    {
+        return $user->properties->contains($property);
+    }
+}

--- a/app/Policies/RoomPolicy.php
+++ b/app/Policies/RoomPolicy.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Property;
+use App\Models\Room;
+use App\Models\User;
+
+class RoomPolicy
+{
+    public function viewAny(User $user, Property $property): bool
+    {
+        return $user->properties->contains($property);
+    }
+
+    public function view(User $user, Room $room): bool
+    {
+        return $user->properties->contains($room->property_id);
+    }
+
+    public function create(User $user, Property $property): bool
+    {
+        return $user->properties->contains($property);
+    }
+
+    public function update(User $user, Room $room): bool
+    {
+        return $user->properties->contains($room->property_id);
+    }
+
+    public function delete(User $user, Room $room): bool
+    {
+        return $user->properties->contains($room->property_id);
+    }
+}

--- a/app/Policies/TenantPolicy.php
+++ b/app/Policies/TenantPolicy.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Room;
+use App\Models\Tenant;
+use App\Models\User;
+
+class TenantPolicy
+{
+    public function view(User $user, Tenant $tenant): bool
+    {
+        return $tenant->leases()
+            ->whereHas('room.property.users', fn ($q) => $q->whereKey($user->id))
+            ->exists();
+    }
+
+    public function create(User $user): bool
+    {
+        return true;
+    }
+
+    public function update(User $user, Tenant $tenant): bool
+    {
+        return $tenant->leases()
+            ->whereHas('room.property.users', fn ($q) => $q->whereKey($user->id))
+            ->exists();
+    }
+
+    public function delete(User $user, Tenant $tenant): bool
+    {
+        return $tenant->leases()
+            ->whereHas('room.property.users', fn ($q) => $q->whereKey($user->id))
+            ->exists();
+    }
+
+    public function assignRoom(User $user, Room $room): bool
+    {
+        return $user->properties->contains($room->property_id);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,13 +2,11 @@
 
 namespace App\Providers;
 
-use App\Enums\Role;
 use Carbon\CarbonImmutable;
 use Illuminate\Auth\Events\Login;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
-use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Validation\Rules\Password;
 
@@ -28,7 +26,6 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->configureDefaults();
-        $this->configureAuthorization();
         $this->configureAuthEvents();
     }
 
@@ -52,13 +49,6 @@ class AppServiceProvider extends ServiceProvider
                 ->uncompromised()
             : null,
         );
-    }
-
-    protected function configureAuthorization(): void
-    {
-        Gate::before(function ($user, $ability) {
-            return $user->hasRole(Role::Owner->value) ? true : null;
-        });
     }
 
     protected function configureAuthEvents(): void

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Providers;
+
+use App\Enums\Role;
+use App\Models\Lease;
+use App\Models\MaintenanceTicket;
+use App\Models\Payment;
+use App\Models\Property;
+use App\Models\Room;
+use App\Models\Tenant;
+use App\Policies\LeasePolicy;
+use App\Policies\MaintenanceTicketPolicy;
+use App\Policies\PaymentPolicy;
+use App\Policies\PropertyPolicy;
+use App\Policies\RoomPolicy;
+use App\Policies\TenantPolicy;
+use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Gate;
+
+class AuthServiceProvider extends ServiceProvider
+{
+    protected $policies = [
+        Property::class => PropertyPolicy::class,
+        Room::class => RoomPolicy::class,
+        Tenant::class => TenantPolicy::class,
+        Lease::class => LeasePolicy::class,
+        Payment::class => PaymentPolicy::class,
+        MaintenanceTicket::class => MaintenanceTicketPolicy::class,
+    ];
+
+    public function boot(): void
+    {
+        $this->registerPolicies();
+
+        Gate::before(function ($user, $ability) {
+            return $user->hasRole(Role::Owner->value) ? true : null;
+        });
+    }
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -1,9 +1,11 @@
 <?php
 
 use App\Providers\AppServiceProvider;
+use App\Providers\AuthServiceProvider;
 use App\Providers\FortifyServiceProvider;
 
 return [
     AppServiceProvider::class,
+    AuthServiceProvider::class,
     FortifyServiceProvider::class,
 ];

--- a/tests/Feature/LeaseTest.php
+++ b/tests/Feature/LeaseTest.php
@@ -250,6 +250,106 @@ describe('move room', function () {
         expect($newLease->deposit_amount)->toBe('500000.00');
     });
 
+    it('denies admin from accessing leases of a property they are not assigned to', function () {
+        $admin = User::factory()->admin()->create();
+        [$propertyA] = createPropertyWithRoom();
+        [$propertyB, $roomB] = createPropertyWithRoom();
+        $admin->properties()->sync([$propertyA->id]);
+
+        $this->actingAs($admin)
+            ->get(route('properties.rooms.leases.index', [$propertyB, $roomB]))
+            ->assertForbidden();
+    });
+
+    it('denies admin from creating a lease in a property they are not assigned to', function () {
+        $admin = User::factory()->admin()->create();
+        [$propertyA] = createPropertyWithRoom();
+        [$propertyB, $roomB] = createPropertyWithRoom();
+        $admin->properties()->sync([$propertyA->id]);
+        $tenant = Tenant::factory()->create();
+
+        $this->actingAs($admin)
+            ->post(route('properties.rooms.leases.store', [$propertyB, $roomB]), [
+                'tenant_id' => $tenant->id,
+                'start_date' => '2026-06-01',
+            ])
+            ->assertForbidden();
+    });
+
+    it('denies admin from updating a lease in a property they are not assigned to', function () {
+        $admin = User::factory()->admin()->create();
+        [$propertyA] = createPropertyWithRoom();
+        [$propertyB, $roomB] = createPropertyWithRoom();
+        $admin->properties()->sync([$propertyA->id]);
+        $tenant = Tenant::factory()->create();
+        $lease = Lease::factory()->create([
+            'tenant_id' => $tenant->id,
+            'room_id' => $roomB->id,
+        ]);
+
+        $this->actingAs($admin)
+            ->put(route('properties.rooms.leases.update', [$propertyB, $roomB, $lease]), [
+                'monthly_rent' => 9_999_999,
+            ])
+            ->assertForbidden();
+    });
+
+    it('denies admin from terminating a lease in a property they are not assigned to', function () {
+        $admin = User::factory()->admin()->create();
+        [$propertyA] = createPropertyWithRoom();
+        [$propertyB, $roomB] = createPropertyWithRoom();
+        $admin->properties()->sync([$propertyA->id]);
+        $tenant = Tenant::factory()->create();
+        $lease = Lease::factory()->create([
+            'tenant_id' => $tenant->id,
+            'room_id' => $roomB->id,
+            'status' => 'active',
+        ]);
+
+        $this->actingAs($admin)
+            ->delete(route('properties.rooms.leases.destroy', [$propertyB, $roomB, $lease]))
+            ->assertForbidden();
+    });
+
+    it('denies admin from moving a lease to a room in a property they are not assigned to', function () {
+        $admin = User::factory()->admin()->create();
+        [$propertyA] = createPropertyWithRoom();
+        [$propertyB, $roomB] = createPropertyWithRoom();
+        $admin->properties()->sync([$propertyA->id]);
+        $tenant = Tenant::factory()->create();
+        $lease = Lease::factory()->create([
+            'tenant_id' => $tenant->id,
+            'room_id' => $roomB->id,
+            'status' => 'active',
+        ]);
+
+        $this->actingAs($admin)
+            ->post(route('properties.rooms.leases.move', [$propertyB, $roomB, $lease]), [
+                'target_room_id' => Room::factory()->for($propertyB)->create()->id,
+            ])
+            ->assertForbidden();
+    });
+
+    it('denies admin from moving a lease to a target room in a different property', function () {
+        $admin = User::factory()->admin()->create();
+        [$propertyA, $roomA] = createPropertyWithRoom();
+        [$propertyB] = createPropertyWithRoom();
+        $admin->properties()->sync([$propertyA->id]);
+        $tenant = Tenant::factory()->create();
+        $lease = Lease::factory()->create([
+            'tenant_id' => $tenant->id,
+            'room_id' => $roomA->id,
+            'status' => 'active',
+        ]);
+        $targetRoomInB = Room::factory()->for($propertyB)->create();
+
+        $this->actingAs($admin)
+            ->post(route('properties.rooms.leases.move', [$propertyA, $roomA, $lease]), [
+                'target_room_id' => $targetRoomInB->id,
+            ])
+            ->assertForbidden();
+    });
+
     it('prevents moving to an already occupied room', function () {
         [$property, $roomA] = createPropertyWithRoom();
         $roomB = Room::factory()->create([

--- a/tests/Feature/MaintenanceTicketTest.php
+++ b/tests/Feature/MaintenanceTicketTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\Models\MaintenanceTicket;
+use App\Models\Property;
+use App\Models\Room;
+use App\Models\User;
+use Database\Seeders\RoleAndPermissionSeeder;
+
+uses()->beforeEach(function () {
+    $this->seed(RoleAndPermissionSeeder::class);
+});
+
+describe('authorization', function () {
+    it('allows owner to view ticket', function () {
+        $user = User::factory()->owner()->create();
+        $ticket = MaintenanceTicket::factory()->create();
+
+        expect($user->can('view', $ticket))->toBeTrue();
+    });
+
+    it('allows admin assigned to the property to view ticket', function () {
+        $admin = User::factory()->admin()->create();
+        $property = Property::factory()->create();
+        $admin->properties()->sync([$property->id]);
+        $room = Room::factory()->for($property)->create();
+        $ticket = MaintenanceTicket::factory()->create(['room_id' => $room->id]);
+
+        expect($admin->can('view', $ticket))->toBeTrue();
+    });
+
+    it('denies admin not assigned to the property from viewing ticket', function () {
+        $admin = User::factory()->admin()->create();
+        $propertyA = Property::factory()->create();
+        $propertyB = Property::factory()->create();
+        $admin->properties()->sync([$propertyA->id]);
+        $room = Room::factory()->for($propertyB)->create();
+        $ticket = MaintenanceTicket::factory()->create(['room_id' => $room->id]);
+
+        expect($admin->can('view', $ticket))->toBeFalse();
+    });
+});

--- a/tests/Feature/PaymentTest.php
+++ b/tests/Feature/PaymentTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use App\Models\Lease;
+use App\Models\Payment;
+use App\Models\Property;
+use App\Models\Room;
+use App\Models\Tenant;
+use App\Models\User;
+use Database\Seeders\RoleAndPermissionSeeder;
+
+uses()->beforeEach(function () {
+    $this->seed(RoleAndPermissionSeeder::class);
+});
+
+describe('authorization', function () {
+    it('allows owner to view payment', function () {
+        $user = User::factory()->owner()->create();
+        $payment = Payment::factory()->create();
+
+        expect($user->can('view', $payment))->toBeTrue();
+    });
+
+    it('allows admin assigned to the property to view payment', function () {
+        $admin = User::factory()->admin()->create();
+        $property = Property::factory()->create();
+        $admin->properties()->sync([$property->id]);
+        $room = Room::factory()->for($property)->create();
+        $tenant = Tenant::factory()->create();
+        $lease = Lease::factory()->create(['room_id' => $room->id, 'tenant_id' => $tenant->id]);
+        $payment = Payment::factory()->create(['lease_id' => $lease->id]);
+
+        expect($admin->can('view', $payment))->toBeTrue();
+    });
+
+    it('denies admin not assigned to the property from viewing payment', function () {
+        $admin = User::factory()->admin()->create();
+        $propertyA = Property::factory()->create();
+        $propertyB = Property::factory()->create();
+        $admin->properties()->sync([$propertyA->id]);
+        $room = Room::factory()->for($propertyB)->create();
+        $tenant = Tenant::factory()->create();
+        $lease = Lease::factory()->create(['room_id' => $room->id, 'tenant_id' => $tenant->id]);
+        $payment = Payment::factory()->create(['lease_id' => $lease->id]);
+
+        expect($admin->can('view', $payment))->toBeFalse();
+    });
+});

--- a/tests/Feature/PropertyTest.php
+++ b/tests/Feature/PropertyTest.php
@@ -115,3 +115,27 @@ describe('CRUD', function () {
         expect($property->is_active)->toBeFalse();
     });
 });
+
+describe('cross-property access', function () {
+    it('denies admin from updating a property they are not assigned to', function () {
+        $admin = User::factory()->admin()->create();
+        $propertyA = Property::factory()->create();
+        $propertyB = Property::factory()->create();
+        $admin->properties()->sync([$propertyA->id]);
+
+        $this->actingAs($admin)
+            ->put(route('properties.update', $propertyB), ['name' => 'Hacked Name'])
+            ->assertForbidden();
+    });
+
+    it('denies admin from archiving a property they are not assigned to', function () {
+        $admin = User::factory()->admin()->create();
+        $propertyA = Property::factory()->create();
+        $propertyB = Property::factory()->create();
+        $admin->properties()->sync([$propertyA->id]);
+
+        $this->actingAs($admin)
+            ->delete(route('properties.destroy', $propertyB))
+            ->assertForbidden();
+    });
+});

--- a/tests/Feature/RoomTest.php
+++ b/tests/Feature/RoomTest.php
@@ -150,3 +150,59 @@ describe('CRUD', function () {
         );
     });
 });
+
+describe('cross-property access', function () {
+    it('denies admin viewing rooms of a property they are not assigned to', function () {
+        $admin = User::factory()->admin()->create();
+        $propertyA = Property::factory()->create();
+        $propertyB = Property::factory()->create();
+        $admin->properties()->sync([$propertyA->id]);
+
+        $this->actingAs($admin)
+            ->get(route('properties.rooms.index', $propertyB))
+            ->assertForbidden();
+    });
+
+    it('denies admin creating a room in a property they are not assigned to', function () {
+        $admin = User::factory()->admin()->create();
+        $propertyA = Property::factory()->create();
+        $propertyB = Property::factory()->create();
+        $admin->properties()->sync([$propertyA->id]);
+
+        $this->actingAs($admin)
+            ->post(route('properties.rooms.store', $propertyB), [
+                'name' => 'Room 101',
+                'base_price' => 1_000_000,
+                'capacity' => 1,
+            ])
+            ->assertForbidden();
+    });
+
+    it('denies admin updating a room in a property they are not assigned to', function () {
+        $admin = User::factory()->admin()->create();
+        $propertyA = Property::factory()->create();
+        $propertyB = Property::factory()->create();
+        $admin->properties()->sync([$propertyA->id]);
+        $room = Room::factory()->for($propertyB)->create();
+
+        $this->actingAs($admin)
+            ->put(route('properties.rooms.update', [$propertyB, $room]), [
+                'name' => 'Hacked',
+                'base_price' => 1_000_000,
+                'capacity' => 1,
+            ])
+            ->assertForbidden();
+    });
+
+    it('denies admin deleting a room in a property they are not assigned to', function () {
+        $admin = User::factory()->admin()->create();
+        $propertyA = Property::factory()->create();
+        $propertyB = Property::factory()->create();
+        $admin->properties()->sync([$propertyA->id]);
+        $room = Room::factory()->for($propertyB)->create();
+
+        $this->actingAs($admin)
+            ->delete(route('properties.rooms.destroy', [$propertyB, $room]))
+            ->assertForbidden();
+    });
+});

--- a/tests/Feature/TenantTest.php
+++ b/tests/Feature/TenantTest.php
@@ -1,5 +1,8 @@
 <?php
 
+use App\Models\Lease;
+use App\Models\Property;
+use App\Models\Room;
 use App\Models\Tenant;
 use App\Models\User;
 use Database\Seeders\RoleAndPermissionSeeder;
@@ -185,5 +188,57 @@ describe('CRUD', function () {
             ->component('tenants/index')
             ->has('tenants.data', 1)
         );
+    });
+});
+
+describe('cross-property access', function () {
+    it('denies admin from updating a tenant in a property they are not assigned to', function () {
+        $admin = User::factory()->admin()->create();
+        $propertyA = Property::factory()->create();
+        $propertyB = Property::factory()->create();
+        $admin->properties()->sync([$propertyA->id]);
+        $room = Room::factory()->for($propertyB)->create();
+        $tenant = Tenant::factory()->create();
+        Lease::factory()->create([
+            'tenant_id' => $tenant->id,
+            'room_id' => $room->id,
+        ]);
+
+        $this->actingAs($admin)
+            ->put(route('tenants.update', $tenant), ['name' => 'Hacked Name'])
+            ->assertForbidden();
+    });
+
+    it('denies admin from archiving a tenant in a property they are not assigned to', function () {
+        $admin = User::factory()->admin()->create();
+        $propertyA = Property::factory()->create();
+        $propertyB = Property::factory()->create();
+        $admin->properties()->sync([$propertyA->id]);
+        $room = Room::factory()->for($propertyB)->create();
+        $tenant = Tenant::factory()->create();
+        Lease::factory()->create([
+            'tenant_id' => $tenant->id,
+            'room_id' => $room->id,
+        ]);
+
+        $this->actingAs($admin)
+            ->delete(route('tenants.destroy', $tenant))
+            ->assertForbidden();
+    });
+
+    it('denies admin assigning a tenant to a room in a property they are not assigned to', function () {
+        $admin = User::factory()->admin()->create();
+        $propertyA = Property::factory()->create();
+        $propertyB = Property::factory()->create();
+        $admin->properties()->sync([$propertyA->id]);
+        $tenant = Tenant::factory()->create();
+        $roomInB = Room::factory()->for($propertyB)->create();
+
+        $this->actingAs($admin)
+            ->post(route('tenants.assign-room', $tenant), [
+                'room_id' => $roomInB->id,
+                'start_date' => '2026-06-01',
+            ])
+            ->assertForbidden();
     });
 });


### PR DESCRIPTION
…olicies (OPE-45)

- Create AuthServiceProvider with Gate::before (owner bypass) and 6 policy registrations
- Create PropertyPolicy, RoomPolicy, TenantPolicy, LeasePolicy, PaymentPolicy, MaintenanceTicketPolicy
- Replace all 16 abort_unless(canAccessProperty()) calls with ->authorize()
- Add missing authorization to TenantController::update and ::destroy
- Add AuthorizesRequests trait to base Controller
- Write 21 new tests covering cross-property access denial across all modules