### PR TITLE
feat: maintenance ticket CRUD (OPE-24)

### DIFF
--- a/app/Enums/Permission.php
+++ b/app/Enums/Permission.php
@@ -51,6 +51,12 @@ enum Permission: string
     case FinancialsView = 'financials.view';
     case ReportsView = 'reports.view';
 
+    case MaintenanceTicketsView = 'maintenance-tickets.view';
+    case MaintenanceTicketsCreate = 'maintenance-tickets.create';
+    case MaintenanceTicketsUpdate = 'maintenance-tickets.update';
+    case MaintenanceTicketsDelete = 'maintenance-tickets.delete';
+    case MaintenanceTicketsAssign = 'maintenance-tickets.assign';
+
     public function label(): string
     {
         $action = explode('.', $this->value)[1] ?? '';
@@ -69,6 +75,7 @@ enum Permission: string
             'renew' => 'Renew Lease',
             'send' => 'Send',
             'clone' => 'Clone',
+            'assign' => 'Assign',
             default => $action,
         };
     }
@@ -120,6 +127,12 @@ enum Permission: string
             self::RemindersSend => 'Send rent reminders to tenants.',
             self::FinancialsView => 'View financial reports and payment data.',
             self::ReportsView => 'Access generated reports.',
+
+            self::MaintenanceTicketsView => 'View the maintenance ticket list.',
+            self::MaintenanceTicketsCreate => 'Report new maintenance issues.',
+            self::MaintenanceTicketsUpdate => 'Update existing maintenance ticket details.',
+            self::MaintenanceTicketsDelete => 'Delete maintenance tickets.',
+            self::MaintenanceTicketsAssign => 'Assign maintenance tickets to staff.',
         };
     }
 

--- a/app/Http/Controllers/MaintenanceTicketController.php
+++ b/app/Http/Controllers/MaintenanceTicketController.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Enums\MaintenanceStatus;
+use App\Http\Requests\Maintenance\StoreMaintenanceTicketRequest;
+use App\Http\Requests\Maintenance\UpdateMaintenanceTicketRequest;
+use App\Models\MaintenanceTicket;
+use App\Models\Property;
+use App\Models\Room;
+use App\Tables\Column;
+use App\Tables\Filter;
+use App\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class MaintenanceTicketController extends Controller
+{
+    public function index(Request $request): Response
+    {
+        $this->authorize('viewAny', MaintenanceTicket::class);
+
+        $table = Table::make()
+            ->columns([
+                Column::make('title', 'Title')->sortable()->searchable(),
+                Column::make('property_name', 'Property')->sortable(),
+                Column::make('priority', 'Priority')->sortable(),
+                Column::make('status', 'Status')->sortable(),
+                Column::make('created_at', 'Created')->sortable(),
+            ])
+            ->filters([
+                Filter::select('status', 'Status', array_map(fn (MaintenanceStatus $s) => $s->value, MaintenanceStatus::cases()))
+                    ->query(fn (Builder $q, string $value) => $q->where('status', $value)),
+                Filter::select('priority', 'Priority', ['low', 'medium', 'high', 'urgent'])
+                    ->query(fn (Builder $q, string $value) => $q->where('priority', $value)),
+            ])
+            ->defaultSort('-created_at');
+
+        $query = MaintenanceTicket::query()
+            ->with(['property:id,name', 'room:id,name', 'assignee.roles', 'creator.roles']);
+
+        $propertyId = $request->query('property_id');
+        if ($propertyId) {
+            $query->where('property_id', (int) $propertyId);
+        }
+
+        $result = $table->paginate($query, $request, 'tickets');
+
+        $properties = Property::query()
+            ->when(! $request->user()->isOwner(), fn (Builder $q) => $q->whereHas(
+                'users',
+                fn (Builder $q) => $q->whereKey($request->user()->id),
+            ))
+            ->orderBy('name')
+            ->get(['id', 'name']);
+
+        $rooms = Room::query()
+            ->select(['id', 'name', 'property_id'])
+            ->orderBy('name')
+            ->get();
+
+        return Inertia::render('maintenance-tickets/index', [
+            ...$result,
+            'properties' => $properties,
+            'rooms' => $rooms,
+            'can' => [
+                'create' => $request->user()->can('maintenance-tickets.create'),
+                'update' => $request->user()->can('maintenance-tickets.update'),
+                'delete' => $request->user()->can('maintenance-tickets.delete'),
+                'assign' => $request->user()->can('maintenance-tickets.assign'),
+            ],
+        ]);
+    }
+
+    public function store(StoreMaintenanceTicketRequest $request): RedirectResponse
+    {
+        $this->authorize('create', MaintenanceTicket::class);
+
+        $data = $request->validated();
+        $data['created_by'] = $request->user()->id;
+        $data['status'] = MaintenanceStatus::Reported->value;
+
+        MaintenanceTicket::create($data);
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Maintenance ticket created.')]);
+
+        return to_route('maintenance-tickets.index');
+    }
+
+    public function update(UpdateMaintenanceTicketRequest $request, MaintenanceTicket $ticket): RedirectResponse
+    {
+        $this->authorize('update', $ticket);
+
+        $validated = $request->validated();
+
+        if (isset($validated['status'])) {
+            $newStatus = MaintenanceStatus::from($validated['status']);
+            $this->validateTransition($ticket->status, $newStatus);
+
+            if ($newStatus === MaintenanceStatus::Resolved) {
+                $validated['resolved_at'] ??= now();
+            }
+        }
+
+        $ticket->update($validated);
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Maintenance ticket updated.')]);
+
+        return to_route('maintenance-tickets.index');
+    }
+
+    public function assign(Request $request, MaintenanceTicket $ticket): RedirectResponse
+    {
+        $this->authorize('update', $ticket);
+
+        $validated = $request->validate([
+            'assigned_to' => ['required', 'integer', 'exists:users,id'],
+        ]);
+
+        if ((int) $validated['assigned_to'] !== $request->user()->id) {
+            $this->authorize('assign', $ticket);
+        }
+
+        $ticket->update(['assigned_to' => $validated['assigned_to']]);
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Ticket assigned.')]);
+
+        return to_route('maintenance-tickets.index');
+    }
+
+    public function destroy(MaintenanceTicket $ticket): RedirectResponse
+    {
+        $this->authorize('delete', $ticket);
+
+        $ticket->delete();
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Maintenance ticket deleted.')]);
+
+        return to_route('maintenance-tickets.index');
+    }
+
+    private function validateTransition(MaintenanceStatus $current, MaintenanceStatus $next): void
+    {
+        $allowed = match ($current) {
+            MaintenanceStatus::Reported => [MaintenanceStatus::InProgress, MaintenanceStatus::Cancelled],
+            MaintenanceStatus::InProgress => [MaintenanceStatus::Resolved, MaintenanceStatus::Cancelled],
+            default => [],
+        };
+
+        abort_unless(in_array($next, $allowed), 422, __('Cannot transition from :current to :next.', [
+            'current' => $current->label(),
+            'next' => $next->label(),
+        ]));
+    }
+}

--- a/app/Http/Requests/Maintenance/StoreMaintenanceTicketRequest.php
+++ b/app/Http/Requests/Maintenance/StoreMaintenanceTicketRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests\Maintenance;
+
+use App\Enums\MaintenancePriority;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreMaintenanceTicketRequest extends FormRequest
+{
+    /** @return array<string, ValidationRule|array<mixed>|string> */
+    public function rules(): array
+    {
+        return [
+            'property_id' => ['required', 'integer', 'exists:properties,id'],
+            'room_id' => ['nullable', 'integer', 'exists:rooms,id'],
+            'location' => ['nullable', 'string', 'max:255'],
+            'title' => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+            'priority' => ['required', 'string', Rule::in(MaintenancePriority::values())],
+        ];
+    }
+}

--- a/app/Http/Requests/Maintenance/UpdateMaintenanceTicketRequest.php
+++ b/app/Http/Requests/Maintenance/UpdateMaintenanceTicketRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests\Maintenance;
+
+use App\Enums\MaintenancePriority;
+use App\Enums\MaintenanceStatus;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateMaintenanceTicketRequest extends FormRequest
+{
+    /** @return array<string, ValidationRule|array<mixed>|string> */
+    public function rules(): array
+    {
+        return [
+            'title' => ['nullable', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+            'priority' => ['nullable', 'string', Rule::in(MaintenancePriority::values())],
+            'status' => ['nullable', 'string', Rule::in(MaintenanceStatus::values())],
+            'resolution_notes' => ['nullable', 'string'],
+            'cost' => ['nullable', 'numeric', 'min:0'],
+            'resolved_at' => ['nullable', 'date'],
+        ];
+    }
+}

--- a/app/Models/MaintenanceTicket.php
+++ b/app/Models/MaintenanceTicket.php
@@ -2,32 +2,65 @@
 
 namespace App\Models;
 
+use App\Enums\MaintenancePriority;
+use App\Enums\MaintenanceStatus;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 #[Fillable([
+    'property_id',
     'room_id',
+    'location',
     'title',
     'description',
     'status',
     'priority',
     'assigned_to',
+    'created_by',
     'cost',
     'resolved_at',
     'resolution_notes',
+    'reference',
 ])]
 class MaintenanceTicket extends Model
 {
     use HasFactory;
 
+    protected static function boot(): void
+    {
+        parent::boot();
+
+        static::creating(function (MaintenanceTicket $ticket) {
+            if ($ticket->reference === null) {
+                $year = now()->format('Y');
+                $pattern = 'TKT'.$year.'%';
+
+                $max = static::where('reference', 'like', $pattern)
+                    ->orderBy('reference', 'desc')
+                    ->value('reference');
+
+                $seq = $max ? (int) substr($max, -4) + 1 : 1;
+
+                $ticket->reference = 'TKT'.$year.str_pad((string) $seq, 4, '0', STR_PAD_LEFT);
+            }
+        });
+    }
+
     protected function casts(): array
     {
         return [
+            'status' => MaintenanceStatus::class,
+            'priority' => MaintenancePriority::class,
             'cost' => 'decimal:2',
             'resolved_at' => 'datetime',
         ];
+    }
+
+    public function property(): BelongsTo
+    {
+        return $this->belongsTo(Property::class);
     }
 
     public function room(): BelongsTo
@@ -35,8 +68,13 @@ class MaintenanceTicket extends Model
         return $this->belongsTo(Room::class);
     }
 
-    public function assignedTo(): BelongsTo
+    public function assignee(): BelongsTo
     {
         return $this->belongsTo(User::class, 'assigned_to');
+    }
+
+    public function creator(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
     }
 }

--- a/app/Policies/MaintenanceTicketPolicy.php
+++ b/app/Policies/MaintenanceTicketPolicy.php
@@ -7,8 +7,33 @@ use App\Models\User;
 
 class MaintenanceTicketPolicy
 {
+    public function viewAny(?User $user): bool
+    {
+        return true;
+    }
+
+    public function create(?User $user): bool
+    {
+        return true;
+    }
+
     public function view(User $user, MaintenanceTicket $ticket): bool
     {
-        return $user->properties->contains($ticket->room->property_id);
+        return $user->properties->contains($ticket->property_id);
+    }
+
+    public function update(User $user, MaintenanceTicket $ticket): bool
+    {
+        return $user->properties->contains($ticket->property_id);
+    }
+
+    public function delete(User $user, MaintenanceTicket $ticket): bool
+    {
+        return $user->properties->contains($ticket->property_id);
+    }
+
+    public function assign(User $user, MaintenanceTicket $ticket): bool
+    {
+        return $user->properties->contains($ticket->property_id);
     }
 }

--- a/database/factories/MaintenanceTicketFactory.php
+++ b/database/factories/MaintenanceTicketFactory.php
@@ -15,8 +15,11 @@ class MaintenanceTicketFactory extends Factory
 
     public function definition(): array
     {
+        $room = Room::factory()->create();
+
         return [
-            'room_id' => Room::factory(),
+            'property_id' => $room->property_id,
+            'room_id' => $room->id,
             'title' => fake()->sentence(4),
             'description' => fake()->paragraph(),
             'status' => 'reported',

--- a/database/migrations/2026_07_01_100302_alter_maintenance_tickets_add_property_id.php
+++ b/database/migrations/2026_07_01_100302_alter_maintenance_tickets_add_property_id.php
@@ -15,7 +15,28 @@ return new class extends Migration
             $table->string('location')->nullable()->after('room_id');
         });
 
-        DB::statement('ALTER TABLE maintenance_tickets ALTER COLUMN room_id DROP NOT NULL');
+        if (DB::getDriverName() === 'pgsql') {
+            DB::statement('ALTER TABLE maintenance_tickets ALTER COLUMN room_id DROP NOT NULL');
+        } elseif (DB::getDriverName() === 'sqlite') {
+            Schema::table('maintenance_tickets', function (Blueprint $table) {
+                $table->dropForeign(['room_id']);
+            });
+
+            Schema::table('maintenance_tickets', function (Blueprint $table) {
+                $table->unsignedBigInteger('room_id_new')->nullable()->after('location');
+            });
+
+            DB::statement('UPDATE maintenance_tickets SET room_id_new = room_id');
+
+            Schema::table('maintenance_tickets', function (Blueprint $table) {
+                $table->dropColumn('room_id');
+                $table->renameColumn('room_id_new', 'room_id');
+            });
+
+            Schema::table('maintenance_tickets', function (Blueprint $table) {
+                $table->foreign('room_id')->references('id')->on('rooms')->cascadeOnDelete();
+            });
+        }
     }
 
     public function down(): void
@@ -28,6 +49,8 @@ return new class extends Migration
             $table->dropColumn('location');
         });
 
-        DB::statement('ALTER TABLE maintenance_tickets ALTER COLUMN room_id SET NOT NULL');
+        if (DB::getDriverName() === 'pgsql') {
+            DB::statement('ALTER TABLE maintenance_tickets ALTER COLUMN room_id SET NOT NULL');
+        }
     }
 };

--- a/database/migrations/2026_07_01_100302_alter_maintenance_tickets_add_property_id.php
+++ b/database/migrations/2026_07_01_100302_alter_maintenance_tickets_add_property_id.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('maintenance_tickets', function (Blueprint $table) {
+            $table->foreignId('property_id')->after('id')->constrained()->cascadeOnDelete();
+            $table->foreignId('created_by')->nullable()->after('assigned_to')->constrained('users')->nullOnDelete();
+            $table->string('location')->nullable()->after('room_id');
+        });
+
+        DB::statement('ALTER TABLE maintenance_tickets ALTER COLUMN room_id DROP NOT NULL');
+    }
+
+    public function down(): void
+    {
+        Schema::table('maintenance_tickets', function (Blueprint $table) {
+            $table->dropForeign(['property_id']);
+            $table->dropColumn('property_id');
+            $table->dropForeign(['created_by']);
+            $table->dropColumn('created_by');
+            $table->dropColumn('location');
+        });
+
+        DB::statement('ALTER TABLE maintenance_tickets ALTER COLUMN room_id SET NOT NULL');
+    }
+};

--- a/database/migrations/2026_07_02_044653_add_reference_to_maintenance_tickets.php
+++ b/database/migrations/2026_07_02_044653_add_reference_to_maintenance_tickets.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('maintenance_tickets', function (Blueprint $table) {
+            $table->string('reference')->nullable()->unique()->after('id');
+        });
+
+        // Backfill existing tickets with auto-generated references
+        $tickets = DB::table('maintenance_tickets')->whereNull('reference')->orderBy('id')->get();
+
+        foreach ($tickets as $ticket) {
+            $year = substr($ticket->created_at, 0, 4);
+            $pattern = 'TKT'.$year.'%';
+
+            $max = DB::table('maintenance_tickets')
+                ->where('reference', 'like', $pattern)
+                ->orderBy('reference', 'desc')
+                ->value('reference');
+
+            $seq = $max ? (int) substr($max, -4) + 1 : 1;
+
+            DB::table('maintenance_tickets')
+                ->where('id', $ticket->id)
+                ->update(['reference' => 'TKT'.$year.str_pad((string) $seq, 4, '0', STR_PAD_LEFT)]);
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::table('maintenance_tickets', function (Blueprint $table) {
+            $table->dropColumn('reference');
+        });
+    }
+};

--- a/resources/js/components/features/app/app-sidebar.tsx
+++ b/resources/js/components/features/app/app-sidebar.tsx
@@ -9,6 +9,7 @@ import {
     Shield,
     UserCog,
     Users,
+    Wrench,
 } from 'lucide-react';
 import AppLogo from '@/components/features/app/app-logo';
 import { NavFooter } from '@/components/features/app/nav-footer';
@@ -26,6 +27,7 @@ import {
 import { dashboard } from '@/routes';
 import { rent as dashboardRent } from '@/routes/dashboard';
 import leases from '@/routes/leases';
+import maintenanceTickets from '@/routes/maintenance-tickets';
 import properties from '@/routes/properties';
 import roles from '@/routes/roles';
 import tenants from '@/routes/tenants';
@@ -65,6 +67,9 @@ export function AppSidebar() {
             : []),
         ...(isOwner || permissions.includes('leases.view')
             ? [{ title: 'Leases', href: leases.index(), icon: FileText }]
+            : []),
+        ...(isOwner || permissions.includes('maintenance-tickets.view')
+            ? [{ title: 'Maintenance', href: maintenanceTickets.index(), icon: Wrench }]
             : []),
         ...(isOwner || permissions.includes('users.view')
             ? [{ title: 'Users', href: userRoutes.index(), icon: UserCog }]

--- a/resources/js/components/features/index.ts
+++ b/resources/js/components/features/index.ts
@@ -1,6 +1,7 @@
 export * from './app';
 export * from './auth';
 export * from './leases';
+export * from './maintenance';
 export * from './payments';
 export * from './properties';
 export * from './roles';

--- a/resources/js/components/features/maintenance/index.ts
+++ b/resources/js/components/features/maintenance/index.ts
@@ -1,0 +1,2 @@
+export { default as TicketDetailSheet } from './ticket-detail-sheet';
+export { default as TicketFormSheet } from './ticket-form-sheet';

--- a/resources/js/components/features/maintenance/ticket-detail-sheet.tsx
+++ b/resources/js/components/features/maintenance/ticket-detail-sheet.tsx
@@ -1,0 +1,162 @@
+import { router, usePage } from '@inertiajs/react';
+import { Check, Pencil, Trash2, UserPlus } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet';
+import maintenanceTickets from '@/routes/maintenance-tickets';
+import type { MaintenanceTicket } from '@/types';
+
+const statusLabel: Record<string, string> = {
+    reported: 'Reported',
+    in_progress: 'In Progress',
+    resolved: 'Resolved',
+    cancelled: 'Cancelled',
+};
+
+const priorityLabel: Record<string, string> = {
+    low: 'Low',
+    medium: 'Medium',
+    high: 'High',
+    urgent: 'Urgent',
+};
+
+export default function TicketDetailSheet({
+    ticket,
+    open,
+    onOpenChange,
+    canUpdate,
+    canDelete,
+    onEdit,
+}: {
+    ticket: MaintenanceTicket | null;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    canUpdate: boolean;
+    canDelete: boolean;
+    onEdit?: () => void;
+}) {
+    const { auth } = usePage<{ auth: { user: { id: number } } }>().props;
+
+    if (! ticket) {
+return null;
+}
+
+    const roleLabel = (name: string | undefined, roles?: { name: string; label?: string }[]) => {
+        const displayName = name ?? '—';
+        const role = roles?.[0];
+
+        if (role) {
+            return `${displayName} — ${role.label ?? role.name}`;
+        }
+
+        return displayName;
+    };
+
+    const handleStatusChange = (status: string) => {
+        router.put(maintenanceTickets.update.url(ticket.id), { status });
+    };
+
+    const handleAssignToMe = () => {
+        router.post(maintenanceTickets.assign.url(ticket.id), {
+            assigned_to: auth.user.id,
+        });
+    };
+
+    const handleDelete = () => {
+        if (confirm('Delete this ticket?')) {
+            router.delete(maintenanceTickets.destroy.url(ticket.id));
+            onOpenChange(false);
+        }
+    };
+
+    return (
+        <Sheet open={open} onOpenChange={onOpenChange}>
+            <SheetContent className="sm:max-w-lg">
+                <SheetHeader>
+                    <SheetTitle>{ticket.title}</SheetTitle>
+                    <SheetDescription>
+                        {ticket.reference ?? `#${ticket.id}`} &middot; {statusLabel[ticket.status] ?? ticket.status}
+                    </SheetDescription>
+                </SheetHeader>
+
+                <div className="flex h-full flex-col px-4">
+                    <div className="flex-1 overflow-y-auto pt-6">
+                        <div className="space-y-4">
+                            <div className="grid grid-cols-2 gap-4">
+                                <div>
+                                    <p className="text-xs text-muted-foreground">Property</p>
+                                    <p className="text-sm">{ticket.property?.name ?? '—'}</p>
+                                </div>
+                                <div>
+                                    <p className="text-xs text-muted-foreground">Location</p>
+                                    <p className="text-sm">{ticket.room?.name ?? ticket.location ?? '—'}</p>
+                                </div>
+                                <div>
+                                    <p className="text-xs text-muted-foreground">Priority</p>
+                                    <p className="text-sm">{priorityLabel[ticket.priority] ?? ticket.priority}</p>
+                                </div>
+                                <div>
+                                    <p className="text-xs text-muted-foreground">Assigned To</p>
+                                    <p className="text-sm">{roleLabel(ticket.assignee?.name, ticket.assignee?.roles)}</p>
+                                </div>
+                                <div>
+                                    <p className="text-xs text-muted-foreground">Created By</p>
+                                    <p className="text-sm">{roleLabel(ticket.creator?.name, ticket.creator?.roles)}</p>
+                                </div>
+                                <div>
+                                    <p className="text-xs text-muted-foreground">Created At</p>
+                                    <p className="text-sm">{new Date(ticket.created_at).toLocaleDateString()}</p>
+                                </div>
+                            </div>
+
+                            {ticket.description && (
+                                <div>
+                                    <p className="text-xs text-muted-foreground">Description</p>
+                                    <p className="mt-1 text-sm whitespace-pre-wrap">{ticket.description}</p>
+                                </div>
+                            )}
+
+                            {ticket.resolution_notes && (
+                                <div>
+                                    <p className="text-xs text-muted-foreground">Resolution</p>
+                                    <p className="mt-1 text-sm whitespace-pre-wrap">{ticket.resolution_notes}</p>
+                                </div>
+                            )}
+                        </div>
+                    </div>
+
+                    <div className="flex items-center gap-2 border-t py-3 [&_button]:cursor-pointer">
+                        {canUpdate && (
+                            <Button size="sm" variant="outline" onClick={onEdit}>
+                                <Pencil className="size-3.5" />
+                                <span className="ml-1">Edit</span>
+                            </Button>
+                        )}
+                        {ticket.status === 'reported' && canUpdate && (
+                            <Button size="sm" onClick={() => handleStatusChange('in_progress')}>Start</Button>
+                        )}
+                        {ticket.status === 'in_progress' && canUpdate && (
+                            <Button size="sm" onClick={() => handleStatusChange('resolved')}>
+                                <Check className="size-3.5" />
+                                <span className="ml-1">Resolve</span>
+                            </Button>
+                        )}
+                        {(ticket.status === 'reported' || ticket.status === 'in_progress') && canUpdate && (
+                            <Button size="sm" variant="outline" onClick={() => handleStatusChange('cancelled')}>Cancel</Button>
+                        )}
+                        {canUpdate && (
+                            <Button size="sm" variant="outline" onClick={handleAssignToMe}>
+                                <UserPlus className="size-3.5" />
+                                <span className="ml-1">Assign to me</span>
+                            </Button>
+                        )}
+                        {canDelete && (
+                            <Button size="sm" variant="destructive" onClick={handleDelete}>
+                                <Trash2 className="size-3.5" />
+                            </Button>
+                        )}
+                    </div>
+                </div>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/resources/js/components/features/maintenance/ticket-form-sheet.tsx
+++ b/resources/js/components/features/maintenance/ticket-form-sheet.tsx
@@ -1,0 +1,206 @@
+import { Form } from '@inertiajs/react';
+import { useState } from 'react';
+import { InputError } from '@/components/shared';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet';
+import { Textarea } from '@/components/ui/textarea';
+import maintenanceTickets from '@/routes/maintenance-tickets';
+import type { MaintenanceTicket } from '@/types';
+
+export default function TicketFormSheet({
+    open,
+    onOpenChange,
+    ticket,
+    properties,
+    rooms,
+}: {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    ticket?: MaintenanceTicket | null;
+    properties: { id: number; name: string }[];
+    rooms: { id: number; name: string; property_id: number }[];
+}) {
+    const isEdit = Boolean(ticket);
+    const formAction = isEdit
+        ? maintenanceTickets.update.url(ticket!.id)
+        : maintenanceTickets.store.url();
+    const formMethod = isEdit ? ('put' as const) : ('post' as const);
+
+    const [locationType, setLocationType] = useState(ticket?.room_id ? 'room' : ticket?.location ? 'area' : 'room');
+    const [selectedProperty, setSelectedProperty] = useState(ticket?.property_id ? String(ticket.property_id) : '');
+    const [priority, setPriority] = useState(ticket?.priority ?? 'medium');
+
+    const filteredRooms = selectedProperty
+        ? rooms.filter((r) => r.property_id === Number(selectedProperty))
+        : [];
+
+    return (
+        <Sheet open={open} onOpenChange={onOpenChange}>
+            <SheetContent className="sm:max-w-lg">
+                <SheetHeader>
+                    <SheetTitle>{isEdit ? 'Edit Ticket' : 'New Maintenance Ticket'}</SheetTitle>
+                    <SheetDescription>
+                        {isEdit ? 'Update ticket details.' : 'Report a maintenance issue.'}
+                    </SheetDescription>
+                </SheetHeader>
+
+                <div className="flex-1 overflow-y-auto px-4">
+                    <Form
+                        action={formAction}
+                        method={formMethod}
+                        onSuccess={() => onOpenChange(false)}
+                    >
+                        {({ processing, errors }) => (
+                            <div className="space-y-6 pt-4">
+                                {! isEdit && (
+                                    <div className="grid gap-2">
+                                        <Label>Property</Label>
+                                        <Select
+                                            name="property_id"
+                                            value={selectedProperty}
+                                            onValueChange={setSelectedProperty}
+                                        >
+                                            <SelectTrigger className="w-full">
+                                                <SelectValue placeholder="Select property" />
+                                            </SelectTrigger>
+                                            <SelectContent>
+                                                {properties.map((p) => (
+                                                    <SelectItem key={p.id} value={String(p.id)}>
+                                                        {p.name}
+                                                    </SelectItem>
+                                                ))}
+                                            </SelectContent>
+                                        </Select>
+                                        <InputError message={errors.property_id} />
+                                    </div>
+                                )}
+
+                                {! isEdit && (
+                                    <div className="grid gap-2">
+                                        <Label>Location</Label>
+                                        <div className="flex gap-2">
+                                            <Select value={locationType} onValueChange={setLocationType}>
+                                                <SelectTrigger className="w-36 shrink-0">
+                                                    <SelectValue />
+                                                </SelectTrigger>
+                                                <SelectContent>
+                                                    <SelectItem value="room">Room</SelectItem>
+                                                    <SelectItem value="area">Common Area</SelectItem>
+                                                </SelectContent>
+                                            </Select>
+                                            {locationType === 'room' ? (
+                                                <Select name="room_id" defaultValue={ticket?.room_id ? String(ticket.room_id) : undefined}>
+                                                    <SelectTrigger className="w-full">
+                                                        <SelectValue placeholder="Select a room (optional)" />
+                                                    </SelectTrigger>
+                                                    <SelectContent>
+                                                        {filteredRooms.map((r) => (
+                                                            <SelectItem key={r.id} value={String(r.id)}>
+                                                                {r.name}
+                                                            </SelectItem>
+                                                        ))}
+                                                    </SelectContent>
+                                                </Select>
+                                            ) : (
+                                                <Input
+                                                    name="location"
+                                                    defaultValue={ticket?.location ?? ''}
+                                                    placeholder="e.g. Lobby, 3rd Floor Hallway"
+                                                />
+                                            )}
+                                        </div>
+                                        <InputError message={errors.room_id ?? errors.location} />
+                                    </div>
+                                )}
+
+                                <div className="grid gap-2">
+                                    <Label>Title</Label>
+                                    <Input
+                                        name="title"
+                                        required={! isEdit}
+                                        defaultValue={ticket?.title ?? ''}
+                                        placeholder="e.g. Leaking faucet"
+                                    />
+                                    <InputError message={errors.title} />
+                                </div>
+
+                                <div className="grid gap-2">
+                                    <Label htmlFor="description">Description</Label>
+                                    <Textarea
+                                        id="description"
+                                        name="description"
+                                        defaultValue={ticket?.description ?? ''}
+                                        placeholder="Describe the issue in detail"
+                                    />
+                                    <InputError message={errors.description} />
+                                </div>
+
+                                <div className="grid gap-2">
+                                    <Label>Priority</Label>
+                                    <Select name="priority" value={priority} onValueChange={setPriority}>
+                                        <SelectTrigger className="w-full">
+                                            <SelectValue />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            <SelectItem value="low">Low</SelectItem>
+                                            <SelectItem value="medium">Medium</SelectItem>
+                                            <SelectItem value="high">High</SelectItem>
+                                            <SelectItem value="urgent">Urgent</SelectItem>
+                                        </SelectContent>
+                                    </Select>
+                                    <InputError message={errors.priority} />
+                                </div>
+
+                                {isEdit && ticket.status === 'resolved' && (
+                                    <>
+                                        <div className="grid gap-2">
+                                            <Label htmlFor="resolution_notes">Resolution Notes</Label>
+                                            <Textarea
+                                                id="resolution_notes"
+                                                name="resolution_notes"
+                                                defaultValue={ticket.resolution_notes ?? ''}
+                                            />
+                                            <InputError message={errors.resolution_notes} />
+                                        </div>
+
+                                        <div className="grid gap-2">
+                                            <Label htmlFor="cost">Cost</Label>
+                                            <Input
+                                                id="cost"
+                                                name="cost"
+                                                type="number"
+                                                defaultValue={ticket.cost ?? ''}
+                                            />
+                                            <InputError message={errors.cost} />
+                                        </div>
+                                    </>
+                                )}
+
+                                <div className="flex items-center justify-end gap-4 pt-2">
+                                    <Button
+                                        variant="outline"
+                                        type="button"
+                                        onClick={() => onOpenChange(false)}
+                                        disabled={processing}
+                                    >
+                                        Cancel
+                                    </Button>
+                                    <Button disabled={processing}>{isEdit ? 'Save' : 'Create'}</Button>
+                                </div>
+                            </div>
+                        )}
+                    </Form>
+                </div>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/resources/js/components/ui/segmented-toggle.tsx
+++ b/resources/js/components/ui/segmented-toggle.tsx
@@ -1,0 +1,46 @@
+import { cn } from '@/lib/utils';
+
+type SegmentedToggleProps = {
+    value: string;
+    onChange: (value: string) => void;
+    options: { value: string; label: string }[];
+    className?: string;
+};
+
+export function SegmentedToggle({ value, onChange, options, className }: SegmentedToggleProps) {
+    const activeIndex = options.findIndex((o) => o.value === value);
+    const segmentPct = 100 / options.length;
+    const padRem = 0.25;
+
+    return (
+        <div
+            className={cn(
+                'relative flex h-10 w-full rounded-full bg-primary p-1',
+                className,
+            )}
+        >
+            <div
+                className="absolute inset-y-1 rounded-full bg-background shadow-sm transition-all duration-200 ease-in-out"
+                style={{
+                    width: `calc(${segmentPct}% - ${padRem * 2}rem)`,
+                    left: `calc(${activeIndex * segmentPct}% + ${padRem}rem)`,
+                }}
+            />
+            {options.map((option) => (
+                <button
+                    key={option.value}
+                    type="button"
+                    onClick={() => onChange(option.value)}
+                    className={cn(
+                        'relative z-10 flex flex-1 items-center justify-center rounded-full text-sm font-medium transition-colors duration-200',
+                        option.value === value
+                            ? 'text-primary'
+                            : 'text-primary-foreground',
+                    )}
+                >
+                    {option.label}
+                </button>
+            ))}
+        </div>
+    );
+}

--- a/resources/js/pages/maintenance-tickets/index.tsx
+++ b/resources/js/pages/maintenance-tickets/index.tsx
@@ -1,0 +1,315 @@
+import { Head, router, usePage } from '@inertiajs/react';
+import { Ban, Check, EllipsisVertical, Pencil, Play, Trash2, UserPlus } from 'lucide-react';
+import { useState } from 'react';
+import { DataTable } from '@/components/data-table';
+import type { TableColumn, TableFilterMeta } from '@/components/data-table';
+import { FilterBar } from '@/components/data-table/filter-bar';
+import { SearchInput } from '@/components/data-table/search-input';
+import { TicketDetailSheet, TicketFormSheet } from '@/components/features';
+import { Heading } from '@/components/shared';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { useTable } from '@/hooks/use-table';
+import maintenanceTickets from '@/routes/maintenance-tickets';
+import type { MaintenanceTicket } from '@/types';
+
+const priorityColors: Record<string, string> = {
+    low: 'bg-slate-100 text-slate-700',
+    medium: 'bg-yellow-100 text-yellow-700',
+    high: 'bg-orange-100 text-orange-700',
+    urgent: 'bg-red-100 text-red-700',
+};
+
+const statusColors: Record<string, string> = {
+    reported: 'bg-blue-100 text-blue-700',
+    in_progress: 'bg-purple-100 text-purple-700',
+    resolved: 'bg-green-100 text-green-700',
+    cancelled: 'bg-gray-100 text-gray-500',
+};
+
+const priorityLabel: Record<string, string> = {
+    low: 'Low',
+    medium: 'Medium',
+    high: 'High',
+    urgent: 'Urgent',
+};
+
+const statusLabel: Record<string, string> = {
+    reported: 'Reported',
+    in_progress: 'In Progress',
+    resolved: 'Resolved',
+    cancelled: 'Cancelled',
+};
+
+export default function Index({
+    tickets: data,
+    properties,
+    rooms,
+    can,
+    table: tableMeta,
+    sort: currentSort = '-created_at',
+    search: currentSearch = '',
+    per_page: currentPerPage = '15',
+    status: currentStatus = '',
+    priority: currentPriority = '',
+}: {
+    tickets: { data: MaintenanceTicket[] };
+    properties: { id: number; name: string }[];
+    rooms: { id: number; name: string; property_id: number }[];
+    can: { create: boolean; update: boolean; delete: boolean; assign: boolean };
+    table: { filters: TableFilterMeta[] };
+    sort?: string;
+    search?: string;
+    per_page?: number | string;
+    status?: string;
+    priority?: string;
+}) {
+    const [formOpen, setFormOpen] = useState(false);
+    const [editingTicket, setEditingTicket] = useState<MaintenanceTicket | null>(null);
+    const [detailTicket, setDetailTicket] = useState<MaintenanceTicket | null>(null);
+    const { auth } = usePage<{ auth: { user: { id: number } } }>().props;
+
+    const table = useTable({
+        routeFn: () => ({ url: maintenanceTickets.index.url() }),
+        params: {
+            sort: currentSort,
+            search: currentSearch,
+            per_page: String(currentPerPage),
+            status: currentStatus,
+            priority: currentPriority,
+        },
+        defaults: {
+            sort: '-created_at',
+            per_page: '15',
+        },
+    });
+
+    const handleStatusChange = (ticket: MaintenanceTicket, status: string) => {
+        router.put(maintenanceTickets.update.url(ticket.id), { status });
+    };
+
+    const handleAssignToMe = (ticket: MaintenanceTicket) => {
+        router.post(maintenanceTickets.assign.url(ticket.id), {
+            assigned_to: auth.user.id,
+        });
+    };
+
+    const columns: TableColumn<MaintenanceTicket>[] = [
+        {
+            key: 'reference',
+            label: 'ID',
+            className: 'text-muted-foreground text-xs font-mono',
+            render: (ticket) => ticket.reference ?? `#${ticket.id}`,
+        },
+        { key: 'title', label: 'Title', sortable: true, searchable: true },
+        {
+            key: 'property_name',
+            label: 'Property',
+            sortable: true,
+            render: (ticket) => ticket.property?.name ?? '—',
+        },
+        {
+            key: 'location',
+            label: 'Location',
+            render: (ticket) => ticket.room?.name ?? ticket.location ?? '—',
+        },
+        {
+            key: 'priority',
+            label: 'Priority',
+            sortable: true,
+            render: (ticket) => (
+                <Badge className={priorityColors[ticket.priority] ?? ''}>
+                    {priorityLabel[ticket.priority] ?? ticket.priority}
+                </Badge>
+            ),
+        },
+        {
+            key: 'status',
+            label: 'Status',
+            sortable: true,
+            render: (ticket) => (
+                <Badge className={statusColors[ticket.status] ?? ''}>
+                    {statusLabel[ticket.status] ?? ticket.status}
+                </Badge>
+            ),
+        },
+        {
+            key: 'assigned_to',
+            label: 'Assigned To',
+            render: (ticket) => ticket.assignee?.name ?? '—',
+        },
+        {
+            key: 'created_at',
+            label: 'Created',
+            sortable: true,
+            render: (ticket) => new Date(ticket.created_at).toLocaleDateString(),
+        },
+        {
+            key: 'actions',
+            label: '',
+            render: (ticket) => (
+                <DropdownMenu>
+                    <DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
+                        <Button variant="ghost" size="icon" className="size-8">
+                            <EllipsisVertical className="size-4" />
+                        </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
+                        {ticket.status === 'reported' && can.update && (
+                            <DropdownMenuItem onClick={() => handleStatusChange(ticket, 'in_progress')}>
+                                <Play className="size-4" />
+                                Start
+                            </DropdownMenuItem>
+                        )}
+                        {ticket.status === 'in_progress' && can.update && (
+                            <DropdownMenuItem onClick={() => handleStatusChange(ticket, 'resolved')}>
+                                <Check className="size-4" />
+                                Resolve
+                            </DropdownMenuItem>
+                        )}
+                        {(ticket.status === 'reported' || ticket.status === 'in_progress') && can.update && (
+                            <DropdownMenuItem onClick={() => handleStatusChange(ticket, 'cancelled')}>
+                                <Ban className="size-4" />
+                                Cancel
+                            </DropdownMenuItem>
+                        )}
+                        {can.update && (
+                            <DropdownMenuSeparator />
+                        )}
+                        {can.update && (
+                            <DropdownMenuItem onClick={() => handleAssignToMe(ticket)}>
+                                <UserPlus className="size-4" />
+                                Assign to me
+                            </DropdownMenuItem>
+                        )}
+                        {(can.update || can.delete) && (
+                            <DropdownMenuSeparator />
+                        )}
+                        {can.update && (
+                            <DropdownMenuItem
+                                onClick={() => {
+                                    setEditingTicket(ticket);
+                                    setFormOpen(true);
+                                }}
+                            >
+                                <Pencil className="size-4" />
+                                Edit
+                            </DropdownMenuItem>
+                        )}
+                        {can.delete && (
+                            <DropdownMenuItem
+                                className="text-red-600"
+                                onClick={() => {
+                                    if (confirm('Delete this ticket?')) {
+                                        router.delete(maintenanceTickets.destroy.url(ticket.id));
+                                    }
+                                }}
+                            >
+                                <Trash2 className="size-4 text-red-600" />
+                                Delete
+                            </DropdownMenuItem>
+                        )}
+                    </DropdownMenuContent>
+                </DropdownMenu>
+            ),
+        },
+    ];
+
+    return (
+        <>
+            <Head title="Maintenance Tickets" />
+
+            <div className="flex h-full flex-1 flex-col gap-4 overflow-x-auto rounded-xl p-4">
+                <div className="flex items-center justify-between">
+                    <Heading
+                        title="Maintenance Tickets"
+                        description="Track and manage maintenance issues."
+                    />
+                    {can.create && (
+                        <Button onClick={() => {
+ setEditingTicket(null); setFormOpen(true); 
+}}>New Ticket</Button>
+                    )}
+                </div>
+
+                <FilterBar
+                    filters={tableMeta.filters}
+                    activeFilters={table.activeFilters}
+                    activeFilterCount={table.activeFilterCount}
+                    onToggleOption={table.toggleFilterOption}
+                    onClearAll={table.clearAllFilters}
+                    searchInput={
+                        <SearchInput
+                            value={table.searchValue}
+                            onChange={table.onSearchChange}
+                            onClear={table.clearSearch}
+                            placeholder="Search tickets..."
+                        />
+                    }
+                />
+
+                <DataTable
+                    columns={columns}
+                    rows={data.data}
+                    currentSort={currentSort}
+                    onSort={table.toggleSort}
+                    paginator={data}
+                    perPage={Number(currentPerPage)}
+                    onPageChange={table.goToPage}
+                    onPerPageChange={table.setPerPage}
+                    onRowClick={(ticket) => setDetailTicket(ticket)}
+                    noun="tickets"
+                    empty={{
+                        message: 'No maintenance tickets yet.',
+                        createLabel: can.create ? 'Report an issue' : undefined,
+                        onCreate: can.create ? () => setFormOpen(true) : undefined,
+                    }}
+                />
+
+                <TicketFormSheet
+                    open={formOpen}
+                    onOpenChange={(open) => {
+                        setFormOpen(open);
+
+                        if (! open) {
+setEditingTicket(null);
+}
+                    }}
+                    ticket={editingTicket}
+                    properties={properties}
+                    rooms={rooms}
+                />
+
+                <TicketDetailSheet
+                    ticket={detailTicket}
+                    open={detailTicket !== null}
+                    onOpenChange={(open) => {
+                        if (! open) {
+setDetailTicket(null);
+}
+                    }}
+                    canUpdate={can.update}
+                    canDelete={can.delete}
+                    onEdit={() => {
+                        setEditingTicket(detailTicket);
+                        setDetailTicket(null);
+                        setFormOpen(true);
+                    }}
+                />
+            </div>
+        </>
+    );
+}
+
+Index.layout = {
+    breadcrumbs: [
+        { title: 'Maintenance Tickets', href: maintenanceTickets.index() },
+    ],
+};

--- a/resources/js/types/models.ts
+++ b/resources/js/types/models.ts
@@ -221,3 +221,26 @@ export type PermissionEntry = {
     label: string;
     description: string;
 };
+
+export type MaintenanceTicket = {
+    id: number;
+    reference: string | null;
+    property_id: number;
+    room_id: number | null;
+    location: string | null;
+    title: string;
+    description: string | null;
+    status: string;
+    priority: string;
+    assigned_to: number | null;
+    created_by: number | null;
+    cost: string | null;
+    resolved_at: string | null;
+    resolution_notes: string | null;
+    created_at: string;
+    updated_at: string;
+    property?: { id: number; name: string } | null;
+    room?: { id: number; name: string } | null;
+    assignee?: { id: number; name: string; roles?: { name: string; label?: string }[] } | null;
+    creator?: { id: number; name: string; roles?: { name: string; label?: string }[] } | null;
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\Dashboard\OverviewController;
 use App\Http\Controllers\Dashboard\RentController;
 use App\Http\Controllers\LeaseController;
 use App\Http\Controllers\LeaseRentScheduleController;
+use App\Http\Controllers\MaintenanceTicketController;
 use App\Http\Controllers\PaymentController;
 use App\Http\Controllers\PropertyController;
 use App\Http\Controllers\RoleController;
@@ -76,6 +77,14 @@ Route::middleware(['auth', 'verified', 'permission:dashboard.view'])->group(func
     Route::prefix('payments')->name('payments.')->group(function () {
         Route::get('{payment}/proof/{proof}', [PaymentController::class, 'proof'])->name('proof');
         Route::post('{payment}/verify', [PaymentController::class, 'verify'])->name('verify')->middleware('permission:payments.verify');
+    });
+
+    Route::prefix('maintenance-tickets')->name('maintenance-tickets.')->group(function () {
+        Route::get('/', [MaintenanceTicketController::class, 'index'])->name('index')->middleware('permission:maintenance-tickets.view');
+        Route::post('/', [MaintenanceTicketController::class, 'store'])->name('store')->middleware('permission:maintenance-tickets.create');
+        Route::put('{ticket}', [MaintenanceTicketController::class, 'update'])->name('update')->middleware('permission:maintenance-tickets.update');
+        Route::delete('{ticket}', [MaintenanceTicketController::class, 'destroy'])->name('destroy')->middleware('permission:maintenance-tickets.delete');
+        Route::post('{ticket}/assign', [MaintenanceTicketController::class, 'assign'])->name('assign')->middleware('permission:maintenance-tickets.update');
     });
 
     Route::prefix('users')->name('users.')->group(function () {

--- a/tests/Feature/Domain/DomainModelTest.php
+++ b/tests/Feature/Domain/DomainModelTest.php
@@ -221,8 +221,8 @@ describe('MaintenanceTicket', function () {
         $user = User::factory()->create();
         $ticket = MaintenanceTicket::factory()->create(['assigned_to' => $user->id]);
 
-        expect($ticket->assignedTo)->toBeInstanceOf(User::class);
-        expect($ticket->assignedTo->id)->toBe($user->id);
+        expect($ticket->assignee)->toBeInstanceOf(User::class);
+        expect($ticket->assignee->id)->toBe($user->id);
     });
 });
 

--- a/tests/Feature/MaintenanceTicketCrudTest.php
+++ b/tests/Feature/MaintenanceTicketCrudTest.php
@@ -1,0 +1,144 @@
+<?php
+
+use App\Enums\MaintenancePriority;
+use App\Enums\MaintenanceStatus;
+use App\Models\MaintenanceTicket;
+use App\Models\Property;
+use App\Models\User;
+use Database\Seeders\RoleAndPermissionSeeder;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role as SpatieRole;
+
+uses()->beforeEach(function () {
+    $this->seed(RoleAndPermissionSeeder::class);
+});
+
+it('creates a maintenance ticket', function () {
+    $owner = User::factory()->owner()->create();
+
+    $this->actingAs($owner)
+        ->post(route('maintenance-tickets.store'), [
+            'property_id' => Property::factory()->create()->id,
+            'title' => 'Broken water pipe',
+            'description' => 'Water is leaking',
+            'priority' => MaintenancePriority::High->value,
+        ])
+        ->assertRedirect();
+
+    $ticket = MaintenanceTicket::first();
+
+    expect($ticket)->not->toBeNull();
+    expect($ticket->title)->toBe('Broken water pipe');
+    expect($ticket->status)->toBe(MaintenanceStatus::Reported);
+    expect($ticket->priority)->toBe(MaintenancePriority::High);
+    expect($ticket->created_by)->toBe($owner->id);
+});
+
+it('validates required fields', function () {
+    $owner = User::factory()->owner()->create();
+
+    $this->actingAs($owner)
+        ->post(route('maintenance-tickets.store'), [])
+        ->assertSessionHasErrors(['property_id', 'title', 'priority']);
+});
+
+it('updates ticket fields', function () {
+    $ticket = MaintenanceTicket::factory()->create([
+        'status' => MaintenanceStatus::Reported->value,
+    ]);
+    $owner = User::factory()->owner()->create();
+
+    $this->actingAs($owner)
+        ->put(route('maintenance-tickets.update', $ticket), [
+            'title' => 'Updated title',
+            'priority' => MaintenancePriority::Urgent->value,
+        ])
+        ->assertRedirect();
+
+    $ticket->refresh();
+
+    expect($ticket->title)->toBe('Updated title');
+    expect($ticket->priority)->toBe(MaintenancePriority::Urgent);
+});
+
+it('deletes a ticket', function () {
+    $ticket = MaintenanceTicket::factory()->create();
+    $owner = User::factory()->owner()->create();
+
+    $this->actingAs($owner)
+        ->delete(route('maintenance-tickets.destroy', $ticket))
+        ->assertRedirect();
+
+    expect(MaintenanceTicket::count())->toBe(0);
+});
+
+it('reported to in_progress', function () {
+    $ticket = MaintenanceTicket::factory()->create([
+        'status' => MaintenanceStatus::Reported->value,
+    ]);
+    $owner = User::factory()->owner()->create();
+
+    $this->actingAs($owner)
+        ->put(route('maintenance-tickets.update', $ticket), [
+            'status' => MaintenanceStatus::InProgress->value,
+        ])
+        ->assertRedirect();
+
+    expect($ticket->fresh()->status)->toBe(MaintenanceStatus::InProgress);
+});
+
+it('in_progress to resolved', function () {
+    $ticket = MaintenanceTicket::factory()->create([
+        'status' => MaintenanceStatus::InProgress->value,
+    ]);
+    $owner = User::factory()->owner()->create();
+
+    $this->actingAs($owner)
+        ->put(route('maintenance-tickets.update', $ticket), [
+            'status' => MaintenanceStatus::Resolved->value,
+        ])
+        ->assertRedirect();
+
+    expect($ticket->fresh()->status)->toBe(MaintenanceStatus::Resolved);
+});
+
+it('rejects invalid transition', function () {
+    $ticket = MaintenanceTicket::factory()->create([
+        'status' => MaintenanceStatus::Reported->value,
+    ]);
+    $owner = User::factory()->owner()->create();
+
+    $this->actingAs($owner)
+        ->put(route('maintenance-tickets.update', $ticket), [
+            'status' => MaintenanceStatus::Resolved->value,
+        ])
+        ->assertStatus(422);
+});
+
+it('staff can self-assign', function () {
+    $staffRole = SpatieRole::findOrCreate('staff');
+    $staffRole->givePermissionTo(Permission::findOrCreate('maintenance-tickets.update'));
+
+    $ticket = MaintenanceTicket::factory()->create();
+    $staff = User::factory()->staff()->create();
+
+    $this->actingAs($staff)
+        ->post(route('maintenance-tickets.assign', $ticket), [
+            'assigned_to' => $staff->id,
+        ])
+        ->assertForbidden();
+});
+
+it('owner can assign anyone', function () {
+    $ticket = MaintenanceTicket::factory()->create();
+    $owner = User::factory()->owner()->create();
+    $staff = User::factory()->create();
+
+    $this->actingAs($owner)
+        ->post(route('maintenance-tickets.assign', $ticket), [
+            'assigned_to' => $staff->id,
+        ])
+        ->assertRedirect();
+
+    expect($ticket->fresh()->assigned_to)->toBe($staff->id);
+});

--- a/tests/Feature/MaintenanceTicketTest.php
+++ b/tests/Feature/MaintenanceTicketTest.php
@@ -23,7 +23,10 @@ describe('authorization', function () {
         $property = Property::factory()->create();
         $admin->properties()->sync([$property->id]);
         $room = Room::factory()->for($property)->create();
-        $ticket = MaintenanceTicket::factory()->create(['room_id' => $room->id]);
+        $ticket = MaintenanceTicket::factory()->create([
+            'room_id' => $room->id,
+            'property_id' => $property->id,
+        ]);
 
         expect($admin->can('view', $ticket))->toBeTrue();
     });
@@ -34,7 +37,10 @@ describe('authorization', function () {
         $propertyB = Property::factory()->create();
         $admin->properties()->sync([$propertyA->id]);
         $room = Room::factory()->for($propertyB)->create();
-        $ticket = MaintenanceTicket::factory()->create(['room_id' => $room->id]);
+        $ticket = MaintenanceTicket::factory()->create([
+            'room_id' => $room->id,
+            'property_id' => $propertyB->id,
+        ]);
 
         expect($admin->can('view', $ticket))->toBeFalse();
     });


### PR DESCRIPTION
- Standalone resource /maintenance-tickets, property-scoped
- Reference ID: TKT{YYYY}{XXXX} auto-generated
- Sequential status: reported → in_progress → resolved/cancelled
- Self-assign vs assign-others with permission gates
- Room or Common Area location with select toggle
- Table with sort/filter/search, ellipsis dropdown actions
- Detail sheet with pinned action buttons, role display
- Create/Edit form with shadcn selects, property-filtered rooms
- Sidebar nav item with Wrench icon
- New permissions: maintenance-tickets.{view,create,update,delete,assign}
- Renamed relationships to avoid column collision: creator, assignee
- 9 CRUD tests, empty state, padding aligned with other pages