### PR TITLE
perf(db): add composite indexes for production query patterns

### DIFF
--- a/app/Business/Dashboard/OverviewStatsCalculator.php
+++ b/app/Business/Dashboard/OverviewStatsCalculator.php
@@ -4,6 +4,7 @@ namespace App\Business\Dashboard;
 
 use App\Models\Lease;
 use App\Models\Payment;
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 
 class OverviewStatsCalculator
@@ -18,17 +19,18 @@ class OverviewStatsCalculator
 
         $leaseIds = (clone $activeLeasesQuery)->pluck('id');
 
+        $periodStart = Carbon::create($currentYear, $currentMonth, 1)->startOfDay();
+        $periodEnd = Carbon::create($currentYear, $currentMonth, 1)->endOfMonth()->endOfDay();
+
         $revenueThisMonth = Payment::where('paymentable_type', Lease::class)
             ->where('status', 'confirmed')
-            ->whereMonth('period_start', $currentMonth)
-            ->whereYear('period_start', $currentYear)
+            ->whereBetween('period_start', [$periodStart, $periodEnd])
             ->whereHasMorph('paymentable', [Lease::class], fn (Builder $q) => $q->whereIn('id', $leaseIds))
             ->sum('amount');
 
         $paidIds = Payment::where('paymentable_type', Lease::class)
             ->where('status', 'confirmed')
-            ->whereMonth('period_start', $currentMonth)
-            ->whereYear('period_start', $currentYear)
+            ->whereBetween('period_start', [$periodStart, $periodEnd])
             ->whereHasMorph('paymentable', [Lease::class], fn (Builder $q) => $q->whereIn('id', $leaseIds))
             ->distinct('paymentable_id')
             ->pluck('paymentable_id');

--- a/app/Business/Dashboard/RentStatsCalculator.php
+++ b/app/Business/Dashboard/RentStatsCalculator.php
@@ -4,6 +4,7 @@ namespace App\Business\Dashboard;
 
 use App\Models\Lease;
 use App\Models\Payment;
+use Carbon\Carbon;
 use Illuminate\Support\Collection;
 
 class RentStatsCalculator
@@ -15,8 +16,10 @@ class RentStatsCalculator
         $paidLeaseIds = Payment::query()
             ->where('paymentable_type', Lease::class)
             ->whereNotIn('status', ['cancelled'])
-            ->whereMonth('period_start', $currentMonth)
-            ->whereYear('period_start', $currentYear)
+            ->whereBetween('period_start', [
+                Carbon::create($currentYear, $currentMonth, 1)->startOfDay(),
+                Carbon::create($currentYear, $currentMonth, 1)->endOfMonth()->endOfDay(),
+            ])
             ->whereIn('paymentable_id', $leaseIds)
             ->distinct()
             ->pluck('paymentable_id')

--- a/app/Http/Controllers/Dashboard/RentController.php
+++ b/app/Http/Controllers/Dashboard/RentController.php
@@ -10,6 +10,7 @@ use App\Models\Property;
 use App\Tables\Column;
 use App\Tables\Filter;
 use App\Tables\Table;
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
@@ -40,6 +41,9 @@ class RentController extends Controller
 
         $statsResult = $stats->computeStats($allActive, $today, $currentMonth, $currentYear);
 
+        $periodStart = Carbon::create($currentYear, $currentMonth, 1)->startOfDay();
+        $periodEnd = Carbon::create($currentYear, $currentMonth, 1)->endOfMonth()->endOfDay();
+
         $table = Table::make()
             ->columns([
                 Column::make('tenant_name', 'Tenant')->searchable(function (Builder $q, string $search): void {
@@ -59,18 +63,16 @@ class RentController extends Controller
                     ['value' => 'due_soon', 'label' => 'Due Soon'],
                     ['value' => 'paid', 'label' => 'Paid'],
                 ])
-                    ->query(function (Builder $q, string $value) use ($today, $currentMonth, $currentYear): void {
+                    ->query(function (Builder $q, string $value) use ($today, $periodStart, $periodEnd): void {
                         $hasPayment = fn (Builder $q) => $q->whereHas('payments', fn (Builder $q) => $q
                             ->where('paymentable_type', Lease::class)
                             ->whereNotIn('status', ['cancelled'])
-                            ->whereMonth('period_start', $currentMonth)
-                            ->whereYear('period_start', $currentYear));
+                            ->whereBetween('period_start', [$periodStart, $periodEnd]));
 
                         $noPayment = fn (Builder $q) => $q->whereDoesntHave('payments', fn (Builder $q) => $q
                             ->where('paymentable_type', Lease::class)
                             ->whereNotIn('status', ['cancelled'])
-                            ->whereMonth('period_start', $currentMonth)
-                            ->whereYear('period_start', $currentYear));
+                            ->whereBetween('period_start', [$periodStart, $periodEnd]));
 
                         match ($value) {
                             'paid' => $hasPayment($q),
@@ -104,8 +106,7 @@ class RentController extends Controller
                 ->whereColumn('paymentable_id', 'leases.id')
                 ->where('paymentable_type', Lease::class)
                 ->whereNotIn('status', ['cancelled'])
-                ->whereMonth('period_start', $currentMonth)
-                ->whereYear('period_start', $currentYear),
+                ->whereBetween('period_start', [$periodStart, $periodEnd]),
             ]);
 
         $result = $table->paginate($query, $request, 'entries');

--- a/app/Http/Controllers/LeaseController.php
+++ b/app/Http/Controllers/LeaseController.php
@@ -27,6 +27,7 @@ use App\Models\Unit;
 use App\Tables\Column;
 use App\Tables\Filter;
 use App\Tables\Table;
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -182,17 +183,20 @@ class LeaseController extends Controller
                     ['value' => 'paid', 'label' => 'Paid'],
                     ['value' => 'overdue', 'label' => 'Overdue'],
                 ])
-                    ->query(fn (Builder $q, string $value) => $value === 'paid'
-                        ? $q->whereHas('payments', fn (Builder $q) => $q
-                            ->where('paymentable_type', Lease::class)
-                            ->whereNotIn('status', [PaymentStatus::Cancelled->value])
-                            ->whereMonth('period_start', now()->month)
-                            ->whereYear('period_start', now()->year))
-                        : $q->where('status', LeaseStatus::Active->value)->whereDoesntHave('payments', fn (Builder $q) => $q
-                            ->where('paymentable_type', Lease::class)
-                            ->whereNotIn('status', [PaymentStatus::Cancelled->value])
-                            ->whereMonth('period_start', now()->month)
-                            ->whereYear('period_start', now()->year))),
+                    ->query(function (Builder $q, string $value) {
+                        $periodStart = Carbon::now()->startOfMonth()->startOfDay();
+                        $periodEnd = Carbon::now()->endOfMonth()->endOfDay();
+
+                        return $value === 'paid'
+                            ? $q->whereHas('payments', fn (Builder $q) => $q
+                                ->where('paymentable_type', Lease::class)
+                                ->whereNotIn('status', [PaymentStatus::Cancelled->value])
+                                ->whereBetween('period_start', [$periodStart, $periodEnd]))
+                            : $q->where('status', LeaseStatus::Active->value)->whereDoesntHave('payments', fn (Builder $q) => $q
+                                ->where('paymentable_type', Lease::class)
+                                ->whereNotIn('status', [PaymentStatus::Cancelled->value])
+                                ->whereBetween('period_start', [$periodStart, $periodEnd]));
+                    }),
                 Filter::select('properties', 'Property', $allProperties->map(fn (Property $p) => [
                     'value' => (string) $p->id,
                     'label' => $p->name,
@@ -211,8 +215,7 @@ class LeaseController extends Controller
                 ->whereColumn('paymentable_id', 'leases.id')
                 ->where('paymentable_type', Lease::class)
                 ->whereNotIn('status', [PaymentStatus::Cancelled->value])
-                ->whereMonth('period_start', now()->month)
-                ->whereYear('period_start', now()->year),
+                ->whereBetween('period_start', [Carbon::now()->startOfMonth()->startOfDay(), Carbon::now()->endOfMonth()->endOfDay()]),
             ])
             ->when(! $request->user()->isOwner(), fn (Builder $q) => $q->whereHas(
                 'unit.property.users',
@@ -245,11 +248,13 @@ class LeaseController extends Controller
             ->when($accessibleQuery)
             ->count();
 
+        $periodStart = Carbon::now()->startOfMonth()->startOfDay();
+        $periodEnd = Carbon::now()->endOfMonth()->endOfDay();
+
         $collectedThisMonth = (float) Payment::query()
             ->where('paymentable_type', Lease::class)
             ->whereNotIn('status', [PaymentStatus::Cancelled->value])
-            ->whereMonth('period_start', now()->month)
-            ->whereYear('period_start', now()->year)
+            ->whereBetween('period_start', [$periodStart, $periodEnd])
             ->whereHasMorph('paymentable', [Lease::class], fn (Builder $q) => $q->where('status', LeaseStatus::Active->value)->when($accessibleQuery))
             ->sum('amount');
 
@@ -259,8 +264,7 @@ class LeaseController extends Controller
             ->whereDoesntHave('payments', fn (Builder $q) => $q
                 ->where('paymentable_type', Lease::class)
                 ->whereNotIn('status', [PaymentStatus::Cancelled->value])
-                ->whereMonth('period_start', now()->month)
-                ->whereYear('period_start', now()->year))
+                ->whereBetween('period_start', [$periodStart, $periodEnd]))
             ->when($accessibleQuery)
             ->sum('rent_amount');
 

--- a/database/migrations/2026_07_05_150000_add_composite_indexes.php
+++ b/database/migrations/2026_07_05_150000_add_composite_indexes.php
@@ -1,0 +1,93 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // payments: covers dashboard rent stats (whereNotIn status),
+        // overview finance (where status = confirmed), lease overdue checks
+        // period_start is excluded — whereMonth/whereYear wraps it in EXTRACT()
+        // which a B-tree index can't use. The queries now use range conditions.
+        Schema::table('payments', function (Blueprint $table) {
+            $table->index(['paymentable_type', 'paymentable_id', 'status'], 'idx_payments_type_id_status');
+
+            // The morphs() call created (paymentable_type, paymentable_id) —
+            // the 3-column index above is a superset, so drop the morphs one.
+            $table->dropIndex(['paymentable_type', 'paymentable_id']);
+        });
+
+        // leases: covers dashboard base query where(status = 'active', start_date <= now)
+        // and the overdue lease check in LeaseController::globalIndex
+        Schema::table('leases', function (Blueprint $table) {
+            $table->index(['status', 'start_date'], 'idx_leases_status_start_date');
+        });
+
+        // maintenance_tickets: covers property-scoped ticket filtering
+        // and unit-scoped maintenance history lookups
+        Schema::table('maintenance_tickets', function (Blueprint $table) {
+            $table->index(['property_id', 'status'], 'idx_maintenance_tickets_property_status');
+            $table->index(['unit_id', 'status'], 'idx_maintenance_tickets_unit_status');
+        });
+
+        // units: covers unit availability listings (property-scoped status filter
+        // used in scopeAvailableForAssignment and property unit lists)
+        Schema::table('units', function (Blueprint $table) {
+            $table->index(['property_id', 'status'], 'idx_units_property_status');
+        });
+
+        // lease_unit_histories: covers maintenance transfer lookups
+        // filter by from_unit_id + reason, ordered by effective_date
+        Schema::table('lease_unit_histories', function (Blueprint $table) {
+            $table->index(['from_unit_id', 'reason', 'effective_date'], 'idx_luh_from_reason_date');
+        });
+
+        // unit_rates: covers activeRates() relation filter
+        Schema::table('unit_rates', function (Blueprint $table) {
+            $table->index(['unit_id', 'is_active', 'billing_interval'], 'idx_unit_rates_unit_active_interval');
+        });
+
+        // properties: covers admin property dropdowns filtered by is_active
+        Schema::table('properties', function (Blueprint $table) {
+            $table->index(['is_active', 'name'], 'idx_properties_active_name');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('payments', function (Blueprint $table) {
+            $table->dropIndex('idx_payments_type_id_status');
+
+            // Re-create the morphs index that was dropped
+            $table->index(['paymentable_type', 'paymentable_id']);
+        });
+
+        Schema::table('leases', function (Blueprint $table) {
+            $table->dropIndex('idx_leases_status_start_date');
+        });
+
+        Schema::table('maintenance_tickets', function (Blueprint $table) {
+            $table->dropIndex('idx_maintenance_tickets_property_status');
+            $table->dropIndex('idx_maintenance_tickets_unit_status');
+        });
+
+        Schema::table('units', function (Blueprint $table) {
+            $table->dropIndex('idx_units_property_status');
+        });
+
+        Schema::table('lease_unit_histories', function (Blueprint $table) {
+            $table->dropIndex('idx_luh_from_reason_date');
+        });
+
+        Schema::table('unit_rates', function (Blueprint $table) {
+            $table->dropIndex('idx_unit_rates_unit_active_interval');
+        });
+
+        Schema::table('properties', function (Blueprint $table) {
+            $table->dropIndex('idx_properties_active_name');
+        });
+    }
+};

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -283,6 +283,26 @@ Every foreign key intentionally chooses one of four strategies:
 
 The full FK inventory with per-constraint rationale is enforced by `tests/Feature/Schema/ForeignKeyDeleteStrategyTest.php`.
 
+### Composite Indexes
+
+Composite indexes are added to support production query patterns (filtering and sorting across multiple columns). The rationale for each:
+
+| Table | Index | Columns | Query pattern |
+|-------|-------|---------|---------------|
+| `payments` | `idx_payments_type_id_status` | `paymentable_type, paymentable_id, status` | Dashboard rent stats (`whereNotIn status`), overview finance (`where status = confirmed`), lease overdue checks. The previous morphs-only index `(paymentable_type, paymentable_id)` was a prefix — this superset covers it and status filtering together. |
+| `leases` | `idx_leases_status_start_date` | `status, start_date` | Dashboard base query `where(status='active', start_date <= now)`, overdue lease calculation. |
+| `maintenance_tickets` | `idx_maintenance_tickets_property_status` | `property_id, status` | Property-scoped ticket filtering. |
+| `maintenance_tickets` | `idx_maintenance_tickets_unit_status` | `unit_id, status` | Unit-scoped maintenance history queries. |
+| `units` | `idx_units_property_status` | `property_id, status` | Unit availability listings (`scopeAvailableForAssignment`). |
+| `lease_unit_histories` | `idx_luh_from_reason_date` | `from_unit_id, reason, effective_date` | Maintenance transfer lookups — equality on first 2 columns + ORDER BY on third. |
+| `unit_rates` | `idx_unit_rates_unit_active_interval` | `unit_id, is_active, billing_interval` | `activeRates()` relation. |
+| `properties` | `idx_properties_active_name` | `is_active, name` | Admin property dropdowns sorted by name. |
+
+**Design decisions:**
+- `period_start` was intentionally excluded from the payments index. The original queries used `whereMonth()`/`whereYear()`, which wrap the column in `EXTRACT()` — a B-tree index cannot accelerate function-wrapped predicates. Those queries were rewritten to range conditions (`whereBetween`) so the index is usable.
+- Existing single-column indexes (`status`, `priority`) are preserved — they serve queries that filter on those columns alone without additional columns (e.g., global status filter on maintenance tickets).
+- The set of composite indexes is enforced by `tests/Feature/Schema/CompositeIndexTest.php`.
+
 ## Testing
 
 - Pest 4 for both Feature and Unit tests.

--- a/tests/Feature/Schema/CompositeIndexTest.php
+++ b/tests/Feature/Schema/CompositeIndexTest.php
@@ -90,7 +90,7 @@ function loadIndexesPgsql(array $tables): array
         JOIN pg_class i ON i.oid = idx.indexrelid
         JOIN pg_class t ON t.oid = idx.indrelid
         JOIN pg_attribute a ON a.attrelid = idx.indrelid
-        CROSS JOIN LATERAL unnest(idx.indkey) WITH ORDINALITY AS ik(key, ord)
+        JOIN LATERAL unnest(idx.indkey) WITH ORDINALITY AS ik(key, ord)
             ON a.attnum = ik.key
         WHERE t.relname IN ({$placeholders})
             AND NOT idx.indisunique

--- a/tests/Feature/Schema/CompositeIndexTest.php
+++ b/tests/Feature/Schema/CompositeIndexTest.php
@@ -1,0 +1,108 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Expected composite indexes for each table.
+ *
+ * Map of [table => [index_name => [columns...]]].
+ * If a migration changes an index without updating this test, it will fail.
+ */
+$expected = [
+    'payments' => [
+        'idx_payments_type_id_status' => ['paymentable_type', 'paymentable_id', 'status'],
+    ],
+    'leases' => [
+        'idx_leases_status_start_date' => ['status', 'start_date'],
+    ],
+    'maintenance_tickets' => [
+        'idx_maintenance_tickets_property_status' => ['property_id', 'status'],
+        'idx_maintenance_tickets_unit_status' => ['unit_id', 'status'],
+    ],
+    'units' => [
+        'idx_units_property_status' => ['property_id', 'status'],
+    ],
+    'lease_unit_histories' => [
+        'idx_luh_from_reason_date' => ['from_unit_id', 'reason', 'effective_date'],
+    ],
+    'unit_rates' => [
+        'idx_unit_rates_unit_active_interval' => ['unit_id', 'is_active', 'billing_interval'],
+    ],
+    'properties' => [
+        'idx_properties_active_name' => ['is_active', 'name'],
+    ],
+];
+
+$appTables = array_keys($expected);
+
+it('every expected composite index exists with correct columns', function () use ($expected, $appTables) {
+    $driver = DB::getDriverName();
+    $actual = $driver === 'sqlite' ? loadIndexesSqlite($appTables) : loadIndexesPgsql($appTables);
+
+    foreach ($expected as $table => $indexes) {
+        foreach ($indexes as $indexName => $expectedColumns) {
+            expect(isset($actual[$table][$indexName]))
+                ->toBeTrue("Missing index {$indexName} on {$table}");
+
+            $actualColumns = $actual[$table][$indexName];
+            expect($actualColumns)
+                ->toBe($expectedColumns, "{$table}.{$indexName}: expected columns [".implode(', ', $expectedColumns).'], got ['.implode(', ', $actualColumns).']');
+        }
+    }
+
+    foreach ($actual as $table => $indexes) {
+        expect(isset($expected[$table]))->toBeTrue("Unexpected index entry for table: {$table}");
+    }
+});
+
+function loadIndexesSqlite(array $tables): array
+{
+    $indexes = [];
+
+    foreach ($tables as $table) {
+        $rows = DB::select("PRAGMA index_list({$table})");
+        foreach ($rows as $row) {
+            $name = $row->name;
+
+            // Skip auto-generated indexes (unique, primary)
+            if (str_starts_with($name, 'sqlite_autoindex')) {
+                continue;
+            }
+
+            $info = DB::select("PRAGMA index_info({$name})");
+            $columns = array_column($info, 'name');
+            $indexes[$table][$name] = $columns;
+        }
+    }
+
+    return $indexes;
+}
+
+function loadIndexesPgsql(array $tables): array
+{
+    $placeholders = implode(', ', array_fill(0, count($tables), '?'));
+    $rows = DB::select("
+        SELECT
+            i.relname AS index_name,
+            t.relname AS table_name,
+            a.attname AS column_name,
+            i.indisunique,
+            i.indisprimary
+        FROM pg_index idx
+        JOIN pg_class i ON i.oid = idx.indexrelid
+        JOIN pg_class t ON t.oid = idx.indrelid
+        JOIN pg_attribute a ON a.attrelid = idx.indrelid
+            AND a.attnum = ANY(idx.indkey)
+        WHERE t.relname IN ({$placeholders})
+            AND NOT i.indisunique
+            AND NOT i.indisprimary
+        ORDER BY i.relname, a.attnum
+    ", $tables);
+
+    $indexes = [];
+    foreach ($rows as $row) {
+        $indexes[$row->table_name][$row->index_name][] = $row->column_name;
+    }
+
+    return $indexes;
+}

--- a/tests/Feature/Schema/CompositeIndexTest.php
+++ b/tests/Feature/Schema/CompositeIndexTest.php
@@ -85,18 +85,17 @@ function loadIndexesPgsql(array $tables): array
         SELECT
             i.relname AS index_name,
             t.relname AS table_name,
-            a.attname AS column_name,
-            i.indisunique,
-            i.indisprimary
+            a.attname AS column_name
         FROM pg_index idx
         JOIN pg_class i ON i.oid = idx.indexrelid
         JOIN pg_class t ON t.oid = idx.indrelid
         JOIN pg_attribute a ON a.attrelid = idx.indrelid
-            AND a.attnum = ANY(idx.indkey)
+        CROSS JOIN LATERAL unnest(idx.indkey) WITH ORDINALITY AS ik(key, ord)
+            ON a.attnum = ik.key
         WHERE t.relname IN ({$placeholders})
-            AND NOT i.indisunique
-            AND NOT i.indisprimary
-        ORDER BY i.relname, a.attnum
+            AND NOT idx.indisunique
+            AND NOT idx.indisprimary
+        ORDER BY i.relname, ik.ord
     ", $tables);
 
     $indexes = [];


### PR DESCRIPTION
Add 8 composite indexes across 7 tables targeting dashboard, overview, lease, and maintenance query patterns. Rewrite 22 whereMonth/whereYear calls to range conditions so the indexes are usable. Drop the now-redundant morphs-generated index on payments.

Closes OPE-64

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/senatroxx/OpenKos/pull/42?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

