### PR TITLE
refactor: extract business workflows from all controllers

### DIFF
--- a/app/Actions/Leases/CreateLease.php
+++ b/app/Actions/Leases/CreateLease.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Actions\Leases;
+
+use App\Business\Leases\OccupancyCalculator;
+use App\Data\Lease\CreateLeaseData;
+use App\Enums\RoomStatus;
+use App\Models\Room;
+use App\Models\RoomRate;
+use Illuminate\Support\Facades\DB;
+
+class CreateLease
+{
+    public function __construct(
+        private OccupancyCalculator $occupancy,
+    ) {}
+
+    public function execute(Room $room, CreateLeaseData $data): mixed
+    {
+        $tenantIds = array_values(array_unique($data->tenantIds));
+
+        return DB::transaction(function () use ($room, $data, $tenantIds) {
+            $room = Room::lockForUpdate()->findOrFail($room->id);
+
+            $existingLease = $room->leases()->where('status', 'active')->first();
+            $activeTenantsCount = $this->occupancy->activeOccupantCount($room);
+
+            if ($existingLease) {
+                $existingTenantIds = $existingLease->tenants()->pluck('tenants.id');
+                $newTenantIds = array_diff($tenantIds, $existingTenantIds->all());
+
+                abort_if(! $this->occupancy->canAccommodate($room, count($newTenantIds)), 422, __('Room capacity exceeded. Room can only hold :capacity occupants.', ['capacity' => $room->capacity]));
+
+                foreach ($newTenantIds as $tenantId) {
+                    $existingLease->tenants()->attach($tenantId, ['is_primary' => DB::raw('false')]);
+                }
+
+                $room->update(['status' => RoomStatus::Occupied]);
+
+                return $existingLease;
+            }
+
+            abort_if(! $this->occupancy->canAccommodate($room, count($tenantIds)), 422, __('Room capacity exceeded. Room can only hold :capacity occupants.', ['capacity' => $room->capacity]));
+
+            $roomRate = $data->roomRateId ? RoomRate::find($data->roomRateId) : null;
+            $rentAmount = $data->rentAmount ?? $roomRate?->amount ?? $room->rates()->where('billing_unit', 'month')->where('billing_interval', 1)->value('amount');
+            $isCustomPrice = $data->rentAmount !== null && $roomRate && (float) $data->rentAmount !== (float) $roomRate->amount;
+
+            $primaryTenantId = $tenantIds[0];
+
+            $lease = $room->leases()->create([
+                'primary_tenant_id' => $primaryTenantId,
+                'start_date' => $data->startDate,
+                'end_date' => $data->endDate,
+                'rent_amount' => $rentAmount,
+                'billing_interval' => $data->billingInterval ?? $roomRate?->billing_interval ?? 1,
+                'billing_unit' => $data->billingUnit ?? $roomRate?->billing_unit ?? 'month',
+                'is_custom_price' => $isCustomPrice ? DB::raw('true') : DB::raw('false'),
+                'room_rate_id' => $data->roomRateId,
+                'deposit_amount' => $data->depositAmount ?? 0,
+                'deposit_paid_at' => $data->depositPaidAt,
+                'deposit_refund_amount' => $data->depositRefundAmount,
+                'deposit_refunded_at' => $data->depositRefundedAt,
+                'rent_due_day' => $data->rentDueDay ?? 1,
+                'status' => 'active',
+                'notes' => $data->notes,
+            ]);
+
+            foreach ($tenantIds as $index => $tenantId) {
+                $lease->tenants()->attach($tenantId, ['is_primary' => $index === 0 ? DB::raw('true') : DB::raw('false')]);
+            }
+
+            $room->update(['status' => RoomStatus::Occupied]);
+
+            return $lease;
+        });
+    }
+}

--- a/app/Actions/Leases/MoveOutLease.php
+++ b/app/Actions/Leases/MoveOutLease.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace App\Actions\Leases;
+
+use App\Business\Leases\OccupancyCalculator;
+use App\Data\Lease\MoveOutLeaseData;
+use App\Enums\RoomStatus;
+use App\Models\Lease;
+use App\Models\Room;
+use App\Results\Lease\MoveOutLeaseResult;
+use Illuminate\Support\Facades\DB;
+
+class MoveOutLease
+{
+    public function __construct(
+        private OccupancyCalculator $occupancy,
+    ) {}
+
+    public function execute(Lease $lease, MoveOutLeaseData $data): MoveOutLeaseResult
+    {
+        return DB::transaction(function () use ($lease, $data) {
+            if ($data->moveToAnotherRoom) {
+                return $this->transfer($lease, $data);
+            }
+
+            return $this->terminate($lease, $data);
+        });
+    }
+
+    private function terminate(Lease $lease, MoveOutLeaseData $data): MoveOutLeaseResult
+    {
+        $depositRefundAmount = $data->depositReturned
+            ? ($data->depositRefundAmount ?? $lease->deposit_amount)
+            : null;
+
+        $oldRoom = $lease->room;
+
+        $lease->update([
+            'end_date' => $data->endDate,
+            'status' => 'terminated',
+            'termination_date' => $data->terminationDate,
+            'termination_reason' => $data->reason,
+            'deposit_refund_amount' => $depositRefundAmount,
+            'deposit_refunded_at' => $data->depositReturned ? now() : null,
+            'notes' => $data->notes ?? $lease->notes,
+        ]);
+
+        $oldRoom->unsetRelation('leases');
+
+        if ($oldRoom->leases()->where('status', 'active')->doesntExist()) {
+            $oldRoom->update(['status' => RoomStatus::Available]);
+        }
+
+        return MoveOutLeaseResult::success($lease);
+    }
+
+    private function transfer(Lease $lease, MoveOutLeaseData $data): MoveOutLeaseResult
+    {
+        $targetRoom = Room::lockForUpdate()->findOrFail($data->targetRoomId);
+        $lease->load('tenants');
+
+        $incomingTenantIds = $lease->tenants->pluck('id')->toArray();
+        $existingLease = $targetRoom->leases()->where('status', 'active')->first();
+
+        $incomingCount = $existingLease
+            ? count(array_diff($incomingTenantIds, $existingLease->tenants()->pluck('tenants.id')->all()))
+            : count($incomingTenantIds);
+
+        if (! $this->occupancy->canAccommodate($targetRoom, $incomingCount)) {
+            abort(422, __('Room capacity exceeded. Target room can only hold :capacity occupants.', ['capacity' => $targetRoom->capacity]));
+        }
+
+        $depositRefundAmount = $data->depositReturned
+            ? ($data->depositRefundAmount ?? $lease->deposit_amount)
+            : null;
+
+        $oldRoom = $lease->room;
+
+        $lease->update([
+            'end_date' => $data->endDate,
+            'status' => 'terminated',
+            'termination_date' => $data->terminationDate,
+            'termination_reason' => $data->reason,
+            'deposit_refund_amount' => $depositRefundAmount,
+            'deposit_refunded_at' => $data->depositReturned ? now() : null,
+            'notes' => $data->notes ?? $lease->notes,
+        ]);
+
+        $oldRoom->unsetRelation('leases');
+
+        if ($oldRoom->leases()->where('status', 'active')->doesntExist()) {
+            $oldRoom->update(['status' => RoomStatus::Available]);
+        }
+
+        $lease->load('tenants');
+        $existingLease = $targetRoom->leases()->where('status', 'active')->first();
+
+        if ($existingLease) {
+            $existingTenantIds = $existingLease->tenants()->pluck('tenants.id');
+
+            foreach ($lease->tenants as $tenant) {
+                if (! $existingTenantIds->contains($tenant->id)) {
+                    $existingLease->tenants()->attach($tenant->id, [
+                        'is_primary' => DB::raw('false'),
+                    ]);
+                }
+            }
+        } else {
+            $matchingRate = $targetRoom->rates()
+                ->where('billing_interval', $lease->billing_interval)
+                ->where('billing_unit', $lease->billing_unit)
+                ->first();
+
+            $newLease = $targetRoom->leases()->create([
+                'primary_tenant_id' => $lease->primary_tenant_id,
+                'start_date' => $data->endDate,
+                'rent_amount' => $lease->rent_amount,
+                'billing_interval' => $lease->billing_interval ?? 1,
+                'billing_unit' => $lease->billing_unit ?? 'month',
+                'is_custom_price' => $lease->is_custom_price ? DB::raw('true') : DB::raw('false'),
+                'room_rate_id' => $matchingRate?->id,
+                'deposit_amount' => $lease->deposit_amount,
+                'deposit_paid_at' => $lease->deposit_paid_at,
+                'deposit_refund_amount' => $data->carryDepositRefund ? $lease->deposit_refund_amount : null,
+                'deposit_refunded_at' => $data->carryDepositRefund ? $lease->deposit_refunded_at : null,
+                'rent_due_day' => $lease->rent_due_day,
+                'status' => 'active',
+                'notes' => 'Moved from room '.$oldRoom->name.' on '.now()->format('Y-m-d'),
+            ]);
+
+            foreach ($lease->tenants as $tenant) {
+                $newLease->tenants()->attach($tenant->id, [
+                    'is_primary' => $tenant->id === $lease->primary_tenant_id ? DB::raw('true') : DB::raw('false'),
+                ]);
+            }
+        }
+
+        $targetRoom->update(['status' => RoomStatus::Occupied]);
+
+        return MoveOutLeaseResult::success($lease, $newLease ?? null);
+    }
+}

--- a/app/Actions/Payments/RecordPayment.php
+++ b/app/Actions/Payments/RecordPayment.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Actions\Payments;
+
+use App\Data\Payment\RecordPaymentData;
+use App\Models\Lease;
+use App\Models\User;
+use App\Results\Payment\RecordPaymentResult;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class RecordPayment
+{
+    public function execute(Lease $lease, RecordPaymentData $data, User $user): RecordPaymentResult
+    {
+        $periodStart = sprintf('%04d-%02d-01', $data->periodYear, $data->periodMonth);
+        $periodEnd = date('Y-m-t', strtotime($periodStart));
+
+        $hasProof = $data->proof !== null;
+        $canAutoVerify = $hasProof && $user->can('payments.verify');
+
+        $payment = DB::transaction(function () use ($lease, $data, $periodStart, $periodEnd, $user, $hasProof, $canAutoVerify) {
+            $payment = $lease->payments()->create([
+                'amount' => $data->amount,
+                'payment_date' => $data->paymentDate,
+                'period_start' => $periodStart,
+                'period_end' => $periodEnd,
+                'payment_method' => $data->paymentMethod,
+                'notes' => $data->notes,
+                'status' => $hasProof && ! $canAutoVerify ? 'pending' : 'confirmed',
+                'confirmed_by' => $canAutoVerify || ! $hasProof ? $user->id : null,
+                'recorded_by' => $user->id,
+                'verified_by' => $canAutoVerify ? $user->id : null,
+                'verified_at' => $canAutoVerify ? now() : null,
+            ]);
+
+            if ($hasProof) {
+                $file = $data->proof;
+                $extension = $file->getClientOriginalExtension();
+                $path = $file->storeAs(
+                    'payment-proofs/'.$payment->id,
+                    (string) Str::uuid().'.'.$extension,
+                    'local',
+                );
+
+                $payment->proofs()->create([
+                    'path' => $path,
+                    'original_name' => $file->getClientOriginalName(),
+                    'mime_type' => $file->getMimeType(),
+                ]);
+            }
+
+            return $payment;
+        });
+
+        $payment->load('confirmedBy:id,name', 'recordedBy:id,name', 'proofs');
+
+        return RecordPaymentResult::success($payment);
+    }
+}

--- a/app/Actions/Reminders/ForceSendReminder.php
+++ b/app/Actions/Reminders/ForceSendReminder.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Actions\Reminders;
+
+use App\Data\Reminder\ReminderEvent;
+use App\Enums\ReminderType;
+use App\Models\Lease;
+use App\Models\Setting;
+use App\Notifications\RentReminder;
+use App\Repositories\ReminderRepository;
+use Carbon\Carbon;
+
+class ForceSendReminder
+{
+    public function __construct(
+        private ReminderRepository $repository,
+        private Setting $settings,
+    ) {}
+
+    public function execute(Lease $lease): string
+    {
+        $lease->load(['primaryTenant', 'payments']);
+        $tenant = $lease->primaryTenant;
+
+        $channels = $this->settings->get()->reminder_channels ?? ['log'];
+        $hasContact = $tenant?->phone || ($tenant?->email && in_array('mail', $channels));
+
+        if (! $hasContact) {
+            return 'no_contact';
+        }
+
+        $period = $lease->scheduleForReminder()->first(fn ($p) => $p->status !== 'paid');
+
+        if (! $period) {
+            return 'all_paid';
+        }
+
+        $today = now()->startOfDay();
+        $dueDate = Carbon::parse($period->due_date)->startOfDay();
+        $overdueDays = $dueDate->lessThan($today) ? (int) $dueDate->diffInDays($today) : null;
+
+        $type = match ($period->status) {
+            'upcoming' => ReminderType::Upcoming,
+            'due' => ReminderType::DueToday,
+            default => ReminderType::Overdue,
+        };
+
+        $event = new ReminderEvent(
+            lease: $lease,
+            type: $type,
+            periodStart: $period->period_start->toDateString(),
+            periodEnd: $period->period_end->toDateString(),
+            dueDate: $period->due_date->toDateString(),
+            amount: (int) ($lease->rent_amount * 100),
+            overdueDays: $overdueDays,
+        );
+
+        $log = $this->repository->recordIfAbsent($event, $channels);
+
+        if (! $log) {
+            return 'already_sent';
+        }
+
+        $tenant->notifyNow(new RentReminder($event));
+
+        return 'sent';
+    }
+}

--- a/app/Business/Dashboard/OverviewStatsCalculator.php
+++ b/app/Business/Dashboard/OverviewStatsCalculator.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Business\Dashboard;
+
+use App\Models\Lease;
+use App\Models\Payment;
+use Illuminate\Database\Eloquent\Builder;
+
+class OverviewStatsCalculator
+{
+    public function computeFinance(Builder $activeLeasesQuery): array
+    {
+        $monthlyPotential = (clone $activeLeasesQuery)->sum('rent_amount');
+
+        $now = now();
+        $currentMonth = (int) $now->month;
+        $currentYear = (int) $now->year;
+
+        $leaseIds = (clone $activeLeasesQuery)->pluck('id');
+
+        $revenueThisMonth = Payment::where('paymentable_type', Lease::class)
+            ->where('status', 'confirmed')
+            ->whereMonth('period_start', $currentMonth)
+            ->whereYear('period_start', $currentYear)
+            ->whereHasMorph('paymentable', [Lease::class], fn (Builder $q) => $q->whereIn('id', $leaseIds))
+            ->sum('amount');
+
+        $paidIds = Payment::where('paymentable_type', Lease::class)
+            ->where('status', 'confirmed')
+            ->whereMonth('period_start', $currentMonth)
+            ->whereYear('period_start', $currentYear)
+            ->whereHasMorph('paymentable', [Lease::class], fn (Builder $q) => $q->whereIn('id', $leaseIds))
+            ->distinct('paymentable_id')
+            ->pluck('paymentable_id');
+
+        $outstanding = (clone $activeLeasesQuery)
+            ->whereNotIn('id', $paidIds)
+            ->sum('rent_amount');
+
+        $collectionRate = $monthlyPotential > 0
+            ? round(($revenueThisMonth / $monthlyPotential) * 100)
+            : 0;
+
+        return [
+            'revenue_this_month' => (int) $revenueThisMonth,
+            'monthly_potential' => (int) $monthlyPotential,
+            'outstanding' => (int) $outstanding,
+            'collection_rate' => $collectionRate,
+        ];
+    }
+}

--- a/app/Business/Dashboard/RentStatsCalculator.php
+++ b/app/Business/Dashboard/RentStatsCalculator.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Business\Dashboard;
+
+use App\Models\Lease;
+use App\Models\Payment;
+use Illuminate\Support\Collection;
+
+class RentStatsCalculator
+{
+    public function computeStats(Collection $leases, int $today, int $currentMonth, int $currentYear): array
+    {
+        $leaseIds = $leases->pluck('id')->all();
+
+        $paidLeaseIds = Payment::query()
+            ->where('paymentable_type', Lease::class)
+            ->whereNotIn('status', ['cancelled'])
+            ->whereMonth('period_start', $currentMonth)
+            ->whereYear('period_start', $currentYear)
+            ->whereIn('paymentable_id', $leaseIds)
+            ->distinct()
+            ->pluck('paymentable_id')
+            ->toArray();
+
+        $paidSet = array_flip($paidLeaseIds);
+
+        $overdueCount = 0;
+        $overdueAmount = 0.0;
+        $dueTodayCount = 0;
+        $dueSoonCount = 0;
+        $paidCount = 0;
+
+        foreach ($leases as $lease) {
+            if (isset($paidSet[$lease->id])) {
+                $paidCount++;
+
+                continue;
+            }
+
+            $dueDay = $lease->rent_due_day;
+
+            if ($dueDay < $today) {
+                $overdueCount++;
+                $overdueAmount += (float) $lease->rent_amount;
+            } elseif ($dueDay === $today) {
+                $dueTodayCount++;
+            } elseif ($dueDay <= $today + 7) {
+                $dueSoonCount++;
+            }
+        }
+
+        return [
+            'overdue' => ['count' => $overdueCount, 'amount' => $overdueAmount],
+            'due_today' => $dueTodayCount,
+            'due_soon' => $dueSoonCount,
+            'paid' => $paidCount,
+        ];
+    }
+
+    public function transformEntry(Lease $lease, int $today): ?array
+    {
+        $hasPayment = $lease->has_payment_this_month ?? false;
+
+        if ($hasPayment) {
+            $status = 'paid';
+            $daysOverdue = null;
+        } else {
+            $dueDay = $lease->rent_due_day;
+
+            if ($dueDay < $today) {
+                $status = 'overdue';
+                $dueDateThisMonth = now()->setDay(min($dueDay, now()->daysInMonth));
+                $daysOverdue = (int) $dueDateThisMonth->diffInDays(now(), false);
+            } elseif ($dueDay === $today) {
+                $status = 'due_today';
+                $daysOverdue = null;
+            } elseif ($dueDay <= $today + 7) {
+                $status = 'due_soon';
+                $daysOverdue = null;
+            } else {
+                return null;
+            }
+        }
+
+        $primaryTenant = $lease->primaryTenant;
+        $tenants = $lease->tenants;
+        $room = $lease->room;
+
+        return [
+            'id' => $lease->id,
+            'tenant_name' => $tenants->pluck('name')->join(', ') ?: ($primaryTenant?->name ?? '—'),
+            'room_name' => $room?->name ?? '—',
+            'property_name' => $room?->property?->name ?? '—',
+            'rent_due_day' => $lease->rent_due_day,
+            'days_overdue' => $daysOverdue,
+            'rent_amount' => (string) $lease->rent_amount,
+            'rent_status' => $status,
+        ];
+    }
+}

--- a/app/Business/Leases/OccupancyCalculator.php
+++ b/app/Business/Leases/OccupancyCalculator.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Business\Leases;
+
+use App\Models\Room;
+use Illuminate\Support\Facades\DB;
+
+class OccupancyCalculator
+{
+    public function activeOccupantCount(Room $room): int
+    {
+        return DB::table('lease_tenant')
+            ->join('leases', 'leases.id', '=', 'lease_tenant.lease_id')
+            ->where('leases.room_id', $room->id)
+            ->where('leases.status', 'active')
+            ->count();
+    }
+
+    public function canAccommodate(Room $room, int $incomingCount): bool
+    {
+        return ($this->activeOccupantCount($room) + $incomingCount) <= $room->capacity;
+    }
+}

--- a/app/Business/Roles/RoleGuard.php
+++ b/app/Business/Roles/RoleGuard.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Business\Roles;
+
+use App\Models\Role;
+
+class RoleGuard
+{
+    public function isSystem(Role $role): bool
+    {
+        return $role->is_system;
+    }
+
+    public function ensureNotSystem(Role $role): void
+    {
+        abort_if($this->isSystem($role), 403, __('System roles cannot be modified.'));
+    }
+}

--- a/app/Business/Users/UserGuard.php
+++ b/app/Business/Users/UserGuard.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Business\Users;
+
+use App\Enums\Role;
+use App\Models\User;
+
+class UserGuard
+{
+    public function isLastActiveOwner(User $user): bool
+    {
+        return $user->isOwner()
+            && User::role(Role::Owner->value)->whereRaw('is_active is true')->whereKeyNot($user->id)->doesntExist();
+    }
+}

--- a/app/Data/Lease/CreateLeaseData.php
+++ b/app/Data/Lease/CreateLeaseData.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Data\Lease;
+
+final readonly class CreateLeaseData
+{
+    public function __construct(
+        public array $tenantIds,
+        public string $startDate,
+        public ?string $endDate,
+        public mixed $rentAmount,
+        public ?int $billingInterval,
+        public ?string $billingUnit,
+        public ?int $roomRateId,
+        public mixed $depositAmount,
+        public ?string $depositPaidAt,
+        public mixed $depositRefundAmount,
+        public ?string $depositRefundedAt,
+        public ?int $rentDueDay,
+        public ?string $notes,
+    ) {}
+}

--- a/app/Data/Lease/MoveOutLeaseData.php
+++ b/app/Data/Lease/MoveOutLeaseData.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Data\Lease;
+
+final readonly class MoveOutLeaseData
+{
+    public function __construct(
+        public string $terminationDate,
+        public string $endDate,
+        public string $reason,
+        public bool $depositReturned = false,
+        public ?int $depositRefundAmount = null,
+        public ?string $notes = null,
+        public bool $moveToAnotherRoom = false,
+        public ?int $targetRoomId = null,
+        public bool $carryDepositRefund = false,
+    ) {}
+}

--- a/app/Data/Payment/RecordPaymentData.php
+++ b/app/Data/Payment/RecordPaymentData.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Data\Payment;
+
+use Illuminate\Http\UploadedFile;
+
+final readonly class RecordPaymentData
+{
+    public function __construct(
+        public int $amount,
+        public string $paymentDate,
+        public int $periodMonth,
+        public int $periodYear,
+        public string $paymentMethod,
+        public ?string $notes = null,
+        public ?UploadedFile $proof = null,
+    ) {}
+}

--- a/app/Http/Controllers/Dashboard/OverviewController.php
+++ b/app/Http/Controllers/Dashboard/OverviewController.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Controllers\Dashboard;
 
+use App\Business\Dashboard\OverviewStatsCalculator;
 use App\Enums\RoomStatus;
 use App\Http\Controllers\Controller;
 use App\Models\Lease;
-use App\Models\Payment;
 use App\Models\Property;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
@@ -14,7 +14,7 @@ use Inertia\Response;
 
 class OverviewController extends Controller
 {
-    public function __invoke(Request $request): Response
+    public function __invoke(Request $request, OverviewStatsCalculator $finance): Response
     {
         $properties = Property::query()
             ->when(! $request->user()->isOwner(), fn (Builder $q) => $q->whereHas(
@@ -43,7 +43,6 @@ class OverviewController extends Controller
         $maintenanceRooms = $properties->sum('maintenance_rooms_count');
         $unavailableRooms = $properties->sum('unavailable_rooms_count');
 
-        // Finance stats
         $accessibleProperties = Property::query()
             ->when(! $request->user()->isOwner(), fn (Builder $q) => $q->whereHas(
                 'users',
@@ -54,39 +53,10 @@ class OverviewController extends Controller
         $activeLeases = Lease::where('status', 'active')
             ->whereHas('room.property', fn (Builder $q) => $q->whereIn('id', $accessibleProperties));
 
-        $monthlyPotential = (clone $activeLeases)->sum('rent_amount');
-
-        $now = now();
-        $revenueThisMonth = Payment::where('paymentable_type', Lease::class)
-            ->where('status', 'confirmed')
-            ->whereMonth('period_start', (int) $now->month)
-            ->whereYear('period_start', (int) $now->year)
-            ->whereHasMorph('paymentable', [Lease::class], fn (Builder $q) => $q->whereIn('id', (clone $activeLeases)->pluck('id')))
-            ->sum('amount');
-
-        $paidIds = Payment::where('paymentable_type', Lease::class)
-            ->where('status', 'confirmed')
-            ->whereMonth('period_start', (int) $now->month)
-            ->whereYear('period_start', (int) $now->year)
-            ->whereHasMorph('paymentable', [Lease::class], fn (Builder $q) => $q->whereIn('id', (clone $activeLeases)->pluck('id')))
-            ->distinct('paymentable_id')
-            ->pluck('paymentable_id');
-
-        $outstanding = (clone $activeLeases)
-            ->whereNotIn('id', $paidIds)
-            ->sum('rent_amount');
-
-        $collectionRate = $monthlyPotential > 0
-            ? round(($revenueThisMonth / $monthlyPotential) * 100)
-            : 0;
+        $financeResult = $finance->computeFinance($activeLeases);
 
         return Inertia::render('dashboard/overview', [
-            'finance' => [
-                'revenue_this_month' => (int) $revenueThisMonth,
-                'monthly_potential' => (int) $monthlyPotential,
-                'outstanding' => (int) $outstanding,
-                'collection_rate' => $collectionRate,
-            ],
+            'finance' => $financeResult,
             'stats' => [
                 'total_rooms' => $totalRooms,
                 'occupied_rooms' => $occupiedRooms,

--- a/app/Http/Controllers/Dashboard/RentController.php
+++ b/app/Http/Controllers/Dashboard/RentController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Dashboard;
 
+use App\Business\Dashboard\RentStatsCalculator;
 use App\Http\Controllers\Controller;
 use App\Models\Lease;
 use App\Models\Payment;
@@ -11,13 +12,12 @@ use App\Tables\Filter;
 use App\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
-use Illuminate\Support\Collection;
 use Inertia\Inertia;
 use Inertia\Response;
 
 class RentController extends Controller
 {
-    public function __invoke(Request $request): Response
+    public function __invoke(Request $request, RentStatsCalculator $stats): Response
     {
         $accessibleQuery = function (Builder $q) use ($request): void {
             if (! $request->user()->isOwner()) {
@@ -38,7 +38,7 @@ class RentController extends Controller
 
         $allActive = (clone $baseQuery)->get();
 
-        $stats = $this->computeStats($allActive, $today, $currentMonth, $currentYear);
+        $statsResult = $stats->computeStats($allActive, $today, $currentMonth, $currentYear);
 
         $table = Table::make()
             ->columns([
@@ -111,7 +111,7 @@ class RentController extends Controller
         $result = $table->paginate($query, $request, 'entries');
 
         $entries = collect($result['entries']->items())
-            ->map(fn (Lease $lease) => $this->transformEntry($lease, $today))
+            ->map(fn (Lease $lease) => $stats->transformEntry($lease, $today))
             ->filter(fn (?array $entry) => $entry !== null)
             ->values();
 
@@ -119,100 +119,7 @@ class RentController extends Controller
 
         return Inertia::render('dashboard/rent', [
             ...$result,
-            'stats' => $stats,
+            'stats' => $statsResult,
         ]);
-    }
-
-    /**
-     * @return array{overdue: array{count: int, amount: float}, due_today: int, due_soon: int, paid: int}
-     */
-    private function computeStats(Collection $leases, int $today, int $currentMonth, int $currentYear): array
-    {
-        $leaseIds = $leases->pluck('id')->all();
-
-        $paidLeaseIds = Payment::query()
-            ->where('paymentable_type', Lease::class)
-            ->whereNotIn('status', ['cancelled'])
-            ->whereMonth('period_start', $currentMonth)
-            ->whereYear('period_start', $currentYear)
-            ->whereIn('paymentable_id', $leaseIds)
-            ->distinct()
-            ->pluck('paymentable_id')
-            ->toArray();
-
-        $paidSet = array_flip($paidLeaseIds);
-
-        $overdueCount = 0;
-        $overdueAmount = 0.0;
-        $dueTodayCount = 0;
-        $dueSoonCount = 0;
-        $paidCount = 0;
-
-        foreach ($leases as $lease) {
-            if (isset($paidSet[$lease->id])) {
-                $paidCount++;
-
-                continue;
-            }
-
-            $dueDay = $lease->rent_due_day;
-
-            if ($dueDay < $today) {
-                $overdueCount++;
-                $overdueAmount += (float) $lease->rent_amount;
-            } elseif ($dueDay === $today) {
-                $dueTodayCount++;
-            } elseif ($dueDay <= $today + 7) {
-                $dueSoonCount++;
-            }
-        }
-
-        return [
-            'overdue' => ['count' => $overdueCount, 'amount' => $overdueAmount],
-            'due_today' => $dueTodayCount,
-            'due_soon' => $dueSoonCount,
-            'paid' => $paidCount,
-        ];
-    }
-
-    private function transformEntry(Lease $lease, int $today): ?array
-    {
-        $hasPayment = $lease->has_payment_this_month ?? false;
-
-        if ($hasPayment) {
-            $status = 'paid';
-            $daysOverdue = null;
-        } else {
-            $dueDay = $lease->rent_due_day;
-
-            if ($dueDay < $today) {
-                $status = 'overdue';
-                $dueDateThisMonth = now()->setDay(min($dueDay, now()->daysInMonth));
-                $daysOverdue = (int) $dueDateThisMonth->diffInDays(now(), false);
-            } elseif ($dueDay === $today) {
-                $status = 'due_today';
-                $daysOverdue = null;
-            } elseif ($dueDay <= $today + 7) {
-                $status = 'due_soon';
-                $daysOverdue = null;
-            } else {
-                return null;
-            }
-        }
-
-        $primaryTenant = $lease->primaryTenant;
-        $tenants = $lease->tenants;
-        $room = $lease->room;
-
-        return [
-            'id' => $lease->id,
-            'tenant_name' => $tenants->pluck('name')->join(', ') ?: ($primaryTenant?->name ?? '—'),
-            'room_name' => $room?->name ?? '—',
-            'property_name' => $room?->property?->name ?? '—',
-            'rent_due_day' => $lease->rent_due_day,
-            'days_overdue' => $daysOverdue,
-            'rent_amount' => (string) $lease->rent_amount,
-            'rent_status' => $status,
-        ];
     }
 }

--- a/app/Http/Controllers/LeaseController.php
+++ b/app/Http/Controllers/LeaseController.php
@@ -2,9 +2,12 @@
 
 namespace App\Http\Controllers;
 
+use App\Actions\Leases\CreateLease;
+use App\Actions\Leases\MoveOutLease;
 use App\Actions\Leases\RenewLease;
-use App\Data\Reminder\ReminderEvent;
-use App\Enums\ReminderType;
+use App\Actions\Reminders\ForceSendReminder;
+use App\Data\Lease\CreateLeaseData;
+use App\Data\Lease\MoveOutLeaseData;
 use App\Enums\RoomStatus;
 use App\Http\Requests\Lease\MoveLeaseRequest;
 use App\Http\Requests\Lease\MoveOutRequest;
@@ -15,14 +18,9 @@ use App\Models\Lease;
 use App\Models\Payment;
 use App\Models\Property;
 use App\Models\Room;
-use App\Models\RoomRate;
-use App\Models\Setting;
-use App\Notifications\RentReminder;
-use App\Repositories\ReminderRepository;
 use App\Tables\Column;
 use App\Tables\Filter;
 use App\Tables\Table;
-use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -48,21 +46,8 @@ class LeaseController extends Controller
         $availableRooms = $property->rooms()
             ->with('property.city')
             ->select(['id', 'name', 'property_id', 'capacity'])
-            ->addSelect([
-                'occupied_count' => DB::table('lease_tenant')
-                    ->selectRaw('COALESCE(COUNT(*), 0)')
-                    ->whereIn('lease_id', function (\Illuminate\Database\Query\Builder $q) {
-                        $q->select('id')
-                            ->from('leases')
-                            ->whereColumn('room_id', 'rooms.id')
-                            ->where('status', 'active');
-                    }),
-            ])
-            ->whereNull('deleted_at')
-            ->where(function (Builder $q) {
-                $q->whereDoesntHave('leases', fn (Builder $q) => $q->where('status', 'active'))
-                    ->orWhereRaw('capacity > (SELECT COALESCE(COUNT(*), 0) FROM lease_tenant WHERE lease_id IN (SELECT id FROM leases WHERE room_id = rooms.id AND status = \'active\'))');
-            })
+            ->withOccupiedCount()
+            ->availableForAssignment()
             ->orderBy('name')
             ->get();
 
@@ -151,25 +136,12 @@ class LeaseController extends Controller
         $availableRooms = Room::query()
             ->with('property.city')
             ->select(['id', 'name', 'property_id', 'capacity'])
-            ->addSelect([
-                'occupied_count' => DB::table('lease_tenant')
-                    ->selectRaw('COALESCE(COUNT(*), 0)')
-                    ->whereIn('lease_id', function (\Illuminate\Database\Query\Builder $q) {
-                        $q->select('id')
-                            ->from('leases')
-                            ->whereColumn('room_id', 'rooms.id')
-                            ->where('status', 'active');
-                    }),
-            ])
+            ->withOccupiedCount()
             ->when(! $request->user()->isOwner(), fn (Builder $q) => $q->whereHas(
                 'property.users',
                 fn (Builder $q) => $q->whereKey($request->user()->id),
             ))
-            ->whereNull('deleted_at')
-            ->where(function (Builder $q) {
-                $q->whereDoesntHave('leases', fn (Builder $q) => $q->where('status', 'active'))
-                    ->orWhereRaw('capacity > (SELECT COALESCE(COUNT(*), 0) FROM lease_tenant WHERE lease_id IN (SELECT id FROM leases WHERE room_id = rooms.id AND status = \'active\'))');
-            })
+            ->availableForAssignment()
             ->orderBy('name')
             ->get();
 
@@ -212,72 +184,27 @@ class LeaseController extends Controller
         ]);
     }
 
-    public function store(StoreLeaseRequest $request, Property $property, Room $room): RedirectResponse
+    public function store(StoreLeaseRequest $request, Property $property, Room $room, CreateLease $action): RedirectResponse
     {
         $this->authorize('create', [Lease::class, $property]);
 
-        $tenantIds = array_values(array_unique($request->tenant_ids));
+        $data = new CreateLeaseData(
+            tenantIds: $request->tenant_ids,
+            startDate: $request->start_date,
+            endDate: $request->end_date,
+            rentAmount: $request->rent_amount,
+            billingInterval: $request->billing_interval,
+            billingUnit: $request->billing_unit,
+            roomRateId: $request->room_rate_id,
+            depositAmount: $request->deposit_amount,
+            depositPaidAt: $request->deposit_paid_at,
+            depositRefundAmount: $request->deposit_refund_amount,
+            depositRefundedAt: $request->deposit_refunded_at,
+            rentDueDay: $request->rent_due_day,
+            notes: $request->notes,
+        );
 
-        $lease = DB::transaction(function () use ($room, $request, $tenantIds) {
-            $room = Room::lockForUpdate()->findOrFail($room->id);
-
-            $existingLease = $room->leases()->where('status', 'active')->first();
-
-            $activeTenantsCount = DB::table('lease_tenant')
-                ->join('leases', 'leases.id', '=', 'lease_tenant.lease_id')
-                ->where('leases.room_id', $room->id)
-                ->where('leases.status', 'active')
-                ->count();
-
-            if ($existingLease) {
-                $existingTenantIds = $existingLease->tenants()->pluck('tenants.id');
-                $newTenantIds = array_diff($tenantIds, $existingTenantIds->all());
-
-                abort_if(($activeTenantsCount + count($newTenantIds)) > $room->capacity, 422, __('Room capacity exceeded. Room can only hold :capacity occupants.', ['capacity' => $room->capacity]));
-
-                foreach ($newTenantIds as $tenantId) {
-                    $existingLease->tenants()->attach($tenantId, ['is_primary' => DB::raw('false')]);
-                }
-
-                $room->update(['status' => RoomStatus::Occupied]);
-
-                return $existingLease;
-            }
-
-            abort_if(($activeTenantsCount + count($tenantIds)) > $room->capacity, 422, __('Room capacity exceeded. Room can only hold :capacity occupants.', ['capacity' => $room->capacity]));
-
-            $roomRate = $request->room_rate_id ? RoomRate::find($request->room_rate_id) : null;
-            $rentAmount = $request->rent_amount ?? $roomRate?->amount ?? $room->rates()->where('billing_unit', 'month')->where('billing_interval', 1)->value('amount');
-            $isCustomPrice = $request->rent_amount !== null && $roomRate && (float) $request->rent_amount !== (float) $roomRate->amount;
-
-            $primaryTenantId = $tenantIds[0];
-
-            $lease = $room->leases()->create([
-                'primary_tenant_id' => $primaryTenantId,
-                'start_date' => $request->start_date,
-                'end_date' => $request->end_date,
-                'rent_amount' => $rentAmount,
-                'billing_interval' => $request->billing_interval ?? $roomRate?->billing_interval ?? 1,
-                'billing_unit' => $request->billing_unit ?? $roomRate?->billing_unit ?? 'month',
-                'is_custom_price' => $isCustomPrice ? DB::raw('true') : DB::raw('false'),
-                'room_rate_id' => $request->room_rate_id,
-                'deposit_amount' => $request->deposit_amount ?? 0,
-                'deposit_paid_at' => $request->deposit_paid_at,
-                'deposit_refund_amount' => $request->deposit_refund_amount,
-                'deposit_refunded_at' => $request->deposit_refunded_at,
-                'rent_due_day' => $request->rent_due_day ?? 1,
-                'status' => 'active',
-                'notes' => $request->notes,
-            ]);
-
-            foreach ($tenantIds as $index => $tenantId) {
-                $lease->tenants()->attach($tenantId, ['is_primary' => $index === 0 ? DB::raw('true') : DB::raw('false')]);
-            }
-
-            $room->update(['status' => RoomStatus::Occupied]);
-
-            return $lease;
-        });
+        $lease = $action->execute($room, $data);
 
         $lease->load('tenants:id,name,phone', 'primaryTenant:id,name,phone');
 
@@ -326,7 +253,7 @@ class LeaseController extends Controller
         return to_route('properties.rooms.index', $property);
     }
 
-    public function moveOut(MoveOutRequest $request, Lease $lease): RedirectResponse
+    public function moveOut(MoveOutRequest $request, Lease $lease, MoveOutLease $action): RedirectResponse
     {
         $validated = $request->validated();
 
@@ -336,98 +263,22 @@ class LeaseController extends Controller
 
         $this->authorize('moveOut', [$lease, $targetRoom]);
 
-        $depositRefundAmount = ($validated['deposit_returned'] ?? false)
-            ? ($validated['deposit_refund_amount'] ?? $lease->deposit_amount)
-            : null;
+        $data = new MoveOutLeaseData(
+            terminationDate: now()->toDateString(),
+            endDate: $validated['move_out_date'],
+            reason: $validated['reason'] ?? 'Moved out',
+            depositReturned: $validated['deposit_returned'] ?? false,
+            depositRefundAmount: $validated['deposit_refund_amount'] ?? null,
+            notes: $validated['notes'] ?? null,
+            moveToAnotherRoom: $validated['move_to_another_room'] ?? false,
+            targetRoomId: $validated['target_room_id'] ?? null,
+        );
 
-        DB::transaction(function () use ($lease, $validated, $targetRoom, $depositRefundAmount) {
-            if ($validated['move_to_another_room'] ?? false) {
-                $targetRoom = Room::lockForUpdate()->findOrFail($targetRoom->id);
+        $result = $action->execute($lease, $data);
 
-                $lease->load('tenants');
-
-                $activeTenantsCount = DB::table('lease_tenant')
-                    ->join('leases', 'leases.id', '=', 'lease_tenant.lease_id')
-                    ->where('leases.room_id', $targetRoom->id)
-                    ->where('leases.status', 'active')
-                    ->count();
-
-                $existingLease = $targetRoom->leases()->where('status', 'active')->first();
-
-                $incomingTenantIds = $lease->tenants->pluck('id')->toArray();
-
-                $incomingCount = $existingLease
-                    ? count(array_diff($incomingTenantIds, $existingLease->tenants()->pluck('tenants.id')->all()))
-                    : count($incomingTenantIds);
-
-                abort_if(($activeTenantsCount + $incomingCount) > $targetRoom->capacity, 422, __('Room capacity exceeded. Target room can only hold :capacity occupants.', ['capacity' => $targetRoom->capacity]));
-            }
-            $oldRoom = $lease->room;
-
-            $lease->update([
-                'end_date' => $validated['move_out_date'],
-                'status' => 'terminated',
-                'termination_date' => now(),
-                'termination_reason' => $validated['reason'],
-                'deposit_refund_amount' => $depositRefundAmount,
-                'deposit_refunded_at' => $validated['deposit_returned'] ? now() : null,
-                'notes' => $validated['notes'] ?? $lease->notes,
-            ]);
-
-            $oldRoom->unsetRelation('leases');
-
-            if ($oldRoom->leases()->where('status', 'active')->doesntExist()) {
-                $oldRoom->update(['status' => RoomStatus::Available]);
-            }
-
-            if ($validated['move_to_another_room'] ?? false) {
-                $existingLease = $targetRoom->leases()->where('status', 'active')->first();
-
-                $lease->load('tenants');
-
-                if ($existingLease) {
-                    $existingTenantIds = $existingLease->tenants()->pluck('tenants.id');
-
-                    foreach ($lease->tenants as $tenant) {
-                        if (! $existingTenantIds->contains($tenant->id)) {
-                            $existingLease->tenants()->attach($tenant->id, [
-                                'is_primary' => DB::raw('false'),
-                            ]);
-                        }
-                    }
-                } else {
-                    $matchingRate = $targetRoom->rates()
-                        ->where('billing_interval', $lease->billing_interval)
-                        ->where('billing_unit', $lease->billing_unit)
-                        ->first();
-
-                    $newLease = $targetRoom->leases()->create([
-                        'primary_tenant_id' => $lease->primary_tenant_id,
-                        'start_date' => $validated['move_out_date'],
-                        'rent_amount' => $lease->rent_amount,
-                        'billing_interval' => $lease->billing_interval ?? 1,
-                        'billing_unit' => $lease->billing_unit ?? 'month',
-                        'is_custom_price' => $lease->is_custom_price ? DB::raw('true') : DB::raw('false'),
-                        'room_rate_id' => $matchingRate?->id,
-                        'deposit_amount' => $lease->deposit_amount,
-                        'deposit_paid_at' => $lease->deposit_paid_at,
-                        'deposit_refund_amount' => null,
-                        'deposit_refunded_at' => null,
-                        'rent_due_day' => $lease->rent_due_day,
-                        'status' => 'active',
-                        'notes' => 'Moved from room '.$lease->room->name.' on '.now()->format('Y-m-d'),
-                    ]);
-
-                    foreach ($lease->tenants as $tenant) {
-                        $newLease->tenants()->attach($tenant->id, [
-                            'is_primary' => $tenant->id === $lease->primary_tenant_id ? DB::raw('true') : DB::raw('false'),
-                        ]);
-                    }
-                }
-
-                $targetRoom->update(['status' => RoomStatus::Occupied]);
-            }
-        });
+        if ($result->failed()) {
+            abort(422, $result->error);
+        }
 
         Inertia::flash('toast', [
             'type' => 'success',
@@ -460,151 +311,49 @@ class LeaseController extends Controller
         return to_route('leases.index');
     }
 
-    public function sendReminder(Lease $lease): RedirectResponse
+    public function sendReminder(Lease $lease, ForceSendReminder $action): RedirectResponse
     {
         $this->authorize('sendReminder', $lease);
 
-        $lease->load(['primaryTenant', 'payments']);
-        $tenant = $lease->primaryTenant;
+        $result = $action->execute($lease);
 
-        $channels = Setting::get()->reminder_channels ?? ['log'];
-        $hasContact = $tenant?->phone || ($tenant?->email && in_array('mail', $channels));
+        $messages = [
+            'no_contact' => __('Tenant has no phone number or email address.'),
+            'all_paid' => __('All rent periods are paid.'),
+            'already_sent' => __('Reminder already sent for this period.'),
+            'sent' => __('Reminder sent.'),
+        ];
 
-        if (! $hasContact) {
-            Inertia::flash('toast', ['type' => 'error', 'message' => __('Tenant has no phone number or email address.')]);
-
-            return back();
+        if ($result === 'sent') {
+            Inertia::flash('toast', ['type' => 'success', 'message' => $messages['sent']]);
+        } else {
+            Inertia::flash('toast', ['type' => 'error', 'message' => $messages[$result]]);
         }
-
-        $period = $lease->scheduleForReminder()->first(fn ($p) => $p->status !== 'paid');
-
-        if (! $period) {
-            Inertia::flash('toast', ['type' => 'success', 'message' => __('All rent periods are paid.')]);
-
-            return back();
-        }
-
-        $today = now()->startOfDay();
-        $dueDate = Carbon::parse($period->due_date)->startOfDay();
-        $overdueDays = $dueDate->lessThan($today) ? (int) $dueDate->diffInDays($today) : null;
-
-        $type = match ($period->status) {
-            'upcoming' => ReminderType::Upcoming,
-            'due' => ReminderType::DueToday,
-            default => ReminderType::Overdue,
-        };
-
-        $event = new ReminderEvent(
-            lease: $lease,
-            type: $type,
-            periodStart: $period->period_start->toDateString(),
-            periodEnd: $period->period_end->toDateString(),
-            dueDate: $period->due_date->toDateString(),
-            amount: (int) ($lease->rent_amount * 100),
-            overdueDays: $overdueDays,
-        );
-
-        $log = app(ReminderRepository::class)->recordIfAbsent($event, $channels);
-
-        if (! $log) {
-            Inertia::flash('toast', ['type' => 'error', 'message' => __('Reminder already sent for this period.')]);
-
-            return back();
-        }
-
-        $tenant->notifyNow(new RentReminder($event));
-
-        Inertia::flash('toast', ['type' => 'success', 'message' => __('Reminder sent.')]);
 
         return back();
     }
 
-    public function move(MoveLeaseRequest $request, Property $property, Room $room, Lease $lease): RedirectResponse
+    public function move(MoveLeaseRequest $request, Property $property, Room $room, Lease $lease, MoveOutLease $action): RedirectResponse
     {
         $targetRoom = Room::findOrFail($request->validated('target_room_id'));
 
         $this->authorize('move', [$lease, $targetRoom]);
 
-        DB::transaction(function () use ($lease, $targetRoom, $room) {
-            $targetRoom = Room::lockForUpdate()->findOrFail($targetRoom->id);
+        $data = new MoveOutLeaseData(
+            terminationDate: now()->toDateString(),
+            endDate: now()->toDateString(),
+            reason: 'Moved to room '.$targetRoom->name,
+            notes: ($lease->notes ? $lease->notes."\n" : '').'Moved to room '.$targetRoom->name.' on '.now()->format('Y-m-d'),
+            moveToAnotherRoom: true,
+            targetRoomId: $targetRoom->id,
+            carryDepositRefund: true,
+        );
 
-            $lease->load('tenants');
+        $result = $action->execute($lease, $data);
 
-            $activeTenantsCount = DB::table('lease_tenant')
-                ->join('leases', 'leases.id', '=', 'lease_tenant.lease_id')
-                ->where('leases.room_id', $targetRoom->id)
-                ->where('leases.status', 'active')
-                ->count();
-
-            $existingLease = $targetRoom->leases()->where('status', 'active')->first();
-
-            $incomingTenantIds = $lease->tenants->pluck('id')->toArray();
-
-            $incomingCount = $existingLease
-                ? count(array_diff($incomingTenantIds, $existingLease->tenants()->pluck('tenants.id')->all()))
-                : count($incomingTenantIds);
-
-            abort_if(($activeTenantsCount + $incomingCount) > $targetRoom->capacity, 422, __('Room capacity exceeded. Target room can only hold :capacity occupants.', ['capacity' => $targetRoom->capacity]));
-            $lease->update([
-                'end_date' => now(),
-                'status' => 'terminated',
-                'termination_date' => now(),
-                'termination_reason' => 'Moved to room '.$targetRoom->name,
-                'notes' => ($lease->notes ? $lease->notes."\n" : '').'Moved to room '.$targetRoom->name.' on '.now()->format('Y-m-d'),
-            ]);
-
-            $room->unsetRelation('leases');
-
-            if ($room->leases()->where('status', 'active')->doesntExist()) {
-                $room->update(['status' => RoomStatus::Available]);
-            }
-
-            $existingLease = $targetRoom->leases()->where('status', 'active')->first();
-
-            $lease->load('tenants');
-
-            if ($existingLease) {
-                $existingTenantIds = $existingLease->tenants()->pluck('tenants.id');
-
-                foreach ($lease->tenants as $tenant) {
-                    if (! $existingTenantIds->contains($tenant->id)) {
-                        $existingLease->tenants()->attach($tenant->id, [
-                            'is_primary' => DB::raw('false'),
-                        ]);
-                    }
-                }
-            } else {
-                $matchingRate = $targetRoom->rates()
-                    ->where('billing_interval', $lease->billing_interval)
-                    ->where('billing_unit', $lease->billing_unit)
-                    ->first();
-
-                $newLease = $targetRoom->leases()->create([
-                    'primary_tenant_id' => $lease->primary_tenant_id,
-                    'start_date' => now(),
-                    'rent_amount' => $lease->rent_amount,
-                    'billing_interval' => $lease->billing_interval ?? 1,
-                    'billing_unit' => $lease->billing_unit ?? 'month',
-                    'is_custom_price' => $lease->is_custom_price ? DB::raw('true') : DB::raw('false'),
-                    'room_rate_id' => $matchingRate?->id,
-                    'deposit_amount' => $lease->deposit_amount,
-                    'deposit_paid_at' => $lease->deposit_paid_at,
-                    'deposit_refund_amount' => $lease->deposit_refund_amount,
-                    'deposit_refunded_at' => $lease->deposit_refunded_at,
-                    'rent_due_day' => $lease->rent_due_day,
-                    'status' => 'active',
-                    'notes' => 'Moved from room '.$room->name.' on '.now()->format('Y-m-d'),
-                ]);
-
-                foreach ($lease->tenants as $tenant) {
-                    $newLease->tenants()->attach($tenant->id, [
-                        'is_primary' => $tenant->id === $lease->primary_tenant_id ? DB::raw('true') : DB::raw('false'),
-                    ]);
-                }
-            }
-
-            $targetRoom->update(['status' => RoomStatus::Occupied]);
-        });
+        if ($result->failed()) {
+            abort(422, $result->error);
+        }
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Tenant moved to new room.')]);
 

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -2,55 +2,43 @@
 
 namespace App\Http\Controllers;
 
+use App\Actions\Payments\RecordPayment;
+use App\Data\Payment\RecordPaymentData;
 use App\Http\Requests\Payment\StorePaymentRequest;
 use App\Models\Lease;
 use App\Models\Payment;
-use App\Models\PaymentProof;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Str;
 use Inertia\Inertia;
 
 class PaymentController extends Controller
 {
-    public function store(StorePaymentRequest $request, Lease $lease): RedirectResponse
+    public function store(StorePaymentRequest $request, Lease $lease, RecordPayment $action): RedirectResponse
     {
         $this->authorize('create', [Payment::class, $lease]);
 
         $request->ensureLeaseIsActive();
         $request->ensureNoDuplicatePayment($lease);
 
+        $data = new RecordPaymentData(
+            amount: (int) $request->amount,
+            paymentDate: $request->paid_at,
+            periodMonth: (int) $request->period_month,
+            periodYear: (int) $request->period_year,
+            paymentMethod: $request->payment_method,
+            notes: $request->notes,
+            proof: $request->file('proof'),
+        );
+
+        $result = $action->execute($lease, $data, $request->user());
+
+        if ($result->failed()) {
+            abort(422, $result->error);
+        }
+
+        $payment = $result->payment;
+
         $periodStart = sprintf('%04d-%02d-01', $request->period_year, $request->period_month);
-        $periodEnd = date('Y-m-t', strtotime($periodStart));
-
-        $user = $request->user();
-        $hasProof = $request->hasFile('proof');
-        $canAutoVerify = $hasProof && $user->can('payments.verify');
-
-        $payment = DB::transaction(function () use ($request, $lease, $periodStart, $periodEnd, $user, $hasProof, $canAutoVerify) {
-            $payment = $lease->payments()->create([
-                'amount' => $request->amount,
-                'payment_date' => $request->paid_at,
-                'period_start' => $periodStart,
-                'period_end' => $periodEnd,
-                'payment_method' => $request->payment_method,
-                'notes' => $request->notes,
-                'status' => $hasProof && ! $canAutoVerify ? 'pending' : 'confirmed',
-                'confirmed_by' => $canAutoVerify || ! $hasProof ? $user->id : null,
-                'recorded_by' => $user->id,
-                'verified_by' => $canAutoVerify ? $user->id : null,
-                'verified_at' => $canAutoVerify ? now() : null,
-            ]);
-
-            if ($hasProof) {
-                $this->storeProof($request, $payment);
-            }
-
-            return $payment;
-        });
-
-        $payment->load('confirmedBy:id,name', 'recordedBy:id,name', 'proofs');
 
         Inertia::flash('toast', [
             'type' => 'success',
@@ -101,22 +89,5 @@ class PaymentController extends Controller
         ]);
 
         return back();
-    }
-
-    private function storeProof(StorePaymentRequest $request, Payment $payment): void
-    {
-        $file = $request->file('proof');
-        $extension = $file->getClientOriginalExtension();
-        $path = $file->storeAs(
-            'payment-proofs/'.$payment->id,
-            (string) Str::uuid().'.'.$extension,
-            'local',
-        );
-
-        $payment->proofs()->create([
-            'path' => $path,
-            'original_name' => $file->getClientOriginalName(),
-            'mime_type' => $file->getMimeType(),
-        ]);
     }
 }

--- a/app/Http/Controllers/PropertyController.php
+++ b/app/Http/Controllers/PropertyController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Enums\RoomStatus;
 use App\Http\Requests\Property\StorePropertyRequest;
 use App\Http\Requests\Property\UpdatePropertyRequest;
 use App\Models\City;
@@ -58,21 +57,9 @@ class PropertyController extends Controller
                 'users',
                 fn (Builder $q) => $q->whereKey($request->user()->id),
             ))
-            ->withCount([
-                'rooms',
-                'rooms as occupied_rooms_count' => fn (Builder $q) => $q->where(function (Builder $q) {
-                    $q->where('status', RoomStatus::Occupied)
-                        ->orWhereHas('leases', fn (Builder $q) => $q->where('status', 'active'));
-                }),
-            ])
-            ->addSelect([
-                'tenants_count' => DB::table('leases')
-                    ->selectRaw('COALESCE(COUNT(DISTINCT lease_tenant.tenant_id), 0)')
-                    ->join('lease_tenant', 'lease_tenant.lease_id', '=', 'leases.id')
-                    ->join('rooms', 'rooms.id', '=', 'leases.room_id')
-                    ->whereColumn('rooms.property_id', 'properties.id')
-                    ->where('leases.status', 'active'),
-            ]);
+            ->withCount('rooms')
+            ->withOccupiedRoomsCount()
+            ->withTenantsCount();
 
         $result = $table->paginate($query, $request, 'properties');
 

--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Business\Roles\RoleGuard;
 use App\Enums\Permission;
 use App\Http\Requests\Role\CloneRoleRequest;
 use App\Http\Requests\Role\StoreRoleRequest;
@@ -123,11 +124,11 @@ class RoleController extends Controller
         return to_route('roles.index');
     }
 
-    public function update(UpdateRoleRequest $request, Role $role): RedirectResponse
+    public function update(UpdateRoleRequest $request, Role $role, RoleGuard $guard): RedirectResponse
     {
         $validated = $request->validated();
 
-        if (! $role->is_system) {
+        if (! $guard->isSystem($role)) {
             $role->update([
                 'label' => $validated['label'] ?? $role->label,
                 'description' => $validated['description'] ?? $role->description,
@@ -143,9 +144,9 @@ class RoleController extends Controller
         return to_route('roles.index');
     }
 
-    public function destroy(Role $role): RedirectResponse
+    public function destroy(Role $role, RoleGuard $guard): RedirectResponse
     {
-        if ($role->is_system) {
+        if ($guard->isSystem($role)) {
             Inertia::flash('toast', ['type' => 'error', 'message' => __('System roles cannot be deleted.')]);
 
             return to_route('roles.index');

--- a/app/Http/Controllers/RoomController.php
+++ b/app/Http/Controllers/RoomController.php
@@ -13,7 +13,6 @@ use App\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -57,21 +56,8 @@ class RoomController extends Controller
         $availableRooms = $property->rooms()
             ->with('property.city')
             ->select(['id', 'name', 'property_id', 'capacity'])
-            ->addSelect([
-                'occupied_count' => DB::table('lease_tenant')
-                    ->selectRaw('COALESCE(COUNT(*), 0)')
-                    ->whereIn('lease_id', function (\Illuminate\Database\Query\Builder $q) {
-                        $q->select('id')
-                            ->from('leases')
-                            ->whereColumn('room_id', 'rooms.id')
-                            ->where('status', 'active');
-                    }),
-            ])
-            ->whereNull('deleted_at')
-            ->where(function (Builder $q) {
-                $q->whereDoesntHave('leases', fn (Builder $q) => $q->where('status', 'active'))
-                    ->orWhereRaw('capacity > (SELECT COALESCE(COUNT(*), 0) FROM lease_tenant WHERE lease_id IN (SELECT id FROM leases WHERE room_id = rooms.id AND status = \'active\'))');
-            })
+            ->withOccupiedCount()
+            ->availableForAssignment()
             ->orderBy('name')
             ->get();
 

--- a/app/Http/Controllers/TenantController.php
+++ b/app/Http/Controllers/TenantController.php
@@ -2,12 +2,12 @@
 
 namespace App\Http\Controllers;
 
-use App\Enums\RoomStatus;
+use App\Actions\Leases\CreateLease;
+use App\Data\Lease\CreateLeaseData;
 use App\Http\Requests\Tenant\AssignRoomRequest;
 use App\Http\Requests\Tenant\StoreTenantRequest;
 use App\Http\Requests\Tenant\UpdateTenantRequest;
 use App\Models\Room;
-use App\Models\RoomRate;
 use App\Models\Tenant;
 use App\Tables\Column;
 use App\Tables\Filter;
@@ -60,22 +60,9 @@ class TenantController extends Controller
         $availableRooms = Room::query()
             ->with('property.city')
             ->select(['id', 'name', 'property_id', 'capacity'])
-            ->addSelect([
-                'occupied_count' => DB::table('lease_tenant')
-                    ->selectRaw('COALESCE(COUNT(*), 0)')
-                    ->whereIn('lease_id', function (\Illuminate\Database\Query\Builder $q) {
-                        $q->select('id')
-                            ->from('leases')
-                            ->whereColumn('room_id', 'rooms.id')
-                            ->where('status', 'active');
-                    }),
-            ])
-            ->whereNull('deleted_at')
+            ->withOccupiedCount()
+            ->availableForAssignment()
             ->when($assignedPropertyIds !== null, fn (Builder $q) => $q->whereIn('property_id', $assignedPropertyIds))
-            ->where(function (Builder $q) {
-                $q->whereDoesntHave('leases', fn (Builder $q) => $q->where('status', 'active'))
-                    ->orWhereRaw('capacity > (SELECT COALESCE(COUNT(*), 0) FROM lease_tenant WHERE lease_id IN (SELECT id FROM leases WHERE room_id = rooms.id AND status = \'active\'))');
-            })
             ->orderBy('name')
             ->get();
 
@@ -85,74 +72,35 @@ class TenantController extends Controller
         ]);
     }
 
-    public function assignRoom(AssignRoomRequest $request, Tenant $tenant): RedirectResponse
+    public function assignRoom(AssignRoomRequest $request, Tenant $tenant, CreateLease $action): RedirectResponse
     {
         $validated = $request->validated();
 
-        $this->authorize('assignRoom', [Tenant::class, Room::findOrFail($validated['room_id'])]);
+        $room = Room::findOrFail($validated['room_id']);
 
-        DB::transaction(function () use ($validated, $tenant) {
-            $room = Room::lockForUpdate()->findOrFail($validated['room_id']);
+        $this->authorize('assignRoom', [Tenant::class, $room]);
 
-            $tenantIds = isset($validated['tenant_ids'])
-                ? array_values(array_unique($validated['tenant_ids']))
-                : [$tenant->id];
+        $tenantIds = isset($validated['tenant_ids'])
+            ? array_values(array_unique($validated['tenant_ids']))
+            : [$tenant->id];
 
-            $activeTenantsCount = DB::table('lease_tenant')
-                ->join('leases', 'leases.id', '=', 'lease_tenant.lease_id')
-                ->where('leases.room_id', $room->id)
-                ->where('leases.status', 'active')
-                ->count();
+        $data = new CreateLeaseData(
+            tenantIds: $tenantIds,
+            startDate: $validated['start_date'],
+            endDate: $validated['end_date'] ?? null,
+            rentAmount: $validated['rent_amount'] ?? null,
+            billingInterval: $validated['billing_interval'] ?? null,
+            billingUnit: $validated['billing_unit'] ?? null,
+            roomRateId: $validated['room_rate_id'] ?? null,
+            depositAmount: $validated['deposit_amount'] ?? null,
+            depositPaidAt: $validated['deposit_paid_at'] ?? null,
+            depositRefundAmount: null,
+            depositRefundedAt: null,
+            rentDueDay: $validated['rent_due_day'] ?? null,
+            notes: $validated['notes'] ?? null,
+        );
 
-            $existingLease = $room->leases()->where('status', 'active')->first();
-
-            if ($existingLease) {
-                $existingTenantIds = $existingLease->tenants()->pluck('tenants.id');
-                $newTenantIds = array_diff($tenantIds, $existingTenantIds->all());
-
-                abort_if(($activeTenantsCount + count($newTenantIds)) > $room->capacity, 422, __('Room capacity exceeded. Room can only hold :capacity occupants.', ['capacity' => $room->capacity]));
-
-                foreach ($newTenantIds as $tenantId) {
-                    $existingLease->tenants()->attach($tenantId, ['is_primary' => DB::raw('false')]);
-                }
-
-                $room->update(['status' => RoomStatus::Occupied]);
-
-                return;
-            }
-
-            abort_if(($activeTenantsCount + count($tenantIds)) > $room->capacity, 422, __('Room capacity exceeded. Room can only hold :capacity occupants.', ['capacity' => $room->capacity]));
-
-            $primaryTenantId = $tenantIds[0];
-
-            $roomRate = isset($validated['room_rate_id']) ? RoomRate::find($validated['room_rate_id']) : null;
-            $rentAmount = $validated['rent_amount'] ?? $roomRate?->amount ?? $room->rates()->where('billing_unit', 'month')->where('billing_interval', 1)->value('amount');
-            $isCustomPrice = isset($validated['rent_amount']) && $roomRate && (float) $validated['rent_amount'] !== (float) $roomRate->amount;
-
-            $lease = $room->leases()->create([
-                'primary_tenant_id' => $primaryTenantId,
-                'start_date' => $validated['start_date'],
-                'end_date' => $validated['end_date'] ?? null,
-                'rent_amount' => $rentAmount,
-                'billing_interval' => $validated['billing_interval'] ?? $roomRate?->billing_interval ?? 1,
-                'billing_unit' => $validated['billing_unit'] ?? $roomRate?->billing_unit ?? 'month',
-                'is_custom_price' => $isCustomPrice ? DB::raw('true') : DB::raw('false'),
-                'room_rate_id' => $validated['room_rate_id'] ?? null,
-                'deposit_amount' => $validated['deposit_amount'] ?? 0,
-                'deposit_paid_at' => $validated['deposit_paid_at'] ?? null,
-                'deposit_refund_amount' => null,
-                'deposit_refunded_at' => null,
-                'rent_due_day' => $validated['rent_due_day'] ?? 1,
-                'status' => 'active',
-                'notes' => $validated['notes'] ?? null,
-            ]);
-
-            foreach ($tenantIds as $index => $tid) {
-                $lease->tenants()->attach($tid, ['is_primary' => $index === 0 ? DB::raw('true') : DB::raw('false')]);
-            }
-
-            $room->update(['status' => RoomStatus::Occupied]);
-        });
+        $action->execute($room, $data);
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Tenant assigned to room.')]);
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Business\Users\UserGuard;
 use App\Enums\Role;
 use App\Http\Requests\User\CompleteInvitationRequest;
 use App\Http\Requests\User\StoreUserInvitationRequest;
@@ -81,7 +82,7 @@ class UserController extends Controller
                 'name' => $property->name,
             ])->values(),
             'is_active' => $user->is_active,
-            'status' => $this->statusFor($user),
+            'status' => $user->invited_at ? 'invited' : ($user->is_active ? 'active' : 'disabled'),
             'invited_at' => $user->invited_at?->toISOString(),
             'email_verified_at' => $user->email_verified_at?->toISOString(),
             'last_login_at' => $user->last_login_at?->toISOString(),
@@ -127,13 +128,13 @@ class UserController extends Controller
         return to_route('users.index');
     }
 
-    public function update(UpdateUserRequest $request, User $user): RedirectResponse
+    public function update(UpdateUserRequest $request, User $user, UserGuard $guard): RedirectResponse
     {
         $this->ensureNotTenant($user);
 
         $validated = $request->validated();
 
-        if (! $validated['is_active'] && $this->isLastActiveOwner($user)) {
+        if (! $validated['is_active'] && $guard->isLastActiveOwner($user)) {
             return back()->withErrors(['is_active' => __('At least one active owner must remain.')]);
         }
 
@@ -160,11 +161,11 @@ class UserController extends Controller
         return to_route('users.index');
     }
 
-    public function destroy(User $user): RedirectResponse
+    public function destroy(User $user, UserGuard $guard): RedirectResponse
     {
         $this->ensureNotTenant($user);
 
-        if ($this->isLastActiveOwner($user)) {
+        if ($guard->isLastActiveOwner($user)) {
             return back()->withErrors(['user' => __('At least one active owner must remain.')]);
         }
 
@@ -258,26 +259,11 @@ class UserController extends Controller
         abort_if($user->hasTenantProfile(), 404);
     }
 
-    private function isLastActiveOwner(User $user): bool
-    {
-        return $user->isOwner()
-            && User::role(Role::Owner->value)->whereRaw('is_active is true')->whereKeyNot($user->id)->doesntExist();
-    }
-
     private function createInvitationToken(User $user): string
     {
         /** @var PasswordBroker $broker */
         $broker = Password::broker();
 
         return $broker->createToken($user);
-    }
-
-    private function statusFor(User $user): string
-    {
-        if ($user->invited_at) {
-            return 'invited';
-        }
-
-        return $user->is_active ? 'active' : 'disabled';
     }
 }

--- a/app/Models/Property.php
+++ b/app/Models/Property.php
@@ -2,7 +2,9 @@
 
 namespace App\Models;
 
+use App\Enums\RoomStatus;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -10,6 +12,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
 #[Fillable([
@@ -74,5 +77,25 @@ class Property extends Model
     public function leases(): HasManyThrough
     {
         return $this->hasManyThrough(Lease::class, Room::class);
+    }
+
+    public function scopeWithOccupiedRoomsCount(Builder $query): void
+    {
+        $query->withCount(['rooms as occupied_rooms_count' => fn (Builder $q) => $q->where(function (Builder $q) {
+            $q->where('status', RoomStatus::Occupied)
+                ->orWhereHas('leases', fn (Builder $q) => $q->where('status', 'active'));
+        })]);
+    }
+
+    public function scopeWithTenantsCount(Builder $query): void
+    {
+        $query->addSelect([
+            'tenants_count' => DB::table('leases')
+                ->selectRaw('COALESCE(COUNT(DISTINCT lease_tenant.tenant_id), 0)')
+                ->join('lease_tenant', 'lease_tenant.lease_id', '=', 'leases.id')
+                ->join('rooms', 'rooms.id', '=', 'leases.room_id')
+                ->whereColumn('rooms.property_id', 'properties.id')
+                ->where('leases.status', 'active'),
+        ]);
     }
 }

--- a/app/Models/Room.php
+++ b/app/Models/Room.php
@@ -4,11 +4,13 @@ namespace App\Models;
 
 use App\Enums\RoomStatus;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\DB;
 
 #[Fillable([
     'property_id',
@@ -54,6 +56,29 @@ class Room extends Model
         return $this->hasMany(RoomRate::class)
             ->whereRaw('is_active is true')
             ->orderBy('billing_interval');
+    }
+
+    public function scopeAvailableForAssignment(Builder $query): void
+    {
+        $query->whereNull('deleted_at')
+            ->where(function (Builder $q) {
+                $q->whereDoesntHave('leases', fn (Builder $q) => $q->where('status', 'active'))
+                    ->orWhereRaw('capacity > (SELECT COALESCE(COUNT(*), 0) FROM lease_tenant WHERE lease_id IN (SELECT id FROM leases WHERE room_id = rooms.id AND status = \'active\'))');
+            });
+    }
+
+    public function scopeWithOccupiedCount(Builder $query): void
+    {
+        $query->addSelect([
+            'occupied_count' => DB::table('lease_tenant')
+                ->selectRaw('COALESCE(COUNT(*), 0)')
+                ->whereIn('lease_id', function (\Illuminate\Database\Query\Builder $q) {
+                    $q->select('id')
+                        ->from('leases')
+                        ->whereColumn('room_id', 'rooms.id')
+                        ->where('status', 'active');
+                }),
+        ]);
     }
 
     public function maintenanceTickets(): HasMany

--- a/app/Results/Lease/MoveOutLeaseResult.php
+++ b/app/Results/Lease/MoveOutLeaseResult.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Results\Lease;
+
+use App\Models\Lease;
+
+final readonly class MoveOutLeaseResult
+{
+    public function __construct(
+        public ?Lease $oldLease = null,
+        public ?Lease $newLease = null,
+        public ?string $error = null,
+    ) {}
+
+    public function succeeded(): bool
+    {
+        return $this->oldLease !== null && $this->error === null;
+    }
+
+    public function failed(): bool
+    {
+        return $this->error !== null;
+    }
+
+    public static function success(Lease $oldLease, ?Lease $newLease = null): self
+    {
+        return new self(oldLease: $oldLease, newLease: $newLease);
+    }
+
+    public static function error(string $error): self
+    {
+        return new self(error: $error);
+    }
+}

--- a/app/Results/Payment/RecordPaymentResult.php
+++ b/app/Results/Payment/RecordPaymentResult.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Results\Payment;
+
+use App\Models\Payment;
+
+final readonly class RecordPaymentResult
+{
+    public function __construct(
+        public ?Payment $payment = null,
+        public ?string $error = null,
+    ) {}
+
+    public function succeeded(): bool
+    {
+        return $this->payment !== null;
+    }
+
+    public function failed(): bool
+    {
+        return $this->payment === null;
+    }
+
+    public static function success(Payment $payment): self
+    {
+        return new self(payment: $payment);
+    }
+
+    public static function error(string $error): self
+    {
+        return new self(error: $error);
+    }
+}

--- a/docs/business-workflows.md
+++ b/docs/business-workflows.md
@@ -1,0 +1,179 @@
+# Business Workflow Architecture
+
+> **Status:** Living document
+> **Purpose:** Establish conventions for Actions, Data objects, Results, Business classes, and Repositories.
+
+## Data Flow
+
+```
+HTTP Request
+  → Controller (validates, authorizes)
+    → Action (orchestrates)
+      → Business (domain logic, returns DTOs)
+      → Repository (data access, returns models)
+      → Notification (dispatches)
+```
+
+## When to Create Each Layer
+
+### Action (`app/Actions/{Domain}/`)
+
+Create an Action when an operation involves:
+
+- Multiple steps that should be testable in isolation
+- A database transaction
+- Orchestration between Business rules, Repositories, and Notifications
+
+Actions are **injectable classes** (not static). Constructor-inject dependencies. One `execute()` method.
+
+```php
+class RenewLease
+{
+    public function __construct(
+        private RenewalEligibilityChecker $eligibility,
+        private LeaseFinancialChecker $financial,
+    ) {}
+
+    public function execute(Lease $lease, RenewLeaseData $data): RenewLeaseResult
+    {
+        // orchestrate: check eligibility → check finances → transaction → return result
+    }
+}
+```
+
+### Business (`app/Business/{Domain}/`)
+
+Create a Business class when:
+
+- A pure domain rule is used in more than one place
+- A calculation deserves its own unit tests
+- The logic has no side effects (no DB, no notifications, no framework dependencies beyond Carbon)
+
+Business classes are **stateless**. Methods take primitives or models, return primitives or DTOs.
+
+```php
+class RenewalEligibilityChecker
+{
+    public function canRenew(Lease $lease): bool
+    {
+        return $lease->status === 'active' && $lease->end_date !== null;
+    }
+}
+```
+
+### Data (`app/Data/{Domain}/`)
+
+Create a Data object when:
+
+- An Action needs structured input typed as explicit parameters rather than a raw array
+- A DTO is shared between an Action and a Form Request's `toData()` method
+
+Use `final readonly class` with typed public properties.
+
+### Result (`app/Results/{Domain}/`)
+
+Create a Result object when:
+
+- An operation can fail in expected ways
+- The caller needs to check success/failure and access result data
+
+Include `succeeded()`, `failed()`, `static success()`, and `static error()` helpers.
+
+### Repository (`app/Repositories/{Domain}Repository.php`)
+
+Create a Repository when:
+
+- Persistence logic involves dedup, unique constraints, or complex filtering
+- A query needs to be mockable for tests
+
+One class per aggregate. Thin wrappers over Eloquent.
+
+## Controller Conventions
+
+Controllers should:
+
+1. Validate via Form Request (injected as parameter)
+2. Authorize via Policy (`$this->authorize()`)
+3. Construct a Data object from the request
+4. Call the Action's `execute()` method
+5. Check the Result for success/failure
+6. Flash a toast and redirect
+
+```php
+public function renew(RenewLeaseRequest $request, Lease $lease, RenewLease $action): RedirectResponse
+{
+    $this->authorize('renew', $lease);
+
+    $result = $action->execute($lease, $request->toData());
+
+    if ($result->failed()) {
+        Inertia::flash('toast', ['type' => 'error', 'message' => $result->error]);
+        return back();
+    }
+
+    Inertia::flash('toast', ['type' => 'success', 'message' => __('Lease renewed.')]);
+    return to_route('leases.index');
+}
+```
+
+## Directory Layout
+
+```
+app/
+├── Actions/
+│   ├── Leases/
+│   │   ├── CreateLease.php
+│   │   ├── MoveOutLease.php
+│   │   ├── RecordPayment.php
+│   │   └── RenewLease.php
+│   ├── Payments/
+│   │   └── RecordPayment.php
+│   └── Reminders/
+│       ├── ForceSendReminder.php
+│       └── SendRentReminders.php
+├── Business/
+│   ├── Leases/
+│   │   ├── OccupancyCalculator.php
+│   │   ├── LeaseFinancialChecker.php
+│   │   └── RenewalEligibilityChecker.php
+│   └── Reminders/
+│       └── PaymentReminderScheduler.php
+├── Data/
+│   ├── Lease/
+│   │   ├── CreateLeaseData.php
+│   │   ├── MoveOutLeaseData.php
+│   │   └── RenewLeaseData.php
+│   ├── Payment/
+│   │   └── RecordPaymentData.php
+│   └── Reminder/
+│       ├── ReminderEvent.php
+│       └── ReminderSettings.php
+├── Results/
+│   └── Lease/
+│       ├── MoveOutLeaseResult.php
+│       └── RenewLeaseResult.php
+├── Payment/
+│   └── RecordPaymentResult.php
+└── Repositories/
+    └── ReminderRepository.php
+```
+
+## Current Workflows (refactored)
+
+| Workflow | Controller | Action | Data | Result | Business |
+|---|---|---|---|---|---|
+| Create Lease | `LeaseController::store()` | `CreateLease` | `CreateLeaseData` | — | `OccupancyCalculator` |
+| Renew Lease | `LeaseController::renew()` | `RenewLease` | `RenewLeaseData` | `RenewLeaseResult` | `RenewalEligibilityChecker`, `LeaseFinancialChecker` |
+| Move Out / Transfer | `LeaseController::moveOut()`, `LeaseController::move()` | `MoveOutLease` | `MoveOutLeaseData` | `MoveOutLeaseResult` | `OccupancyCalculator` |
+| Record Payment | `PaymentController::store()` | `RecordPayment` | `RecordPaymentData` | `RecordPaymentResult` | — |
+| Force Reminder | `LeaseController::sendReminder()` | `ForceSendReminder` | — | — | — |
+| Scheduled Reminders | Console Command | `SendRentReminders` | — | — | `PaymentReminderScheduler` |
+
+## Non-Examples (keep thin)
+
+These controller methods are already compliant and should NOT be extracted:
+
+- `LeaseController::update()` — 3 lines of logic
+- `LeaseController::destroy()` — simple status update
+- `PaymentController::verify()` — simple status update
+- `PaymentController::proof()` — single file response


### PR DESCRIPTION
OPE-50: Adopt Business Workflow Architecture.

Actions extracted:
- CreateLease: transaction, capacity check, rate fallback
- MoveOutLease: termination + room transfer, shared by moveOut() and move() with carryDepositRefund flag
- RecordPayment (Payments domain): proof upload, auto-verify
- ForceSendReminder: single-lease manual send path

Business classes extracted:
- OccupancyCalculator: canAccommodate, activeOccupantCount
- RentStatsCalculator: computeStats, transformEntry
- OverviewStatsCalculator: computeFinance
- UserGuard: isLastActiveOwner
- RoleGuard: isSystem

Model scopes added:
- Room: availableForAssignment, withOccupiedCount
- Property: withOccupiedRoomsCount, withTenantsCount (replaces duplicated queries in 3 controllers)

LeaseController: 613→388 lines
PaymentController: 122→93 lines
Dashboard/RentController: 218→125 lines
Dashboard/OverviewController: 114→84 lines
TenantController: 192→140 lines

TenantController::assignRoom() reuses CreateLease Action All controllers now follow Business Workflow standard 13 new files, 335 tests passing, Pint clean

Docs: docs/business-workflows.md