### PR TITLE
fix: use rent_amount instead of monthly_rent for lease API field

### DIFF
--- a/resources/js/components/features/leases/assign-room-sheet.tsx
+++ b/resources/js/components/features/leases/assign-room-sheet.tsx
@@ -237,18 +237,18 @@ export default function AssignRoomSheet({
 
                                     <div className="mt-4 grid grid-cols-2 gap-4">
                                         <div className="grid gap-2">
-                                            <Label htmlFor="monthly_rent">
+                                            <Label htmlFor="rent_amount">
                                                 Monthly Rent (IDR)
                                             </Label>
                                             <Input
-                                                id="monthly_rent"
-                                                name="monthly_rent"
+                                                id="rent_amount"
+                                                name="rent_amount"
                                                 type="number"
                                                 min={0}
                                                 placeholder="Leave empty for room price"
                                             />
                                             <InputError
-                                                message={errors.monthly_rent}
+                                                message={errors.rent_amount}
                                             />
                                         </div>
                                         <div className="grid gap-2">

--- a/resources/js/components/features/leases/lease-detail-sheet.tsx
+++ b/resources/js/components/features/leases/lease-detail-sheet.tsx
@@ -7,34 +7,8 @@ import {
     SheetTitle,
 } from '@/components/ui/sheet';
 
+import { formatDate, formatPrice } from '@/lib/formatters';
 import type { Lease } from '@/types';
-
-function formatPrice(cents: string | null): string {
-    if (!cents) {
-        return '—';
-    }
-
-    const num = Number.parseFloat(cents);
-
-    return new Intl.NumberFormat('id-ID', {
-        style: 'currency',
-        currency: 'IDR',
-        minimumFractionDigits: 0,
-        maximumFractionDigits: 0,
-    }).format(num);
-}
-
-function formatDate(date: string | null): string {
-    if (!date) {
-        return '—';
-    }
-
-    return new Date(date).toLocaleDateString('id-ID', {
-        year: 'numeric',
-        month: 'short',
-        day: 'numeric',
-    });
-}
 
 const DUE_DAY_LABELS: Record<number, string> = {
     1: '1st',

--- a/resources/js/components/features/tenants/tenant-detail-sheet.tsx
+++ b/resources/js/components/features/tenants/tenant-detail-sheet.tsx
@@ -8,6 +8,7 @@ import {
     SheetHeader,
     SheetTitle,
 } from '@/components/ui/sheet';
+import { formatDate, formatPrice } from '@/lib/formatters';
 import tenants from '@/routes/tenants';
 import type { TenantInfo } from '@/types';
 
@@ -15,7 +16,7 @@ type Lease = {
     id: number;
     start_date: string;
     end_date: string | null;
-    monthly_rent: string;
+    rent_amount: string;
     room: {
         id: number;
         name: string;
@@ -45,25 +46,6 @@ type Tenant = {
     leases?: Lease[];
     documents?: { id: number; type: string; original_name: string; size: number; mime_type: string; created_at: string; download_url: string }[];
 };
-
-function formatPrice(cents: string): string {
-    const num = Number.parseFloat(cents);
-
-    return new Intl.NumberFormat('id-ID', {
-        style: 'currency',
-        currency: 'IDR',
-        minimumFractionDigits: 0,
-        maximumFractionDigits: 0,
-    }).format(num);
-}
-
-function formatDate(dateStr: string): string {
-    return new Date(dateStr).toLocaleDateString('id-ID', {
-        year: 'numeric',
-        month: 'short',
-        day: 'numeric',
-    });
-}
 
 export default function TenantDetailSheet({
     tenant,
@@ -154,7 +136,7 @@ export default function TenantDetailSheet({
                                             </span>
                                             <span className="font-medium tabular-nums">
                                                 {formatPrice(
-                                                    activeLease.monthly_rent,
+                                                    activeLease.rent_amount,
                                                 )}
                                                 /mo
                                             </span>
@@ -162,34 +144,69 @@ export default function TenantDetailSheet({
                                         {(activeLease.tenants ?? []).length >
                                             1 && (
                                             <div className="border-t pt-2">
-                                                <p className="mb-1 text-xs text-muted-foreground">
-                                                    Co-tenants
-                                                </p>
-                                                <div className="space-y-1">
-                                                    {activeLease.tenants
-                                                        .filter(
-                                                            (t) =>
-                                                                !t.pivot
-                                                                    ?.is_primary,
-                                                        )
-                                                        .map((t) => (
-                                                            <div
-                                                                key={t.id}
-                                                                className="flex items-center justify-between text-sm"
-                                                            >
-                                                                <span>
-                                                                    {t.name}
-                                                                </span>
-                                                                {t.phone && (
-                                                                    <span className="text-xs text-muted-foreground">
-                                                                        {
-                                                                            t.phone
+                                                {activeLease.primary_tenant
+                                                    ?.id === tenant.id ? (
+                                                    <>
+                                                        <p className="mb-1 text-xs text-muted-foreground">
+                                                            Co-tenants
+                                                        </p>
+                                                        <div className="space-y-1">
+                                                            {activeLease.tenants
+                                                                .filter(
+                                                                    (t) =>
+                                                                        !t.pivot
+                                                                            ?.is_primary,
+                                                                )
+                                                                .map((t) => (
+                                                                    <div
+                                                                        key={
+                                                                            t.id
                                                                         }
-                                                                    </span>
-                                                                )}
-                                                            </div>
-                                                        ))}
-                                                </div>
+                                                                        className="flex items-center justify-between text-sm"
+                                                                    >
+                                                                        <span>
+                                                                            {
+                                                                                t.name
+                                                                            }
+                                                                        </span>
+                                                                        {t.phone && (
+                                                                            <span className="text-xs text-muted-foreground">
+                                                                                {
+                                                                                    t.phone
+                                                                                }
+                                                                            </span>
+                                                                        )}
+                                                                    </div>
+                                                                ))}
+                                                        </div>
+                                                    </>
+                                                ) : activeLease.primary_tenant ? (
+                                                    <>
+                                                        <p className="mb-1 text-xs text-muted-foreground">
+                                                            Main tenant
+                                                        </p>
+                                                        <div className="flex items-center justify-between text-sm">
+                                                            <span>
+                                                                {
+                                                                    activeLease
+                                                                        .primary_tenant
+                                                                        .name
+                                                                }
+                                                            </span>
+                                                            {activeLease
+                                                                .primary_tenant
+                                                                .phone && (
+                                                                <span className="text-xs text-muted-foreground">
+                                                                    {
+                                                                        activeLease
+                                                                            .primary_tenant
+                                                                            .phone
+                                                                    }
+                                                                </span>
+                                                            )}
+                                                        </div>
+                                                    </>
+                                                ) : null}
                                             </div>
                                         )}
                                     </div>

--- a/resources/js/pages/tenants/index.tsx
+++ b/resources/js/pages/tenants/index.tsx
@@ -57,7 +57,7 @@ type Lease = {
     id: number;
     start_date: string;
     end_date: string | null;
-    monthly_rent: string;
+    rent_amount: string;
     room: RoomWithProperty | null;
     tenants: TenantInfo[];
     primary_tenant: TenantInfo | null;

--- a/resources/js/types/models.ts
+++ b/resources/js/types/models.ts
@@ -105,7 +105,7 @@ export type TenantLease = {
     id: number;
     start_date: string;
     end_date: string | null;
-    monthly_rent: string;
+    rent_amount: string;
     room: Room | null;
     tenants: TenantInfo[];
     primary_tenant: TenantInfo | null;


### PR DESCRIPTION
- API returns rent_amount, not monthly_rent
- Form field names now match backend validation (rent_amount)
- Use shared formatPrice/formatDate from lib/formatters

feat: show main tenant when viewing co-tenant on lease detail

- If viewed tenant is not the primary tenant, show main tenant info
- If viewed tenant is primary, show co-tenants as before