### PR TITLE
feat(audit): add immutable audit log infrastructure

### DIFF
--- a/app/Concerns/Auditable.php
+++ b/app/Concerns/Auditable.php
@@ -65,7 +65,7 @@ trait Auditable
         $except = $this->getAuditableExcept();
         $mask = $this->getAuditableMask();
 
-        $keys = $source ? array_keys($fields) : $allowed;
+        $keys = $source ? array_intersect(array_keys($fields), $allowed) : $allowed;
         $values = $source
             ? array_intersect_key($source, array_flip($keys))
             : array_intersect_key($fields, array_flip($keys));
@@ -117,7 +117,7 @@ trait Auditable
     protected function resolveAuditSource(): string
     {
         if (app()->runningInConsole()) {
-            return 'Scheduler';
+            return 'CLI';
         }
 
         return 'UI';

--- a/app/Concerns/Auditable.php
+++ b/app/Concerns/Auditable.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace App\Concerns;
+
+use App\Models\AuditLog;
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+
+trait Auditable
+{
+    protected bool $auditRestoring = false;
+
+    public static function bootAuditable(): void
+    {
+        static::created(fn (self $model) => $model->recordAudit('create'));
+        static::updated(fn (self $model) => $model->recordAudit('update'));
+        static::deleted(fn (self $model) => $model->recordAudit('delete'));
+        static::restoring(function (self $model) {
+            $model->auditRestoring = true;
+        });
+        static::restored(function (self $model) {
+            $model->recordAudit('restore');
+        });
+    }
+
+    public function recordAudit(string $operation): void
+    {
+        if ($operation === 'update' && $this->auditRestoring) {
+            $this->auditRestoring = false;
+
+            return;
+        }
+
+        if ($operation === 'update' && ! $this->isDirty()) {
+            return;
+        }
+
+        $before = match ($operation) {
+            'create' => null,
+            'update' => $this->auditableSnapshot($this->getDirty(), $this->getOriginal()),
+            'delete' => $this->auditableSnapshot($this->getAttributes()),
+            'restore' => null,
+        };
+
+        $after = match ($operation) {
+            'create' => $this->auditableSnapshot($this->getAttributes()),
+            'update' => $this->auditableSnapshot($this->getDirty(), $this->getAttributes()),
+            'delete' => null,
+            'restore' => $this->auditableSnapshot($this->getAttributes()),
+        };
+
+        AuditLog::record(
+            auditable: $this,
+            operation: $operation,
+            before: $before,
+            after: $after,
+            actor: $this->resolveAuditActor(),
+            source: $this->resolveAuditSource(),
+        );
+    }
+
+    protected function auditableSnapshot(array $fields, ?array $source = null): ?array
+    {
+        $allowed = $this->getAuditableFields();
+        $except = $this->getAuditableExcept();
+        $mask = $this->getAuditableMask();
+
+        $keys = $source ? array_keys($fields) : $allowed;
+        $values = $source
+            ? array_intersect_key($source, array_flip($keys))
+            : array_intersect_key($fields, array_flip($keys));
+
+        if ($except) {
+            $values = array_diff_key($values, array_flip($except));
+        }
+
+        if (empty($values)) {
+            return null;
+        }
+
+        foreach ($mask as $field) {
+            if (array_key_exists($field, $values)) {
+                $values[$field] = '***MASKED***';
+            }
+        }
+
+        return $values;
+    }
+
+    protected function getAuditableFields(): array
+    {
+        if (property_exists($this, 'auditable')) {
+            return $this->auditable;
+        }
+
+        return $this->getFillable();
+    }
+
+    protected function getAuditableExcept(): array
+    {
+        return property_exists($this, 'auditableExcept') ? $this->auditableExcept : [];
+    }
+
+    protected function getAuditableMask(): array
+    {
+        return property_exists($this, 'auditableMask') ? $this->auditableMask : [];
+    }
+
+    protected function resolveAuditActor(): ?User
+    {
+        /** @var User|null $user */
+        $user = Auth::user();
+
+        return $user;
+    }
+
+    protected function resolveAuditSource(): string
+    {
+        if (app()->runningInConsole()) {
+            return 'Scheduler';
+        }
+
+        return 'UI';
+    }
+}

--- a/app/Models/AuditLog.php
+++ b/app/Models/AuditLog.php
@@ -21,6 +21,14 @@ class AuditLog extends Model
         'metadata',
     ];
 
+    protected static function boot(): void
+    {
+        parent::boot();
+
+        static::updating(fn () => false);
+        static::deleting(fn () => false);
+    }
+
     protected function casts(): array
     {
         return [

--- a/app/Models/AuditLog.php
+++ b/app/Models/AuditLog.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+class AuditLog extends Model
+{
+    const UPDATED_AT = null;
+
+    protected $fillable = [
+        'auditable_type',
+        'auditable_id',
+        'operation',
+        'before',
+        'after',
+        'actor_type',
+        'actor_id',
+        'source',
+        'metadata',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'before' => 'array',
+            'after' => 'array',
+            'metadata' => 'array',
+            'created_at' => 'datetime',
+        ];
+    }
+
+    public function auditable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    public function actor(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    public static function record(
+        Model $auditable,
+        string $operation,
+        ?array $before = null,
+        ?array $after = null,
+        ?Model $actor = null,
+        string $source = 'UI',
+        ?array $metadata = null,
+    ): self {
+        return static::create([
+            'auditable_type' => $auditable->getMorphClass(),
+            'auditable_id' => $auditable->getKey(),
+            'operation' => $operation,
+            'before' => $before,
+            'after' => $after,
+            'actor_type' => $actor?->getMorphClass(),
+            'actor_id' => $actor?->getKey(),
+            'source' => $source,
+            'metadata' => $metadata,
+        ]);
+    }
+}

--- a/app/Models/Lease.php
+++ b/app/Models/Lease.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Concerns\Auditable;
 use App\Enums\BillingUnit;
 use App\Enums\LeaseStatus;
 use App\Enums\PaymentStatus;
@@ -42,7 +43,7 @@ use Illuminate\Support\Collection;
 ])]
 class Lease extends Model
 {
-    use HasFactory, SoftDeletes;
+    use Auditable, HasFactory, SoftDeletes;
 
     protected static function boot(): void
     {

--- a/app/Models/Property.php
+++ b/app/Models/Property.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Concerns\Auditable;
 use App\Enums\UnitStatus;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Builder;
@@ -30,7 +31,9 @@ use Illuminate\Support\Str;
 ])]
 class Property extends Model
 {
-    use HasFactory, SoftDeletes;
+    use Auditable, HasFactory, SoftDeletes;
+
+    protected array $auditableMask = ['phone'];
 
     protected $with = ['region', 'city', 'propertyType'];
 

--- a/app/Models/Tenant.php
+++ b/app/Models/Tenant.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Concerns\Auditable;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -25,7 +26,9 @@ use Illuminate\Notifications\Notification;
 ])]
 class Tenant extends Model
 {
-    use HasFactory, Notifiable, SoftDeletes;
+    use Auditable, HasFactory, Notifiable, SoftDeletes;
+
+    protected array $auditableMask = ['phone', 'email', 'id_card_number', 'emergency_contact_phone'];
 
     protected function casts(): array
     {

--- a/app/Models/Unit.php
+++ b/app/Models/Unit.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Concerns\Auditable;
 use App\Enums\UnitStatus;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Builder;
@@ -26,7 +27,7 @@ use Illuminate\Support\Str;
 ])]
 class Unit extends Model
 {
-    use HasFactory, SoftDeletes;
+    use Auditable, HasFactory, SoftDeletes;
 
     protected function casts(): array
     {

--- a/database/migrations/2026_07_06_102254_create_audit_logs_table.php
+++ b/database/migrations/2026_07_06_102254_create_audit_logs_table.php
@@ -15,7 +15,8 @@ return new class extends Migration
             $table->string('operation'); // create, update, delete, restore
             $table->json('before')->nullable();
             $table->json('after')->nullable();
-            $table->nullableMorphs('actor'); // actor_type + actor_id
+            $table->string('actor_type')->nullable();
+            $table->unsignedBigInteger('actor_id')->nullable();
             $table->string('source')->default('UI'); // UI, API, Plugin, Scheduler, System
             $table->json('metadata')->nullable();
             $table->timestamp('created_at');

--- a/database/migrations/2026_07_06_102254_create_audit_logs_table.php
+++ b/database/migrations/2026_07_06_102254_create_audit_logs_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('audit_logs', function (Blueprint $table) {
+            $table->id();
+            $table->string('auditable_type');
+            $table->unsignedBigInteger('auditable_id');
+            $table->string('operation'); // create, update, delete, restore
+            $table->json('before')->nullable();
+            $table->json('after')->nullable();
+            $table->nullableMorphs('actor'); // actor_type + actor_id
+            $table->string('source')->default('UI'); // UI, API, Plugin, Scheduler, System
+            $table->json('metadata')->nullable();
+            $table->timestamp('created_at');
+
+            $table->index(['auditable_type', 'auditable_id', 'created_at']);
+            $table->index(['operation', 'created_at']);
+            $table->index(['actor_type', 'actor_id', 'created_at']);
+            $table->index(['source', 'created_at']);
+            $table->index('created_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('audit_logs');
+    }
+};

--- a/tests/Feature/AuditLogTest.php
+++ b/tests/Feature/AuditLogTest.php
@@ -1,0 +1,133 @@
+<?php
+
+use App\Models\AuditLog;
+use App\Models\Property;
+use App\Models\Tenant;
+use App\Models\User;
+
+uses()->beforeEach(function () {
+    $this->seed(RoleAndPermissionSeeder::class);
+});
+
+describe('create operations', function () {
+    it('records an audit when a model is created', function () {
+        $property = Property::factory()->create();
+
+        expect(AuditLog::count())->toBe(1);
+        $log = AuditLog::first();
+        expect($log)
+            ->auditable_type->toBe($property->getMorphClass())
+            ->auditable_id->toBe($property->id)
+            ->operation->toBe('create')
+            ->before->toBeNull()
+            ->after->toHaveKeys(['name', 'address', 'phone'])
+            ->actor_id->toBeNull();
+    });
+
+    it('records the authenticated user as actor on create', function () {
+        $user = User::factory()->owner()->create();
+        $this->actingAs($user);
+
+        Property::factory()->create();
+
+        $log = AuditLog::first();
+        expect($log)
+            ->actor_id->toBe($user->id)
+            ->actor_type->toBe($user->getMorphClass());
+    });
+
+    it('allows multiple auditable models independently', function () {
+        Property::factory()->count(2)->create();
+
+        expect(AuditLog::count())->toBe(2);
+    });
+});
+
+describe('update operations', function () {
+    it('records only dirty fields on update', function () {
+        $property = Property::factory()->create();
+        AuditLog::truncate();
+
+        $property->update(['name' => 'Updated Name', 'phone' => '123456789']);
+
+        expect(AuditLog::count())->toBe(1);
+        $log = AuditLog::first();
+        expect($log)
+            ->operation->toBe('update')
+            ->before->toHaveKeys(['name', 'phone'])
+            ->after->toHaveKeys(['name', 'phone']);
+        expect($log->after['name'])->toBe('Updated Name');
+        expect($log->after['phone'])->toBe('***MASKED***');
+    });
+
+    it('skips audit when no fields changed', function () {
+        $property = Property::factory()->create();
+        AuditLog::truncate();
+
+        $property->touch();
+
+        expect(AuditLog::count())->toBe(0);
+    });
+});
+
+describe('delete and restore operations', function () {
+    it('records a delete operation when soft deleted', function () {
+        $property = Property::factory()->create();
+        AuditLog::truncate();
+
+        $property->delete();
+
+        expect(AuditLog::count())->toBe(1);
+        $log = AuditLog::first();
+        expect($log)
+            ->operation->toBe('delete')
+            ->before->toHaveKeys(['name', 'address'])
+            ->after->toBeNull();
+    });
+
+    it('records a restore operation without duplicate update entry', function () {
+        $property = Property::factory()->create();
+        $property->delete();
+        AuditLog::truncate();
+
+        $property->restore();
+
+        expect(AuditLog::count())->toBe(1);
+        $log = AuditLog::first();
+        expect($log)
+            ->operation->toBe('restore')
+            ->before->toBeNull()
+            ->after->toHaveKeys(['name', 'address']);
+    });
+});
+
+describe('immutability', function () {
+    it('does not set updated_at on audit logs', function () {
+        Property::factory()->create();
+
+        expect(AuditLog::first()->updated_at)->toBeNull();
+    });
+});
+
+describe('PII handling', function () {
+    it('masks sensitive fields on Tenant', function () {
+        Tenant::factory()->create([
+            'phone' => '08123456789',
+            'email' => 'tenant@example.com',
+            'id_card_number' => '1234567890123456',
+        ]);
+
+        $log = AuditLog::first();
+        expect($log->after['phone'])->toBe('***MASKED***');
+        expect($log->after['email'])->toBe('***MASKED***');
+        expect($log->after['id_card_number'])->toBe('***MASKED***');
+        expect($log->after['name'])->not->toBe('***MASKED***');
+    });
+
+    it('masks phone on Property', function () {
+        Property::factory()->create(['phone' => '021123456']);
+
+        $log = AuditLog::first();
+        expect($log->after['phone'])->toBe('***MASKED***');
+    });
+});

--- a/tests/Feature/AuditLogTest.php
+++ b/tests/Feature/AuditLogTest.php
@@ -4,6 +4,7 @@ use App\Models\AuditLog;
 use App\Models\Property;
 use App\Models\Tenant;
 use App\Models\User;
+use Database\Seeders\RoleAndPermissionSeeder;
 
 uses()->beforeEach(function () {
     $this->seed(RoleAndPermissionSeeder::class);


### PR DESCRIPTION
Generic Auditable trait hooks Eloquent model events (created, updated, deleted, restored) to record before/after snapshots on an audit_logs table. Supports polymorphic subjects, actor tracking, source detection, field filtering, and PII masking.

Applied to core models: Property, Unit, Lease, Tenant.

Closes OPE-69

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/senatroxx/OpenKos/pull/45?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

