### PR TITLE
feat(activity): add activity log infrastructure

### DIFF
--- a/app/Events/Lease/LeaseCreated.php
+++ b/app/Events/Lease/LeaseCreated.php
@@ -12,5 +12,6 @@ class LeaseCreated
     public function __construct(
         public readonly Lease $lease,
         public readonly array $tenantIds,
+        public readonly ?int $actorId = null,
     ) {}
 }

--- a/app/Events/Lease/LeaseStatusChanged.php
+++ b/app/Events/Lease/LeaseStatusChanged.php
@@ -14,5 +14,6 @@ class LeaseStatusChanged
         public readonly Lease $lease,
         public readonly LeaseStatus $from,
         public readonly LeaseStatus $to,
+        public readonly ?int $actorId = null,
     ) {}
 }

--- a/app/Events/Maintenance/MaintenanceResolved.php
+++ b/app/Events/Maintenance/MaintenanceResolved.php
@@ -11,5 +11,6 @@ class MaintenanceResolved
 
     public function __construct(
         public readonly MaintenanceTicket $ticket,
+        public readonly ?int $actorId = null,
     ) {}
 }

--- a/app/Events/Maintenance/MaintenanceTicketCreated.php
+++ b/app/Events/Maintenance/MaintenanceTicketCreated.php
@@ -11,5 +11,6 @@ class MaintenanceTicketCreated
 
     public function __construct(
         public readonly MaintenanceTicket $ticket,
+        public readonly ?int $actorId = null,
     ) {}
 }

--- a/app/Events/Payment/PaymentRecorded.php
+++ b/app/Events/Payment/PaymentRecorded.php
@@ -13,5 +13,8 @@ class PaymentRecorded
 {
     use Dispatchable;
 
-    public function __construct(public readonly Payment $payment) {}
+    public function __construct(
+        public readonly Payment $payment,
+        public readonly ?int $actorId = null,
+    ) {}
 }

--- a/app/Events/Payment/PaymentStatusChanged.php
+++ b/app/Events/Payment/PaymentStatusChanged.php
@@ -14,5 +14,6 @@ class PaymentStatusChanged
         public readonly Payment $payment,
         public readonly PaymentStatus $from,
         public readonly PaymentStatus $to,
+        public readonly ?int $actorId = null,
     ) {}
 }

--- a/app/Events/Unit/UnitStatusChanged.php
+++ b/app/Events/Unit/UnitStatusChanged.php
@@ -14,5 +14,6 @@ class UnitStatusChanged
         public readonly Unit $unit,
         public readonly UnitStatus $from,
         public readonly UnitStatus $to,
+        public readonly ?int $actorId = null,
     ) {}
 }

--- a/app/Http/Controllers/LeaseController.php
+++ b/app/Http/Controllers/LeaseController.php
@@ -33,6 +33,7 @@ use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -308,12 +309,12 @@ class LeaseController extends Controller
         $lease->load('tenants:id,name,phone', 'primaryTenant:id,name,phone');
 
         if ($lease->wasRecentlyCreated) {
-            LeaseCreated::dispatch($lease, $lease->tenants->pluck('id')->toArray());
+            LeaseCreated::dispatch($lease, $lease->tenants->pluck('id')->toArray(), actorId: Auth::id());
         }
 
         $unit->refresh();
         if ($oldUnitStatus !== $unit->status) {
-            UnitStatusChanged::dispatch($unit, $oldUnitStatus, $unit->status);
+            UnitStatusChanged::dispatch($unit, $oldUnitStatus, $unit->status, actorId: Auth::id());
         }
 
         $count = $lease->tenants->count();
@@ -360,12 +361,12 @@ class LeaseController extends Controller
                 $unit->update(['status' => UnitStatus::Available]);
 
                 if ($oldUnitStatus !== $unit->status) {
-                    UnitStatusChanged::dispatch($unit, $oldUnitStatus, $unit->status);
+                    UnitStatusChanged::dispatch($unit, $oldUnitStatus, $unit->status, actorId: Auth::id());
                 }
             }
         });
 
-        LeaseStatusChanged::dispatch($lease, $oldStatus, LeaseStatus::Terminated);
+        LeaseStatusChanged::dispatch($lease, $oldStatus, LeaseStatus::Terminated, actorId: Auth::id());
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Lease terminated.')]);
 
@@ -407,18 +408,18 @@ class LeaseController extends Controller
 
         $lease->refresh();
         if ($oldLeaseStatus !== $lease->status) {
-            LeaseStatusChanged::dispatch($lease, $oldLeaseStatus, $lease->status);
+            LeaseStatusChanged::dispatch($lease, $oldLeaseStatus, $lease->status, actorId: Auth::id());
         }
 
         $sourceUnit->refresh();
         if ($oldSourceStatus !== $sourceUnit->status) {
-            UnitStatusChanged::dispatch($sourceUnit, $oldSourceStatus, $sourceUnit->status);
+            UnitStatusChanged::dispatch($sourceUnit, $oldSourceStatus, $sourceUnit->status, actorId: Auth::id());
         }
 
         if ($targetUnit) {
             $targetUnit->refresh();
             if ($oldTargetStatus !== $targetUnit->status) {
-                UnitStatusChanged::dispatch($targetUnit, $oldTargetStatus, $targetUnit->status);
+                UnitStatusChanged::dispatch($targetUnit, $oldTargetStatus, $targetUnit->status, actorId: Auth::id());
             }
         }
 
@@ -452,7 +453,7 @@ class LeaseController extends Controller
 
         $lease->refresh();
         if ($oldLeaseStatus !== $lease->status) {
-            LeaseStatusChanged::dispatch($lease, $oldLeaseStatus, $lease->status);
+            LeaseStatusChanged::dispatch($lease, $oldLeaseStatus, $lease->status, actorId: Auth::id());
         }
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Lease renewed. New lease created.')]);
@@ -510,17 +511,17 @@ class LeaseController extends Controller
 
         $lease->refresh();
         if ($oldLeaseStatus !== $lease->status) {
-            LeaseStatusChanged::dispatch($lease, $oldLeaseStatus, $lease->status);
+            LeaseStatusChanged::dispatch($lease, $oldLeaseStatus, $lease->status, actorId: Auth::id());
         }
 
         $unit->refresh();
         if ($oldSourceStatus !== $unit->status) {
-            UnitStatusChanged::dispatch($unit, $oldSourceStatus, $unit->status);
+            UnitStatusChanged::dispatch($unit, $oldSourceStatus, $unit->status, actorId: Auth::id());
         }
 
         $targetUnit->refresh();
         if ($oldTargetStatus !== $targetUnit->status) {
-            UnitStatusChanged::dispatch($targetUnit, $oldTargetStatus, $targetUnit->status);
+            UnitStatusChanged::dispatch($targetUnit, $oldTargetStatus, $targetUnit->status, actorId: Auth::id());
         }
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Tenant moved to new unit.')]);

--- a/app/Http/Controllers/MaintenanceTicketController.php
+++ b/app/Http/Controllers/MaintenanceTicketController.php
@@ -23,6 +23,7 @@ use App\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -162,7 +163,7 @@ class MaintenanceTicketController extends Controller
 
         $ticket = MaintenanceTicket::create($data);
 
-        MaintenanceTicketCreated::dispatch($ticket);
+        MaintenanceTicketCreated::dispatch($ticket, actorId: Auth::id());
 
         if ($blockUnit && ! empty($data['unit_id'])) {
             $unit = Unit::findOrFail($data['unit_id']);
@@ -175,13 +176,13 @@ class MaintenanceTicketController extends Controller
 
             $unit->refresh();
             if ($oldStatus !== $unit->status) {
-                UnitStatusChanged::dispatch($unit, $oldStatus, $unit->status);
+                UnitStatusChanged::dispatch($unit, $oldStatus, $unit->status, actorId: Auth::id());
             }
 
             if ($targetUnit) {
                 $targetUnit->refresh();
                 if ($oldTargetStatus !== $targetUnit->status) {
-                    UnitStatusChanged::dispatch($targetUnit, $oldTargetStatus, $targetUnit->status);
+                    UnitStatusChanged::dispatch($targetUnit, $oldTargetStatus, $targetUnit->status, actorId: Auth::id());
                 }
             }
         }
@@ -215,7 +216,7 @@ class MaintenanceTicketController extends Controller
         $ticket->update($validated);
 
         if (($statusChangedToResolved ?? false)) {
-            MaintenanceResolved::dispatch($ticket);
+            MaintenanceResolved::dispatch($ticket, actorId: Auth::id());
         }
 
         if ($restoreUnit && $ticket->unit_id) {
@@ -234,13 +235,13 @@ class MaintenanceTicketController extends Controller
 
             $unit->refresh();
             if ($oldStatus !== $unit->status) {
-                UnitStatusChanged::dispatch($unit, $oldStatus, $unit->status);
+                UnitStatusChanged::dispatch($unit, $oldStatus, $unit->status, actorId: Auth::id());
             }
 
             if ($targetUnit) {
                 $targetUnit->refresh();
                 if ($oldTargetStatus !== $targetUnit->status) {
-                    UnitStatusChanged::dispatch($targetUnit, $oldTargetStatus, $targetUnit->status);
+                    UnitStatusChanged::dispatch($targetUnit, $oldTargetStatus, $targetUnit->status, actorId: Auth::id());
                 }
             }
 

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -13,6 +13,7 @@ use App\Models\Lease;
 use App\Models\Payment;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Inertia\Inertia;
 
 class PaymentController extends Controller
@@ -42,7 +43,7 @@ class PaymentController extends Controller
 
         $payment = $result->payment;
 
-        PaymentRecorded::dispatch($payment);
+        PaymentRecorded::dispatch($payment, actorId: Auth::id());
 
         $periodStart = sprintf('%04d-%02d-01', $request->period_year, $request->period_month);
 
@@ -94,7 +95,7 @@ class PaymentController extends Controller
             'verified_at' => now(),
         ]);
 
-        PaymentStatusChanged::dispatch($payment, $oldStatus, $newStatus);
+        PaymentStatusChanged::dispatch($payment, $oldStatus, $newStatus, actorId: Auth::id());
 
         $message = $request->action === 'confirm'
             ? __('Payment verified successfully.')

--- a/app/Listeners/RecordActivitySubscriber.php
+++ b/app/Listeners/RecordActivitySubscriber.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\Lease\LeaseCreated;
+use App\Events\Lease\LeaseStatusChanged;
+use App\Events\Maintenance\MaintenanceResolved;
+use App\Events\Maintenance\MaintenanceTicketCreated;
+use App\Events\Payment\PaymentRecorded;
+use App\Events\Payment\PaymentStatusChanged;
+use App\Events\Unit\UnitStatusChanged;
+use App\Models\ActivityLog;
+use Illuminate\Events\Dispatcher;
+
+class RecordActivitySubscriber
+{
+    public function subscribe(Dispatcher $events): array
+    {
+        return [
+            LeaseCreated::class => 'handleLeaseCreated',
+            LeaseStatusChanged::class => 'handleLeaseStatusChanged',
+            PaymentRecorded::class => 'handlePaymentRecorded',
+            PaymentStatusChanged::class => 'handlePaymentStatusChanged',
+            MaintenanceTicketCreated::class => 'handleMaintenanceTicketCreated',
+            MaintenanceResolved::class => 'handleMaintenanceResolved',
+            UnitStatusChanged::class => 'handleUnitStatusChanged',
+        ];
+    }
+
+    public function handleLeaseCreated(LeaseCreated $event): void
+    {
+        ActivityLog::record(
+            event: 'lease.created',
+            subject: $event->lease,
+            metadata: ['tenant_ids' => $event->tenantIds],
+            actorId: $event->actorId,
+        );
+    }
+
+    public function handleLeaseStatusChanged(LeaseStatusChanged $event): void
+    {
+        ActivityLog::record(
+            event: 'lease.status_changed',
+            subject: $event->lease,
+            metadata: [
+                'from' => $event->from->value,
+                'to' => $event->to->value,
+            ],
+            actorId: $event->actorId,
+        );
+    }
+
+    public function handlePaymentRecorded(PaymentRecorded $event): void
+    {
+        ActivityLog::record(
+            event: 'payment.recorded',
+            subject: $event->payment,
+            metadata: [
+                'amount' => $event->payment->amount,
+                'method' => $event->payment->payment_method,
+                'status' => $event->payment->status,
+            ],
+            actorId: $event->actorId,
+        );
+    }
+
+    public function handlePaymentStatusChanged(PaymentStatusChanged $event): void
+    {
+        ActivityLog::record(
+            event: 'payment.status_changed',
+            subject: $event->payment,
+            metadata: [
+                'from' => $event->from->value,
+                'to' => $event->to->value,
+            ],
+            actorId: $event->actorId,
+        );
+    }
+
+    public function handleMaintenanceTicketCreated(MaintenanceTicketCreated $event): void
+    {
+        ActivityLog::record(
+            event: 'maintenance.ticket_created',
+            subject: $event->ticket,
+            actorId: $event->actorId,
+        );
+    }
+
+    public function handleMaintenanceResolved(MaintenanceResolved $event): void
+    {
+        ActivityLog::record(
+            event: 'maintenance.resolved',
+            subject: $event->ticket,
+            actorId: $event->actorId,
+        );
+    }
+
+    public function handleUnitStatusChanged(UnitStatusChanged $event): void
+    {
+        ActivityLog::record(
+            event: 'unit.status_changed',
+            subject: $event->unit,
+            metadata: [
+                'from' => $event->from->value,
+                'to' => $event->to->value,
+            ],
+            actorId: $event->actorId,
+        );
+    }
+}

--- a/app/Models/ActivityLog.php
+++ b/app/Models/ActivityLog.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+class ActivityLog extends Model
+{
+    const UPDATED_AT = null;
+
+    protected $fillable = [
+        'subject_type',
+        'subject_id',
+        'event',
+        'actor_id',
+        'metadata',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'metadata' => 'array',
+            'created_at' => 'datetime',
+        ];
+    }
+
+    public function subject(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    public function actor(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'actor_id');
+    }
+
+    public static function record(
+        string $event,
+        Model $subject,
+        ?array $metadata = null,
+        ?int $actorId = null,
+    ): ?self {
+        if ($subject->getKey() === null) {
+            return null;
+        }
+
+        return static::create([
+            'subject_type' => $subject->getMorphClass(),
+            'subject_id' => $subject->getKey(),
+            'event' => $event,
+            'metadata' => $metadata,
+            'actor_id' => $actorId,
+        ]);
+    }
+}

--- a/database/migrations/2026_07_06_000000_create_activity_logs_table.php
+++ b/database/migrations/2026_07_06_000000_create_activity_logs_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('activity_logs', function (Blueprint $table) {
+            $table->id();
+            $table->string('subject_type');
+            $table->unsignedBigInteger('subject_id');
+            $table->string('event');
+            $table->unsignedBigInteger('actor_id')->nullable();
+            $table->json('metadata')->nullable();
+            $table->timestamp('created_at');
+
+            $table->foreign('actor_id')
+                ->references('id')
+                ->on('users')
+                ->nullOnDelete();
+
+            $table->index(['subject_type', 'subject_id', 'created_at']);
+            $table->index(['event', 'created_at']);
+            $table->index('created_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('activity_logs');
+    }
+};

--- a/tests/Feature/ActivityLogTest.php
+++ b/tests/Feature/ActivityLogTest.php
@@ -1,0 +1,164 @@
+<?php
+
+use App\Enums\LeaseStatus;
+use App\Enums\MaintenanceStatus;
+use App\Enums\PaymentStatus;
+use App\Enums\UnitStatus;
+use App\Events\Lease\LeaseCreated;
+use App\Events\Lease\LeaseStatusChanged;
+use App\Events\Maintenance\MaintenanceResolved;
+use App\Events\Maintenance\MaintenanceTicketCreated;
+use App\Events\Payment\PaymentRecorded;
+use App\Events\Payment\PaymentStatusChanged;
+use App\Events\Unit\UnitStatusChanged;
+use App\Models\ActivityLog;
+use App\Models\Lease;
+use App\Models\MaintenanceTicket;
+use App\Models\Payment;
+use App\Models\Unit;
+use App\Models\User;
+
+uses()->beforeEach(function () {
+    $this->seed(RoleAndPermissionSeeder::class);
+});
+
+describe('lease events', function () {
+    it('records lease.created', function () {
+        $lease = Lease::factory()->create();
+        $actor = User::factory()->owner()->create();
+
+        LeaseCreated::dispatch($lease, [$lease->primary_tenant_id], actorId: $actor->id);
+
+        expect(ActivityLog::count())->toBe(1);
+        $log = ActivityLog::first();
+        expect($log)
+            ->event->toBe('lease.created')
+            ->subject_type->toBe($lease->getMorphClass())
+            ->subject_id->toBe($lease->id)
+            ->actor_id->toBe($actor->id)
+            ->metadata->toBe(['tenant_ids' => [$lease->primary_tenant_id]]);
+    });
+
+    it('records lease.status_changed', function () {
+        $lease = Lease::factory()->create(['status' => LeaseStatus::Active]);
+        $actor = User::factory()->owner()->create();
+
+        LeaseStatusChanged::dispatch($lease, LeaseStatus::Active, LeaseStatus::Terminated, actorId: $actor->id);
+
+        expect(ActivityLog::count())->toBe(1);
+        $log = ActivityLog::first();
+        expect($log)
+            ->event->toBe('lease.status_changed')
+            ->subject_type->toBe($lease->getMorphClass())
+            ->subject_id->toBe($lease->id)
+            ->actor_id->toBe($actor->id)
+            ->metadata->toBe(['from' => LeaseStatus::Active->value, 'to' => LeaseStatus::Terminated->value]);
+    });
+});
+
+describe('payment events', function () {
+    it('records payment.recorded', function () {
+        $lease = Lease::factory()->create();
+        $payment = Payment::factory()->create([
+            'paymentable_type' => $lease->getMorphClass(),
+            'paymentable_id' => $lease->id,
+            'amount' => 150000,
+            'payment_method' => 'cash',
+            'status' => PaymentStatus::Pending,
+        ]);
+        $actor = User::factory()->owner()->create();
+
+        PaymentRecorded::dispatch($payment, actorId: $actor->id);
+
+        expect(ActivityLog::count())->toBe(1);
+        $log = ActivityLog::first();
+        expect($log)
+            ->event->toBe('payment.recorded')
+            ->subject_type->toBe($payment->getMorphClass())
+            ->subject_id->toBe($payment->id)
+            ->actor_id->toBe($actor->id)
+            ->metadata->toBe([
+                'amount' => '150000.00',
+                'method' => 'cash',
+                'status' => PaymentStatus::Pending->value,
+            ]);
+    });
+
+    it('records payment.status_changed', function () {
+        $lease = Lease::factory()->create();
+        $payment = Payment::factory()->create([
+            'paymentable_type' => $lease->getMorphClass(),
+            'paymentable_id' => $lease->id,
+        ]);
+        $actor = User::factory()->owner()->create();
+
+        PaymentStatusChanged::dispatch($payment, PaymentStatus::Pending, PaymentStatus::Confirmed, actorId: $actor->id);
+
+        expect(ActivityLog::count())->toBe(1);
+        $log = ActivityLog::first();
+        expect($log)
+            ->event->toBe('payment.status_changed')
+            ->metadata->toBe(['from' => PaymentStatus::Pending->value, 'to' => PaymentStatus::Confirmed->value]);
+    });
+});
+
+describe('maintenance events', function () {
+    it('records maintenance.ticket_created', function () {
+        $ticket = MaintenanceTicket::factory()->create();
+        $actor = User::factory()->owner()->create();
+
+        MaintenanceTicketCreated::dispatch($ticket, actorId: $actor->id);
+
+        expect(ActivityLog::count())->toBe(1);
+        $log = ActivityLog::first();
+        expect($log)
+            ->event->toBe('maintenance.ticket_created')
+            ->subject_type->toBe($ticket->getMorphClass())
+            ->subject_id->toBe($ticket->id)
+            ->actor_id->toBe($actor->id);
+    });
+
+    it('records maintenance.resolved', function () {
+        $ticket = MaintenanceTicket::factory()->create(['status' => MaintenanceStatus::Resolved]);
+        $actor = User::factory()->owner()->create();
+
+        MaintenanceResolved::dispatch($ticket, actorId: $actor->id);
+
+        expect(ActivityLog::count())->toBe(1);
+        $log = ActivityLog::first();
+        expect($log)
+            ->event->toBe('maintenance.resolved')
+            ->subject_type->toBe($ticket->getMorphClass())
+            ->subject_id->toBe($ticket->id)
+            ->actor_id->toBe($actor->id);
+    });
+});
+
+describe('unit events', function () {
+    it('records unit.status_changed', function () {
+        $unit = Unit::factory()->create(['status' => UnitStatus::Available]);
+        $actor = User::factory()->owner()->create();
+
+        UnitStatusChanged::dispatch($unit, UnitStatus::Available, UnitStatus::Occupied, actorId: $actor->id);
+
+        expect(ActivityLog::count())->toBe(1);
+        $log = ActivityLog::first();
+        expect($log)
+            ->event->toBe('unit.status_changed')
+            ->subject_type->toBe($unit->getMorphClass())
+            ->subject_id->toBe($unit->id)
+            ->actor_id->toBe($actor->id)
+            ->metadata->toBe(['from' => UnitStatus::Available->value, 'to' => UnitStatus::Occupied->value]);
+    });
+});
+
+describe('actor behavior', function () {
+    it('allows null actor_id', function () {
+        $lease = Lease::factory()->create();
+
+        LeaseCreated::dispatch($lease, [$lease->primary_tenant_id]);
+
+        expect(ActivityLog::count())->toBe(1);
+        expect(ActivityLog::first()->actor_id)->toBeNull();
+    });
+});

--- a/tests/Feature/ActivityLogTest.php
+++ b/tests/Feature/ActivityLogTest.php
@@ -17,6 +17,7 @@ use App\Models\MaintenanceTicket;
 use App\Models\Payment;
 use App\Models\Unit;
 use App\Models\User;
+use Database\Seeders\RoleAndPermissionSeeder;
 
 uses()->beforeEach(function () {
     $this->seed(RoleAndPermissionSeeder::class);


### PR DESCRIPTION
Centralized activity_logs table consuming domain events via subscriber. All 7 domain events carry optional actorId. Controllers pass Auth::id() at dispatch. Skipped frontend timeline — pure backend infra.

Closes OPE-65

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/senatroxx/OpenKos/pull/44?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

