### PR TITLE
feat(events): add domain events, centralize dispatch in controllers

### DIFF
--- a/app/Actions/Leases/MoveOutLease.php
+++ b/app/Actions/Leases/MoveOutLease.php
@@ -7,7 +7,6 @@ use App\Business\Leases\OccupancyCalculator;
 use App\Data\Lease\MoveOutLeaseData;
 use App\Enums\LeaseStatus;
 use App\Enums\UnitStatus;
-use App\Events\Lease\LeaseStatusChanged;
 use App\Models\Lease;
 use App\Models\Unit;
 use App\Results\Lease\MoveOutLeaseResult;
@@ -52,8 +51,6 @@ class MoveOutLease
             'deposit_refunded_at' => $data->depositReturned ? now() : null,
             'notes' => $data->notes ?? $lease->notes,
         ]);
-
-        LeaseStatusChanged::dispatch($lease, $oldStatus, LeaseStatus::Terminated);
 
         if ($oldUnit->leases()->where('status', LeaseStatus::Active->value)->doesntExist() && $oldUnit->status !== UnitStatus::Maintenance) {
             $oldUnit->update(['status' => UnitStatus::Available]);
@@ -100,8 +97,6 @@ class MoveOutLease
             'deposit_refunded_at' => $data->depositReturned ? now() : null,
             'notes' => $data->notes ?? $lease->notes,
         ]);
-
-        LeaseStatusChanged::dispatch($lease, $oldStatus, LeaseStatus::Terminated);
 
         $oldUnit->unsetRelation('leases');
 

--- a/app/Actions/Leases/RenewLease.php
+++ b/app/Actions/Leases/RenewLease.php
@@ -7,7 +7,6 @@ use App\Business\Leases\LeaseStatusValidator;
 use App\Business\Leases\RenewalEligibilityChecker;
 use App\Data\Lease\RenewLeaseData;
 use App\Enums\LeaseStatus;
-use App\Events\Lease\LeaseStatusChanged;
 use App\Exceptions\LeaseRenewalException;
 use App\Models\Lease;
 use App\Models\Unit;
@@ -86,10 +85,6 @@ class RenewLease
 
             return RenewLeaseResult::success($newLease);
         });
-
-        if ($result->succeeded()) {
-            LeaseStatusChanged::dispatch($lease, $oldStatus, LeaseStatus::Renewed);
-        }
 
         return $result;
     }

--- a/app/Actions/Maintenance/BlockUnit.php
+++ b/app/Actions/Maintenance/BlockUnit.php
@@ -17,8 +17,6 @@ class BlockUnit
 
         if ($activeLease && $moveToUnitId) {
             $this->transferOccupants($unit, $activeLease, $moveToUnitId);
-        } elseif ($activeLease) {
-            $unit->update(['status' => UnitStatus::Maintenance]);
         } else {
             $unit->update(['status' => UnitStatus::Maintenance]);
         }
@@ -66,6 +64,7 @@ class BlockUnit
         ]);
 
         $targetUnit->update(['status' => UnitStatus::Occupied]);
+
         $unit->update(['status' => UnitStatus::Maintenance]);
     }
 }

--- a/app/Actions/Maintenance/ResolveTicket.php
+++ b/app/Actions/Maintenance/ResolveTicket.php
@@ -34,8 +34,7 @@ class ResolveTicket
         }
 
         $hasActiveLease = $unit->leases()->where('status', LeaseStatus::Active->value)->exists();
-        $newUnitStatus = $hasActiveLease ? UnitStatus::Occupied : UnitStatus::Available;
-        $unit->update(['status' => $newUnitStatus]);
+        $unit->update(['status' => $hasActiveLease ? UnitStatus::Occupied : UnitStatus::Available]);
     }
 
     private function moveOccupantsBack(MaintenanceTicket $ticket, Unit $unit): void

--- a/app/Actions/Payments/RecordPayment.php
+++ b/app/Actions/Payments/RecordPayment.php
@@ -4,7 +4,6 @@ namespace App\Actions\Payments;
 
 use App\Data\Payment\RecordPaymentData;
 use App\Enums\PaymentStatus;
-use App\Events\PaymentRecorded;
 use App\Models\Lease;
 use App\Models\User;
 use App\Results\Payment\RecordPaymentResult;
@@ -56,8 +55,6 @@ class RecordPayment
         });
 
         $payment->load('confirmedBy:id,name', 'recordedBy:id,name', 'proofs');
-
-        PaymentRecorded::dispatch($payment);
 
         return RecordPaymentResult::success($payment);
     }

--- a/app/Events/Lease/LeaseCreated.php
+++ b/app/Events/Lease/LeaseCreated.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Events\Lease;
+
+use App\Models\Lease;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class LeaseCreated
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly Lease $lease,
+        public readonly array $tenantIds,
+    ) {}
+}

--- a/app/Events/Maintenance/MaintenanceResolved.php
+++ b/app/Events/Maintenance/MaintenanceResolved.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Events\Maintenance;
+
+use App\Models\MaintenanceTicket;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class MaintenanceResolved
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly MaintenanceTicket $ticket,
+    ) {}
+}

--- a/app/Events/Maintenance/MaintenanceTicketCreated.php
+++ b/app/Events/Maintenance/MaintenanceTicketCreated.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Events\Maintenance;
+
+use App\Models\MaintenanceTicket;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class MaintenanceTicketCreated
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly MaintenanceTicket $ticket,
+    ) {}
+}

--- a/app/Events/Payment/PaymentRecorded.php
+++ b/app/Events/Payment/PaymentRecorded.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Events;
+namespace App\Events\Payment;
 
 use App\Models\Payment;
 use Illuminate\Foundation\Events\Dispatchable;

--- a/app/Events/Unit/UnitStatusChanged.php
+++ b/app/Events/Unit/UnitStatusChanged.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Events\Unit;
+
+use App\Enums\UnitStatus;
+use App\Models\Unit;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class UnitStatusChanged
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly Unit $unit,
+        public readonly UnitStatus $from,
+        public readonly UnitStatus $to,
+    ) {}
+}

--- a/app/Http/Controllers/LeaseController.php
+++ b/app/Http/Controllers/LeaseController.php
@@ -13,7 +13,9 @@ use App\Enums\LeaseStatus;
 use App\Enums\PaymentMethod;
 use App\Enums\PaymentStatus;
 use App\Enums\UnitStatus;
+use App\Events\Lease\LeaseCreated;
 use App\Events\Lease\LeaseStatusChanged;
+use App\Events\Unit\UnitStatusChanged;
 use App\Http\Requests\Lease\MoveLeaseRequest;
 use App\Http\Requests\Lease\MoveOutRequest;
 use App\Http\Requests\Lease\RenewLeaseRequest;
@@ -299,9 +301,20 @@ class LeaseController extends Controller
             notes: $request->notes,
         );
 
+        $oldUnitStatus = $unit->status;
+
         $lease = $action->execute($unit, $data);
 
         $lease->load('tenants:id,name,phone', 'primaryTenant:id,name,phone');
+
+        if ($lease->wasRecentlyCreated) {
+            LeaseCreated::dispatch($lease, $lease->tenants->pluck('id')->toArray());
+        }
+
+        $unit->refresh();
+        if ($oldUnitStatus !== $unit->status) {
+            UnitStatusChanged::dispatch($unit, $oldUnitStatus, $unit->status);
+        }
 
         $count = $lease->tenants->count();
         $message = $count > 1
@@ -343,7 +356,12 @@ class LeaseController extends Controller
             $unit->unsetRelation('leases');
 
             if ($unit->leases()->where('status', LeaseStatus::Active->value)->doesntExist() && $unit->status !== UnitStatus::Maintenance) {
+                $oldUnitStatus = $unit->status;
                 $unit->update(['status' => UnitStatus::Available]);
+
+                if ($oldUnitStatus !== $unit->status) {
+                    UnitStatusChanged::dispatch($unit, $oldUnitStatus, $unit->status);
+                }
             }
         });
 
@@ -375,10 +393,33 @@ class LeaseController extends Controller
             targetUnitId: $validated['target_unit_id'] ?? null,
         );
 
+        $oldLeaseStatus = $lease->status;
+        $sourceUnit = $lease->unit;
+        $oldSourceStatus = $sourceUnit->status;
+
+        $oldTargetStatus = $targetUnit?->status;
+
         $result = $action->execute($lease, $data);
 
         if ($result->failed()) {
             abort(422, $result->error);
+        }
+
+        $lease->refresh();
+        if ($oldLeaseStatus !== $lease->status) {
+            LeaseStatusChanged::dispatch($lease, $oldLeaseStatus, $lease->status);
+        }
+
+        $sourceUnit->refresh();
+        if ($oldSourceStatus !== $sourceUnit->status) {
+            UnitStatusChanged::dispatch($sourceUnit, $oldSourceStatus, $sourceUnit->status);
+        }
+
+        if ($targetUnit) {
+            $targetUnit->refresh();
+            if ($oldTargetStatus !== $targetUnit->status) {
+                UnitStatusChanged::dispatch($targetUnit, $oldTargetStatus, $targetUnit->status);
+            }
         }
 
         Inertia::flash('toast', [
@@ -399,12 +440,19 @@ class LeaseController extends Controller
     {
         $this->authorize('renew', $lease);
 
+        $oldLeaseStatus = $lease->status;
+
         $result = $action->execute($lease, $request->toData());
 
         if ($result->failed()) {
             Inertia::flash('toast', ['type' => 'error', 'message' => $result->error]);
 
             return back();
+        }
+
+        $lease->refresh();
+        if ($oldLeaseStatus !== $lease->status) {
+            LeaseStatusChanged::dispatch($lease, $oldLeaseStatus, $lease->status);
         }
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Lease renewed. New lease created.')]);
@@ -450,10 +498,29 @@ class LeaseController extends Controller
             carryDepositRefund: true,
         );
 
+        $oldLeaseStatus = $lease->status;
+        $oldSourceStatus = $unit->status;
+        $oldTargetStatus = $targetUnit->status;
+
         $result = $action->execute($lease, $data);
 
         if ($result->failed()) {
             abort(422, $result->error);
+        }
+
+        $lease->refresh();
+        if ($oldLeaseStatus !== $lease->status) {
+            LeaseStatusChanged::dispatch($lease, $oldLeaseStatus, $lease->status);
+        }
+
+        $unit->refresh();
+        if ($oldSourceStatus !== $unit->status) {
+            UnitStatusChanged::dispatch($unit, $oldSourceStatus, $unit->status);
+        }
+
+        $targetUnit->refresh();
+        if ($oldTargetStatus !== $targetUnit->status) {
+            UnitStatusChanged::dispatch($targetUnit, $oldTargetStatus, $targetUnit->status);
         }
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Tenant moved to new unit.')]);

--- a/app/Http/Controllers/MaintenanceTicketController.php
+++ b/app/Http/Controllers/MaintenanceTicketController.php
@@ -7,6 +7,9 @@ use App\Actions\Maintenance\ResolveTicket;
 use App\Business\Maintenance\TransitionValidator;
 use App\Enums\LeaseStatus;
 use App\Enums\MaintenanceStatus;
+use App\Events\Maintenance\MaintenanceResolved;
+use App\Events\Maintenance\MaintenanceTicketCreated;
+use App\Events\Unit\UnitStatusChanged;
 use App\Http\Requests\Maintenance\StoreMaintenanceTicketRequest;
 use App\Http\Requests\Maintenance\UpdateMaintenanceTicketRequest;
 use App\Models\LeaseUnitHistory;
@@ -157,10 +160,30 @@ class MaintenanceTicketController extends Controller
         $moveToUnitId = $data['move_tenant_to_unit_id'] ?? null;
         unset($data['block_unit'], $data['move_tenant_to_unit_id']);
 
-        MaintenanceTicket::create($data);
+        $ticket = MaintenanceTicket::create($data);
+
+        MaintenanceTicketCreated::dispatch($ticket);
 
         if ($blockUnit && ! empty($data['unit_id'])) {
+            $unit = Unit::findOrFail($data['unit_id']);
+            $oldStatus = $unit->status;
+
+            $targetUnit = $moveToUnitId ? Unit::find($moveToUnitId) : null;
+            $oldTargetStatus = $targetUnit?->status;
+
             $this->blockUnit->execute($data['unit_id'], $moveToUnitId);
+
+            $unit->refresh();
+            if ($oldStatus !== $unit->status) {
+                UnitStatusChanged::dispatch($unit, $oldStatus, $unit->status);
+            }
+
+            if ($targetUnit) {
+                $targetUnit->refresh();
+                if ($oldTargetStatus !== $targetUnit->status) {
+                    UnitStatusChanged::dispatch($targetUnit, $oldTargetStatus, $targetUnit->status);
+                }
+            }
         }
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Maintenance ticket created.')]);
@@ -181,6 +204,8 @@ class MaintenanceTicketController extends Controller
             if ($newStatus === MaintenanceStatus::Resolved) {
                 $validated['resolved_at'] ??= now();
             }
+
+            $statusChangedToResolved = $newStatus === MaintenanceStatus::Resolved;
         }
 
         $restoreUnit = ! empty($validated['restore_unit']);
@@ -189,10 +214,37 @@ class MaintenanceTicketController extends Controller
 
         $ticket->update($validated);
 
+        if (($statusChangedToResolved ?? false)) {
+            MaintenanceResolved::dispatch($ticket);
+        }
+
         if ($restoreUnit && $ticket->unit_id) {
+            $unit = Unit::findOrFail($ticket->unit_id);
+            $oldStatus = $unit->status;
+
+            $transfer = LeaseUnitHistory::query()
+                ->where('from_unit_id', $ticket->unit_id)
+                ->where('reason', 'maintenance')
+                ->orderBy('effective_date', 'desc')
+                ->first();
+            $targetUnit = $transfer ? Unit::find($transfer->to_unit_id) : null;
+            $oldTargetStatus = $targetUnit?->status;
+
             $this->resolveTicket->execute($ticket, $moveBack);
 
-            $unitName = Unit::find($ticket->unit_id)?->name ?? '';
+            $unit->refresh();
+            if ($oldStatus !== $unit->status) {
+                UnitStatusChanged::dispatch($unit, $oldStatus, $unit->status);
+            }
+
+            if ($targetUnit) {
+                $targetUnit->refresh();
+                if ($oldTargetStatus !== $targetUnit->status) {
+                    UnitStatusChanged::dispatch($targetUnit, $oldTargetStatus, $targetUnit->status);
+                }
+            }
+
+            $unitName = $unit->name ?? '';
             Inertia::flash('toast', ['type' => 'success', 'message' => __('Ticket updated. Unit :name restored.', ['name' => $unitName])]);
 
             return to_route('maintenance-tickets.index');

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -6,6 +6,7 @@ use App\Actions\Payments\RecordPayment;
 use App\Business\Payments\PaymentStatusValidator;
 use App\Data\Payment\RecordPaymentData;
 use App\Enums\PaymentStatus;
+use App\Events\Payment\PaymentRecorded;
 use App\Events\Payment\PaymentStatusChanged;
 use App\Http\Requests\Payment\StorePaymentRequest;
 use App\Models\Lease;
@@ -40,6 +41,8 @@ class PaymentController extends Controller
         }
 
         $payment = $result->payment;
+
+        PaymentRecorded::dispatch($payment);
 
         $periodStart = sprintf('%04d-%02d-01', $request->period_year, $request->period_month);
 

--- a/docs/domain-events.md
+++ b/docs/domain-events.md
@@ -14,7 +14,7 @@
 ### Lease
 
 | Event | Payload | Dispatched from |
-|---|---|---|---|
+|---|---|---|
 | `Lease\LeaseCreated` | `Lease $lease, array $tenantIds` | `LeaseController::store` |
 | `Lease\LeaseStatusChanged` | `Lease $lease, LeaseStatus $from, LeaseStatus $to` | `LeaseController::moveOut`, `LeaseController::move`, `LeaseController::renew`, `LeaseController::destroy` |
 

--- a/docs/domain-events.md
+++ b/docs/domain-events.md
@@ -1,0 +1,82 @@
+# Domain Events
+
+> **Status:** Active
+> **Purpose:** Catalog of domain events, their payload contracts, and dispatch points. Reference for plugin authors and core developers.
+
+## Naming Convention
+
+- All events live in `App\Events\{Domain}\` — one sub-namespace per aggregate.
+- Event names are past-tense verb phrases: `{Entity}{PastAction}`.
+- Events are immutable classes with `readonly` properties and `Dispatchable` trait.
+
+## Event Catalog
+
+### Lease
+
+| Event | Payload | Dispatched from |
+|---|---|---|
+| `Lease\LeaseCreated` | `Lease $lease, array $tenantIds` | `Actions\Leases\CreateLease` |
+| `Lease\LeaseStatusChanged` | `Lease $lease, LeaseStatus $from, LeaseStatus $to` | `Actions\Leases\MoveOutLease`, `Actions\Leases\RenewLease`, `LeaseController` |
+
+**Payload: `LeaseCreated`**
+
+```php
+public readonly Lease $lease;
+public readonly array $tenantIds;   // IDs of attached tenants
+```
+
+### Payment
+
+| Event | Payload | Dispatched from |
+|---|---|---|
+| `Payment\PaymentRecorded` | `Payment $payment` | `Actions\Payments\RecordPayment` |
+| `Payment\PaymentStatusChanged` | `Payment $payment, PaymentStatus $from, PaymentStatus $to` | `PaymentController::verify` |
+
+### Maintenance
+
+| Event | Payload | Dispatched from |
+|---|---|---|
+| `Maintenance\MaintenanceTicketCreated` | `MaintenanceTicket $ticket` | `MaintenanceTicketController::store` |
+| `Maintenance\MaintenanceResolved` | `MaintenanceTicket $ticket` | `MaintenanceTicketController::update`, `Actions\Maintenance\ResolveTicket` |
+
+### Unit
+
+| Event | Payload | Dispatched from |
+|---|---|---|
+| `Unit\UnitStatusChanged` | `Unit $unit, UnitStatus $from, UnitStatus $to` | `CreateLease`, `MoveOutLease`, `BlockUnit`, `ResolveTicket` |
+
+**Payload: `UnitStatusChanged`**
+
+```php
+public readonly Unit $unit;
+public readonly UnitStatus $from;   // previous status
+public readonly UnitStatus $to;     // new status
+```
+
+## Plugin Subscription
+
+Plugins subscribe to events via `listens()` in their `Plugin` subclass:
+
+```php
+public function listens(): array
+{
+    return [
+        App\Events\Lease\LeaseCreated::class => MyListener::class,
+    ];
+}
+```
+
+Listeners are wired onto Laravel's dispatcher by `PlatformServiceProvider::boot()` after all plugins have registered.
+
+## Adding a New Event
+
+1. Create the event class in `App\Events\{Domain}\`. Minimal boilerplate: `Dispatchable`, `readonly` constructor properties.
+2. Dispatch it at the point of state change (Action or Controller, matching the existing pattern).
+3. Document the event in this catalog.
+4. Add a test in `tests/Feature/Domain/DomainEventTest.php`.
+
+## Extension Guidance
+
+- Events are the stable plugin API — never change a published event's payload without a major version bump.
+- Prefer adding new properties as nullable (backward-compatible) over breaking changes.
+- Keep events fired **after** the state change is committed (inside or after the DB transaction, matching the existing pattern).

--- a/docs/domain-events.md
+++ b/docs/domain-events.md
@@ -14,9 +14,9 @@
 ### Lease
 
 | Event | Payload | Dispatched from |
-|---|---|---|
-| `Lease\LeaseCreated` | `Lease $lease, array $tenantIds` | `Actions\Leases\CreateLease` |
-| `Lease\LeaseStatusChanged` | `Lease $lease, LeaseStatus $from, LeaseStatus $to` | `Actions\Leases\MoveOutLease`, `Actions\Leases\RenewLease`, `LeaseController` |
+|---|---|---|---|
+| `Lease\LeaseCreated` | `Lease $lease, array $tenantIds` | `LeaseController::store` |
+| `Lease\LeaseStatusChanged` | `Lease $lease, LeaseStatus $from, LeaseStatus $to` | `LeaseController::moveOut`, `LeaseController::move`, `LeaseController::renew`, `LeaseController::destroy` |
 
 **Payload: `LeaseCreated`**
 
@@ -29,7 +29,7 @@ public readonly array $tenantIds;   // IDs of attached tenants
 
 | Event | Payload | Dispatched from |
 |---|---|---|
-| `Payment\PaymentRecorded` | `Payment $payment` | `Actions\Payments\RecordPayment` |
+| `Payment\PaymentRecorded` | `Payment $payment` | `PaymentController::store` |
 | `Payment\PaymentStatusChanged` | `Payment $payment, PaymentStatus $from, PaymentStatus $to` | `PaymentController::verify` |
 
 ### Maintenance
@@ -37,13 +37,13 @@ public readonly array $tenantIds;   // IDs of attached tenants
 | Event | Payload | Dispatched from |
 |---|---|---|
 | `Maintenance\MaintenanceTicketCreated` | `MaintenanceTicket $ticket` | `MaintenanceTicketController::store` |
-| `Maintenance\MaintenanceResolved` | `MaintenanceTicket $ticket` | `MaintenanceTicketController::update`, `Actions\Maintenance\ResolveTicket` |
+| `Maintenance\MaintenanceResolved` | `MaintenanceTicket $ticket` | `MaintenanceTicketController::update` |
 
 ### Unit
 
 | Event | Payload | Dispatched from |
 |---|---|---|
-| `Unit\UnitStatusChanged` | `Unit $unit, UnitStatus $from, UnitStatus $to` | `CreateLease`, `MoveOutLease`, `BlockUnit`, `ResolveTicket` |
+| `Unit\UnitStatusChanged` | `Unit $unit, UnitStatus $from, UnitStatus $to` | `LeaseController::store`, `LeaseController::moveOut`, `LeaseController::move`, `LeaseController::destroy`, `MaintenanceTicketController::store`, `MaintenanceTicketController::update` |
 
 **Payload: `UnitStatusChanged`**
 
@@ -71,7 +71,7 @@ Listeners are wired onto Laravel's dispatcher by `PlatformServiceProvider::boot(
 ## Adding a New Event
 
 1. Create the event class in `App\Events\{Domain}\`. Minimal boilerplate: `Dispatchable`, `readonly` constructor properties.
-2. Dispatch it at the point of state change (Action or Controller, matching the existing pattern).
+2. Dispatch it from the Controller after the state change is committed.
 3. Document the event in this catalog.
 4. Add a test in `tests/Feature/Domain/DomainEventTest.php`.
 
@@ -79,4 +79,4 @@ Listeners are wired onto Laravel's dispatcher by `PlatformServiceProvider::boot(
 
 - Events are the stable plugin API — never change a published event's payload without a major version bump.
 - Prefer adding new properties as nullable (backward-compatible) over breaking changes.
-- Keep events fired **after** the state change is committed (inside or after the DB transaction, matching the existing pattern).
+- Keep events fired **after** the state change is committed (inside or after the DB transaction, dispatched from Controllers).

--- a/docs/platform.md
+++ b/docs/platform.md
@@ -32,7 +32,7 @@ src/
                               database/migrations/) — disabled by default (see below)
 ```
 
-Core also dispatches domain events plugins can subscribe to, e.g. `App\Events\PaymentRecorded`.
+Core also dispatches domain events plugins can subscribe to, e.g. `App\Events\Payment\PaymentRecorded`.
 
 `src/Core/` currently holds only contracts. It is the designated future home for domain code migrating out of `app/` — nothing has been moved yet, deliberately.
 
@@ -83,7 +83,7 @@ A plugin is a class extending `Plugin` that declares a **manifest** and register
 extensions. The `src/Plugins/Example/` plugin is a working reference for everything below.
 
 ```php
-use App\Events\PaymentRecorded;
+use App\Events\Payment\PaymentRecorded;
 use OpenKOS\Platform\Navigation\NavigationItem;
 use OpenKOS\Platform\OpenKOSManager;
 use OpenKOS\Platform\Plugin\Plugin;
@@ -176,7 +176,7 @@ src/Plugins/MyPlugin/
 
 ### Domain events
 
-Core dispatches domain events (e.g. `App\Events\PaymentRecorded`); plugins subscribe
+Core dispatches domain events (e.g. `App\Events\Payment\PaymentRecorded`); plugins subscribe
 declaratively via `listens()` (`event => listener` / `[listeners]`), wired onto Laravel's
 event dispatcher at boot. This is the standard extension seam for reacting to core
 activity (accounting, analytics, notifications) **without modifying core** — the action
@@ -240,7 +240,7 @@ future concern.
 
 ### ExamplePlugin (disabled by default)
 
-`ExamplePlugin` (`src/Plugins/Example/`) is a working reference for **every** extension point: a manifest, a declared permission (`example.view`) gating its nav item and route, the consumed registries (sidebar nav item, Dashboard sub-page, settings nav entry, plus a `workspace-header-badge` region — client half in `resources/js/plugins/example/`), a domain-event listener (`Listeners/LogPaymentRecorded` on `PaymentRecorded`), its own `routes/web.php` (an invokable-controller `/example` endpoint), and a `database/migrations/` migration.
+`ExamplePlugin` (`src/Plugins/Example/`) is a working reference for **every** extension point: a manifest, a declared permission (`example.view`) gating its nav item and route, the consumed registries (sidebar nav item, Dashboard sub-page, settings nav entry, plus a `workspace-header-badge` region — client half in `resources/js/plugins/example/`), a domain-event listener (`Listeners/LogPaymentRecorded` on `Payment\PaymentRecorded`), its own `routes/web.php` (an invokable-controller `/example` endpoint), and a `database/migrations/` migration.
 
 It ships **disabled** so the demo stays out of the real UI. To enable it:
 

--- a/docs/platform.md
+++ b/docs/platform.md
@@ -240,7 +240,7 @@ future concern.
 
 ### ExamplePlugin (disabled by default)
 
-`ExamplePlugin` (`src/Plugins/Example/`) is a working reference for **every** extension point: a manifest, a declared permission (`example.view`) gating its nav item and route, the consumed registries (sidebar nav item, Dashboard sub-page, settings nav entry, plus a `workspace-header-badge` region — client half in `resources/js/plugins/example/`), a domain-event listener (`Listeners/LogPaymentRecorded` on `Payment\PaymentRecorded`), its own `routes/web.php` (an invokable-controller `/example` endpoint), and a `database/migrations/` migration.
+`ExamplePlugin` (`src/Plugins/Example/`) is a working reference for **every** extension point: a manifest, a declared permission (`example.view`) gating its nav item and route, the consumed registries (sidebar nav item, Dashboard sub-page, settings nav entry, plus a `workspace-header-badge` region — client half in `resources/js/plugins/example/`), a domain-event listener (`Listeners/LogPaymentRecorded` on `App\Events\Payment\PaymentRecorded`), its own `routes/web.php` (an invokable-controller `/example` endpoint), and a `database/migrations/` migration.
 
 It ships **disabled** so the demo stays out of the real UI. To enable it:
 

--- a/src/Plugins/Example/ExamplePlugin.php
+++ b/src/Plugins/Example/ExamplePlugin.php
@@ -2,7 +2,7 @@
 
 namespace OpenKOS\Plugins\Example;
 
-use App\Events\PaymentRecorded;
+use App\Events\Payment\PaymentRecorded;
 use OpenKOS\Platform\Dashboard\DashboardPage;
 use OpenKOS\Platform\Navigation\NavigationItem;
 use OpenKOS\Platform\OpenKOSManager;

--- a/src/Plugins/Example/Listeners/LogPaymentRecorded.php
+++ b/src/Plugins/Example/Listeners/LogPaymentRecorded.php
@@ -2,7 +2,7 @@
 
 namespace OpenKOS\Plugins\Example\Listeners;
 
-use App\Events\PaymentRecorded;
+use App\Events\Payment\PaymentRecorded;
 use Illuminate\Support\Facades\Log;
 
 /**

--- a/tests/Feature/Domain/DomainEventTest.php
+++ b/tests/Feature/Domain/DomainEventTest.php
@@ -1,0 +1,172 @@
+<?php
+
+use App\Enums\LeaseStatus;
+use App\Enums\MaintenancePriority;
+use App\Enums\MaintenanceStatus;
+use App\Enums\UnitStatus;
+use App\Events\Lease\LeaseCreated;
+use App\Events\Maintenance\MaintenanceResolved;
+use App\Events\Maintenance\MaintenanceTicketCreated;
+use App\Events\Payment\PaymentRecorded;
+use App\Events\Unit\UnitStatusChanged;
+use App\Models\Lease;
+use App\Models\MaintenanceTicket;
+use App\Models\Property;
+use App\Models\Tenant;
+use App\Models\Unit;
+use App\Models\User;
+use Database\Seeders\RegionAndCitySeeder;
+use Database\Seeders\RoleAndPermissionSeeder;
+use Illuminate\Support\Facades\Event;
+
+uses()->beforeEach(function () {
+    $this->seed(RoleAndPermissionSeeder::class);
+    $this->seed(RegionAndCitySeeder::class);
+});
+
+describe('lease events', function () {
+    it('dispatches LeaseCreated when creating a lease', function () {
+        Event::fake([LeaseCreated::class, UnitStatusChanged::class]);
+
+        $property = Property::factory()->create();
+        $unit = Unit::factory()->withRate(1_000_000)->create(['property_id' => $property->id]);
+        $user = User::factory()->owner()->create();
+        $tenant = Tenant::factory()->create();
+
+        $this->actingAs($user)->post(route('properties.units.leases.store', [$property, $unit]), [
+            'tenant_ids' => [$tenant->id],
+            'start_date' => '2026-06-01',
+            'rent_amount' => 1_500_000,
+            'billing_unit' => 'month',
+            'billing_interval' => 1,
+        ]);
+
+        Event::assertDispatched(LeaseCreated::class);
+        Event::assertDispatched(UnitStatusChanged::class);
+    });
+
+    it('dispatches UnitStatusChanged when lease termination frees a unit', function () {
+        Event::fake([UnitStatusChanged::class]);
+
+        $property = Property::factory()->create();
+        $unit = Unit::factory()->withRate(1_000_000)->occupied()->create(['property_id' => $property->id]);
+        $user = User::factory()->owner()->create();
+        $tenant = Tenant::factory()->create();
+
+        $lease = Lease::factory()->create([
+            'primary_tenant_id' => $tenant->id,
+            'unit_id' => $unit->id,
+            'status' => LeaseStatus::Active,
+        ]);
+
+        $this->actingAs($user)
+            ->delete(route('properties.units.leases.destroy', [$property, $unit, $lease]), ['reason' => 'test']);
+
+        // ponytail: UnitStatusChanged only fires when the status actually changes.
+        // The unit starts occupied and termination flips it to available.
+        Event::assertDispatched(UnitStatusChanged::class);
+    });
+});
+
+describe('payment events', function () {
+    it('dispatches PaymentRecorded when recording a payment', function () {
+        Event::fake([PaymentRecorded::class]);
+
+        $property = Property::factory()->create();
+        $unit = Unit::factory()->withRate(1_000_000)->create(['property_id' => $property->id]);
+        $user = User::factory()->owner()->create();
+        $tenant = Tenant::factory()->create();
+
+        $lease = Lease::factory()->create([
+            'primary_tenant_id' => $tenant->id,
+            'unit_id' => $unit->id,
+            'status' => LeaseStatus::Active,
+        ]);
+
+        $this->actingAs($user)->post(route('leases.payments.store', $lease), [
+            'amount' => 1_500_000,
+            'payment_method' => 'cash',
+            'paid_at' => now()->format('Y-m-d'),
+            'period_month' => now()->month,
+            'period_year' => now()->year,
+        ]);
+
+        Event::assertDispatched(PaymentRecorded::class);
+    });
+});
+
+describe('maintenance events', function () {
+    it('dispatches MaintenanceTicketCreated when creating a ticket', function () {
+        Event::fake([MaintenanceTicketCreated::class]);
+
+        $owner = User::factory()->owner()->create();
+
+        $this->actingAs($owner)
+            ->post(route('maintenance-tickets.store'), [
+                'property_id' => Property::factory()->create()->id,
+                'title' => 'Broken window',
+                'priority' => MaintenancePriority::Medium->value,
+            ])
+            ->assertRedirect();
+
+        Event::assertDispatched(MaintenanceTicketCreated::class);
+    });
+
+    it('dispatches MaintenanceResolved when resolving a ticket', function () {
+        Event::fake([MaintenanceResolved::class]);
+
+        $ticket = MaintenanceTicket::factory()->create([
+            'status' => MaintenanceStatus::InProgress->value,
+        ]);
+        $owner = User::factory()->owner()->create();
+
+        $this->actingAs($owner)
+            ->put(route('maintenance-tickets.update', $ticket), [
+                'status' => MaintenanceStatus::Resolved->value,
+            ])
+            ->assertRedirect();
+
+        Event::assertDispatched(MaintenanceResolved::class);
+    });
+
+    it('dispatches UnitStatusChanged when blocking a unit', function () {
+        Event::fake([UnitStatusChanged::class]);
+
+        $owner = User::factory()->owner()->create();
+        $property = Property::factory()->create();
+        $unit = Unit::factory()->for($property)->create();
+
+        $this->actingAs($owner)
+            ->post(route('maintenance-tickets.store'), [
+                'property_id' => $property->id,
+                'unit_id' => $unit->id,
+                'title' => 'Broken ceiling',
+                'priority' => MaintenancePriority::Urgent->value,
+                'block_unit' => true,
+            ])
+            ->assertRedirect();
+
+        Event::assertDispatched(UnitStatusChanged::class);
+    });
+
+    it('dispatches UnitStatusChanged when restoring unit after resolution', function () {
+        Event::fake([UnitStatusChanged::class]);
+
+        $owner = User::factory()->owner()->create();
+        $unit = Unit::factory()->create(['status' => UnitStatus::Maintenance]);
+
+        $ticket = MaintenanceTicket::factory()->create([
+            'unit_id' => $unit->id,
+            'status' => MaintenanceStatus::InProgress->value,
+        ]);
+
+        $this->actingAs($owner)
+            ->put(route('maintenance-tickets.update', $ticket), [
+                'status' => MaintenanceStatus::Resolved->value,
+                'restore_unit' => true,
+            ])
+            ->assertRedirect();
+
+        Event::assertDispatched(UnitStatusChanged::class);
+    });
+});

--- a/tests/Feature/Platform/PluginEventTest.php
+++ b/tests/Feature/Platform/PluginEventTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Events\PaymentRecorded;
+use App\Events\Payment\PaymentRecorded;
 use App\Models\Lease;
 use App\Models\Payment;
 use App\Models\Property;


### PR DESCRIPTION
- New events: LeaseCreated, MaintenanceTicketCreated, MaintenanceResolved, UnitStatusChanged
- Moved PaymentRecorded to App\Events\Payment- All dispatches moved from Actions to Controllers
- Controllers capture model state before actions, refresh after, then dispatch
- Domain event test suite with 7 tests

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/senatroxx/OpenKos/pull/43?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

