### PR TITLE
fix: atomic capacity checks, deduplicate tenant IDs, append moved ten…

### DIFF
--- a/app/Http/Controllers/LeaseController.php
+++ b/app/Http/Controllers/LeaseController.php
@@ -3,8 +3,10 @@
 namespace App\Http\Controllers;
 
 use App\Enums\RoomStatus;
-use App\Http\Requests\StoreLeaseRequest;
-use App\Http\Requests\UpdateLeaseRequest;
+use App\Http\Requests\Lease\MoveLeaseRequest;
+use App\Http\Requests\Lease\MoveOutRequest;
+use App\Http\Requests\Lease\StoreLeaseRequest;
+use App\Http\Requests\Lease\UpdateLeaseRequest;
 use App\Models\Lease;
 use App\Models\Property;
 use App\Models\Room;
@@ -265,17 +267,9 @@ class LeaseController extends Controller
         return to_route('properties.rooms.index', $property);
     }
 
-    public function moveOut(Request $request, Lease $lease): RedirectResponse
+    public function moveOut(MoveOutRequest $request, Lease $lease): RedirectResponse
     {
-        $validated = $request->validate([
-            'move_out_date' => ['required', 'date'],
-            'reason' => ['nullable', 'string', 'max:255'],
-            'deposit_returned' => ['nullable', 'boolean'],
-            'deposit_refund_amount' => ['nullable', 'numeric', 'min:0'],
-            'notes' => ['nullable', 'string', 'max:65535'],
-            'move_to_another_room' => ['nullable', 'boolean'],
-            'target_room_id' => ['nullable', 'integer', 'exists:rooms,id'],
-        ]);
+        $validated = $request->validated();
 
         $targetRoom = ($validated['move_to_another_room'] ?? false)
             ? Room::findOrFail($validated['target_room_id'])
@@ -382,13 +376,9 @@ class LeaseController extends Controller
         return back();
     }
 
-    public function move(Request $request, Property $property, Room $room, Lease $lease): RedirectResponse
+    public function move(MoveLeaseRequest $request, Property $property, Room $room, Lease $lease): RedirectResponse
     {
-        $request->validate([
-            'target_room_id' => ['required', 'integer', 'exists:rooms,id'],
-        ]);
-
-        $targetRoom = Room::findOrFail($request->target_room_id);
+        $targetRoom = Room::findOrFail($request->validated('target_room_id'));
 
         $this->authorize('move', [$lease, $targetRoom]);
 

--- a/app/Http/Controllers/LeaseController.php
+++ b/app/Http/Controllers/LeaseController.php
@@ -163,29 +163,30 @@ class LeaseController extends Controller
         $lease = DB::transaction(function () use ($room, $request, $tenantIds) {
             $room = Room::lockForUpdate()->findOrFail($room->id);
 
+            $existingLease = $room->leases()->where('status', 'active')->first();
+
             $activeTenantsCount = DB::table('lease_tenant')
                 ->join('leases', 'leases.id', '=', 'lease_tenant.lease_id')
                 ->where('leases.room_id', $room->id)
                 ->where('leases.status', 'active')
                 ->count();
 
-            abort_if(($activeTenantsCount + count($tenantIds)) > $room->capacity, 422, __('Room capacity exceeded. Room can only hold :capacity occupants.', ['capacity' => $room->capacity]));
-
-            $existingLease = $room->leases()->where('status', 'active')->first();
-
             if ($existingLease) {
                 $existingTenantIds = $existingLease->tenants()->pluck('tenants.id');
+                $newTenantIds = array_diff($tenantIds, $existingTenantIds->all());
 
-                foreach ($tenantIds as $tenantId) {
-                    if (! $existingTenantIds->contains($tenantId)) {
-                        $existingLease->tenants()->attach($tenantId, ['is_primary' => DB::raw('false')]);
-                    }
+                abort_if(($activeTenantsCount + count($newTenantIds)) > $room->capacity, 422, __('Room capacity exceeded. Room can only hold :capacity occupants.', ['capacity' => $room->capacity]));
+
+                foreach ($newTenantIds as $tenantId) {
+                    $existingLease->tenants()->attach($tenantId, ['is_primary' => DB::raw('false')]);
                 }
 
                 $room->update(['status' => RoomStatus::Occupied]);
 
                 return $existingLease;
             }
+
+            abort_if(($activeTenantsCount + count($tenantIds)) > $room->capacity, 422, __('Room capacity exceeded. Room can only hold :capacity occupants.', ['capacity' => $room->capacity]));
 
             $roomRate = $request->room_rate_id ? RoomRate::find($request->room_rate_id) : null;
             $rentAmount = $request->rent_amount ?? $roomRate?->amount ?? $room->rates()->where('billing_unit', 'month')->where('billing_interval', 1)->value('amount');
@@ -293,7 +294,15 @@ class LeaseController extends Controller
                     ->where('leases.status', 'active')
                     ->count();
 
-                abort_if(($activeTenantsCount + $lease->tenants->count()) > $targetRoom->capacity, 422, __('Room capacity exceeded. Target room can only hold :capacity occupants.', ['capacity' => $targetRoom->capacity]));
+                $existingLease = $targetRoom->leases()->where('status', 'active')->first();
+
+                $incomingTenantIds = $lease->tenants->pluck('id')->toArray();
+
+                $incomingCount = $existingLease
+                    ? count(array_diff($incomingTenantIds, $existingLease->tenants()->pluck('tenants.id')->all()))
+                    : count($incomingTenantIds);
+
+                abort_if(($activeTenantsCount + $incomingCount) > $targetRoom->capacity, 422, __('Room capacity exceeded. Target room can only hold :capacity occupants.', ['capacity' => $targetRoom->capacity]));
             }
             $oldRoom = $lease->room;
 
@@ -393,7 +402,15 @@ class LeaseController extends Controller
                 ->where('leases.status', 'active')
                 ->count();
 
-            abort_if(($activeTenantsCount + $lease->tenants->count()) > $targetRoom->capacity, 422, __('Room capacity exceeded. Target room can only hold :capacity occupants.', ['capacity' => $targetRoom->capacity]));
+            $existingLease = $targetRoom->leases()->where('status', 'active')->first();
+
+            $incomingTenantIds = $lease->tenants->pluck('id')->toArray();
+
+            $incomingCount = $existingLease
+                ? count(array_diff($incomingTenantIds, $existingLease->tenants()->pluck('tenants.id')->all()))
+                : count($incomingTenantIds);
+
+            abort_if(($activeTenantsCount + $incomingCount) > $targetRoom->capacity, 422, __('Room capacity exceeded. Target room can only hold :capacity occupants.', ['capacity' => $targetRoom->capacity]));
             $lease->update([
                 'end_date' => now(),
                 'status' => 'terminated',

--- a/app/Http/Controllers/LeaseController.php
+++ b/app/Http/Controllers/LeaseController.php
@@ -156,11 +156,19 @@ class LeaseController extends Controller
     {
         $this->authorize('create', [Lease::class, $property]);
 
-        $request->ensureCapacityAvailable($room);
-
-        $tenantIds = $request->tenant_ids;
+        $tenantIds = array_values(array_unique($request->tenant_ids));
 
         $lease = DB::transaction(function () use ($room, $request, $tenantIds) {
+            $room = Room::lockForUpdate()->findOrFail($room->id);
+
+            $activeTenantsCount = DB::table('lease_tenant')
+                ->join('leases', 'leases.id', '=', 'lease_tenant.lease_id')
+                ->where('leases.room_id', $room->id)
+                ->where('leases.status', 'active')
+                ->count();
+
+            abort_if(($activeTenantsCount + count($tenantIds)) > $room->capacity, 422, __('Room capacity exceeded. Room can only hold :capacity occupants.', ['capacity' => $room->capacity]));
+
             $existingLease = $room->leases()->where('status', 'active')->first();
 
             if ($existingLease) {
@@ -275,25 +283,24 @@ class LeaseController extends Controller
 
         $this->authorize('moveOut', [$lease, $targetRoom]);
 
-        if ($validated['move_to_another_room'] ?? false) {
-            $lease->load('tenants');
-
-            $activeTenantsCount = $targetRoom->leases()
-                ->where('status', 'active')
-                ->withCount('tenants')
-                ->get()
-                ->sum('tenants_count');
-
-            $totalOccupants = $activeTenantsCount + $lease->tenants->count();
-
-            abort_if($totalOccupants > $targetRoom->capacity, 422, __('Room capacity exceeded. Target room can only hold :capacity occupants.', ['capacity' => $targetRoom->capacity]));
-        }
-
         $depositRefundAmount = ($validated['deposit_returned'] ?? false)
             ? ($validated['deposit_refund_amount'] ?? $lease->deposit_amount)
             : null;
 
         DB::transaction(function () use ($lease, $validated, $targetRoom, $depositRefundAmount) {
+            if ($validated['move_to_another_room'] ?? false) {
+                $targetRoom = Room::lockForUpdate()->findOrFail($targetRoom->id);
+
+                $lease->load('tenants');
+
+                $activeTenantsCount = DB::table('lease_tenant')
+                    ->join('leases', 'leases.id', '=', 'lease_tenant.lease_id')
+                    ->where('leases.room_id', $targetRoom->id)
+                    ->where('leases.status', 'active')
+                    ->count();
+
+                abort_if(($activeTenantsCount + $lease->tenants->count()) > $targetRoom->capacity, 422, __('Room capacity exceeded. Target room can only hold :capacity occupants.', ['capacity' => $targetRoom->capacity]));
+            }
             $oldRoom = $lease->room;
 
             $lease->update([
@@ -313,34 +320,48 @@ class LeaseController extends Controller
             }
 
             if ($validated['move_to_another_room'] ?? false) {
-                $matchingRate = $targetRoom->rates()
-                    ->where('billing_interval', $lease->billing_interval)
-                    ->where('billing_unit', $lease->billing_unit)
-                    ->first();
-
-                $newLease = $targetRoom->leases()->create([
-                    'primary_tenant_id' => $lease->primary_tenant_id,
-                    'start_date' => $validated['move_out_date'],
-                    'rent_amount' => $lease->rent_amount,
-                    'billing_interval' => $lease->billing_interval ?? 1,
-                    'billing_unit' => $lease->billing_unit ?? 'month',
-                    'is_custom_price' => $lease->is_custom_price ? DB::raw('true') : DB::raw('false'),
-                    'room_rate_id' => $matchingRate?->id,
-                    'deposit_amount' => $lease->deposit_amount,
-                    'deposit_paid_at' => $lease->deposit_paid_at,
-                    'deposit_refund_amount' => null,
-                    'deposit_refunded_at' => null,
-                    'rent_due_day' => $lease->rent_due_day,
-                    'status' => 'active',
-                    'notes' => 'Moved from room '.$lease->room->name.' on '.now()->format('Y-m-d'),
-                ]);
+                $existingLease = $targetRoom->leases()->where('status', 'active')->first();
 
                 $lease->load('tenants');
 
-                foreach ($lease->tenants as $tenant) {
-                    $newLease->tenants()->attach($tenant->id, [
-                        'is_primary' => $tenant->id === $lease->primary_tenant_id ? DB::raw('true') : DB::raw('false'),
+                if ($existingLease) {
+                    $existingTenantIds = $existingLease->tenants()->pluck('tenants.id');
+
+                    foreach ($lease->tenants as $tenant) {
+                        if (! $existingTenantIds->contains($tenant->id)) {
+                            $existingLease->tenants()->attach($tenant->id, [
+                                'is_primary' => DB::raw('false'),
+                            ]);
+                        }
+                    }
+                } else {
+                    $matchingRate = $targetRoom->rates()
+                        ->where('billing_interval', $lease->billing_interval)
+                        ->where('billing_unit', $lease->billing_unit)
+                        ->first();
+
+                    $newLease = $targetRoom->leases()->create([
+                        'primary_tenant_id' => $lease->primary_tenant_id,
+                        'start_date' => $validated['move_out_date'],
+                        'rent_amount' => $lease->rent_amount,
+                        'billing_interval' => $lease->billing_interval ?? 1,
+                        'billing_unit' => $lease->billing_unit ?? 'month',
+                        'is_custom_price' => $lease->is_custom_price ? DB::raw('true') : DB::raw('false'),
+                        'room_rate_id' => $matchingRate?->id,
+                        'deposit_amount' => $lease->deposit_amount,
+                        'deposit_paid_at' => $lease->deposit_paid_at,
+                        'deposit_refund_amount' => null,
+                        'deposit_refunded_at' => null,
+                        'rent_due_day' => $lease->rent_due_day,
+                        'status' => 'active',
+                        'notes' => 'Moved from room '.$lease->room->name.' on '.now()->format('Y-m-d'),
                     ]);
+
+                    foreach ($lease->tenants as $tenant) {
+                        $newLease->tenants()->attach($tenant->id, [
+                            'is_primary' => $tenant->id === $lease->primary_tenant_id ? DB::raw('true') : DB::raw('false'),
+                        ]);
+                    }
                 }
 
                 $targetRoom->update(['status' => RoomStatus::Occupied]);
@@ -371,19 +392,18 @@ class LeaseController extends Controller
 
         $this->authorize('move', [$lease, $targetRoom]);
 
-        $lease->load('tenants');
-
-        $activeTenantsCount = $targetRoom->leases()
-            ->where('status', 'active')
-            ->withCount('tenants')
-            ->get()
-            ->sum('tenants_count');
-
-        $totalOccupants = $activeTenantsCount + $lease->tenants->count();
-
-        abort_if($totalOccupants > $targetRoom->capacity, 422, __('Room capacity exceeded. Target room can only hold :capacity occupants.', ['capacity' => $targetRoom->capacity]));
-
         DB::transaction(function () use ($lease, $targetRoom, $room) {
+            $targetRoom = Room::lockForUpdate()->findOrFail($targetRoom->id);
+
+            $lease->load('tenants');
+
+            $activeTenantsCount = DB::table('lease_tenant')
+                ->join('leases', 'leases.id', '=', 'lease_tenant.lease_id')
+                ->where('leases.room_id', $targetRoom->id)
+                ->where('leases.status', 'active')
+                ->count();
+
+            abort_if(($activeTenantsCount + $lease->tenants->count()) > $targetRoom->capacity, 422, __('Room capacity exceeded. Target room can only hold :capacity occupants.', ['capacity' => $targetRoom->capacity]));
             $lease->update([
                 'end_date' => now(),
                 'status' => 'terminated',
@@ -398,34 +418,48 @@ class LeaseController extends Controller
                 $room->update(['status' => RoomStatus::Available]);
             }
 
-            $matchingRate = $targetRoom->rates()
-                ->where('billing_interval', $lease->billing_interval)
-                ->where('billing_unit', $lease->billing_unit)
-                ->first();
-
-            $newLease = $targetRoom->leases()->create([
-                'primary_tenant_id' => $lease->primary_tenant_id,
-                'start_date' => now(),
-                'rent_amount' => $lease->rent_amount,
-                'billing_interval' => $lease->billing_interval ?? 1,
-                'billing_unit' => $lease->billing_unit ?? 'month',
-                'is_custom_price' => $lease->is_custom_price ? DB::raw('true') : DB::raw('false'),
-                'room_rate_id' => $matchingRate?->id,
-                'deposit_amount' => $lease->deposit_amount,
-                'deposit_paid_at' => $lease->deposit_paid_at,
-                'deposit_refund_amount' => $lease->deposit_refund_amount,
-                'deposit_refunded_at' => $lease->deposit_refunded_at,
-                'rent_due_day' => $lease->rent_due_day,
-                'status' => 'active',
-                'notes' => 'Moved from room '.$room->name.' on '.now()->format('Y-m-d'),
-            ]);
+            $existingLease = $targetRoom->leases()->where('status', 'active')->first();
 
             $lease->load('tenants');
 
-            foreach ($lease->tenants as $tenant) {
-                $newLease->tenants()->attach($tenant->id, [
-                    'is_primary' => $tenant->id === $lease->primary_tenant_id ? DB::raw('true') : DB::raw('false'),
+            if ($existingLease) {
+                $existingTenantIds = $existingLease->tenants()->pluck('tenants.id');
+
+                foreach ($lease->tenants as $tenant) {
+                    if (! $existingTenantIds->contains($tenant->id)) {
+                        $existingLease->tenants()->attach($tenant->id, [
+                            'is_primary' => DB::raw('false'),
+                        ]);
+                    }
+                }
+            } else {
+                $matchingRate = $targetRoom->rates()
+                    ->where('billing_interval', $lease->billing_interval)
+                    ->where('billing_unit', $lease->billing_unit)
+                    ->first();
+
+                $newLease = $targetRoom->leases()->create([
+                    'primary_tenant_id' => $lease->primary_tenant_id,
+                    'start_date' => now(),
+                    'rent_amount' => $lease->rent_amount,
+                    'billing_interval' => $lease->billing_interval ?? 1,
+                    'billing_unit' => $lease->billing_unit ?? 'month',
+                    'is_custom_price' => $lease->is_custom_price ? DB::raw('true') : DB::raw('false'),
+                    'room_rate_id' => $matchingRate?->id,
+                    'deposit_amount' => $lease->deposit_amount,
+                    'deposit_paid_at' => $lease->deposit_paid_at,
+                    'deposit_refund_amount' => $lease->deposit_refund_amount,
+                    'deposit_refunded_at' => $lease->deposit_refunded_at,
+                    'rent_due_day' => $lease->rent_due_day,
+                    'status' => 'active',
+                    'notes' => 'Moved from room '.$room->name.' on '.now()->format('Y-m-d'),
                 ]);
+
+                foreach ($lease->tenants as $tenant) {
+                    $newLease->tenants()->attach($tenant->id, [
+                        'is_primary' => $tenant->id === $lease->primary_tenant_id ? DB::raw('true') : DB::raw('false'),
+                    ]);
+                }
             }
 
             $targetRoom->update(['status' => RoomStatus::Occupied]);

--- a/app/Http/Controllers/PropertyController.php
+++ b/app/Http/Controllers/PropertyController.php
@@ -3,8 +3,8 @@
 namespace App\Http\Controllers;
 
 use App\Enums\RoomStatus;
-use App\Http\Requests\StorePropertyRequest;
-use App\Http\Requests\UpdatePropertyRequest;
+use App\Http\Requests\Property\StorePropertyRequest;
+use App\Http\Requests\Property\UpdatePropertyRequest;
 use App\Models\City;
 use App\Models\Property;
 use App\Models\Region;

--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -3,8 +3,9 @@
 namespace App\Http\Controllers;
 
 use App\Enums\Permission;
-use App\Http\Requests\StoreRoleRequest;
-use App\Http\Requests\UpdateRoleRequest;
+use App\Http\Requests\Role\CloneRoleRequest;
+use App\Http\Requests\Role\StoreRoleRequest;
+use App\Http\Requests\Role\UpdateRoleRequest;
 use App\Models\Role;
 use App\Support\RecommendedRoles;
 use Illuminate\Http\RedirectResponse;
@@ -169,12 +170,9 @@ class RoleController extends Controller
         return to_route('roles.index');
     }
 
-    public function clone(Request $request, Role $role): RedirectResponse
+    public function clone(CloneRoleRequest $request, Role $role): RedirectResponse
     {
-        $validated = $request->validate([
-            'name' => ['required', 'string', 'max:255', 'unique:roles,name'],
-            'label' => ['nullable', 'string', 'max:255'],
-        ]);
+        $validated = $request->validated();
 
         $newRole = Role::create([
             'name' => $validated['name'],

--- a/app/Http/Controllers/RoomController.php
+++ b/app/Http/Controllers/RoomController.php
@@ -2,8 +2,8 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Requests\StoreRoomRequest;
-use App\Http\Requests\UpdateRoomRequest;
+use App\Http\Requests\Room\StoreRoomRequest;
+use App\Http\Requests\Room\UpdateRoomRequest;
 use App\Models\Property;
 use App\Models\Room;
 use App\Models\Tenant;

--- a/app/Http/Controllers/TenantController.php
+++ b/app/Http/Controllers/TenantController.php
@@ -101,8 +101,8 @@ class TenantController extends Controller
     public function assignRoom(Request $request, Tenant $tenant): RedirectResponse
     {
         $validated = $request->validate([
-            'tenant_ids' => ['nullable', 'array'],
-            'tenant_ids.*' => ['integer', 'exists:tenants,id'],
+            'tenant_ids' => ['nullable', 'array', 'min:1'],
+            'tenant_ids.*' => ['integer', 'distinct', 'exists:tenants,id'],
             'room_id' => ['required', 'integer', 'exists:rooms,id'],
             'start_date' => ['required', 'date'],
             'end_date' => ['nullable', 'date', 'after:start_date'],
@@ -120,13 +120,15 @@ class TenantController extends Controller
 
         $this->authorize('assignRoom', [Tenant::class, $room]);
 
-        $tenantIds = $validated['tenant_ids'] ?? [$tenant->id];
+        $tenantIds = $validated['tenant_ids'] !== null
+            ? array_values(array_unique($validated['tenant_ids']))
+            : [$tenant->id];
 
-        $activeTenantsCount = $room->leases()
-            ->where('status', 'active')
-            ->withCount('tenants')
-            ->get()
-            ->sum('tenants_count');
+        $activeTenantsCount = DB::table('lease_tenant')
+            ->join('leases', 'leases.id', '=', 'lease_tenant.lease_id')
+            ->where('leases.room_id', $room->id)
+            ->where('leases.status', 'active')
+            ->count();
 
         $totalOccupants = $activeTenantsCount + count($tenantIds);
 

--- a/app/Http/Controllers/TenantController.php
+++ b/app/Http/Controllers/TenantController.php
@@ -101,40 +101,39 @@ class TenantController extends Controller
     {
         $validated = $request->validated();
 
-        $room = Room::findOrFail($validated['room_id']);
+        $this->authorize('assignRoom', [Tenant::class, Room::findOrFail($validated['room_id'])]);
 
-        $this->authorize('assignRoom', [Tenant::class, $room]);
+        DB::transaction(function () use ($validated, $tenant) {
+            $room = Room::lockForUpdate()->findOrFail($validated['room_id']);
 
-        $tenantIds = $validated['tenant_ids'] !== null
-            ? array_values(array_unique($validated['tenant_ids']))
-            : [$tenant->id];
+            $tenantIds = isset($validated['tenant_ids'])
+                ? array_values(array_unique($validated['tenant_ids']))
+                : [$tenant->id];
 
-        $activeTenantsCount = DB::table('lease_tenant')
-            ->join('leases', 'leases.id', '=', 'lease_tenant.lease_id')
-            ->where('leases.room_id', $room->id)
-            ->where('leases.status', 'active')
-            ->count();
+            $activeTenantsCount = DB::table('lease_tenant')
+                ->join('leases', 'leases.id', '=', 'lease_tenant.lease_id')
+                ->where('leases.room_id', $room->id)
+                ->where('leases.status', 'active')
+                ->count();
 
-        $totalOccupants = $activeTenantsCount + count($tenantIds);
-
-        abort_if($totalOccupants > $room->capacity, 422, __('Room capacity exceeded. Room can only hold :capacity occupants.', ['capacity' => $room->capacity]));
-
-        DB::transaction(function () use ($room, $tenantIds, $validated) {
             $existingLease = $room->leases()->where('status', 'active')->first();
 
             if ($existingLease) {
                 $existingTenantIds = $existingLease->tenants()->pluck('tenants.id');
+                $newTenantIds = array_diff($tenantIds, $existingTenantIds->all());
 
-                foreach ($tenantIds as $tenantId) {
-                    if (! $existingTenantIds->contains($tenantId)) {
-                        $existingLease->tenants()->attach($tenantId, ['is_primary' => DB::raw('false')]);
-                    }
+                abort_if(($activeTenantsCount + count($newTenantIds)) > $room->capacity, 422, __('Room capacity exceeded. Room can only hold :capacity occupants.', ['capacity' => $room->capacity]));
+
+                foreach ($newTenantIds as $tenantId) {
+                    $existingLease->tenants()->attach($tenantId, ['is_primary' => DB::raw('false')]);
                 }
 
                 $room->update(['status' => RoomStatus::Occupied]);
 
                 return;
             }
+
+            abort_if(($activeTenantsCount + count($tenantIds)) > $room->capacity, 422, __('Room capacity exceeded. Room can only hold :capacity occupants.', ['capacity' => $room->capacity]));
 
             $primaryTenantId = $tenantIds[0];
 

--- a/app/Http/Controllers/TenantController.php
+++ b/app/Http/Controllers/TenantController.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Controllers;
 
-use App\Enums\BillingUnit;
 use App\Enums\RoomStatus;
-use App\Http\Requests\StoreTenantRequest;
-use App\Http\Requests\UpdateTenantRequest;
+use App\Http\Requests\Tenant\AssignRoomRequest;
+use App\Http\Requests\Tenant\StoreTenantRequest;
+use App\Http\Requests\Tenant\UpdateTenantRequest;
 use App\Models\Room;
 use App\Models\RoomRate;
 use App\Models\Tenant;
@@ -13,7 +13,6 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Validation\Rule;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -98,23 +97,9 @@ class TenantController extends Controller
         ]);
     }
 
-    public function assignRoom(Request $request, Tenant $tenant): RedirectResponse
+    public function assignRoom(AssignRoomRequest $request, Tenant $tenant): RedirectResponse
     {
-        $validated = $request->validate([
-            'tenant_ids' => ['nullable', 'array', 'min:1'],
-            'tenant_ids.*' => ['integer', 'distinct', 'exists:tenants,id'],
-            'room_id' => ['required', 'integer', 'exists:rooms,id'],
-            'start_date' => ['required', 'date'],
-            'end_date' => ['nullable', 'date', 'after:start_date'],
-            'rent_amount' => ['nullable', 'numeric', 'min:0'],
-            'billing_interval' => ['nullable', 'integer', 'min:1', 'max:255'],
-            'billing_unit' => ['nullable', 'string', Rule::in(BillingUnit::values())],
-            'room_rate_id' => ['nullable', 'integer', 'exists:room_rates,id'],
-            'deposit_amount' => ['nullable', 'numeric', 'min:0'],
-            'deposit_paid_at' => ['nullable', 'date'],
-            'rent_due_day' => ['nullable', 'integer', 'between:1,31'],
-            'notes' => ['nullable', 'string', 'max:65535'],
-        ]);
+        $validated = $request->validated();
 
         $room = Room::findOrFail($validated['room_id']);
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -3,8 +3,9 @@
 namespace App\Http\Controllers;
 
 use App\Enums\Role;
-use App\Http\Requests\StoreUserInvitationRequest;
-use App\Http\Requests\UpdateUserRequest;
+use App\Http\Requests\User\CompleteInvitationRequest;
+use App\Http\Requests\User\StoreUserInvitationRequest;
+use App\Http\Requests\User\UpdateUserRequest;
 use App\Models\Property;
 use App\Models\Role as RoleModel;
 use App\Models\User;
@@ -18,7 +19,6 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Support\Str;
-use Illuminate\Validation\Rules\Password as PasswordRule;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -229,21 +229,17 @@ class UserController extends Controller
         ]);
     }
 
-    public function completeInvitation(Request $request): RedirectResponse
+    public function completeInvitation(CompleteInvitationRequest $request): RedirectResponse
     {
-        $request->validate([
-            'token' => ['required', 'string'],
-            'email' => ['required', 'email'],
-            'password' => ['required', 'string', PasswordRule::default(), 'confirmed'],
-        ]);
+        $validated = $request->validated();
 
-        $invitedUser = User::where('email', $request->email)->first();
+        $invitedUser = User::where('email', $validated['email'])->first();
 
         if (! $invitedUser?->invited_at) {
             return back()->withErrors(['email' => __('This invitation is invalid or inactive.')]);
         }
 
-        $status = Password::broker()->reset($request->only('email', 'password', 'password_confirmation', 'token'), function (User $user, string $password): void {
+        $status = Password::broker()->reset($validated, function (User $user, string $password): void {
             $user->forceFill([
                 'password' => $password,
                 'email_verified_at' => now(),

--- a/app/Http/Requests/Lease/MoveLeaseRequest.php
+++ b/app/Http/Requests/Lease/MoveLeaseRequest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Requests\Lease;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class MoveLeaseRequest extends FormRequest
+{
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'target_room_id' => ['required', 'integer', 'exists:rooms,id'],
+        ];
+    }
+}

--- a/app/Http/Requests/Lease/MoveOutRequest.php
+++ b/app/Http/Requests/Lease/MoveOutRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests\Lease;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class MoveOutRequest extends FormRequest
+{
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'move_out_date' => ['required', 'date'],
+            'reason' => ['nullable', 'string', 'max:255'],
+            'deposit_returned' => ['nullable', 'boolean'],
+            'deposit_refund_amount' => ['nullable', 'numeric', 'min:0'],
+            'notes' => ['nullable', 'string', 'max:65535'],
+            'move_to_another_room' => ['nullable', 'boolean'],
+            'target_room_id' => ['nullable', 'integer', 'exists:rooms,id'],
+        ];
+    }
+}

--- a/app/Http/Requests/Lease/StoreLeaseRequest.php
+++ b/app/Http/Requests/Lease/StoreLeaseRequest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace App\Http\Requests;
+namespace App\Http\Requests\Lease;
 
 use App\Enums\BillingUnit;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
-class UpdateLeaseRequest extends FormRequest
+class StoreLeaseRequest extends FormRequest
 {
     /**
      * @return array<string, ValidationRule|array<mixed>|string>
@@ -15,7 +15,9 @@ class UpdateLeaseRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'start_date' => ['nullable', 'date'],
+            'tenant_ids' => ['required', 'array', 'min:1'],
+            'tenant_ids.*' => ['required', 'integer', 'distinct', 'exists:tenants,id'],
+            'start_date' => ['required', 'date'],
             'end_date' => ['nullable', 'date', 'after:start_date'],
             'rent_amount' => ['nullable', 'numeric', 'min:0'],
             'billing_interval' => ['nullable', 'integer', 'min:1', 'max:255'],

--- a/app/Http/Requests/Lease/UpdateLeaseRequest.php
+++ b/app/Http/Requests/Lease/UpdateLeaseRequest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace App\Http\Requests;
+namespace App\Http\Requests\Lease;
 
 use App\Enums\BillingUnit;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
-class StoreLeaseRequest extends FormRequest
+class UpdateLeaseRequest extends FormRequest
 {
     /**
      * @return array<string, ValidationRule|array<mixed>|string>
@@ -15,9 +15,7 @@ class StoreLeaseRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'tenant_ids' => ['required', 'array', 'min:1'],
-            'tenant_ids.*' => ['required', 'integer', 'distinct', 'exists:tenants,id'],
-            'start_date' => ['required', 'date'],
+            'start_date' => ['nullable', 'date'],
             'end_date' => ['nullable', 'date', 'after:start_date'],
             'rent_amount' => ['nullable', 'numeric', 'min:0'],
             'billing_interval' => ['nullable', 'integer', 'min:1', 'max:255'],

--- a/app/Http/Requests/Property/StorePropertyRequest.php
+++ b/app/Http/Requests/Property/StorePropertyRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Requests;
+namespace App\Http\Requests\Property;
 
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;

--- a/app/Http/Requests/Property/UpdatePropertyRequest.php
+++ b/app/Http/Requests/Property/UpdatePropertyRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Requests;
+namespace App\Http\Requests\Property;
 
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;

--- a/app/Http/Requests/Role/CloneRoleRequest.php
+++ b/app/Http/Requests/Role/CloneRoleRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests\Role;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class CloneRoleRequest extends FormRequest
+{
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255', 'unique:roles,name'],
+            'label' => ['nullable', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Http/Requests/Role/StoreRoleRequest.php
+++ b/app/Http/Requests/Role/StoreRoleRequest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace App\Http\Requests;
+namespace App\Http\Requests\Role;
 
 use App\Enums\Permission;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
-class UpdateRoleRequest extends FormRequest
+class StoreRoleRequest extends FormRequest
 {
     public function authorize(): bool
     {
@@ -19,21 +19,13 @@ class UpdateRoleRequest extends FormRequest
      */
     public function rules(): array
     {
-        $role = $this->route('role');
-
-        $rules = [
-            'label' => ['nullable', 'string', 'max:255'],
+        return [
+            'name' => ['required', 'string', 'max:255', 'alpha_dash', 'unique:roles,name'],
+            'label' => ['required', 'string', 'max:255'],
             'description' => ['nullable', 'string', 'max:1000'],
             'color' => ['nullable', 'string', 'regex:/^#[0-9A-Fa-f]{6}$/'],
-            'is_active' => ['boolean'],
             'permissions' => ['array'],
             'permissions.*' => ['string', Rule::in(Permission::values())],
         ];
-
-        if ($role && $role->is_system) {
-            unset($rules['is_active']);
-        }
-
-        return $rules;
     }
 }

--- a/app/Http/Requests/Role/UpdateRoleRequest.php
+++ b/app/Http/Requests/Role/UpdateRoleRequest.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace App\Http\Requests;
+namespace App\Http\Requests\Role;
 
 use App\Enums\Permission;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
-class StoreRoleRequest extends FormRequest
+class UpdateRoleRequest extends FormRequest
 {
     public function authorize(): bool
     {
@@ -19,13 +19,21 @@ class StoreRoleRequest extends FormRequest
      */
     public function rules(): array
     {
-        return [
-            'name' => ['required', 'string', 'max:255', 'alpha_dash', 'unique:roles,name'],
-            'label' => ['required', 'string', 'max:255'],
+        $role = $this->route('role');
+
+        $rules = [
+            'label' => ['nullable', 'string', 'max:255'],
             'description' => ['nullable', 'string', 'max:1000'],
             'color' => ['nullable', 'string', 'regex:/^#[0-9A-Fa-f]{6}$/'],
+            'is_active' => ['boolean'],
             'permissions' => ['array'],
             'permissions.*' => ['string', Rule::in(Permission::values())],
         ];
+
+        if ($role && $role->is_system) {
+            unset($rules['is_active']);
+        }
+
+        return $rules;
     }
 }

--- a/app/Http/Requests/Room/StoreRoomRequest.php
+++ b/app/Http/Requests/Room/StoreRoomRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Requests;
+namespace App\Http\Requests\Room;
 
 use App\Enums\BillingUnit;
 use App\Enums\RoomStatus;

--- a/app/Http/Requests/Room/UpdateRoomRequest.php
+++ b/app/Http/Requests/Room/UpdateRoomRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Requests;
+namespace App\Http\Requests\Room;
 
 use App\Enums\BillingUnit;
 use App\Enums\RoomStatus;

--- a/app/Http/Requests/StoreLeaseRequest.php
+++ b/app/Http/Requests/StoreLeaseRequest.php
@@ -3,7 +3,6 @@
 namespace App\Http\Requests;
 
 use App\Enums\BillingUnit;
-use App\Models\Room;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -17,7 +16,7 @@ class StoreLeaseRequest extends FormRequest
     {
         return [
             'tenant_ids' => ['required', 'array', 'min:1'],
-            'tenant_ids.*' => ['required', 'integer', 'exists:tenants,id'],
+            'tenant_ids.*' => ['required', 'integer', 'distinct', 'exists:tenants,id'],
             'start_date' => ['required', 'date'],
             'end_date' => ['nullable', 'date', 'after:start_date'],
             'rent_amount' => ['nullable', 'numeric', 'min:0'],
@@ -31,19 +30,5 @@ class StoreLeaseRequest extends FormRequest
             'rent_due_day' => ['nullable', 'integer', 'between:1,31'],
             'notes' => ['nullable', 'string', 'max:65535'],
         ];
-    }
-
-    public function ensureCapacityAvailable(Room $room): void
-    {
-        $tenantCount = count($this->tenant_ids);
-        $activeTenantsCount = $room->leases()
-            ->where('status', 'active')
-            ->withCount('tenants')
-            ->get()
-            ->sum('tenants_count');
-
-        $totalOccupants = $activeTenantsCount + $tenantCount;
-
-        abort_if($totalOccupants > $room->capacity, 422, __('Room capacity exceeded. Room can only hold :capacity occupants.', ['capacity' => $room->capacity]));
     }
 }

--- a/app/Http/Requests/Tenant/AssignRoomRequest.php
+++ b/app/Http/Requests/Tenant/AssignRoomRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Requests\Tenant;
+
+use App\Enums\BillingUnit;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class AssignRoomRequest extends FormRequest
+{
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'tenant_ids' => ['nullable', 'array', 'min:1'],
+            'tenant_ids.*' => ['integer', 'distinct', 'exists:tenants,id'],
+            'room_id' => ['required', 'integer', 'exists:rooms,id'],
+            'start_date' => ['required', 'date'],
+            'end_date' => ['nullable', 'date', 'after:start_date'],
+            'rent_amount' => ['nullable', 'numeric', 'min:0'],
+            'billing_interval' => ['nullable', 'integer', 'min:1', 'max:255'],
+            'billing_unit' => ['nullable', 'string', Rule::in(BillingUnit::values())],
+            'room_rate_id' => ['nullable', 'integer', 'exists:room_rates,id'],
+            'deposit_amount' => ['nullable', 'numeric', 'min:0'],
+            'deposit_paid_at' => ['nullable', 'date'],
+            'rent_due_day' => ['nullable', 'integer', 'between:1,31'],
+            'notes' => ['nullable', 'string', 'max:65535'],
+        ];
+    }
+}

--- a/app/Http/Requests/Tenant/StoreTenantRequest.php
+++ b/app/Http/Requests/Tenant/StoreTenantRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Requests;
+namespace App\Http\Requests\Tenant;
 
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;

--- a/app/Http/Requests/Tenant/UpdateTenantRequest.php
+++ b/app/Http/Requests/Tenant/UpdateTenantRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Requests;
+namespace App\Http\Requests\Tenant;
 
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;

--- a/app/Http/Requests/User/CompleteInvitationRequest.php
+++ b/app/Http/Requests/User/CompleteInvitationRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests\User;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Password;
+
+class CompleteInvitationRequest extends FormRequest
+{
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'token' => ['required', 'string'],
+            'email' => ['required', 'email'],
+            'password' => ['required', 'string', Password::default(), 'confirmed'],
+            'password_confirmation' => ['required', 'string'],
+        ];
+    }
+}

--- a/app/Http/Requests/User/StoreUserInvitationRequest.php
+++ b/app/Http/Requests/User/StoreUserInvitationRequest.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace App\Http\Requests;
+namespace App\Http\Requests\User;
 
 use App\Enums\Role;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
-class UpdateUserRequest extends FormRequest
+class StoreUserInvitationRequest extends FormRequest
 {
     public function authorize(): bool
     {
-        return $this->user()?->can('users.update') ?? false;
+        return $this->user()?->can('users.create') ?? false;
     }
 
     /**
@@ -19,16 +19,13 @@ class UpdateUserRequest extends FormRequest
      */
     public function rules(): array
     {
-        $user = $this->route('user');
-
         return [
             'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', Rule::unique('users', 'email')->ignore($user)],
-            'roles' => [$user->isOwner() ? 'nullable' : 'required', 'array', 'min:1'],
+            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:users,email'],
+            'roles' => ['required', 'array', 'min:1'],
             'roles.*' => ['string', Rule::exists('roles', 'name')->where('is_active', true)->whereNot('name', Role::Owner->value)],
             'property_ids' => ['array'],
             'property_ids.*' => ['integer', 'exists:properties,id'],
-            'is_active' => ['required', 'boolean'],
         ];
     }
 }

--- a/app/Http/Requests/User/UpdateUserRequest.php
+++ b/app/Http/Requests/User/UpdateUserRequest.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace App\Http\Requests;
+namespace App\Http\Requests\User;
 
 use App\Enums\Role;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
-class StoreUserInvitationRequest extends FormRequest
+class UpdateUserRequest extends FormRequest
 {
     public function authorize(): bool
     {
-        return $this->user()?->can('users.create') ?? false;
+        return $this->user()?->can('users.update') ?? false;
     }
 
     /**
@@ -19,13 +19,16 @@ class StoreUserInvitationRequest extends FormRequest
      */
     public function rules(): array
     {
+        $user = $this->route('user');
+
         return [
             'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:users,email'],
-            'roles' => ['required', 'array', 'min:1'],
+            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', Rule::unique('users', 'email')->ignore($user)],
+            'roles' => [$user->isOwner() ? 'nullable' : 'required', 'array', 'min:1'],
             'roles.*' => ['string', Rule::exists('roles', 'name')->where('is_active', true)->whereNot('name', Role::Owner->value)],
             'property_ids' => ['array'],
             'property_ids.*' => ['integer', 'exists:properties,id'],
+            'is_active' => ['required', 'boolean'],
         ];
     }
 }

--- a/resources/js/components/app-header.tsx
+++ b/resources/js/components/app-header.tsx
@@ -34,6 +34,7 @@ import { useInitials } from '@/hooks/use-initials';
 import { cn, toUrl } from '@/lib/utils';
 import { dashboard } from '@/routes';
 import type { BreadcrumbItem, NavItem } from '@/types';
+import type { Auth } from '@/types/auth';
 
 type Props = {
     breadcrumbs?: BreadcrumbItem[];
@@ -64,8 +65,7 @@ const activeItemStyles =
     'text-neutral-900 dark:bg-neutral-800 dark:text-neutral-100';
 
 export function AppHeader({ breadcrumbs = [] }: Props) {
-    const page = usePage();
-    const { auth } = page.props;
+    const { auth } = usePage<{ auth: Auth }>().props;
     const getInitials = useInitials();
     const { isCurrentUrl, whenCurrentUrl } = useCurrentUrl();
 

--- a/resources/js/components/app-logo.tsx
+++ b/resources/js/components/app-logo.tsx
@@ -2,7 +2,7 @@ import { usePage } from '@inertiajs/react';
 import AppLogoIcon from '@/components/app-logo-icon';
 
 export default function AppLogo() {
-    const { setting } = usePage().props;
+    const { setting } = usePage<{ setting: { site_name: string } }>().props;
 
     return (
         <>

--- a/resources/js/components/app-shell.tsx
+++ b/resources/js/components/app-shell.tsx
@@ -9,7 +9,7 @@ type Props = {
 };
 
 export function AppShell({ children, variant = 'sidebar' }: Props) {
-    const isOpen = usePage().props.sidebarOpen;
+    const { sidebarOpen: isOpen } = usePage<{ sidebarOpen: boolean }>().props;
 
     if (variant === 'header') {
         return (

--- a/resources/js/components/move-room-sheet.tsx
+++ b/resources/js/components/move-room-sheet.tsx
@@ -17,7 +17,7 @@ type Room = {
     id: number;
     name: string;
     capacity: number;
-    occupied_count: number;
+    occupied_count?: number;
 };
 
 type Property = {
@@ -47,9 +47,10 @@ export default function MoveRoomSheet({
     const [targetRoomId, setTargetRoomId] = useState<number | null>(null);
 
     const roomOptions = availableRooms.map((r) => {
-        const spotsLeft = r.capacity - r.occupied_count;
-        const suffix = r.occupied_count > 0
-            ? ` (${r.occupied_count}/${r.capacity} occupied, ${spotsLeft} spot${spotsLeft === 1 ? '' : 's'} left)`
+        const occupiedCount = r.occupied_count ?? 0;
+        const spotsLeft = r.capacity - occupiedCount;
+        const suffix = occupiedCount > 0
+            ? ` (${occupiedCount}/${r.capacity} occupied, ${spotsLeft} spot${spotsLeft === 1 ? '' : 's'} left)`
             : r.capacity > 1
                 ? ` (capacity ${r.capacity})`
                 : '';

--- a/resources/js/components/nav-user.tsx
+++ b/resources/js/components/nav-user.tsx
@@ -14,9 +14,10 @@ import {
 import { UserInfo } from '@/components/user-info';
 import { UserMenuContent } from '@/components/user-menu-content';
 import { useIsMobile } from '@/hooks/use-mobile';
+import type { Auth } from '@/types/auth';
 
 export function NavUser() {
-    const { auth } = usePage().props;
+    const { auth } = usePage<{ auth: Auth }>().props;
     const { state } = useSidebar();
     const isMobile = useIsMobile();
 

--- a/resources/js/layouts/auth/auth-card-layout.tsx
+++ b/resources/js/layouts/auth/auth-card-layout.tsx
@@ -19,7 +19,7 @@ export default function AuthCardLayout({
     title?: string;
     description?: string;
 }>) {
-    const { setting } = usePage().props;
+    const { setting } = usePage<{ setting: { site_name: string } }>().props;
 
     return (
         <div className="flex min-h-svh flex-col items-center justify-center gap-6 bg-muted p-6 md:p-10">

--- a/resources/js/layouts/auth/auth-simple-layout.tsx
+++ b/resources/js/layouts/auth/auth-simple-layout.tsx
@@ -8,7 +8,7 @@ export default function AuthSimpleLayout({
     title,
     description,
 }: AuthLayoutProps) {
-    const { setting } = usePage().props;
+    const { setting } = usePage<{ setting: { site_name: string } }>().props;
 
     return (
         <div className="flex min-h-svh flex-col items-center justify-center gap-6 bg-background p-6 md:p-10">

--- a/resources/js/layouts/auth/auth-split-layout.tsx
+++ b/resources/js/layouts/auth/auth-split-layout.tsx
@@ -8,7 +8,7 @@ export default function AuthSplitLayout({
     title,
     description,
 }: AuthLayoutProps) {
-    const { setting } = usePage().props;
+    const { setting } = usePage<{ setting: { site_name: string } }>().props;
 
     return (
         <div className="relative grid h-dvh flex-col items-center justify-center px-8 sm:px-0 lg:max-w-none lg:grid-cols-2 lg:px-0">

--- a/resources/js/pages/properties/rooms/index.tsx
+++ b/resources/js/pages/properties/rooms/index.tsx
@@ -374,7 +374,7 @@ export default function Index({
 
     function getFilteredRoomsForMove(
         currentRoomId: number,
-    ): { id: number; name: string }[] {
+    ): (typeof _availableRooms)[number][] {
         return _availableRooms.filter((r) => r.id !== currentRoomId);
     }
 
@@ -759,6 +759,7 @@ export default function Index({
             />
 
             <RoomFormSheet
+                key={editingRoom?.id ?? 'new'}
                 room={editingRoom}
                 property={property}
                 open={dialogOpen}

--- a/resources/js/pages/welcome.tsx
+++ b/resources/js/pages/welcome.tsx
@@ -1,8 +1,9 @@
 import { Head, Link, usePage } from '@inertiajs/react';
 import { dashboard, login } from '@/routes';
+import type { Auth } from '@/types/auth';
 
 export default function Welcome() {
-    const { auth, setting } = usePage().props;
+    const { auth, setting } = usePage<{ auth: Auth; setting: { site_name: string } }>().props;
 
     return (
         <>

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -7,21 +7,20 @@ declare module 'react' {
     }
 }
 
-declare module '@inertiajs/core' {
-    export interface InertiaConfig {
-        sharedPageProps: {
-            name: string;
-            auth: Auth;
-            setting: {
-                id: number;
-                site_name: string;
-                country_code: string;
-                locale: string;
-                currency: string;
-                timezone: string;
+    declare module '@inertiajs/core' {
+        export interface InertiaConfig {
+            sharedPageProps: {
+                name: string;
+                auth: Auth;
+                setting: {
+                    id: number;
+                    site_name: string;
+                    country_code: string;
+                    locale: string;
+                    currency: string;
+                    timezone: string;
+                };
+                sidebarOpen: boolean;
             };
-            sidebarOpen: boolean;
-            [key: string]: unknown;
-        };
+        }
     }
-}


### PR DESCRIPTION
…ants to existing lease, count pivot rows instead of soft-deletable tenants, fix TS types

- Move capacity checks inside DB::transaction with lockForUpdate (LeaseController store/moveOut/move, TenantController assignRoom)
- Remove ensureCapacityAvailable from StoreLeaseRequest (dead code)
- Add distinct validation + array_unique normalization for tenant_ids (StoreLeaseRequest, TenantController)
- Add min:1 validation for tenant_ids in TenantController assignRoom
- Append moved tenants to existing active lease instead of creating second active lease (moveOut, move)
- Count lease_tenant pivot rows directly instead of withCount('tenants') which ignores soft-deleted tenants
- Fix TS errors: typed usePage<> generics, fix getFilteredRoomsForMove return type, make occupied_count optional in move-room-sheet, add RoomFormSheet key prop for proper remount on edit