### PR TITLE
feat(db): enforce FK delete strategy with restrict on business records

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets;
+use Inertia\Inertia;
 use Spatie\Permission\Middleware\PermissionMiddleware;
 use Spatie\Permission\Middleware\RoleMiddleware;
 use Spatie\Permission\Middleware\RoleOrPermissionMiddleware;
@@ -36,7 +37,9 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withExceptions(function (Exceptions $exceptions): void {
         $exceptions->render(function (\Illuminate\Database\QueryException $e) {
             if ($e->getCode() === '23503') {
-                Inertia::flash('toast', ['type' => 'error', 'message' => __('This record cannot be deleted because other records depend on it.')]);
+                if (request()->isMethod('delete')) {
+                    Inertia::flash('toast', ['type' => 'error', 'message' => __('This record cannot be deleted because other records depend on it.')]);
+                }
 
                 return redirect()->back();
             }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -34,5 +34,11 @@ return Application::configure(basePath: dirname(__DIR__))
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
-        //
+        $exceptions->render(function (\Illuminate\Database\QueryException $e) {
+            if ($e->getCode() === '23503') {
+                Inertia::flash('toast', ['type' => 'error', 'message' => __('This record cannot be deleted because other records depend on it.')]);
+
+                return redirect()->back();
+            }
+        });
     })->create();

--- a/database/migrations/2026_07_05_122906_review_foreign_key_delete_strategies.php
+++ b/database/migrations/2026_07_05_122906_review_foreign_key_delete_strategies.php
@@ -1,0 +1,157 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // leases.unit_id — CASCADE → RESTRICT
+        Schema::table('leases', function (Blueprint $table) {
+            $table->dropForeign(['unit_id']);
+            $table->foreign('unit_id')->references('id')->on('units')->restrictOnDelete();
+        });
+
+        // lease_tenant.lease_id — CASCADE → RESTRICT
+        Schema::table('lease_tenant', function (Blueprint $table) {
+            $table->dropForeign(['lease_id']);
+            $table->foreign('lease_id')->references('id')->on('leases')->restrictOnDelete();
+        });
+
+        // lease_tenant.tenant_id — CASCADE → RESTRICT
+        Schema::table('lease_tenant', function (Blueprint $table) {
+            $table->dropForeign(['tenant_id']);
+            $table->foreign('tenant_id')->references('id')->on('tenants')->restrictOnDelete();
+        });
+
+        // lease_unit_histories.* — CASCADE → RESTRICT (3 FKs)
+        Schema::table('lease_unit_histories', function (Blueprint $table) {
+            $table->dropForeign(['lease_id']);
+            $table->foreign('lease_id')->references('id')->on('leases')->restrictOnDelete();
+        });
+
+        Schema::table('lease_unit_histories', function (Blueprint $table) {
+            $table->dropForeign(['from_unit_id']);
+            $table->foreign('from_unit_id')->references('id')->on('units')->restrictOnDelete();
+        });
+
+        Schema::table('lease_unit_histories', function (Blueprint $table) {
+            $table->dropForeign(['to_unit_id']);
+            $table->foreign('to_unit_id')->references('id')->on('units')->restrictOnDelete();
+        });
+
+        // reminder_logs.lease_id — CASCADE → RESTRICT
+        Schema::table('reminder_logs', function (Blueprint $table) {
+            $table->dropForeign(['lease_id']);
+            $table->foreign('lease_id')->references('id')->on('leases')->restrictOnDelete();
+        });
+
+        // tenant_documents.tenant_id — CASCADE → RESTRICT
+        Schema::table('tenant_documents', function (Blueprint $table) {
+            $table->dropForeign(['tenant_id']);
+            $table->foreign('tenant_id')->references('id')->on('tenants')->restrictOnDelete();
+        });
+
+        // unit_rates.unit_id — CASCADE → RESTRICT
+        Schema::table('unit_rates', function (Blueprint $table) {
+            $table->dropForeign(['unit_id']);
+            $table->foreign('unit_id')->references('id')->on('units')->restrictOnDelete();
+        });
+
+        // maintenance_tickets.property_id — CASCADE → RESTRICT
+        Schema::table('maintenance_tickets', function (Blueprint $table) {
+            $table->dropForeign(['property_id']);
+            $table->foreign('property_id')->references('id')->on('properties')->restrictOnDelete();
+        });
+
+        // maintenance_tickets.unit_id — CASCADE → SET NULL
+        Schema::table('maintenance_tickets', function (Blueprint $table) {
+            $table->dropForeign(['unit_id']);
+            $table->foreign('unit_id')->references('id')->on('units')->nullOnDelete();
+        });
+
+        // units.property_id — CASCADE → RESTRICT
+        Schema::table('units', function (Blueprint $table) {
+            $table->dropForeign(['property_id']);
+            $table->foreign('property_id')->references('id')->on('properties')->restrictOnDelete();
+        });
+
+        // cities.region_id — CASCADE → RESTRICT
+        Schema::table('cities', function (Blueprint $table) {
+            $table->dropForeign(['region_id']);
+            $table->foreign('region_id')->references('id')->on('regions')->restrictOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // Restore original cascadeOnDelete for all 13 FKs
+
+        Schema::table('leases', function (Blueprint $table) {
+            $table->dropForeign(['unit_id']);
+            $table->foreign('unit_id')->references('id')->on('units')->cascadeOnDelete();
+        });
+
+        Schema::table('lease_tenant', function (Blueprint $table) {
+            $table->dropForeign(['lease_id']);
+            $table->foreign('lease_id')->references('id')->on('leases')->cascadeOnDelete();
+        });
+
+        Schema::table('lease_tenant', function (Blueprint $table) {
+            $table->dropForeign(['tenant_id']);
+            $table->foreign('tenant_id')->references('id')->on('tenants')->cascadeOnDelete();
+        });
+
+        Schema::table('lease_unit_histories', function (Blueprint $table) {
+            $table->dropForeign(['lease_id']);
+            $table->foreign('lease_id')->references('id')->on('leases')->cascadeOnDelete();
+        });
+
+        Schema::table('lease_unit_histories', function (Blueprint $table) {
+            $table->dropForeign(['from_unit_id']);
+            $table->foreign('from_unit_id')->references('id')->on('units')->cascadeOnDelete();
+        });
+
+        Schema::table('lease_unit_histories', function (Blueprint $table) {
+            $table->dropForeign(['to_unit_id']);
+            $table->foreign('to_unit_id')->references('id')->on('units')->cascadeOnDelete();
+        });
+
+        Schema::table('reminder_logs', function (Blueprint $table) {
+            $table->dropForeign(['lease_id']);
+            $table->foreign('lease_id')->references('id')->on('leases')->cascadeOnDelete();
+        });
+
+        Schema::table('tenant_documents', function (Blueprint $table) {
+            $table->dropForeign(['tenant_id']);
+            $table->foreign('tenant_id')->references('id')->on('tenants')->cascadeOnDelete();
+        });
+
+        Schema::table('unit_rates', function (Blueprint $table) {
+            $table->dropForeign(['unit_id']);
+            $table->foreign('unit_id')->references('id')->on('units')->cascadeOnDelete();
+        });
+
+        Schema::table('maintenance_tickets', function (Blueprint $table) {
+            $table->dropForeign(['property_id']);
+            $table->foreign('property_id')->references('id')->on('properties')->cascadeOnDelete();
+        });
+
+        Schema::table('maintenance_tickets', function (Blueprint $table) {
+            $table->dropForeign(['unit_id']);
+            $table->foreign('unit_id')->references('id')->on('units')->cascadeOnDelete();
+        });
+
+        Schema::table('units', function (Blueprint $table) {
+            $table->dropForeign(['property_id']);
+            $table->foreign('property_id')->references('id')->on('properties')->cascadeOnDelete();
+        });
+
+        Schema::table('cities', function (Blueprint $table) {
+            $table->dropForeign(['region_id']);
+            $table->foreign('region_id')->references('id')->on('regions')->cascadeOnDelete();
+        });
+    }
+};

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -200,10 +200,29 @@ Named routes follow the Laravel resource convention (`{plural}.{action}`). Setti
 
 - Migrations include a descriptive name (not just `create_*_table`).
 - Timestamps use `nullableTimestamps()` where appropriate (pivot tables).
-- Foreign keys use `constrained()` with explicit `cascadeOnDelete` / `nullOnDelete`.
+- Foreign keys use `constrained()` with explicit `cascadeOnDelete` / `nullOnDelete` / `restrictOnDelete`.
 - Unique constraints cover business-unique combinations (e.g., `lease_id + period_start + reminder_type + overdue_days` on `reminder_logs`).
 - Currency values are stored as integers (cents/sen). The frontend divides by 100 for display.
 - The `settings` table is a singleton — one row with columns for each setting group. No key-value pattern.
+
+### Foreign Key Delete Strategy
+
+Every foreign key intentionally chooses one of four strategies:
+
+| Strategy | When to use |
+|---|---|
+| `restrictOnDelete` | Parent references a historical business record. Prevents hard-deleting the parent while children exist. |
+| `nullOnDelete` | The child can logically exist without the parent (nullable audit trails, optional associations). |
+| `cascadeOnDelete` | The child is meaningless without the parent (auth credentials, dependent files), or is a framework table (Spatie). |
+| `noActionOnDelete` | Reserved for transactional integrity (not currently used). |
+
+**Historical business records** (leases, payments, maintenance tickets, reminders, documents, pricing history, audit trails) must use `restrictOnDelete` on their parent FK. This ensures soft deletion is the only path for record removal — hard-deleting a parent is blocked at the database level. Controllers use `$model->delete()` which triggers Eloquent's soft delete; the FK constraint only fires on `forceDelete()` or raw SQL deletes.
+
+**User audit references** (created_by, confirmed_by, recorded_by, etc.) use `nullOnDelete` — the record survives even if the user is hard-deleted.
+
+**Pivot tables and framework tables** use `cascadeOnDelete` — they are ephemeral metadata.
+
+The full FK inventory with per-constraint rationale is enforced by `tests/Feature/Schema/ForeignKeyDeleteStrategyTest.php`.
 
 ## Testing
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -216,11 +216,11 @@ Every foreign key intentionally chooses one of four strategies:
 | `cascadeOnDelete` | The child is meaningless without the parent (auth credentials, dependent files), or is a framework table (Spatie). |
 | `noActionOnDelete` | Reserved for transactional integrity (not currently used). |
 
-**Historical business records** (leases, payments, maintenance tickets, reminders, documents, pricing history, audit trails) must use `restrictOnDelete` on their parent FK. This ensures soft deletion is the only path for record removal — hard-deleting a parent is blocked at the database level. Controllers use `$model->delete()` which triggers Eloquent's soft delete; the FK constraint only fires on `forceDelete()` or raw SQL deletes.
+**Historical business records** (leases, payments, maintenance tickets, reminders, documents, pricing history, audit trails) must use `restrictOnDelete` on their parent FK. This prevents hard-deleting a parent model while its business records still reference it. Soft-deletable parents (Property, Unit, Lease, Tenant) use `$model->delete()` which sets `deleted_at` — the FK constraint only fires on `forceDelete()` or raw SQL deletes. Child records themselves may be hard-deleted (e.g. MaintenanceTicket, TenantDocument) — the constraint protects the parent, not the child.
 
 **User audit references** (created_by, confirmed_by, recorded_by, etc.) use `nullOnDelete` — the record survives even if the user is hard-deleted.
 
-**Pivot tables and framework tables** use `cascadeOnDelete` — they are ephemeral metadata.
+**Framework pivot tables** (Spatie role/permission assignments, property_user) use `cascadeOnDelete` — they are ephemeral metadata. Domain pivot tables linking business records (e.g. `lease_tenant`) follow the same strategy as the business records they connect.
 
 The full FK inventory with per-constraint rationale is enforced by `tests/Feature/Schema/ForeignKeyDeleteStrategyTest.php`.
 

--- a/tests/Feature/Schema/ForeignKeyDeleteStrategyTest.php
+++ b/tests/Feature/Schema/ForeignKeyDeleteStrategyTest.php
@@ -1,0 +1,102 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Expected delete strategy for each foreign key.
+ *
+ * Map of [table][column] => strategy.
+ * All app foreign keys are enumerated here.
+ * If a migration changes an FK without updating this test, it will fail.
+ */
+$expected = [
+    // RESTRICT — historical business records, block parent force-delete
+    'leases' => ['unit_id' => 'RESTRICT'],
+    'lease_tenant' => ['lease_id' => 'RESTRICT', 'tenant_id' => 'RESTRICT'],
+    'lease_unit_histories' => ['lease_id' => 'RESTRICT', 'from_unit_id' => 'RESTRICT', 'to_unit_id' => 'RESTRICT'],
+    'reminder_logs' => ['lease_id' => 'RESTRICT'],
+    'tenant_documents' => ['tenant_id' => 'RESTRICT'],
+    'unit_rates' => ['unit_id' => 'RESTRICT'],
+    'maintenance_tickets' => ['property_id' => 'RESTRICT'],
+    'units' => ['property_id' => 'RESTRICT'],
+    'cities' => ['region_id' => 'RESTRICT'],
+
+    // SET NULL — nullable audit/user references, record survives
+    'lease_unit_histories' => ['transferred_by' => 'SET NULL'],
+    'leases' => ['primary_tenant_id' => 'SET NULL', 'unit_rate_id' => 'SET NULL', 'previous_lease_id' => 'SET NULL'],
+    'maintenance_tickets' => ['unit_id' => 'SET NULL', 'assigned_to' => 'SET NULL', 'created_by' => 'SET NULL'],
+    'payments' => ['confirmed_by' => 'SET NULL', 'recorded_by' => 'SET NULL', 'verified_by' => 'SET NULL'],
+    'properties' => ['region_id' => 'SET NULL', 'city_id' => 'SET NULL'],
+    'tenants' => ['user_id' => 'SET NULL'],
+
+    // CASCADE — auth, framework, pivot, dependent content
+    'passkeys' => ['user_id' => 'CASCADE'],
+    'model_has_permissions' => ['permission_id' => 'CASCADE'],
+    'model_has_roles' => ['role_id' => 'CASCADE'],
+    'role_has_permissions' => ['permission_id' => 'CASCADE', 'role_id' => 'CASCADE'],
+    'property_user' => ['user_id' => 'CASCADE', 'property_id' => 'CASCADE'],
+    'payment_proofs' => ['payment_id' => 'CASCADE'],
+];
+
+$appTables = array_keys($expected);
+
+it('every foreign key matches its declared delete strategy', function () use ($expected, $appTables) {
+    $driver = DB::getDriverName();
+    $actual = $driver === 'sqlite' ? loadFkSqlite($appTables) : loadFkPgsql($appTables);
+
+    foreach ($expected as $table => $columns) {
+        foreach ($columns as $column => $expectedStrategy) {
+            $actualStrategy = $actual[$table][$column] ?? null;
+            expect($actualStrategy)
+                ->toBe($expectedStrategy, "{$table}.{$column}: expected {$expectedStrategy}, got {$actualStrategy}");
+        }
+    }
+});
+
+/**
+ * Load FK rules from SQLite via PRAGMA.
+ */
+function loadFkSqlite(array $tables): array
+{
+    $fk = [];
+    foreach ($tables as $table) {
+        $rows = DB::select("PRAGMA foreign_key_list({$table})");
+        foreach ($rows as $row) {
+            $fk[$table][$row->from] = strtoupper($row->on_delete);
+        }
+    }
+
+    return $fk;
+}
+
+/**
+ * Load FK rules from PostgreSQL via information_schema.
+ */
+function loadFkPgsql(array $tables): array
+{
+    $placeholders = implode(', ', array_fill(0, count($tables), '?'));
+    $rows = DB::select("
+        SELECT
+            tc.table_name,
+            kcu.column_name,
+            rc.delete_rule
+        FROM information_schema.table_constraints tc
+        JOIN information_schema.key_column_usage kcu
+            ON tc.constraint_name = kcu.constraint_name
+            AND tc.table_schema = kcu.table_schema
+        JOIN information_schema.referential_constraints rc
+            ON tc.constraint_name = rc.constraint_name
+            AND tc.table_schema = rc.constraint_schema
+        WHERE tc.constraint_type = 'FOREIGN KEY'
+            AND tc.table_schema = 'public'
+            AND tc.table_name IN ({$placeholders})
+        ORDER BY tc.table_name, kcu.column_name
+    ", $tables);
+
+    $fk = [];
+    foreach ($rows as $row) {
+        $fk[$row->table_name][$row->column_name] = $row->delete_rule;
+    }
+
+    return $fk;
+}

--- a/tests/Feature/Schema/ForeignKeyDeleteStrategyTest.php
+++ b/tests/Feature/Schema/ForeignKeyDeleteStrategyTest.php
@@ -11,25 +11,37 @@ use Illuminate\Support\Facades\DB;
  */
 $expected = [
     // RESTRICT — historical business records, block parent force-delete
-    'leases' => ['unit_id' => 'RESTRICT'],
+    'leases' => [
+        'unit_id' => 'RESTRICT',
+        'primary_tenant_id' => 'SET NULL',
+        'unit_rate_id' => 'SET NULL',
+        'previous_lease_id' => 'SET NULL',
+    ],
     'lease_tenant' => ['lease_id' => 'RESTRICT', 'tenant_id' => 'RESTRICT'],
-    'lease_unit_histories' => ['lease_id' => 'RESTRICT', 'from_unit_id' => 'RESTRICT', 'to_unit_id' => 'RESTRICT'],
+    'lease_unit_histories' => [
+        'lease_id' => 'RESTRICT',
+        'from_unit_id' => 'RESTRICT',
+        'to_unit_id' => 'RESTRICT',
+        'transferred_by' => 'SET NULL',
+    ],
     'reminder_logs' => ['lease_id' => 'RESTRICT'],
     'tenant_documents' => ['tenant_id' => 'RESTRICT'],
     'unit_rates' => ['unit_id' => 'RESTRICT'],
-    'maintenance_tickets' => ['property_id' => 'RESTRICT'],
+    'maintenance_tickets' => [
+        'property_id' => 'RESTRICT',
+        'unit_id' => 'SET NULL',
+        'assigned_to' => 'SET NULL',
+        'created_by' => 'SET NULL',
+    ],
     'units' => ['property_id' => 'RESTRICT'],
     'cities' => ['region_id' => 'RESTRICT'],
 
     // SET NULL — nullable audit/user references, record survives
-    'lease_unit_histories' => ['transferred_by' => 'SET NULL'],
-    'leases' => ['primary_tenant_id' => 'SET NULL', 'unit_rate_id' => 'SET NULL', 'previous_lease_id' => 'SET NULL'],
-    'maintenance_tickets' => ['unit_id' => 'SET NULL', 'assigned_to' => 'SET NULL', 'created_by' => 'SET NULL'],
     'payments' => ['confirmed_by' => 'SET NULL', 'recorded_by' => 'SET NULL', 'verified_by' => 'SET NULL'],
     'properties' => ['region_id' => 'SET NULL', 'city_id' => 'SET NULL'],
     'tenants' => ['user_id' => 'SET NULL'],
 
-    // CASCADE — auth, framework, pivot, dependent content
+    // CASCADE — framework pivots, dependent content
     'passkeys' => ['user_id' => 'CASCADE'],
     'model_has_permissions' => ['permission_id' => 'CASCADE'],
     'model_has_roles' => ['role_id' => 'CASCADE'],
@@ -49,6 +61,13 @@ it('every foreign key matches its declared delete strategy', function () use ($e
             $actualStrategy = $actual[$table][$column] ?? null;
             expect($actualStrategy)
                 ->toBe($expectedStrategy, "{$table}.{$column}: expected {$expectedStrategy}, got {$actualStrategy}");
+        }
+    }
+
+    foreach ($actual as $table => $columns) {
+        expect(isset($expected[$table]))->toBeTrue("Unexpected FK entry for table: {$table}");
+        foreach ($columns as $column => $actualStrategy) {
+            expect(isset($expected[$table][$column]))->toBeTrue("Unexpected FK {$table}.{$column}");
         }
     }
 });


### PR DESCRIPTION
12 FKs changed from cascade to restrict, 1 to set null. Adds ForeignKeyDeleteStrategyTest to catch drift.
Documents 4-strategy policy in architecture.md.
Protects against raw QueryException with user-friendly toast.

Closes OPE-60

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/senatroxx/OpenKos/pull/39?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

