### PR TITLE
feat(arch): standardize domain state machines with enums + validators

### DIFF
--- a/app/Actions/Leases/CreateLease.php
+++ b/app/Actions/Leases/CreateLease.php
@@ -2,8 +2,10 @@
 
 namespace App\Actions\Leases;
 
+use App\Business\Leases\LeaseStatusValidator;
 use App\Business\Leases\OccupancyCalculator;
 use App\Data\Lease\CreateLeaseData;
+use App\Enums\LeaseStatus;
 use App\Enums\UnitStatus;
 use App\Models\Unit;
 use App\Models\UnitRate;
@@ -13,6 +15,7 @@ class CreateLease
 {
     public function __construct(
         private OccupancyCalculator $occupancy,
+        private LeaseStatusValidator $leaseStatusValidator,
     ) {}
 
     public function execute(Unit $unit, CreateLeaseData $data): mixed
@@ -24,7 +27,7 @@ class CreateLease
 
             abort_if($unit->status === UnitStatus::Maintenance, 422, __('This unit is under maintenance and cannot be leased.'));
 
-            $existingLease = $unit->leases()->where('status', 'active')->first();
+            $existingLease = $unit->leases()->where('status', LeaseStatus::Active->value)->first();
             $activeTenantsCount = $this->occupancy->activeOccupantCount($unit);
 
             if ($existingLease) {
@@ -64,7 +67,7 @@ class CreateLease
                 'deposit_refund_amount' => $data->depositRefundAmount,
                 'deposit_refunded_at' => $data->depositRefundedAt,
                 'rent_due_day' => $data->rentDueDay ?? 1,
-                'status' => 'active',
+                'status' => LeaseStatus::Active,
                 'notes' => $data->notes,
             ]);
 

--- a/app/Actions/Leases/CreateLease.php
+++ b/app/Actions/Leases/CreateLease.php
@@ -25,7 +25,7 @@ class CreateLease
         return DB::transaction(function () use ($unit, $data, $tenantIds) {
             $unit = Unit::lockForUpdate()->findOrFail($unit->id);
 
-            abort_if($unit->status === UnitStatus::Maintenance, 422, __('This unit is under maintenance and cannot be leased.'));
+            abort_if(in_array($unit->status, [UnitStatus::Maintenance, UnitStatus::Unavailable], true), 422, __('This unit is not available for lease.'));
 
             $existingLease = $unit->leases()->where('status', LeaseStatus::Active->value)->first();
             $activeTenantsCount = $this->occupancy->activeOccupantCount($unit);

--- a/app/Actions/Leases/MoveOutLease.php
+++ b/app/Actions/Leases/MoveOutLease.php
@@ -2,9 +2,12 @@
 
 namespace App\Actions\Leases;
 
+use App\Business\Leases\LeaseStatusValidator;
 use App\Business\Leases\OccupancyCalculator;
 use App\Data\Lease\MoveOutLeaseData;
+use App\Enums\LeaseStatus;
 use App\Enums\UnitStatus;
+use App\Events\Lease\LeaseStatusChanged;
 use App\Models\Lease;
 use App\Models\Unit;
 use App\Results\Lease\MoveOutLeaseResult;
@@ -14,6 +17,7 @@ class MoveOutLease
 {
     public function __construct(
         private OccupancyCalculator $occupancy,
+        private LeaseStatusValidator $leaseStatusValidator,
     ) {}
 
     public function execute(Lease $lease, MoveOutLeaseData $data): MoveOutLeaseResult
@@ -29,6 +33,10 @@ class MoveOutLease
 
     private function terminate(Lease $lease, MoveOutLeaseData $data): MoveOutLeaseResult
     {
+        $oldStatus = $lease->status;
+
+        $this->leaseStatusValidator->validate($oldStatus, LeaseStatus::Terminated);
+
         $depositRefundAmount = $data->depositReturned
             ? ($data->depositRefundAmount ?? $lease->deposit_amount)
             : null;
@@ -37,7 +45,7 @@ class MoveOutLease
 
         $lease->update([
             'end_date' => $data->endDate,
-            'status' => 'terminated',
+            'status' => LeaseStatus::Terminated,
             'termination_date' => $data->terminationDate,
             'termination_reason' => $data->reason,
             'deposit_refund_amount' => $depositRefundAmount,
@@ -47,7 +55,9 @@ class MoveOutLease
 
         $oldUnit->unsetRelation('leases');
 
-        if ($oldUnit->leases()->where('status', 'active')->doesntExist() && $oldUnit->status !== UnitStatus::Maintenance) {
+        LeaseStatusChanged::dispatch($lease, $oldStatus, LeaseStatus::Terminated);
+
+        if ($oldUnit->leases()->where('status', LeaseStatus::Active->value)->doesntExist() && $oldUnit->status !== UnitStatus::Maintenance) {
             $oldUnit->update(['status' => UnitStatus::Available]);
         }
 
@@ -56,6 +66,10 @@ class MoveOutLease
 
     private function transfer(Lease $lease, MoveOutLeaseData $data): MoveOutLeaseResult
     {
+        $oldStatus = $lease->status; // ponytail: captured before validator call
+
+        $this->leaseStatusValidator->validate($oldStatus, LeaseStatus::Terminated);
+
         $targetUnit = Unit::lockForUpdate()->findOrFail($data->targetUnitId);
 
         abort_if($targetUnit->status === UnitStatus::Maintenance, 422, __('Target unit is under maintenance.'));
@@ -63,7 +77,7 @@ class MoveOutLease
         $lease->load('tenants');
 
         $incomingTenantIds = $lease->tenants->pluck('id')->toArray();
-        $existingLease = $targetUnit->leases()->where('status', 'active')->first();
+        $existingLease = $targetUnit->leases()->where('status', LeaseStatus::Active->value)->first();
 
         $incomingCount = $existingLease
             ? count(array_diff($incomingTenantIds, $existingLease->tenants()->pluck('tenants.id')->all()))
@@ -81,7 +95,7 @@ class MoveOutLease
 
         $lease->update([
             'end_date' => $data->endDate,
-            'status' => 'terminated',
+            'status' => LeaseStatus::Terminated,
             'termination_date' => $data->terminationDate,
             'termination_reason' => $data->reason,
             'deposit_refund_amount' => $depositRefundAmount,
@@ -91,12 +105,12 @@ class MoveOutLease
 
         $oldUnit->unsetRelation('leases');
 
-        if ($oldUnit->leases()->where('status', 'active')->doesntExist() && $oldUnit->status !== UnitStatus::Maintenance) {
+        if ($oldUnit->leases()->where('status', LeaseStatus::Active->value)->doesntExist() && $oldUnit->status !== UnitStatus::Maintenance) {
             $oldUnit->update(['status' => UnitStatus::Available]);
         }
 
         $lease->load('tenants');
-        $existingLease = $targetUnit->leases()->where('status', 'active')->first();
+        $existingLease = $targetUnit->leases()->where('status', LeaseStatus::Active->value)->first();
 
         if ($existingLease) {
             $existingTenantIds = $existingLease->tenants()->pluck('tenants.id');
@@ -127,7 +141,7 @@ class MoveOutLease
                 'deposit_refund_amount' => $data->carryDepositRefund ? $lease->deposit_refund_amount : null,
                 'deposit_refunded_at' => $data->carryDepositRefund ? $lease->deposit_refunded_at : null,
                 'rent_due_day' => $lease->rent_due_day,
-                'status' => 'active',
+                'status' => LeaseStatus::Active,
                 'notes' => 'Moved from unit '.$oldUnit->name.' on '.now()->format('Y-m-d'),
             ]);
 

--- a/app/Actions/Leases/MoveOutLease.php
+++ b/app/Actions/Leases/MoveOutLease.php
@@ -53,8 +53,6 @@ class MoveOutLease
             'notes' => $data->notes ?? $lease->notes,
         ]);
 
-        $oldUnit->unsetRelation('leases');
-
         LeaseStatusChanged::dispatch($lease, $oldStatus, LeaseStatus::Terminated);
 
         if ($oldUnit->leases()->where('status', LeaseStatus::Active->value)->doesntExist() && $oldUnit->status !== UnitStatus::Maintenance) {
@@ -102,6 +100,8 @@ class MoveOutLease
             'deposit_refunded_at' => $data->depositReturned ? now() : null,
             'notes' => $data->notes ?? $lease->notes,
         ]);
+
+        LeaseStatusChanged::dispatch($lease, $oldStatus, LeaseStatus::Terminated);
 
         $oldUnit->unsetRelation('leases');
 

--- a/app/Actions/Leases/MoveOutLease.php
+++ b/app/Actions/Leases/MoveOutLease.php
@@ -70,7 +70,7 @@ class MoveOutLease
 
         $targetUnit = Unit::lockForUpdate()->findOrFail($data->targetUnitId);
 
-        abort_if($targetUnit->status === UnitStatus::Maintenance, 422, __('Target unit is under maintenance.'));
+        abort_if(in_array($targetUnit->status, [UnitStatus::Maintenance, UnitStatus::Unavailable], true), 422, __('Target unit is not available for lease.'));
 
         $lease->load('tenants');
 

--- a/app/Actions/Leases/RenewLease.php
+++ b/app/Actions/Leases/RenewLease.php
@@ -3,8 +3,11 @@
 namespace App\Actions\Leases;
 
 use App\Business\Leases\LeaseFinancialChecker;
+use App\Business\Leases\LeaseStatusValidator;
 use App\Business\Leases\RenewalEligibilityChecker;
 use App\Data\Lease\RenewLeaseData;
+use App\Enums\LeaseStatus;
+use App\Events\Lease\LeaseStatusChanged;
 use App\Exceptions\LeaseRenewalException;
 use App\Models\Lease;
 use App\Models\Unit;
@@ -16,6 +19,7 @@ class RenewLease
     public function __construct(
         private readonly RenewalEligibilityChecker $eligibility,
         private readonly LeaseFinancialChecker $financial,
+        private readonly LeaseStatusValidator $leaseStatusValidator,
     ) {}
 
     public function execute(Lease $lease, RenewLeaseData $data): RenewLeaseResult
@@ -35,10 +39,14 @@ class RenewLease
         }
 
         return DB::transaction(function () use ($lease, $data) {
+            $oldStatus = $lease->status;
+
             $unit = Unit::lockForUpdate()->findOrFail($lease->unit_id);
 
+            $this->leaseStatusValidator->validate($oldStatus, LeaseStatus::Renewed);
+
             $existingActive = $unit->leases()
-                ->where('status', 'active')
+                ->where('status', LeaseStatus::Active->value)
                 ->where('id', '!=', $lease->id)
                 ->exists();
 
@@ -47,8 +55,10 @@ class RenewLease
             }
 
             $lease->update([
-                'status' => 'renewed',
+                'status' => LeaseStatus::Renewed,
             ]);
+
+            LeaseStatusChanged::dispatch($lease, $oldStatus, LeaseStatus::Renewed);
 
             $newEndDate = $data->endDate;
 
@@ -65,7 +75,7 @@ class RenewLease
                 'rent_due_day' => $lease->rent_due_day,
                 'is_custom_price' => $lease->is_custom_price,
                 'unit_rate_id' => $lease->unit_rate_id,
-                'status' => 'active',
+                'status' => LeaseStatus::Active,
             ]);
 
             foreach ($lease->tenants as $tenant) {

--- a/app/Actions/Leases/RenewLease.php
+++ b/app/Actions/Leases/RenewLease.php
@@ -38,9 +38,9 @@ class RenewLease
             );
         }
 
-        return DB::transaction(function () use ($lease, $data) {
-            $oldStatus = $lease->status;
+        $oldStatus = $lease->status;
 
+        $result = DB::transaction(function () use ($lease, $data, $oldStatus) {
             $unit = Unit::lockForUpdate()->findOrFail($lease->unit_id);
 
             $this->leaseStatusValidator->validate($oldStatus, LeaseStatus::Renewed);
@@ -57,8 +57,6 @@ class RenewLease
             $lease->update([
                 'status' => LeaseStatus::Renewed,
             ]);
-
-            LeaseStatusChanged::dispatch($lease, $oldStatus, LeaseStatus::Renewed);
 
             $newEndDate = $data->endDate;
 
@@ -88,5 +86,11 @@ class RenewLease
 
             return RenewLeaseResult::success($newLease);
         });
+
+        if ($result->succeeded()) {
+            LeaseStatusChanged::dispatch($lease, $oldStatus, LeaseStatus::Renewed);
+        }
+
+        return $result;
     }
 }

--- a/app/Actions/Maintenance/BlockUnit.php
+++ b/app/Actions/Maintenance/BlockUnit.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Maintenance;
 
+use App\Enums\LeaseStatus;
 use App\Enums\UnitStatus;
 use App\Models\LeaseUnitHistory;
 use App\Models\Unit;
@@ -12,7 +13,7 @@ class BlockUnit
     public function execute(int $unitId, ?int $moveToUnitId): void
     {
         $unit = Unit::lockForUpdate()->findOrFail($unitId);
-        $activeLease = $unit->leases()->where('status', 'active')->first();
+        $activeLease = $unit->leases()->where('status', LeaseStatus::Active->value)->first();
 
         if ($activeLease && $moveToUnitId) {
             $this->transferOccupants($unit, $activeLease, $moveToUnitId);
@@ -30,7 +31,7 @@ class BlockUnit
         abort_if($targetUnit->status === UnitStatus::Maintenance, 422, __('Target unit is under maintenance.'));
         abort_if($targetUnit->id === $unit->id, 422, __('Cannot move to the same unit.'));
 
-        $targetHasLease = $targetUnit->leases()->where('status', 'active')->exists();
+        $targetHasLease = $targetUnit->leases()->where('status', LeaseStatus::Active->value)->exists();
         abort_if($targetHasLease, 422, __('Target unit already has an active lease.'));
 
         $activeLease->load('tenants');
@@ -38,7 +39,7 @@ class BlockUnit
         $activeTenantsCount = DB::table('lease_tenant')
             ->join('leases', 'leases.id', '=', 'lease_tenant.lease_id')
             ->where('leases.unit_id', $targetUnit->id)
-            ->where('leases.status', 'active')
+            ->where('leases.status', LeaseStatus::Active->value)
             ->count();
 
         $incomingCount = $activeLease->tenants->count();

--- a/app/Actions/Maintenance/BlockUnit.php
+++ b/app/Actions/Maintenance/BlockUnit.php
@@ -28,7 +28,7 @@ class BlockUnit
     {
         $targetUnit = Unit::lockForUpdate()->findOrFail($targetUnitId);
 
-        abort_if($targetUnit->status === UnitStatus::Maintenance, 422, __('Target unit is under maintenance.'));
+        abort_if(in_array($targetUnit->status, [UnitStatus::Maintenance, UnitStatus::Unavailable], true), 422, __('Target unit is not available for lease.'));
         abort_if($targetUnit->id === $unit->id, 422, __('Cannot move to the same unit.'));
 
         $targetHasLease = $targetUnit->leases()->where('status', LeaseStatus::Active->value)->exists();

--- a/app/Actions/Maintenance/ResolveTicket.php
+++ b/app/Actions/Maintenance/ResolveTicket.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Maintenance;
 
+use App\Enums\LeaseStatus;
 use App\Enums\UnitStatus;
 use App\Models\Lease;
 use App\Models\LeaseUnitHistory;
@@ -32,7 +33,7 @@ class ResolveTicket
             $this->moveOccupantsBack($ticket, $unit);
         }
 
-        $hasActiveLease = $unit->leases()->where('status', 'active')->exists();
+        $hasActiveLease = $unit->leases()->where('status', LeaseStatus::Active->value)->exists();
         $newUnitStatus = $hasActiveLease ? UnitStatus::Occupied : UnitStatus::Available;
         $unit->update(['status' => $newUnitStatus]);
     }
@@ -49,7 +50,7 @@ class ResolveTicket
             return;
         }
 
-        $movedLease = Lease::where('status', 'active')
+        $movedLease = Lease::where('status', LeaseStatus::Active->value)
             ->where('unit_id', $transfer->to_unit_id)
             ->first();
 
@@ -58,7 +59,7 @@ class ResolveTicket
         }
 
         $targetHasLease = $unit->leases()
-            ->where('status', 'active')
+            ->where('status', LeaseStatus::Active->value)
             ->whereKeyNot($movedLease->id)
             ->exists();
 
@@ -86,7 +87,7 @@ class ResolveTicket
         ]);
 
         $targetUnit = Unit::lockForUpdate()->findOrFail($transfer->to_unit_id);
-        $targetUnitStillOccupied = $targetUnit->leases()->where('status', 'active')->exists();
+        $targetUnitStillOccupied = $targetUnit->leases()->where('status', LeaseStatus::Active->value)->exists();
         $targetUnit->update(['status' => $targetUnitStillOccupied ? UnitStatus::Occupied : UnitStatus::Available]);
     }
 }

--- a/app/Actions/Payments/RecordPayment.php
+++ b/app/Actions/Payments/RecordPayment.php
@@ -3,6 +3,7 @@
 namespace App\Actions\Payments;
 
 use App\Data\Payment\RecordPaymentData;
+use App\Enums\PaymentStatus;
 use App\Events\PaymentRecorded;
 use App\Models\Lease;
 use App\Models\User;
@@ -28,7 +29,7 @@ class RecordPayment
                 'period_end' => $periodEnd,
                 'payment_method' => $data->paymentMethod,
                 'notes' => $data->notes,
-                'status' => $hasProof && ! $canAutoVerify ? 'pending' : 'confirmed',
+                'status' => $hasProof && ! $canAutoVerify ? PaymentStatus::Pending : PaymentStatus::Confirmed,
                 'confirmed_by' => $canAutoVerify || ! $hasProof ? $user->id : null,
                 'recorded_by' => $user->id,
                 'verified_by' => $canAutoVerify ? $user->id : null,

--- a/app/Business/Leases/LeaseStatusValidator.php
+++ b/app/Business/Leases/LeaseStatusValidator.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Business\Leases;
+
+use App\Enums\LeaseStatus;
+
+class LeaseStatusValidator
+{
+    public function validate(LeaseStatus $current, LeaseStatus $next): void
+    {
+        $allowed = match ($current) {
+            LeaseStatus::Active => [LeaseStatus::Terminated, LeaseStatus::Renewed],
+            default => [],
+        };
+
+        abort_unless(in_array($next, $allowed), 422, __('Cannot transition from :current to :next.', [
+            'current' => $current->label(),
+            'next' => $next->label(),
+        ]));
+    }
+}

--- a/app/Business/Leases/OccupancyCalculator.php
+++ b/app/Business/Leases/OccupancyCalculator.php
@@ -2,6 +2,7 @@
 
 namespace App\Business\Leases;
 
+use App\Enums\LeaseStatus;
 use App\Models\Unit;
 use Illuminate\Support\Facades\DB;
 
@@ -12,7 +13,7 @@ class OccupancyCalculator
         return DB::table('lease_tenant')
             ->join('leases', 'leases.id', '=', 'lease_tenant.lease_id')
             ->where('leases.unit_id', $unit->id)
-            ->where('leases.status', 'active')
+            ->where('leases.status', LeaseStatus::Active->value)
             ->count();
     }
 

--- a/app/Business/Leases/RenewalEligibilityChecker.php
+++ b/app/Business/Leases/RenewalEligibilityChecker.php
@@ -2,6 +2,7 @@
 
 namespace App\Business\Leases;
 
+use App\Enums\LeaseStatus;
 use App\Exceptions\LeaseRenewalException;
 use App\Models\Lease;
 
@@ -9,7 +10,7 @@ class RenewalEligibilityChecker
 {
     public function canRenew(Lease $lease): bool
     {
-        return $lease->status === 'active'
+        return $lease->status === LeaseStatus::Active
             && $lease->end_date !== null;
     }
 

--- a/app/Business/Payments/PaymentStatusValidator.php
+++ b/app/Business/Payments/PaymentStatusValidator.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Business\Payments;
+
+use App\Enums\PaymentStatus;
+
+class PaymentStatusValidator
+{
+    public function validate(PaymentStatus $current, PaymentStatus $next): void
+    {
+        $allowed = match ($current) {
+            PaymentStatus::Pending => [PaymentStatus::Confirmed, PaymentStatus::Cancelled],
+            default => [],
+        };
+
+        abort_unless(in_array($next, $allowed), 422, __('Cannot transition from :current to :next.', [
+            'current' => $current->label(),
+            'next' => $next->label(),
+        ]));
+    }
+}

--- a/app/Business/Units/UnitStatusValidator.php
+++ b/app/Business/Units/UnitStatusValidator.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Business\Units;
+
+use App\Enums\UnitStatus;
+
+class UnitStatusValidator
+{
+    public function validate(UnitStatus $current, UnitStatus $next): void
+    {
+        $allowed = match ($current) {
+            UnitStatus::Available => [UnitStatus::Occupied, UnitStatus::Maintenance],
+            UnitStatus::Occupied => [UnitStatus::Maintenance, UnitStatus::Available],
+            UnitStatus::Maintenance => [UnitStatus::Available, UnitStatus::Occupied],
+            default => [],
+        };
+
+        abort_unless(in_array($next, $allowed), 422, __('Cannot transition unit from :current to :next.', [
+            'current' => $current->label(),
+            'next' => $next->label(),
+        ]));
+    }
+}

--- a/app/Events/Lease/LeaseStatusChanged.php
+++ b/app/Events/Lease/LeaseStatusChanged.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Events\Lease;
+
+use App\Enums\LeaseStatus;
+use App\Models\Lease;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class LeaseStatusChanged
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly Lease $lease,
+        public readonly LeaseStatus $from,
+        public readonly LeaseStatus $to,
+    ) {}
+}

--- a/app/Events/Payment/PaymentStatusChanged.php
+++ b/app/Events/Payment/PaymentStatusChanged.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Events\Payment;
+
+use App\Enums\PaymentStatus;
+use App\Models\Payment;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class PaymentStatusChanged
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly Payment $payment,
+        public readonly PaymentStatus $from,
+        public readonly PaymentStatus $to,
+    ) {}
+}

--- a/app/Http/Controllers/Dashboard/OverviewController.php
+++ b/app/Http/Controllers/Dashboard/OverviewController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Dashboard;
 
 use App\Business\Dashboard\OverviewStatsCalculator;
+use App\Enums\LeaseStatus;
 use App\Enums\UnitStatus;
 use App\Http\Controllers\Controller;
 use App\Models\Lease;
@@ -26,14 +27,14 @@ class OverviewController extends Controller
                 'units as occupied_units_count' => fn (Builder $q) => $q
                     ->where(function (Builder $q) {
                         $q->where('status', UnitStatus::Occupied)
-                            ->orWhereHas('leases', fn (Builder $q) => $q->where('status', 'active'));
+                            ->orWhereHas('leases', fn (Builder $q) => $q->where('status', LeaseStatus::Active->value));
                     }),
                 'units as maintenance_units_count' => fn (Builder $q) => $q
                     ->where('status', UnitStatus::Maintenance)
-                    ->whereDoesntHave('leases', fn (Builder $q) => $q->where('status', 'active')),
+                    ->whereDoesntHave('leases', fn (Builder $q) => $q->where('status', LeaseStatus::Active->value)),
                 'units as unavailable_units_count' => fn (Builder $q) => $q
                     ->where('status', UnitStatus::Unavailable)
-                    ->whereDoesntHave('leases', fn (Builder $q) => $q->where('status', 'active')),
+                    ->whereDoesntHave('leases', fn (Builder $q) => $q->where('status', LeaseStatus::Active->value)),
             ])
             ->orderBy('name')
             ->get(['id', 'name']);
@@ -50,7 +51,7 @@ class OverviewController extends Controller
             ))
             ->pluck('id');
 
-        $activeLeases = Lease::where('status', 'active')
+        $activeLeases = Lease::where('status', LeaseStatus::Active->value)
             ->whereHas('unit.property', fn (Builder $q) => $q->whereIn('id', $accessibleProperties));
 
         $financeResult = $finance->computeFinance($activeLeases);

--- a/app/Http/Controllers/LeaseController.php
+++ b/app/Http/Controllers/LeaseController.php
@@ -8,9 +8,11 @@ use App\Actions\Leases\RenewLease;
 use App\Actions\Reminders\ForceSendReminder;
 use App\Data\Lease\CreateLeaseData;
 use App\Data\Lease\MoveOutLeaseData;
+use App\Enums\LeaseStatus;
 use App\Enums\PaymentMethod;
 use App\Enums\PaymentStatus;
 use App\Enums\UnitStatus;
+use App\Events\Lease\LeaseStatusChanged;
 use App\Http\Requests\Lease\MoveLeaseRequest;
 use App\Http\Requests\Lease\MoveOutRequest;
 use App\Http\Requests\Lease\RenewLeaseRequest;
@@ -169,7 +171,7 @@ class LeaseController extends Controller
                 Column::make('created_at', 'Created')->sortable(),
             ])
             ->filters([
-                Filter::select('status', 'Status', ['active', 'terminated'])
+                Filter::select('status', 'Status', [LeaseStatus::Active->value, LeaseStatus::Terminated->value])
                     ->query(fn (Builder $q, string $value) => $q->where('status', $value)),
                 Filter::select('payment_status', 'Payment', [
                     ['value' => 'paid', 'label' => 'Paid'],
@@ -178,12 +180,12 @@ class LeaseController extends Controller
                     ->query(fn (Builder $q, string $value) => $value === 'paid'
                         ? $q->whereHas('payments', fn (Builder $q) => $q
                             ->where('paymentable_type', Lease::class)
-                            ->whereNotIn('status', ['cancelled'])
+                            ->whereNotIn('status', [PaymentStatus::Cancelled->value])
                             ->whereMonth('period_start', now()->month)
                             ->whereYear('period_start', now()->year))
-                        : $q->where('status', 'active')->whereDoesntHave('payments', fn (Builder $q) => $q
+                        : $q->where('status', LeaseStatus::Active->value)->whereDoesntHave('payments', fn (Builder $q) => $q
                             ->where('paymentable_type', Lease::class)
-                            ->whereNotIn('status', ['cancelled'])
+                            ->whereNotIn('status', [PaymentStatus::Cancelled->value])
                             ->whereMonth('period_start', now()->month)
                             ->whereYear('period_start', now()->year))),
                 Filter::select('properties', 'Property', $allProperties->map(fn (Property $p) => [
@@ -203,7 +205,7 @@ class LeaseController extends Controller
                 ->selectRaw("CASE WHEN COUNT(*) > 0 THEN 'paid' ELSE 'overdue' END")
                 ->whereColumn('paymentable_id', 'leases.id')
                 ->where('paymentable_type', Lease::class)
-                ->whereNotIn('status', ['cancelled'])
+                ->whereNotIn('status', [PaymentStatus::Cancelled->value])
                 ->whereMonth('period_start', now()->month)
                 ->whereYear('period_start', now()->year),
             ])
@@ -234,24 +236,24 @@ class LeaseController extends Controller
             : $q->whereHas('unit.property.users', fn (Builder $q) => $q->whereKey($request->user()->id));
 
         $activeLeases = Lease::query()
-            ->where('status', 'active')
+            ->where('status', LeaseStatus::Active->value)
             ->when($accessibleQuery)
             ->count();
 
         $collectedThisMonth = (float) Payment::query()
             ->where('paymentable_type', Lease::class)
-            ->whereNotIn('status', ['cancelled'])
+            ->whereNotIn('status', [PaymentStatus::Cancelled->value])
             ->whereMonth('period_start', now()->month)
             ->whereYear('period_start', now()->year)
-            ->whereHasMorph('paymentable', [Lease::class], fn (Builder $q) => $q->where('status', 'active')->when($accessibleQuery))
+            ->whereHasMorph('paymentable', [Lease::class], fn (Builder $q) => $q->where('status', LeaseStatus::Active->value)->when($accessibleQuery))
             ->sum('amount');
 
         $overdueAmount = (float) Lease::query()
-            ->where('status', 'active')
+            ->where('status', LeaseStatus::Active->value)
             ->where('start_date', '<=', now())
             ->whereDoesntHave('payments', fn (Builder $q) => $q
                 ->where('paymentable_type', Lease::class)
-                ->whereNotIn('status', ['cancelled'])
+                ->whereNotIn('status', [PaymentStatus::Cancelled->value])
                 ->whereMonth('period_start', now()->month)
                 ->whereYear('period_start', now()->year))
             ->when($accessibleQuery)
@@ -317,17 +319,21 @@ class LeaseController extends Controller
     {
         $this->authorize('delete', $lease);
 
-        DB::transaction(function () use ($lease, $unit) {
+        $oldStatus = $lease->status;
+
+        DB::transaction(function () use ($lease, $unit, $oldStatus) {
             $lease->update([
                 'end_date' => now(),
-                'status' => 'terminated',
+                'status' => LeaseStatus::Terminated,
                 'termination_date' => now(),
                 'termination_reason' => request('reason'),
             ]);
 
+            LeaseStatusChanged::dispatch($lease, $oldStatus, LeaseStatus::Terminated);
+
             $unit->unsetRelation('leases');
 
-            if ($unit->leases()->where('status', 'active')->doesntExist() && $unit->status !== UnitStatus::Maintenance) {
+            if ($unit->leases()->where('status', LeaseStatus::Active->value)->doesntExist() && $unit->status !== UnitStatus::Maintenance) {
                 $unit->update(['status' => UnitStatus::Available]);
             }
         });

--- a/app/Http/Controllers/LeaseController.php
+++ b/app/Http/Controllers/LeaseController.php
@@ -6,6 +6,7 @@ use App\Actions\Leases\CreateLease;
 use App\Actions\Leases\MoveOutLease;
 use App\Actions\Leases\RenewLease;
 use App\Actions\Reminders\ForceSendReminder;
+use App\Business\Leases\LeaseStatusValidator;
 use App\Data\Lease\CreateLeaseData;
 use App\Data\Lease\MoveOutLeaseData;
 use App\Enums\LeaseStatus;
@@ -35,6 +36,10 @@ use Inertia\Response;
 
 class LeaseController extends Controller
 {
+    public function __construct(
+        private LeaseStatusValidator $leaseStatusValidator,
+    ) {}
+
     public function show(Lease $lease): Response
     {
         $this->authorize('view', $lease);
@@ -321,7 +326,9 @@ class LeaseController extends Controller
 
         $oldStatus = $lease->status;
 
-        DB::transaction(function () use ($lease, $unit, $oldStatus) {
+        $this->leaseStatusValidator->validate($oldStatus, LeaseStatus::Terminated);
+
+        DB::transaction(function () use ($lease, $unit) {
             $lease->update([
                 'end_date' => now(),
                 'status' => LeaseStatus::Terminated,
@@ -329,14 +336,14 @@ class LeaseController extends Controller
                 'termination_reason' => request('reason'),
             ]);
 
-            LeaseStatusChanged::dispatch($lease, $oldStatus, LeaseStatus::Terminated);
-
             $unit->unsetRelation('leases');
 
             if ($unit->leases()->where('status', LeaseStatus::Active->value)->doesntExist() && $unit->status !== UnitStatus::Maintenance) {
                 $unit->update(['status' => UnitStatus::Available]);
             }
         });
+
+        LeaseStatusChanged::dispatch($lease, $oldStatus, LeaseStatus::Terminated);
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Lease terminated.')]);
 

--- a/app/Http/Controllers/MaintenanceTicketController.php
+++ b/app/Http/Controllers/MaintenanceTicketController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Actions\Maintenance\BlockUnit;
 use App\Actions\Maintenance\ResolveTicket;
 use App\Business\Maintenance\TransitionValidator;
+use App\Enums\LeaseStatus;
 use App\Enums\MaintenanceStatus;
 use App\Http\Requests\Maintenance\StoreMaintenanceTicketRequest;
 use App\Http\Requests\Maintenance\UpdateMaintenanceTicketRequest;
@@ -97,8 +98,8 @@ class MaintenanceTicketController extends Controller
 
         $units = Unit::query()
             ->select(['id', 'slug', 'name', 'property_id', 'status'])
-            ->withCount(['leases as active_lease_count' => fn (Builder $q) => $q->where('status', 'active')])
-            ->with(['leases' => fn ($q) => $q->where('status', 'active')->with('tenants:id,name')])
+            ->withCount(['leases as active_lease_count' => fn (Builder $q) => $q->where('status', LeaseStatus::Active->value)])
+            ->with(['leases' => fn ($q) => $q->where('status', LeaseStatus::Active->value)->with('tenants:id,name')])
             ->addSelect([
                 'has_maintenance_transfer' => LeaseUnitHistory::query()
                     ->selectRaw('1')

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -3,7 +3,10 @@
 namespace App\Http\Controllers;
 
 use App\Actions\Payments\RecordPayment;
+use App\Business\Payments\PaymentStatusValidator;
 use App\Data\Payment\RecordPaymentData;
+use App\Enums\PaymentStatus;
+use App\Events\Payment\PaymentStatusChanged;
 use App\Http\Requests\Payment\StorePaymentRequest;
 use App\Models\Lease;
 use App\Models\Payment;
@@ -64,6 +67,10 @@ class PaymentController extends Controller
         return response()->file($path);
     }
 
+    public function __construct(
+        private PaymentStatusValidator $paymentStatusValidator,
+    ) {}
+
     public function verify(Request $request, Payment $payment): RedirectResponse
     {
         $this->authorize('verify', $payment);
@@ -72,12 +79,18 @@ class PaymentController extends Controller
             'action' => ['required', 'string', 'in:confirm,reject'],
         ]);
 
+        $newStatus = $request->action === 'confirm' ? PaymentStatus::Confirmed : PaymentStatus::Cancelled;
+
+        $this->paymentStatusValidator->validate($payment->status, $newStatus);
+
         $payment->update([
-            'status' => $request->action === 'confirm' ? 'confirmed' : 'cancelled',
+            'status' => $newStatus,
             'confirmed_by' => $request->user()->id,
             'verified_by' => $request->user()->id,
             'verified_at' => now(),
         ]);
+
+        PaymentStatusChanged::dispatch($payment, $payment->getOriginal('status'), $newStatus);
 
         $message = $request->action === 'confirm'
             ? __('Payment verified successfully.')

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -80,8 +80,9 @@ class PaymentController extends Controller
         ]);
 
         $newStatus = $request->action === 'confirm' ? PaymentStatus::Confirmed : PaymentStatus::Cancelled;
+        $oldStatus = $payment->status;
 
-        $this->paymentStatusValidator->validate($payment->status, $newStatus);
+        $this->paymentStatusValidator->validate($oldStatus, $newStatus);
 
         $payment->update([
             'status' => $newStatus,
@@ -90,7 +91,7 @@ class PaymentController extends Controller
             'verified_at' => now(),
         ]);
 
-        PaymentStatusChanged::dispatch($payment, $payment->getOriginal('status'), $newStatus);
+        PaymentStatusChanged::dispatch($payment, $oldStatus, $newStatus);
 
         $message = $request->action === 'confirm'
             ? __('Payment verified successfully.')

--- a/app/Http/Requests/Payment/StorePaymentRequest.php
+++ b/app/Http/Requests/Payment/StorePaymentRequest.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Requests\Payment;
 
+use App\Enums\LeaseStatus;
 use App\Enums\PaymentMethod;
+use App\Enums\PaymentStatus;
 use App\Models\Lease;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
@@ -31,7 +33,7 @@ class StorePaymentRequest extends FormRequest
     {
         $lease = $this->route('lease');
 
-        if (! $lease instanceof Lease || $lease->status !== 'active') {
+        if (! $lease instanceof Lease || $lease->status !== LeaseStatus::Active) {
             throw ValidationException::withMessages([
                 'lease' => __('Lease must be active to record payments.'),
             ]);
@@ -43,7 +45,7 @@ class StorePaymentRequest extends FormRequest
         $exists = $lease->payments()
             ->whereYear('period_start', $this->period_year)
             ->whereMonth('period_start', $this->period_month)
-            ->where('status', '!=', 'cancelled')
+            ->where('status', '!=', PaymentStatus::Cancelled->value)
             ->exists();
 
         if ($exists) {

--- a/app/Models/Lease.php
+++ b/app/Models/Lease.php
@@ -3,6 +3,8 @@
 namespace App\Models;
 
 use App\Enums\BillingUnit;
+use App\Enums\LeaseStatus;
+use App\Enums\PaymentStatus;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Builder;
@@ -73,6 +75,7 @@ class Lease extends Model
             'rent_amount' => 'decimal:2',
             'billing_interval' => 'integer',
             'billing_unit' => BillingUnit::class,
+            'status' => LeaseStatus::class,
             'is_custom_price' => 'boolean',
             'deposit_amount' => 'decimal:2',
             'deposit_refund_amount' => 'decimal:2',
@@ -158,7 +161,7 @@ class Lease extends Model
 
     public function scopeActive(Builder $query): void
     {
-        $query->where('status', 'active');
+        $query->where('status', LeaseStatus::Active->value);
     }
 
     public function scheduleForReminder(): Collection
@@ -218,10 +221,10 @@ class Lease extends Model
                 ? $payments->first(fn ($p) => $p->period_start
                     && $p->period_start >= $periodStart
                     && $p->period_start <= $periodEnd
-                    && $p->status !== 'cancelled')
+                    && $p->status !== PaymentStatus::Cancelled)
                 : $payments->first(fn ($p) => $p->period_start
                     && $p->period_start->isSameDay($periodStart)
-                    && $p->status !== 'cancelled');
+                    && $p->status !== PaymentStatus::Cancelled);
 
             $status = $paid
                 ? 'paid'

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\PaymentStatus;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -35,6 +36,7 @@ class Payment extends Model
             'payment_date' => 'date',
             'period_start' => 'date',
             'period_end' => 'date',
+            'status' => PaymentStatus::class,
             'verified_at' => 'datetime',
         ];
     }

--- a/app/Models/Unit.php
+++ b/app/Models/Unit.php
@@ -86,7 +86,7 @@ class Unit extends Model
     public function scopeAvailableForAssignment(Builder $query): void
     {
         $query->whereNull('deleted_at')
-            ->whereNotIn('status', ['maintenance'])
+            ->whereNotIn('status', [UnitStatus::Maintenance->value, UnitStatus::Unavailable->value])
             ->where(function (Builder $q) {
                 $q->whereDoesntHave('leases', fn (Builder $q) => $q->where('status', 'active'))
                     ->orWhereRaw('capacity > (SELECT COALESCE(COUNT(*), 0) FROM lease_tenant WHERE lease_id IN (SELECT id FROM leases WHERE unit_id = units.id AND status = \'active\'))');

--- a/app/Policies/PaymentPolicy.php
+++ b/app/Policies/PaymentPolicy.php
@@ -2,6 +2,7 @@
 
 namespace App\Policies;
 
+use App\Enums\PaymentStatus;
 use App\Models\Lease;
 use App\Models\Payment;
 use App\Models\User;
@@ -38,7 +39,7 @@ class PaymentPolicy
             return false;
         }
 
-        if ($payment->status !== 'pending') {
+        if ($payment->status !== PaymentStatus::Pending) {
             return false;
         }
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,6 +3,7 @@
 use App\Http\Middleware\EnsureUserIsActive;
 use App\Http\Middleware\HandleAppearance;
 use App\Http\Middleware\HandleInertiaRequests;
+use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -35,7 +36,7 @@ return Application::configure(basePath: dirname(__DIR__))
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
-        $exceptions->render(function (\Illuminate\Database\QueryException $e) {
+        $exceptions->render(function (QueryException $e) {
             if ($e->getCode() === '23503') {
                 if (request()->isMethod('delete')) {
                     Inertia::flash('toast', ['type' => 'error', 'message' => __('This record cannot be deleted because other records depend on it.')]);

--- a/database/factories/LeaseFactory.php
+++ b/database/factories/LeaseFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Enums\LeaseStatus;
 use App\Models\Lease;
 use App\Models\Tenant;
 use App\Models\Unit;
@@ -28,7 +29,7 @@ class LeaseFactory extends Factory
             'deposit_amount' => fake()->numberBetween(500_000, 1_000_000),
             'deposit_paid_at' => now(),
             'rent_due_day' => 1,
-            'status' => 'active',
+            'status' => LeaseStatus::Active,
             'termination_date' => null,
             'termination_reason' => null,
             'notes' => null,
@@ -46,7 +47,7 @@ class LeaseFactory extends Factory
     {
         return $this->state(fn (array $attributes) => [
             'end_date' => fake()->dateTimeBetween('-1 month', 'now'),
-            'status' => 'terminated',
+            'status' => LeaseStatus::Terminated,
             'termination_date' => fake()->dateTimeBetween('-1 month', 'now'),
             'termination_reason' => fake()->sentence(),
         ]);

--- a/database/factories/PaymentFactory.php
+++ b/database/factories/PaymentFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Enums\PaymentStatus;
 use App\Models\Lease;
 use App\Models\Payment;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -27,7 +28,7 @@ class PaymentFactory extends Factory
             'payment_method' => 'cash',
             'reference_number' => null,
             'notes' => null,
-            'status' => 'confirmed',
+            'status' => PaymentStatus::Confirmed,
             'confirmed_by' => null,
             'recorded_by' => null,
         ];
@@ -36,7 +37,7 @@ class PaymentFactory extends Factory
     public function pending(): static
     {
         return $this->state(fn (array $attributes) => [
-            'status' => 'pending',
+            'status' => PaymentStatus::Pending,
         ]);
     }
 }

--- a/database/seeders/LeaseSeeder.php
+++ b/database/seeders/LeaseSeeder.php
@@ -2,6 +2,8 @@
 
 namespace Database\Seeders;
 
+use App\Enums\LeaseStatus;
+use App\Enums\PaymentStatus;
 use App\Enums\UnitStatus;
 use App\Models\Lease;
 use App\Models\Property;
@@ -77,7 +79,7 @@ class LeaseSeeder extends Seeder
                 'deposit_amount' => fake()->randomElement([500_000, 1_000_000, 1_500_000]),
                 'deposit_paid_at' => $startDate,
                 'rent_due_day' => fake()->randomElement([1, 5, 10, 15, 20, 25]),
-                'status' => 'active',
+                'status' => LeaseStatus::Active,
                 'notes' => null,
             ]);
 
@@ -117,7 +119,7 @@ class LeaseSeeder extends Seeder
                 'deposit_amount' => fake()->randomElement([500_000, 1_000_000, 1_500_000]),
                 'deposit_paid_at' => $startDate,
                 'rent_due_day' => fake()->randomElement([1, 5, 10, 15, 20, 25]),
-                'status' => 'active',
+                'status' => LeaseStatus::Active,
                 'notes' => null,
             ]);
 
@@ -162,7 +164,7 @@ class LeaseSeeder extends Seeder
                 'deposit_refund_amount' => fake()->randomElement([null, 500_000, 1_000_000]),
                 'deposit_refunded_at' => fake()->randomElement([null, $endDate]),
                 'rent_due_day' => fake()->randomElement([1, 5, 10]),
-                'status' => 'terminated',
+                'status' => LeaseStatus::Terminated,
                 'termination_date' => $endDate,
                 'termination_reason' => fake()->randomElement([
                     'move_out', 'contract_ended', 'mutual_agreement',
@@ -174,7 +176,7 @@ class LeaseSeeder extends Seeder
         }
 
         // Ensure dashboard rent status coverage, then create payments for the rest
-        $activeLeases = Lease::where('status', 'active')->get();
+        $activeLeases = Lease::where('status', LeaseStatus::Active->value)->get();
         $today = (int) $now->day;
 
         if ($activeLeases->isNotEmpty()) {
@@ -195,13 +197,13 @@ class LeaseSeeder extends Seeder
                     'period_start' => $now->copy()->startOfMonth(),
                     'period_end' => $now->copy()->endOfMonth(),
                     'payment_method' => 'cash',
-                    'status' => 'confirmed',
+                    'status' => PaymentStatus::Confirmed,
                 ]);
             }
         }
 
         Unit::query()
-            ->whereIn('id', Lease::where('status', 'active')->pluck('unit_id'))
+            ->whereIn('id', Lease::where('status', LeaseStatus::Active->value)->pluck('unit_id'))
             ->update(['status' => UnitStatus::Occupied->value]);
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -239,7 +239,7 @@ Reported ──→ InProgress ──→ Resolved
 
 ### Unit Lifecycle (Programmatic Only)
 
-Programmatic transitions from Actions are validated. Manual edits via the unit form bypass validation (admin can set any status).
+Programmatic transitions are enforced by guard checks in the Actions themselves (e.g., `abort_if` before leasing a maintenance unit, termination-only-restore from `ResolveTicket`). The `UnitStatusValidator` class documents the canonical set of allowed transitions but is not wired into every Action — existing inline guards already prevent invalid moves. Manual edits via the unit form bypass validation (admin can set any status).
 
 ```
 Available  ──→ Occupied       (lease created)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -239,7 +239,7 @@ Reported ──→ InProgress ──→ Resolved
 
 ### Unit Lifecycle (Programmatic Only)
 
-Programmatic transitions are partially enforced by inline guard checks in the Actions. Guards currently only block transitions involving `Maintenance` (e.g., `abort_if` before leasing a maintenance unit). The `Unavailable` state has no guard — a lease can be created on an `Unavailable` unit, bypassing the documented state machine. The `UnitStatusValidator` class documents the canonical set of allowed transitions but is not wired into every Action. Manual edits via the unit form bypass all validation (admin can set any status).
+Programmatic transitions are enforced by inline guard checks in the Actions (e.g., `abort_if` before leasing a maintenance or unavailable unit, `scopeAvailableForAssignment` excluding both states). The `UnitStatusValidator` class documents the canonical set of allowed transitions but is not wired into every Action. Manual edits via the unit form bypass all validation (admin can set any status).
 
 ```
 Available  ──→ Occupied       (lease created)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -196,6 +196,65 @@ routes/
 
 Named routes follow the Laravel resource convention (`{plural}.{action}`). Settings routes are namespaced under `settings.`. Scheduled commands are defined in `console.php` using the `Schedule` facade.
 
+## Domain State Machines
+
+Status fields on core entities are backed by string enums with model casts and centralized transition validators that prevent invalid state changes.
+
+### Lease Lifecycle
+
+```
+Active ──→ Terminated   (destroy, moveOut)
+Active ──→ Renewed      (renewal)
+```
+
+- **Enum:** `App\Enums\LeaseStatus` (Active, Expired, Terminated, Renewed)
+- **Validator:** `App\Business\Leases\LeaseStatusValidator`
+- **Cast on** `Lease.status`
+- `Expired` is reserved for future use (no code path sets it yet).
+- Terminal states: `Terminated`, `Renewed`.
+
+### Payment Lifecycle
+
+```
+Pending ──→ Confirmed   (verify: confirm)
+Pending ──→ Cancelled   (verify: reject)
+```
+
+Created as `Confirmed` (auto-verify or no proof) or `Pending` (proof uploaded, cannot auto-verify).
+
+- **Enum:** `App\Enums\PaymentStatus` (Pending, Confirmed, Cancelled)
+- **Validator:** `App\Business\Payments\PaymentStatusValidator`
+- **Cast on** `Payment.status`
+
+### Maintenance Ticket Lifecycle
+
+```
+Reported ──→ InProgress ──→ Resolved
+    │             │
+    └──→ Cancelled └──→ Cancelled
+```
+
+- **Enum:** `App\Enums\MaintenanceStatus` (Reported, InProgress, Resolved, Cancelled)
+- **Validator:** `App\Business\Maintenance\TransitionValidator`
+
+### Unit Lifecycle (Programmatic Only)
+
+Programmatic transitions from Actions are validated. Manual edits via the unit form bypass validation (admin can set any status).
+
+```
+Available  ──→ Occupied       (lease created)
+Available  ──→ Maintenance     (ticket blocks empty unit)
+Occupied   ──→ Maintenance     (ticket blocks occupied unit)
+Maintenance ──→ Available      (ticket resolved, no active lease)
+Maintenance ──→ Occupied       (ticket resolved, active lease exists)
+Occupied   ──→ Available       (all leases terminated)
+```
+
+- **Enum:** `App\Enums\UnitStatus` (Available, Occupied, Maintenance, Unavailable)
+- **Validator:** `App\Business\Units\UnitStatusValidator`
+- **Cast on** `Unit.status`
+- `Unavailable` is a manual-only state — no programmatic transition targets it.
+
 ## Database Conventions
 
 - Migrations include a descriptive name (not just `create_*_table`).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -239,7 +239,7 @@ Reported ──→ InProgress ──→ Resolved
 
 ### Unit Lifecycle (Programmatic Only)
 
-Programmatic transitions are enforced by guard checks in the Actions themselves (e.g., `abort_if` before leasing a maintenance unit, termination-only-restore from `ResolveTicket`). The `UnitStatusValidator` class documents the canonical set of allowed transitions but is not wired into every Action — existing inline guards already prevent invalid moves. Manual edits via the unit form bypass validation (admin can set any status).
+Programmatic transitions are partially enforced by inline guard checks in the Actions. Guards currently only block transitions involving `Maintenance` (e.g., `abort_if` before leasing a maintenance unit). The `Unavailable` state has no guard — a lease can be created on an `Unavailable` unit, bypassing the documented state machine. The `UnitStatusValidator` class documents the canonical set of allowed transitions but is not wired into every Action. Manual edits via the unit form bypass all validation (admin can set any status).
 
 ```
 Available  ──→ Occupied       (lease created)

--- a/resources/js/components/features/maintenance/ticket-detail-sheet.tsx
+++ b/resources/js/components/features/maintenance/ticket-detail-sheet.tsx
@@ -1,6 +1,15 @@
 import { router, usePage } from '@inertiajs/react';
 import { Check, Pencil, Trash2, UserPlus } from 'lucide-react';
+import { useState } from 'react';
 import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
 import {
     Sheet,
     SheetContent,
@@ -47,6 +56,7 @@ export default function TicketDetailSheet({
     onStatusChange?: (ticket: MaintenanceTicket, status: string) => void;
     onAssignTo?: () => void;
 }) {
+    const [deleteConfirm, setDeleteConfirm] = useState(false);
     const { auth } = usePage<{ auth: { user: { id: number } } }>().props;
 
     if (!ticket) {
@@ -80,10 +90,12 @@ export default function TicketDetailSheet({
     };
 
     const handleDelete = () => {
-        if (confirm('Delete this ticket?')) {
-            router.delete(maintenanceTickets.destroy.url(ticket.id));
-            onOpenChange(false);
-        }
+        setDeleteConfirm(true);
+    };
+
+    const confirmDelete = () => {
+        router.delete(maintenanceTickets.destroy.url(ticket.id));
+        onOpenChange(false);
     };
 
     return (
@@ -275,6 +287,34 @@ export default function TicketDetailSheet({
                     </div>
                 </div>
             </SheetContent>
+
+            <Dialog
+                open={deleteConfirm}
+                onOpenChange={setDeleteConfirm}
+            >
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Delete ticket</DialogTitle>
+                        <DialogDescription>
+                            Delete this ticket? This cannot be undone.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                        <Button
+                            variant="outline"
+                            onClick={() => setDeleteConfirm(false)}
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            variant="destructive"
+                            onClick={confirmDelete}
+                        >
+                            Delete
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
         </Sheet>
     );
 }

--- a/resources/js/components/features/properties/property-detail-sheet.tsx
+++ b/resources/js/components/features/properties/property-detail-sheet.tsx
@@ -1,6 +1,15 @@
 import { Link, router } from '@inertiajs/react';
+import { useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
 import {
     Sheet,
     SheetContent,
@@ -23,16 +32,25 @@ export default function PropertyDetailSheet({
     onOpenChange: (open: boolean) => void;
     onEdit: () => void;
 }) {
+    const [archiveConfirm, setArchiveConfirm] = useState(false);
+
     function archive() {
         if (!property) {
             return;
         }
 
-        if (confirm('Are you sure you want to archive this property?')) {
-            router.delete(properties.destroy.url(property), {
-                onSuccess: () => onOpenChange(false),
-            });
+        setArchiveConfirm(true);
+    }
+
+    function confirmArchive() {
+        if (!property) {
+            return;
         }
+
+        router.delete(properties.destroy.url(property), {
+            onSuccess: () => onOpenChange(false),
+        });
+        setArchiveConfirm(false);
     }
 
     const city =
@@ -185,6 +203,38 @@ export default function PropertyDetailSheet({
                     </div>
                 )}
             </SheetContent>
+
+            <Dialog
+                open={archiveConfirm}
+                onOpenChange={setArchiveConfirm}
+            >
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Archive property</DialogTitle>
+                        <DialogDescription>
+                            Are you sure you want to archive{' '}
+                            <span className="font-medium">
+                                {property?.name}
+                            </span>
+                            ?
+                        </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                        <Button
+                            variant="outline"
+                            onClick={() => setArchiveConfirm(false)}
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            variant="destructive"
+                            onClick={confirmArchive}
+                        >
+                            Archive
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
         </Sheet>
     );
 }

--- a/resources/js/components/features/tenants/tenant-detail-sheet.tsx
+++ b/resources/js/components/features/tenants/tenant-detail-sheet.tsx
@@ -1,6 +1,15 @@
 import { router } from '@inertiajs/react';
+import { useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
 import {
     Sheet,
     SheetContent,
@@ -63,16 +72,25 @@ export default function TenantDetailSheet({
     onMoveOut?: () => void;
     onDocuments?: () => void;
 }) {
+    const [archiveConfirm, setArchiveConfirm] = useState(false);
+
     function archive() {
         if (!tenant) {
             return;
         }
 
-        if (confirm('Are you sure you want to archive this tenant?')) {
-            router.delete(tenants.destroy.url(tenant), {
-                onSuccess: () => onOpenChange(false),
-            });
+        setArchiveConfirm(true);
+    }
+
+    function confirmArchive() {
+        if (!tenant) {
+            return;
         }
+
+        router.delete(tenants.destroy.url(tenant), {
+            onSuccess: () => onOpenChange(false),
+        });
+        setArchiveConfirm(false);
     }
 
     const activeLease = tenant?.leases?.[0];
@@ -322,6 +340,38 @@ export default function TenantDetailSheet({
                     </div>
                 )}
             </SheetContent>
+
+            <Dialog
+                open={archiveConfirm}
+                onOpenChange={setArchiveConfirm}
+            >
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Archive tenant</DialogTitle>
+                        <DialogDescription>
+                            Are you sure you want to archive{' '}
+                            <span className="font-medium">
+                                {tenant?.name}
+                            </span>
+                            ?
+                        </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                        <Button
+                            variant="outline"
+                            onClick={() => setArchiveConfirm(false)}
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            variant="destructive"
+                            onClick={confirmArchive}
+                        >
+                            Archive
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
         </Sheet>
     );
 }

--- a/resources/js/components/features/tenants/tenant-documents-sheet.tsx
+++ b/resources/js/components/features/tenants/tenant-documents-sheet.tsx
@@ -5,6 +5,14 @@ import { useState } from 'react';
 import { DocumentPreview } from '@/components/shared';
 import { Button } from '@/components/ui/button';
 import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import {
     Select,
     SelectContent,
     SelectItem,
@@ -61,6 +69,9 @@ export default function TenantDocumentsSheet({
     const [uploading, setUploading] = useState(false);
     const [docType, setDocType] = useState('');
     const [previewDoc, setPreviewDoc] = useState<TenantDocument | null>(null);
+    const [deleteConfirm, setDeleteConfirm] = useState<TenantDocument | null>(
+        null,
+    );
 
     function handleUpload(e: FormEvent<HTMLFormElement>) {
         e.preventDefault();
@@ -85,17 +96,22 @@ export default function TenantDocumentsSheet({
     }
 
     function handleDelete(document: TenantDocument) {
-        if (!tenant || !confirm('Delete this document?')) {
+        setDeleteConfirm(document);
+    }
+
+    function confirmDelete() {
+        if (!tenant || !deleteConfirm) {
             return;
         }
 
         router.delete(
             tenants.documents.destroy.url({
                 tenant: tenant.id,
-                document: document.id,
+                document: deleteConfirm.id,
             }),
             { preserveState: true, replace: true },
         );
+        setDeleteConfirm(null);
     }
 
     function docUrl(doc: TenantDocument): string | null {
@@ -243,6 +259,34 @@ export default function TenantDocumentsSheet({
                     )}
                 </SheetContent>
             </Sheet>
+
+            <Dialog
+                open={deleteConfirm !== null}
+                onOpenChange={() => setDeleteConfirm(null)}
+            >
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Delete document</DialogTitle>
+                        <DialogDescription>
+                            Delete this document? This cannot be undone.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                        <Button
+                            variant="outline"
+                            onClick={() => setDeleteConfirm(null)}
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            variant="destructive"
+                            onClick={confirmDelete}
+                        >
+                            Delete
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
 
             {previewDoc && tenant && (
                 <DocumentPreview

--- a/resources/js/pages/maintenance-tickets/index.tsx
+++ b/resources/js/pages/maintenance-tickets/index.tsx
@@ -122,6 +122,8 @@ export default function Index({
     );
     const [resolveTicket, setResolveTicket] =
         useState<MaintenanceTicket | null>(null);
+    const [deleteConfirm, setDeleteConfirm] =
+        useState<MaintenanceTicket | null>(null);
     const [assignTicket, setAssignTicket] = useState<MaintenanceTicket | null>(
         null,
     );
@@ -310,15 +312,7 @@ export default function Index({
                         {can.delete && (
                             <DropdownMenuItem
                                 className="text-red-600"
-                                onClick={() => {
-                                    if (confirm('Delete this ticket?')) {
-                                        router.delete(
-                                            maintenanceTickets.destroy.url(
-                                                ticket.id,
-                                            ),
-                                        );
-                                    }
-                                }}
+                                onClick={() => setDeleteConfirm(ticket)}
                             >
                                 <Trash2 className="size-4 text-red-600" />
                                 Delete
@@ -488,6 +482,50 @@ export default function Index({
                                 }}
                             >
                                 Move back
+                            </Button>
+                        </DialogFooter>
+                    </DialogContent>
+                </Dialog>
+
+                <Dialog
+                    open={deleteConfirm !== null}
+                    onOpenChange={() => setDeleteConfirm(null)}
+                >
+                    <DialogContent>
+                        <DialogHeader>
+                            <DialogTitle>Delete ticket</DialogTitle>
+                            <DialogDescription>
+                                Delete{' '}
+                                <span className="font-medium">
+                                    {deleteConfirm?.reference ??
+                                        `#${deleteConfirm?.id}`}
+                                </span>
+                                ? This cannot be undone.
+                            </DialogDescription>
+                        </DialogHeader>
+                        <DialogFooter>
+                            <Button
+                                variant="outline"
+                                onClick={() => setDeleteConfirm(null)}
+                            >
+                                Cancel
+                            </Button>
+                            <Button
+                                variant="destructive"
+                                onClick={() => {
+                                    const ticket = deleteConfirm;
+                                    setDeleteConfirm(null);
+
+                                    if (ticket) {
+                                        router.delete(
+                                            maintenanceTickets.destroy.url(
+                                                ticket.id,
+                                            ),
+                                        );
+                                    }
+                                }}
+                            >
+                                Delete
                             </Button>
                         </DialogFooter>
                     </DialogContent>

--- a/resources/js/pages/properties/index.tsx
+++ b/resources/js/pages/properties/index.tsx
@@ -16,6 +16,14 @@ import { Heading } from '@/components/shared';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import {
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuItem,
@@ -71,6 +79,8 @@ export default function Index({
     const [detailOpen, setDetailOpen] = useState(false);
     const [viewingProperty, setViewingProperty] =
         useState<ManagedProperty | null>(null);
+    const [archiveConfirm, setArchiveConfirm] =
+        useState<ManagedProperty | null>(null);
 
     const table = useTable({
         routeFn: () => properties.index(),
@@ -111,9 +121,16 @@ export default function Index({
     }
 
     function archive(property: ManagedProperty) {
-        if (confirm('Are you sure you want to archive this property?')) {
-            router.delete(properties.destroy.url(property));
+        setArchiveConfirm(property);
+    }
+
+    function confirmArchive() {
+        if (!archiveConfirm) {
+            return;
         }
+
+        router.delete(properties.destroy.url(archiveConfirm));
+        setArchiveConfirm(null);
     }
 
     const columns: TableColumn<ManagedProperty>[] = [
@@ -273,6 +290,38 @@ export default function Index({
                 open={dialogOpen}
                 onOpenChange={setDialogOpen}
             />
+
+            <Dialog
+                open={archiveConfirm !== null}
+                onOpenChange={() => setArchiveConfirm(null)}
+            >
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Archive property</DialogTitle>
+                        <DialogDescription>
+                            Are you sure you want to archive{' '}
+                            <span className="font-medium">
+                                {archiveConfirm?.name}
+                            </span>
+                            ?
+                        </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                        <Button
+                            variant="outline"
+                            onClick={() => setArchiveConfirm(null)}
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            variant="destructive"
+                            onClick={confirmArchive}
+                        >
+                            Archive
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
         </>
     );
 }

--- a/resources/js/pages/properties/units/index.tsx
+++ b/resources/js/pages/properties/units/index.tsx
@@ -23,6 +23,14 @@ import {
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import {
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuItem,
@@ -132,6 +140,9 @@ export default function Index({
     } | null>(null);
     const [moveOutOpen, setMoveOutOpen] = useState(false);
 
+    const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+    const [unitToDelete, setUnitToDelete] = useState<Unit | null>(null);
+
     const table = useTable({
         routeFn: () => ({ url: properties.units.index.url(property) }),
         params: {
@@ -228,15 +239,23 @@ export default function Index({
         setMoveOutOpen(true);
     }
 
-    function destroy(unit: Unit) {
-        if (confirm('Are you sure you want to delete this unit?')) {
-            router.delete(
-                properties.units.destroy.url({
-                    property: property.slug,
-                    unit: unit.slug,
-                }),
-            );
+    function confirmDelete(unit: Unit) {
+        setUnitToDelete(unit);
+        setDeleteDialogOpen(true);
+    }
+
+    function destroy() {
+        if (!unitToDelete) {
+            return;
         }
+
+        router.delete(
+            properties.units.destroy.url({
+                property: property.slug,
+                unit: unitToDelete.slug,
+            }),
+        );
+        setDeleteDialogOpen(false);
     }
 
     function getFilteredUnitsForMove(
@@ -407,7 +426,7 @@ export default function Index({
                             </DropdownMenuItem>
                             <DropdownMenuItem
                                 variant="destructive"
-                                onClick={() => destroy(r)}
+                                onClick={() => confirmDelete(r)}
                             >
                                 <Trash2 className="size-4" />
                                 Delete
@@ -508,6 +527,35 @@ export default function Index({
                 open={moveOutOpen}
                 onOpenChange={setMoveOutOpen}
             />
+
+            <Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Delete unit</DialogTitle>
+                        <DialogDescription>
+                            Are you sure you want to delete{' '}
+                            <span className="font-medium">
+                                {unitToDelete?.name}
+                            </span>
+                            ? This action cannot be undone.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                        <Button
+                            variant="outline"
+                            onClick={() => setDeleteDialogOpen(false)}
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            variant="destructive"
+                            onClick={destroy}
+                        >
+                            Delete
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
         </PropertyLayout>
     );
 }

--- a/resources/js/pages/settings/property-types.tsx
+++ b/resources/js/pages/settings/property-types.tsx
@@ -4,6 +4,14 @@ import { useState } from 'react';
 import { InputError } from '@/components/shared';
 import { Button } from '@/components/ui/button';
 import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import {
     Card,
     CardContent,
     CardDescription,
@@ -31,6 +39,8 @@ export default function PropertyTypes({
 }) {
     const [editing, setEditing] = useState<PropertyTypeOption | null>(null);
     const [sheetOpen, setSheetOpen] = useState(false);
+    const [deleteConfirm, setDeleteConfirm] =
+        useState<PropertyTypeOption | null>(null);
 
     function openNew() {
         setEditing(null);
@@ -50,9 +60,16 @@ export default function PropertyTypes({
     }
 
     function destroy(type: PropertyTypeOption) {
-        if (confirm(`Delete "${type.label}"?`)) {
-            router.delete(`${BASE}/${type.slug}`);
+        setDeleteConfirm(type);
+    }
+
+    function confirmDelete() {
+        if (!deleteConfirm) {
+            return;
         }
+
+        router.delete(`${BASE}/${deleteConfirm.slug}`);
+        setDeleteConfirm(null);
     }
 
     return (
@@ -219,6 +236,38 @@ export default function PropertyTypes({
                     </div>
                 </SheetContent>
             </Sheet>
+
+            <Dialog
+                open={deleteConfirm !== null}
+                onOpenChange={() => setDeleteConfirm(null)}
+            >
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Delete type</DialogTitle>
+                        <DialogDescription>
+                            Delete{' '}
+                            <span className="font-medium">
+                                {deleteConfirm?.label}
+                            </span>
+                            ?
+                        </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                        <Button
+                            variant="outline"
+                            onClick={() => setDeleteConfirm(null)}
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            variant="destructive"
+                            onClick={confirmDelete}
+                        >
+                            Delete
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
         </div>
     );
 }

--- a/resources/js/pages/tenants/index.tsx
+++ b/resources/js/pages/tenants/index.tsx
@@ -23,6 +23,14 @@ import { Heading } from '@/components/shared';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import {
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuItem,
@@ -98,6 +106,8 @@ export default function Index({
     const [documentsOpen, setDocumentsOpen] = useState(false);
     const [documentsTenant, setDocumentsTenant] = useState<Tenant | null>(null);
 
+    const [archiveConfirm, setArchiveConfirm] = useState<Tenant | null>(null);
+
     const table = useTable({
         routeFn: () => tenants.index(),
         params: {
@@ -167,9 +177,16 @@ export default function Index({
     }
 
     function archive(tenant: Tenant) {
-        if (confirm('Are you sure you want to archive this tenant?')) {
-            router.delete(tenants.destroy.url(tenant));
+        setArchiveConfirm(tenant);
+    }
+
+    function confirmArchive() {
+        if (!archiveConfirm) {
+            return;
         }
+
+        router.delete(tenants.destroy.url(archiveConfirm));
+        setArchiveConfirm(null);
     }
 
     const columns: TableColumn<Tenant>[] = [
@@ -380,6 +397,38 @@ export default function Index({
                 open={moveOutOpen}
                 onOpenChange={setMoveOutOpen}
             />
+
+            <Dialog
+                open={archiveConfirm !== null}
+                onOpenChange={() => setArchiveConfirm(null)}
+            >
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Archive tenant</DialogTitle>
+                        <DialogDescription>
+                            Are you sure you want to archive{' '}
+                            <span className="font-medium">
+                                {archiveConfirm?.name}
+                            </span>
+                            ?
+                        </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                        <Button
+                            variant="outline"
+                            onClick={() => setArchiveConfirm(null)}
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            variant="destructive"
+                            onClick={confirmArchive}
+                        >
+                            Archive
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
         </>
     );
 }

--- a/resources/js/pages/users/index.tsx
+++ b/resources/js/pages/users/index.tsx
@@ -17,6 +17,14 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import {
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuItem,
@@ -109,6 +117,10 @@ export default function Index({
     const [editingUser, setEditingUser] = useState<ManagedUser | null>(null);
     const [viewingUser, setViewingUser] = useState<ManagedUser | null>(null);
     const [formKey, setFormKey] = useState(0);
+    const [confirmState, setConfirmState] = useState<{
+        user: ManagedUser;
+        action: 'disable' | 'reset' | 'resend';
+    } | null>(null);
 
     const table = useTable({
         routeFn: () => users.index(),
@@ -143,21 +155,33 @@ export default function Index({
     }
 
     function disableAccess(user: ManagedUser) {
-        if (confirm(`Disable access for ${user.name}?`)) {
-            router.delete(destroy.url(user));
-        }
+        setConfirmState({ user, action: 'disable' });
     }
 
     function sendReset(user: ManagedUser) {
-        if (confirm(`Send password reset to ${user.email}?`)) {
-            router.post(resetPassword.url(user));
-        }
+        setConfirmState({ user, action: 'reset' });
     }
 
     function resendInvite(user: ManagedUser) {
-        if (confirm(`Resend invitation to ${user.email}?`)) {
+        setConfirmState({ user, action: 'resend' });
+    }
+
+    function executeConfirmed() {
+        if (!confirmState) {
+            return;
+        }
+
+        const { user, action } = confirmState;
+
+        if (action === 'disable') {
+            router.delete(destroy.url(user));
+        } else if (action === 'reset') {
+            router.post(resetPassword.url(user));
+        } else {
             router.post(resendInvitation.url(user));
         }
+
+        setConfirmState(null);
     }
 
     const columns: TableColumn<ManagedUser>[] = [
@@ -340,6 +364,48 @@ export default function Index({
                 onResetPassword={sendReset}
                 onResendInvitation={resendInvite}
             />
+            <Dialog
+                open={confirmState !== null}
+                onOpenChange={() => setConfirmState(null)}
+            >
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>
+                            {confirmState?.action === 'disable'
+                                ? 'Disable access'
+                                : confirmState?.action === 'reset'
+                                  ? 'Reset password'
+                                  : 'Resend invitation'}
+                        </DialogTitle>
+                        <DialogDescription>
+                            {confirmState?.action === 'disable' && (
+                                <>Disable access for <span className="font-medium">{confirmState.user.name}</span>?</>
+                            )}
+                            {confirmState?.action === 'reset' && (
+                                <>Send password reset to <span className="font-medium">{confirmState.user.email}</span>?</>
+                            )}
+                            {confirmState?.action === 'resend' && (
+                                <>Resend invitation to <span className="font-medium">{confirmState.user.email}</span>?</>
+                            )}
+                        </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                        <Button variant="outline" onClick={() => setConfirmState(null)}>
+                            Cancel
+                        </Button>
+                        <Button
+                            variant={confirmState?.action === 'disable' ? 'destructive' : 'default'}
+                            onClick={executeConfirmed}
+                        >
+                            {confirmState?.action === 'disable'
+                                ? 'Disable'
+                                : confirmState?.action === 'reset'
+                                  ? 'Send Reset'
+                                  : 'Resend'}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
         </>
     );
 }

--- a/tests/Feature/Domain/DomainModelTest.php
+++ b/tests/Feature/Domain/DomainModelTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\LeaseStatus;
 use App\Models\Lease;
 use App\Models\MaintenanceTicket;
 use App\Models\Payment;
@@ -153,13 +154,13 @@ describe('Lease', function () {
     it('has active status by default', function () {
         $lease = Lease::factory()->create();
 
-        expect($lease->status)->toBe('active');
+        expect($lease->status)->toBe(LeaseStatus::Active);
     });
 
     it('can be terminated', function () {
         $lease = Lease::factory()->terminated()->create();
 
-        expect($lease->status)->toBe('terminated');
+        expect($lease->status)->toBe(LeaseStatus::Terminated);
         expect($lease->termination_date)->not->toBeNull();
         expect($lease->termination_reason)->not->toBeNull();
     });

--- a/tests/Feature/Domain/LeaseStatusTransitionsTest.php
+++ b/tests/Feature/Domain/LeaseStatusTransitionsTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use App\Business\Leases\LeaseStatusValidator;
+use App\Enums\LeaseStatus;
+use App\Models\Lease;
+use App\Models\Property;
+use App\Models\Tenant;
+use App\Models\Unit;
+use App\Models\User;
+use Database\Seeders\RegionAndCitySeeder;
+use Database\Seeders\RoleAndPermissionSeeder;
+
+uses()->beforeEach(function () {
+    $this->seed(RoleAndPermissionSeeder::class);
+    $this->seed(RegionAndCitySeeder::class);
+});
+
+it('validates active to terminated transition', function () {
+    $validator = app(LeaseStatusValidator::class);
+
+    expect(fn () => $validator->validate(LeaseStatus::Active, LeaseStatus::Terminated))->not->toThrow(Exception::class);
+});
+
+it('validates active to renewed transition', function () {
+    $validator = app(LeaseStatusValidator::class);
+
+    expect(fn () => $validator->validate(LeaseStatus::Active, LeaseStatus::Renewed))->not->toThrow(Exception::class);
+});
+
+it('rejects terminated to active transition', function () {
+    $validator = app(LeaseStatusValidator::class);
+
+    expect(fn () => $validator->validate(LeaseStatus::Terminated, LeaseStatus::Active))->toThrow(Exception::class);
+});
+
+it('rejects terminated to renewed transition', function () {
+    $validator = app(LeaseStatusValidator::class);
+
+    expect(fn () => $validator->validate(LeaseStatus::Terminated, LeaseStatus::Renewed))->toThrow(Exception::class);
+});
+
+it('rejects renewed to any transition', function () {
+    $validator = app(LeaseStatusValidator::class);
+
+    expect(fn () => $validator->validate(LeaseStatus::Renewed, LeaseStatus::Active))->toThrow(Exception::class);
+    expect(fn () => $validator->validate(LeaseStatus::Renewed, LeaseStatus::Terminated))->toThrow(Exception::class);
+});
+
+it('transitions lease from active to terminated via controller', function () {
+    $property = Property::factory()->create();
+    $unit = Unit::factory()->withRate(1_000_000)->create(['property_id' => $property->id]);
+    $user = User::factory()->owner()->create();
+    $tenant = Tenant::factory()->create();
+
+    $lease = Lease::factory()->create([
+        'primary_tenant_id' => $tenant->id,
+        'unit_id' => $unit->id,
+        'status' => LeaseStatus::Active,
+    ]);
+
+    $this->actingAs($user)
+        ->delete(route('properties.units.leases.destroy', [$property, $unit, $lease]), ['reason' => 'test']);
+
+    expect($lease->fresh()->status)->toBe(LeaseStatus::Terminated);
+});
+
+it('transitions lease from active to renewed via renewal', function () {
+    $property = Property::factory()->create();
+    $unit = Unit::factory()->withRate(1_000_000)->create(['property_id' => $property->id]);
+    $tenant = Tenant::factory()->create();
+    $user = User::factory()->owner()->create();
+
+    $lease = Lease::factory()->create([
+        'primary_tenant_id' => $tenant->id,
+        'unit_id' => $unit->id,
+        'status' => LeaseStatus::Active,
+        'start_date' => now()->subMonths(6),
+        'end_date' => now()->addMonths(6),
+        'rent_amount' => 1_000_000,
+        'deposit_amount' => 500_000,
+        'deposit_paid_at' => now(),
+        'rent_due_day' => 1,
+    ]);
+
+    $this->actingAs($user)
+        ->post(route('leases.renew', $lease), [
+            'rent_amount' => 1_200_000,
+            'extension_value' => 12,
+            'extension_unit' => 'months',
+            'deposit_handling' => 'carry_forward',
+            'confirmed_outstanding' => true,
+        ]);
+
+    expect($lease->fresh()->status)->toBe(LeaseStatus::Renewed);
+});

--- a/tests/Feature/Domain/PaymentStatusTransitionsTest.php
+++ b/tests/Feature/Domain/PaymentStatusTransitionsTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use App\Business\Payments\PaymentStatusValidator;
+use App\Enums\PaymentStatus;
+use App\Models\Lease;
+use App\Models\Payment;
+use App\Models\User;
+use Database\Seeders\RegionAndCitySeeder;
+use Database\Seeders\RoleAndPermissionSeeder;
+
+uses()->beforeEach(function () {
+    $this->seed(RoleAndPermissionSeeder::class);
+    $this->seed(RegionAndCitySeeder::class);
+});
+
+it('validates pending to confirmed transition', function () {
+    $validator = app(PaymentStatusValidator::class);
+
+    expect(fn () => $validator->validate(PaymentStatus::Pending, PaymentStatus::Confirmed))->not->toThrow(Exception::class);
+});
+
+it('validates pending to cancelled transition', function () {
+    $validator = app(PaymentStatusValidator::class);
+
+    expect(fn () => $validator->validate(PaymentStatus::Pending, PaymentStatus::Cancelled))->not->toThrow(Exception::class);
+});
+
+it('rejects confirmed to any transition', function () {
+    $validator = app(PaymentStatusValidator::class);
+
+    expect(fn () => $validator->validate(PaymentStatus::Confirmed, PaymentStatus::Pending))->toThrow(Exception::class);
+    expect(fn () => $validator->validate(PaymentStatus::Confirmed, PaymentStatus::Cancelled))->toThrow(Exception::class);
+});
+
+it('rejects cancelled to any transition', function () {
+    $validator = app(PaymentStatusValidator::class);
+
+    expect(fn () => $validator->validate(PaymentStatus::Cancelled, PaymentStatus::Pending))->toThrow(Exception::class);
+    expect(fn () => $validator->validate(PaymentStatus::Cancelled, PaymentStatus::Confirmed))->toThrow(Exception::class);
+});
+
+it('transitions payment from pending to confirmed via verify', function () {
+    $lease = Lease::factory()->create();
+    $payment = Payment::factory()->pending()->create([
+        'paymentable_id' => $lease->id,
+        'paymentable_type' => Lease::class,
+    ]);
+    $user = User::factory()->owner()->create();
+
+    $this->actingAs($user)
+        ->post(route('payments.verify', $payment), ['action' => 'confirm']);
+
+    expect($payment->fresh()->status)->toBe(PaymentStatus::Confirmed);
+});
+
+it('transitions payment from pending to cancelled via reject', function () {
+    $lease = Lease::factory()->create();
+    $payment = Payment::factory()->pending()->create([
+        'paymentable_id' => $lease->id,
+        'paymentable_type' => Lease::class,
+    ]);
+    $user = User::factory()->owner()->create();
+
+    $this->actingAs($user)
+        ->post(route('payments.verify', $payment), ['action' => 'reject']);
+
+    expect($payment->fresh()->status)->toBe(PaymentStatus::Cancelled);
+});
+
+it('rejects verify on already confirmed payment', function () {
+    $lease = Lease::factory()->create();
+    $payment = Payment::factory()->create([
+        'paymentable_id' => $lease->id,
+        'paymentable_type' => Lease::class,
+        'status' => PaymentStatus::Confirmed,
+    ]);
+    $user = User::factory()->owner()->create();
+
+    $this->actingAs($user)
+        ->post(route('payments.verify', $payment), ['action' => 'confirm'])
+        ->assertStatus(422);
+});

--- a/tests/Feature/Domain/UnitStatusTransitionsTest.php
+++ b/tests/Feature/Domain/UnitStatusTransitionsTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use App\Business\Units\UnitStatusValidator;
+use App\Enums\UnitStatus;
+use Database\Seeders\RoleAndPermissionSeeder;
+
+uses()->beforeEach(function () {
+    $this->seed(RoleAndPermissionSeeder::class);
+});
+
+it('validates available to occupied transition', function () {
+    $validator = app(UnitStatusValidator::class);
+
+    expect(fn () => $validator->validate(UnitStatus::Available, UnitStatus::Occupied))->not->toThrow(Exception::class);
+});
+
+it('validates available to maintenance transition', function () {
+    $validator = app(UnitStatusValidator::class);
+
+    expect(fn () => $validator->validate(UnitStatus::Available, UnitStatus::Maintenance))->not->toThrow(Exception::class);
+});
+
+it('validates occupied to maintenance transition', function () {
+    $validator = app(UnitStatusValidator::class);
+
+    expect(fn () => $validator->validate(UnitStatus::Occupied, UnitStatus::Maintenance))->not->toThrow(Exception::class);
+});
+
+it('validates occupied to available transition', function () {
+    $validator = app(UnitStatusValidator::class);
+
+    expect(fn () => $validator->validate(UnitStatus::Occupied, UnitStatus::Available))->not->toThrow(Exception::class);
+});
+
+it('validates maintenance to available transition', function () {
+    $validator = app(UnitStatusValidator::class);
+
+    expect(fn () => $validator->validate(UnitStatus::Maintenance, UnitStatus::Available))->not->toThrow(Exception::class);
+});
+
+it('validates maintenance to occupied transition', function () {
+    $validator = app(UnitStatusValidator::class);
+
+    expect(fn () => $validator->validate(UnitStatus::Maintenance, UnitStatus::Occupied))->not->toThrow(Exception::class);
+});
+
+it('rejects available to unavailable transition', function () {
+    $validator = app(UnitStatusValidator::class);
+
+    expect(fn () => $validator->validate(UnitStatus::Available, UnitStatus::Unavailable))->toThrow(Exception::class);
+});
+
+it('rejects unavailable to any transition', function () {
+    $validator = app(UnitStatusValidator::class);
+
+    expect(fn () => $validator->validate(UnitStatus::Unavailable, UnitStatus::Available))->toThrow(Exception::class);
+    expect(fn () => $validator->validate(UnitStatus::Unavailable, UnitStatus::Occupied))->toThrow(Exception::class);
+});

--- a/tests/Feature/LeaseRenewTest.php
+++ b/tests/Feature/LeaseRenewTest.php
@@ -2,6 +2,7 @@
 
 use App\Data\Lease\RenewLeaseData;
 use App\Enums\DepositHandling;
+use App\Enums\LeaseStatus;
 use App\Models\Lease;
 use App\Models\Property;
 use App\Models\Tenant;
@@ -134,7 +135,7 @@ describe('eligibility', function () {
             ]);
         $lease->refresh();
 
-        expect($lease->status)->toBe('active');
+        expect($lease->status)->toBe(LeaseStatus::Active);
     });
 
     it('rejects terminated leases', function () {
@@ -152,7 +153,7 @@ describe('eligibility', function () {
             ->assertSessionHasNoErrors();
         $lease->refresh();
 
-        expect($lease->status)->toBe('terminated');
+        expect($lease->status)->toBe(LeaseStatus::Terminated);
     });
 
     it('rejects expired leases', function () {
@@ -169,7 +170,7 @@ describe('eligibility', function () {
             ]);
         $lease->refresh();
 
-        expect($lease->status)->toBe('expired');
+        expect($lease->status)->toBe(LeaseStatus::Expired);
     });
 });
 
@@ -190,13 +191,13 @@ describe('renewal', function () {
 
         $lease->refresh();
 
-        expect($lease->status)->toBe('renewed');
+        expect($lease->status)->toBe(LeaseStatus::Renewed);
 
         $newLease = $lease->fresh()->renewedLease;
 
         expect($newLease)->not->toBeNull();
         expect($newLease->previous_lease_id)->toBe($lease->id);
-        expect($newLease->status)->toBe('active');
+        expect($newLease->status)->toBe(LeaseStatus::Active);
         expect($newLease->rent_amount)->toBe('1500000.00');
         expect($newLease->start_date->format('Y-m-d'))->toBe('2026-07-01');
         expect($newLease->end_date->format('Y-m-d'))->toBe('2027-06-30');
@@ -348,7 +349,7 @@ describe('outstanding balance', function () {
 
         $lease->refresh();
 
-        expect($lease->status)->toBe('renewed');
+        expect($lease->status)->toBe(LeaseStatus::Renewed);
     });
 
     it('blocks renewal with outstanding balance without confirmation', function () {
@@ -375,7 +376,7 @@ describe('outstanding balance', function () {
             ->assertSessionHasNoErrors();
         $lease->refresh();
 
-        expect($lease->status)->toBe('active');
+        expect($lease->status)->toBe(LeaseStatus::Active);
     });
 
     it('allows renewal with paid lease without confirmation', function () {
@@ -441,7 +442,7 @@ describe('outstanding balance', function () {
 
         $lease->refresh();
 
-        expect($lease->status)->toBe('renewed');
+        expect($lease->status)->toBe(LeaseStatus::Renewed);
     });
 
     it('allows renewal with outstanding balance when confirmed', function () {
@@ -470,7 +471,7 @@ describe('outstanding balance', function () {
 
         $lease->refresh();
 
-        expect($lease->status)->toBe('renewed');
+        expect($lease->status)->toBe(LeaseStatus::Renewed);
     });
 });
 

--- a/tests/Feature/LeaseTest.php
+++ b/tests/Feature/LeaseTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\LeaseStatus;
 use App\Models\Lease;
 use App\Models\Property;
 use App\Models\Tenant;
@@ -118,7 +119,7 @@ describe('CRUD', function () {
         expect($lease->rent_amount)->toBe('1500000.00');
         expect($lease->deposit_amount)->toBe('1000000.00');
         expect($lease->rent_due_day)->toBe(5);
-        expect($lease->status)->toBe('active');
+        expect($lease->status)->toBe(LeaseStatus::Active);
     });
 
     it('uses unit base price when rent amount is not specified', function () {
@@ -205,7 +206,7 @@ describe('termination', function () {
 
         $lease->refresh();
 
-        expect($lease->status)->toBe('terminated');
+        expect($lease->status)->toBe(LeaseStatus::Terminated);
         expect($lease->end_date)->not->toBeNull();
         expect($lease->termination_date)->not->toBeNull();
     });
@@ -238,14 +239,14 @@ describe('move unit', function () {
 
         $lease->refresh();
 
-        expect($lease->status)->toBe('terminated');
+        expect($lease->status)->toBe(LeaseStatus::Terminated);
         expect($lease->end_date->format('Y-m-d'))->toBe(now()->format('Y-m-d'));
 
         $newLease = Lease::where('unit_id', $unitB->id)->first();
 
         expect($newLease)->not->toBeNull();
         expect($newLease->primary_tenant_id)->toBe($tenant->id);
-        expect($newLease->status)->toBe('active');
+        expect($newLease->status)->toBe(LeaseStatus::Active);
         expect($newLease->rent_amount)->toBe('1000000.00');
         expect($newLease->deposit_amount)->toBe('500000.00');
     });

--- a/tests/Feature/MaintenanceTicketCrudTest.php
+++ b/tests/Feature/MaintenanceTicketCrudTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\LeaseStatus;
 use App\Enums\MaintenancePriority;
 use App\Enums\MaintenanceStatus;
 use App\Enums\UnitStatus;
@@ -215,10 +216,10 @@ it('moves tenant and blocks unit when move_tenant_to_unit_id provided', function
         ->assertRedirect();
 
     expect($unit->fresh()->status)->toBe(UnitStatus::Maintenance);
-    expect($lease->fresh()->status)->toBe('active');
+    expect($lease->fresh()->status)->toBe(LeaseStatus::Active);
     expect($lease->fresh()->unit_id)->toBe($targetUnit->id);
     expect($targetUnit->fresh()->status)->toBe(UnitStatus::Occupied);
-    expect($targetUnit->leases()->where('status', 'active')->count())->toBe(1);
+    expect($targetUnit->leases()->where('status', LeaseStatus::Active->value)->count())->toBe(1);
     expect($lease->fresh()->unitHistories()->count())->toBe(1);
 });
 

--- a/tests/Feature/PaymentTest.php
+++ b/tests/Feature/PaymentTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\PaymentStatus;
 use App\Models\Lease;
 use App\Models\Payment;
 use App\Models\Property;
@@ -82,7 +83,7 @@ describe('payment recording', function () {
             ]);
 
         expect($lease->fresh()->payments)->toHaveCount(1)
-            ->and($lease->fresh()->payments->first()->status)->toBe('confirmed');
+            ->and($lease->fresh()->payments->first()->status)->toBe(PaymentStatus::Confirmed);
     });
 
     it('allows admin assigned to property to record payment', function () {
@@ -202,6 +203,6 @@ describe('payment recording', function () {
 
         expect((int) $payment->recorded_by)->toBe((int) $user->id);
         expect((int) $payment->confirmed_by)->toBe((int) $user->id);
-        expect($payment->status)->toBe('confirmed');
+        expect($payment->status)->toBe(PaymentStatus::Confirmed);
     });
 });


### PR DESCRIPTION
- Add model casts (LeaseStatus, PaymentStatus) — replaces raw strings
- Add TransitionValidator for Lease, Payment, Unit statuses
- Wire validators into actions/controllers; emit domain events
- Replace all raw string status comparisons with enum references
- Update factories, seeders, tests to use enums
- Document lifecycle diagrams in docs/architecture.md
- 461 tests passing, 1702 assertions, no regressions

Closes OPE-61

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/senatroxx/OpenKos/pull/40?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

