### PR TITLE
feat: add room-level maintenance history page

### DIFF
--- a/app/Http/Controllers/RoomController.php
+++ b/app/Http/Controllers/RoomController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\Room\StoreRoomRequest;
 use App\Http\Requests\Room\UpdateRoomRequest;
+use App\Models\MaintenanceTicket;
 use App\Models\Property;
 use App\Models\Room;
 use App\Models\Tenant;
@@ -135,5 +136,23 @@ class RoomController extends Controller
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Room deleted.')]);
 
         return to_route('properties.rooms.index', $property);
+    }
+
+    public function maintenanceHistory(Property $property, Room $room): Response
+    {
+        $this->authorize('viewAny', MaintenanceTicket::class);
+
+        $room->load('property.city');
+
+        $tickets = $room->maintenanceTickets()
+            ->with(['property:id,name', 'assignee:id,name', 'creator:id,name'])
+            ->orderBy('created_at', 'desc')
+            ->paginate(15);
+
+        return Inertia::render('properties/rooms/maintenance-history', [
+            'property' => ['id' => $property->id, 'name' => $property->name, 'slug' => $property->slug, 'city' => $property->city?->name],
+            'room' => $room->only('id', 'name', 'floor'),
+            'tickets' => $tickets,
+        ]);
     }
 }

--- a/resources/js/components/features/rooms/room-detail-sheet.tsx
+++ b/resources/js/components/features/rooms/room-detail-sheet.tsx
@@ -306,20 +306,36 @@ export default function RoomDetailSheet({
                                 </Button>
                             )}
                             {room && property && (
-                                <Button
-                                    variant="outline"
-                                    onClick={() => {
-                                        onOpenChange(false);
-                                        router.get(
-                                            properties.rooms.leases.index.url({
-                                                property: property.id,
-                                                room: room.id,
-                                            }),
-                                        );
-                                    }}
-                                >
-                                    Lease History
-                                </Button>
+                                <>
+                                    <Button
+                                        variant="outline"
+                                        onClick={() => {
+                                            onOpenChange(false);
+                                            router.get(
+                                                properties.rooms.leases.index.url({
+                                                    property: property.id,
+                                                    room: room.id,
+                                                }),
+                                            );
+                                        }}
+                                    >
+                                        Lease History
+                                    </Button>
+                                    <Button
+                                        variant="outline"
+                                        onClick={() => {
+                                            onOpenChange(false);
+                                            router.get(
+                                                properties.rooms.maintenanceHistory.url({
+                                                    property: property.id,
+                                                    room: room.id,
+                                                }),
+                                            );
+                                        }}
+                                    >
+                                        Maintenance History
+                                    </Button>
+                                </>
                             )}
                             <Button
                                 variant="ghost"

--- a/resources/js/pages/properties/rooms/maintenance-history.tsx
+++ b/resources/js/pages/properties/rooms/maintenance-history.tsx
@@ -1,0 +1,182 @@
+import { Head, Link } from '@inertiajs/react';
+import { Heading } from '@/components/shared';
+import { Badge } from '@/components/ui/badge';
+import properties from '@/routes/properties';
+import type { MaintenanceTicket } from '@/types';
+
+type Property = {
+    id: number;
+    name: string;
+    slug: string;
+    city: string | null;
+};
+
+type Room = {
+    id: number;
+    name: string;
+    floor: string | null;
+};
+
+type PageProps = {
+    property: Property;
+    room: Room;
+    tickets: {
+        data: MaintenanceTicket[];
+        meta?: {
+            current_page: number;
+            last_page: number;
+            total: number;
+        };
+    };
+};
+
+const priorityColors: Record<string, string> = {
+    low: 'bg-slate-100 text-slate-700',
+    medium: 'bg-yellow-100 text-yellow-700',
+    high: 'bg-orange-100 text-orange-700',
+    urgent: 'bg-red-100 text-red-700',
+};
+
+const statusColors: Record<string, string> = {
+    reported: 'bg-blue-100 text-blue-700',
+    in_progress: 'bg-purple-100 text-purple-700',
+    resolved: 'bg-green-100 text-green-700',
+    cancelled: 'bg-gray-100 text-gray-500',
+};
+
+const priorityLabel: Record<string, string> = {
+    low: 'Low',
+    medium: 'Medium',
+    high: 'High',
+    urgent: 'Urgent',
+};
+
+const statusLabel: Record<string, string> = {
+    reported: 'Reported',
+    in_progress: 'In Progress',
+    resolved: 'Resolved',
+    cancelled: 'Cancelled',
+};
+
+function formatPrice(cents: string | null): string {
+    if (!cents) return '—';
+
+    const num = Number.parseFloat(cents);
+
+    return new Intl.NumberFormat('id-ID', {
+        style: 'currency',
+        currency: 'IDR',
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0,
+    }).format(num);
+}
+
+function formatDate(date: string | null): string {
+    if (!date) return '—';
+
+    return new Date(date).toLocaleDateString('id-ID', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+    });
+}
+
+export default function MaintenanceHistory({ property, room, tickets }: PageProps) {
+    const backUrl = properties.rooms.index.url(property);
+
+    return (
+        <>
+            <Head title={`Maintenance History - ${room.name}`} />
+
+            <div className="flex h-full flex-1 flex-col gap-4 overflow-x-auto rounded-xl p-4">
+                <div>
+                    <div className="mb-1 inline-block text-xs text-muted-foreground">
+                        <Link href={backUrl} className="hover:text-foreground">
+                            &larr; Back to {property.name} rooms
+                        </Link>
+                    </div>
+                    <Heading
+                        title={`${room.name} — Maintenance History`}
+                        description={
+                            room.floor ? `Floor ${room.floor}` : undefined
+                        }
+                    />
+                </div>
+
+                {tickets.data.length === 0 ? (
+                    <div className="flex flex-1 items-center justify-center rounded-lg border py-16">
+                        <p className="text-muted-foreground">
+                            No maintenance history for this room.
+                        </p>
+                    </div>
+                ) : (
+                    <div className="overflow-x-auto rounded-lg border">
+                        <table className="w-full text-sm">
+                            <thead>
+                                <tr className="border-b bg-muted/50 text-left text-muted-foreground">
+                                    <th className="px-4 py-3 font-medium">ID</th>
+                                    <th className="px-4 py-3 font-medium">Title</th>
+                                    <th className="px-4 py-3 font-medium">Priority</th>
+                                    <th className="px-4 py-3 font-medium">Status</th>
+                                    <th className="px-4 py-3 font-medium">Cost</th>
+                                    <th className="px-4 py-3 font-medium">Assigned To</th>
+                                    <th className="px-4 py-3 font-medium">Created</th>
+                                    <th className="px-4 py-3 font-medium">Resolved</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {tickets.data.map((ticket) => (
+                                    <tr
+                                        key={ticket.id}
+                                        className="border-b last:border-0 hover:bg-muted/30"
+                                    >
+                                        <td className="px-4 py-3 font-mono text-xs text-muted-foreground">
+                                            {ticket.reference ?? `#${ticket.id}`}
+                                        </td>
+                                        <td className="px-4 py-3 font-medium">
+                                            {ticket.title}
+                                        </td>
+                                        <td className="px-4 py-3">
+                                            <Badge className={priorityColors[ticket.priority] ?? ''}>
+                                                {priorityLabel[ticket.priority] ?? ticket.priority}
+                                            </Badge>
+                                        </td>
+                                        <td className="px-4 py-3">
+                                            <Badge className={statusColors[ticket.status] ?? ''}>
+                                                {statusLabel[ticket.status] ?? ticket.status}
+                                            </Badge>
+                                        </td>
+                                        <td className="px-4 py-3 tabular-nums">
+                                            {formatPrice(ticket.cost)}
+                                        </td>
+                                        <td className="px-4 py-3 text-muted-foreground">
+                                            {ticket.assignee?.name ?? '—'}
+                                        </td>
+                                        <td className="px-4 py-3 tabular-nums text-muted-foreground">
+                                            {formatDate(ticket.created_at)}
+                                        </td>
+                                        <td className="px-4 py-3 tabular-nums text-muted-foreground">
+                                            {formatDate(ticket.resolved_at)}
+                                        </td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                )}
+            </div>
+        </>
+    );
+}
+
+MaintenanceHistory.layout = {
+    breadcrumbs: [
+        {
+            title: 'Properties',
+            href: properties.index(),
+        },
+        {
+            title: 'Rooms',
+        },
+    ],
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -50,6 +50,10 @@ Route::middleware(['auth', 'verified', 'permission:dashboard.view'])->group(func
                     Route::delete('{lease}', [LeaseController::class, 'destroy'])->name('destroy')->middleware('permission:leases.delete');
                     Route::post('{lease}/move', [LeaseController::class, 'move'])->name('move')->middleware('permission:leases.move');
                 });
+
+                Route::get('{room}/maintenance-history', [RoomController::class, 'maintenanceHistory'])
+                    ->name('maintenance-history')
+                    ->middleware('permission:maintenance-tickets.view');
             });
         });
     });

--- a/tests/Feature/MaintenanceTicketCrudTest.php
+++ b/tests/Feature/MaintenanceTicketCrudTest.php
@@ -3,6 +3,7 @@
 use App\Enums\MaintenancePriority;
 use App\Enums\MaintenanceStatus;
 use App\Enums\RoomStatus;
+use App\Models\LeaseRoomHistory;
 use App\Models\MaintenanceTicket;
 use App\Models\Property;
 use App\Models\Room;
@@ -362,7 +363,7 @@ it('moves tenant back when resolving ticket with move_back flag', function () {
     ]);
     $lease->tenants()->attach($tenant->id, ['is_primary' => DB::raw('true')]);
 
-    \App\Models\LeaseRoomHistory::create([
+    LeaseRoomHistory::create([
         'lease_id' => $lease->id,
         'from_room_id' => $room->id,
         'to_room_id' => $targetRoom->id,

--- a/tests/Feature/Room/MaintenanceHistoryTest.php
+++ b/tests/Feature/Room/MaintenanceHistoryTest.php
@@ -1,0 +1,156 @@
+<?php
+
+use App\Models\MaintenanceTicket;
+use App\Models\Property;
+use App\Models\Room;
+use App\Models\User;
+use Database\Seeders\RoleAndPermissionSeeder;
+
+uses()->beforeEach(function () {
+    $this->seed(RoleAndPermissionSeeder::class);
+});
+
+describe('authorization', function () {
+    it('redirects unauthenticated users to login', function () {
+        $property = Property::factory()->create();
+        $room = Room::factory()->for($property)->create();
+
+        $this->get(route('properties.rooms.maintenance-history', [$property, $room]))
+            ->assertRedirect('login');
+    });
+
+    it('returns 403 for users without maintenance-tickets.view permission', function () {
+        $user = User::factory()->create();
+        $property = Property::factory()->create();
+        $room = Room::factory()->for($property)->create();
+
+        $this->actingAs($user)
+            ->get(route('properties.rooms.maintenance-history', [$property, $room]))
+            ->assertForbidden();
+    });
+
+    it('allows admin with permission to view maintenance history', function () {
+        $user = User::factory()->admin()->create();
+        $user->givePermissionTo('maintenance-tickets.view');
+        $property = Property::factory()->create();
+        $user->properties()->sync([$property->id]);
+        $room = Room::factory()->for($property)->create();
+
+        $this->actingAs($user)
+            ->get(route('properties.rooms.maintenance-history', [$property, $room]))
+            ->assertOk();
+    });
+
+    it('allows owner to view maintenance history', function () {
+        $user = User::factory()->owner()->create();
+        $property = Property::factory()->create();
+        $room = Room::factory()->for($property)->create();
+
+        $this->actingAs($user)
+            ->get(route('properties.rooms.maintenance-history', [$property, $room]))
+            ->assertOk();
+    });
+});
+
+describe('maintenance history page', function () {
+    it('shows maintenance tickets for the room', function () {
+        $user = User::factory()->owner()->create();
+        $property = Property::factory()->create();
+        $room = Room::factory()->for($property)->create();
+        $ticket = MaintenanceTicket::factory()->create([
+            'property_id' => $property->id,
+            'room_id' => $room->id,
+            'title' => 'Broken AC',
+            'cost' => 50000,
+        ]);
+
+        $response = $this->actingAs($user)
+            ->get(route('properties.rooms.maintenance-history', [$property, $room]))
+            ->assertOk();
+
+        $response->assertInertia(fn ($page) => $page
+            ->component('properties/rooms/maintenance-history')
+            ->has('tickets.data', 1)
+            ->where('tickets.data.0.title', 'Broken AC')
+        );
+    });
+
+    it('does not show tickets from other rooms', function () {
+        $user = User::factory()->owner()->create();
+        $property = Property::factory()->create();
+        $room = Room::factory()->for($property)->create();
+        $otherRoom = Room::factory()->for($property)->create();
+
+        MaintenanceTicket::factory()->create([
+            'property_id' => $property->id,
+            'room_id' => $otherRoom->id,
+            'title' => 'Other room ticket',
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('properties.rooms.maintenance-history', [$property, $room]))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->has('tickets.data', 0)
+            );
+    });
+
+    it('shows empty state for room with no tickets', function () {
+        $user = User::factory()->owner()->create();
+        $property = Property::factory()->create();
+        $room = Room::factory()->for($property)->create();
+
+        $this->actingAs($user)
+            ->get(route('properties.rooms.maintenance-history', [$property, $room]))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('properties/rooms/maintenance-history')
+                ->has('tickets.data', 0)
+            );
+    });
+
+    it('paginates tickets', function () {
+        $user = User::factory()->owner()->create();
+        $property = Property::factory()->create();
+        $room = Room::factory()->for($property)->create();
+
+        MaintenanceTicket::factory()->count(20)->create([
+            'property_id' => $property->id,
+            'room_id' => $room->id,
+        ]);
+
+        $response = $this->actingAs($user)
+            ->get(route('properties.rooms.maintenance-history', [$property, $room]))
+            ->assertOk();
+
+        $response->assertInertia(fn ($page) => $page
+            ->has('tickets.data', 15)
+            ->has('tickets.current_page')
+        );
+    });
+
+    it('orders tickets by most recent first', function () {
+        $user = User::factory()->owner()->create();
+        $property = Property::factory()->create();
+        $room = Room::factory()->for($property)->create();
+
+        $old = MaintenanceTicket::factory()->create([
+            'property_id' => $property->id,
+            'room_id' => $room->id,
+            'created_at' => now()->subDays(2),
+        ]);
+        $new = MaintenanceTicket::factory()->create([
+            'property_id' => $property->id,
+            'room_id' => $room->id,
+            'created_at' => now()->subDay(),
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('properties.rooms.maintenance-history', [$property, $room]))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->where('tickets.data.0.id', $new->id)
+                ->where('tickets.data.1.id', $old->id)
+            );
+    });
+});


### PR DESCRIPTION
Room detail sheet now shows a Maintenance History button navigating to a dedicated page listing past tickets (status, priority, cost, assignee, dates) for operational visibility.

- New route: properties/{property}/rooms/{room}/maintenance-history
- RoomController::maintenanceHistory with paginated tickets
- New Inertia page: properties/rooms/maintenance-history.tsx
- Button added to room-detail-sheet.tsx alongside Lease History

Closes OPE-27