### PR TITLE
docs: introduce Architecture Decision Records (ADR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ npm run dev
 
 ## Architecture
 
+See [docs/architecture.md](docs/architecture.md) for patterns and conventions, and [docs/architecture/adr/](docs/architecture/adr/README.md) for Architecture Decision Records — PRs that make an architectural decision with lasting trade-offs should include an ADR.
+
 - **Owner**: Full access to all features
 - **Admin**: Operational access (properties, units, tenants, reports)
 - **Staff**: Limited access (tenants, dashboard)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,7 +1,7 @@
 # Architecture
 
 > **Status:** Living document
-> **Purpose:** Describe the application's architectural patterns, layer conventions, and data flow. Not an ADR — decisions with trade-offs belong in their own docs (see `docs/multi-tenant-occupancy.md`, `docs/rent-reminders.md`).
+> **Purpose:** Describe the application's architectural patterns, layer conventions, and data flow. Decisions with trade-offs are recorded as ADRs in [`docs/architecture/adr/`](architecture/adr/README.md); detailed feature designs live in their own docs (see `docs/multi-tenant-occupancy.md`, `docs/rent-reminders.md`).
 
 ## Stack
 

--- a/docs/architecture/adr/001-single-tenant.md
+++ b/docs/architecture/adr/001-single-tenant.md
@@ -1,0 +1,31 @@
+# ADR-001: Single Tenant
+
+**Status:** Accepted
+**Date:** 2026-07-08
+
+## Context
+
+OpenKOS replaces Excel + WhatsApp workflows for a kos (boarding house) owner. Each owner runs their own business with their own data, staff, and configuration. The alternatives were:
+
+- **Multi-tenant SaaS schema** — every table carries a `tenant_id`, every query is scoped, auth and billing become per-organization.
+- **Single tenant per installation** — one installation serves one kos business; isolation comes from running separate installations.
+
+Multi-tenancy taxes every feature (scoping bugs are data-leak bugs), and the target user is a self-hosting owner, not a platform operator.
+
+## Decision
+
+We will build OpenKOS as a **single-tenant application**: one installation = one kos business = one owner.
+
+Concretely:
+
+- Exactly one `owner` account exists, created by `php artisan app:install` (subsequent runs fail).
+- Application-wide configuration lives in a single `settings` store, not per-organization rows.
+- No table carries a tenant/organization discriminator; a "tenant" in the schema (`tenants` table) means a *renter*, never an organization.
+- Serving multiple businesses means multiple installations, not shared infrastructure.
+
+## Consequences
+
+- Every query, policy, and migration is simpler — no scoping layer, no cross-tenant leak class of bugs.
+- The `Gate::before` owner bypass and the singleton settings model are valid designs *because* of this decision.
+- A hosted offering must provision per-customer installations rather than sharing a database (see [ADR-003](003-cloud-separation.md)).
+- **Revisit trigger:** a genuine need to serve many businesses from shared infrastructure with shared operations. Retrofitting `tenant_id` would be a major rework; that cost is accepted knowingly.

--- a/docs/architecture/adr/002-modular-monolith.md
+++ b/docs/architecture/adr/002-modular-monolith.md
@@ -1,0 +1,30 @@
+# ADR-002: Modular Monolith
+
+**Status:** Accepted
+**Date:** 2026-07-08
+
+## Context
+
+OpenKOS needs clear internal structure without operational overhead. The alternatives were:
+
+- **Microservices** — network boundaries between domains; independent deploys at the cost of distributed-systems complexity.
+- **Unstructured monolith** — fat controllers and models; fast at first, unmaintainable at scale.
+- **Modular monolith** — one deployable, with enforced internal layering and domain slices.
+
+The app is self-hosted by individual kos owners ([ADR-001](001-single-tenant.md)): a single PHP process with a database is the only realistic deployment target. Microservices are off the table on operational grounds alone.
+
+## Decision
+
+We will build OpenKOS as a **modular monolith**: a single Laravel application with strict internal boundaries.
+
+- Application code in `app/` follows the layer architecture (Controllers → Actions → Business/Repositories → Notifications) defined in [docs/architecture.md](../../architecture.md).
+- Domains are vertical slices across those layers (`{Layer}/{Domain}/`), e.g. Leases, Reminders.
+- Platform/extensibility code lives separately in `src/` under the `OpenKOS\` namespace ([ADR-005](005-plugin-philosophy.md)).
+- Domains communicate in-process; cross-domain reactions go through domain events (`App\Events`), not direct coupling.
+
+## Consequences
+
+- One deploy, one database, one test suite — the whole stack is testable with `php artisan test`.
+- Refactoring across domains is an IDE operation, not an API-versioning project.
+- Discipline is enforced by convention and review rather than by network boundaries; [docs/architecture.md](../../architecture.md) is the contract.
+- **Revisit trigger:** none foreseen. Extraction pressure (e.g. a heavy async workload) should first be answered with queues inside the monolith.

--- a/docs/architecture/adr/003-cloud-separation.md
+++ b/docs/architecture/adr/003-cloud-separation.md
@@ -1,0 +1,24 @@
+# ADR-003: Cloud Separation
+
+**Status:** Accepted
+**Date:** 2026-07-08
+
+## Context
+
+OpenKOS is open-source and self-hosted first. A hosted ("cloud") offering may exist later. The risk is the common trap where cloud concerns leak into the core: features gated on managed services, code paths that only work on one provider, or open-core crippling where the self-hosted version is a demo.
+
+## Decision
+
+We will keep the **open-source core fully functional and self-hostable, with cloud concerns strictly outside the core**.
+
+- The core must run on commodity infrastructure: PostgreSQL, the `database` queue driver, local/file storage, SMTP. No feature in core may hard-depend on a managed cloud service.
+- External integrations go behind pluggable drivers with a self-hosted default (e.g. the WhatsApp channel defaults to `LogDriver`; drivers are registered via the platform `NotificationRegistry`).
+- Anything cloud-specific (managed hosting, billing, provisioning, telemetry) is built *around* the core — as separate services or plugins ([ADR-005](005-plugin-philosophy.md)) — never as conditional branches inside it.
+- A hosted offering provisions per-customer single-tenant installations ([ADR-001](001-single-tenant.md)); it does not get a privileged multi-tenant fork of the core.
+
+## Consequences
+
+- Self-hosters are first-class: every feature in this repository works without any external account.
+- New integrations must ship a driver seam and a default that works offline, which is slightly more work per integration.
+- A future cloud product cannot demand core schema or behavior changes for its own convenience; it consumes the same extension points as any plugin.
+- **Revisit trigger:** a hosted offering whose requirements genuinely cannot be met through plugins and drivers — that discussion happens in a superseding ADR, not in code.

--- a/docs/architecture/adr/004-rental-unit-abstraction.md
+++ b/docs/architecture/adr/004-rental-unit-abstraction.md
@@ -1,0 +1,28 @@
+# ADR-004: Rental Unit Abstraction
+
+**Status:** Accepted
+**Date:** 2026-07-08
+
+## Context
+
+OpenKOS started as kos (boarding house) management, but properties come in flavors — kos, apartment, villa, hostel, hotel. The alternatives were:
+
+- **Kos-specific model** — `rooms` belonging to `boarding_houses`; simplest, but every new property type forces a schema rework.
+- **Per-type models** — separate entities per property type; heavy duplication for near-identical behavior.
+- **Generic rental unit** — one `Unit` entity under a typed `Property`, with type-specific behavior branching on an enum when it actually diverges.
+
+## Decision
+
+We will model everything rentable as a **Unit belonging to a typed Property**.
+
+- `Property` carries a `type` (`App\Enums\PropertyType`: `kos` default, `apartment`, `villa`, `hostel`, `hotel`). The enum is the *seam* for future divergence — no behavior branches on it yet, deliberately.
+- `Unit` is the universal rentable thing: it owns pricing history (`UnitRates`), lifecycle status (`App\Enums\UnitStatus`), and `capacity`.
+- Leases attach to Units, tenants attach to Leases (`lease_tenant` pivot, multi-occupant with a `primary_tenant_id`), payments attach to Leases. None of this chain knows the property type.
+- Domain vocabulary: a **tenant** is a person renting; a **unit** is what they rent; a **property** groups units.
+
+## Consequences
+
+- Supporting a new property type is a new enum case plus whatever behavior actually differs — no schema change.
+- The lease/payment/reminder machinery is written once and works for all property types.
+- Kos-specific conveniences can't be hardcoded; they must branch on `PropertyType` when introduced, keeping the divergence visible in one place.
+- **Revisit trigger:** a property type whose rentable thing doesn't fit the Unit shape (e.g. time-slot bookings for hotel-style nightly rental). That likely means a booking abstraction *alongside* leases, recorded in a new ADR.

--- a/docs/architecture/adr/005-plugin-philosophy.md
+++ b/docs/architecture/adr/005-plugin-philosophy.md
@@ -1,0 +1,31 @@
+# ADR-005: Plugin Philosophy
+
+**Status:** Accepted
+**Date:** 2026-07-08
+
+## Context
+
+OpenKOS must be extensible (navigation, dashboards, workspace tabs, settings pages, notification drivers, payment gateways) without forks. The alternatives were:
+
+- **Sandboxed plugins** — isolated processes or capability-limited runtimes; safe for untrusted marketplace code, enormously complex.
+- **Hook/filter system** (WordPress-style) — stringly-typed, hard to type-check, invites core monkey-patching.
+- **In-process trusted plugins** — first-class PHP classes registering into typed registries, trusted like any Composer dependency.
+
+## Decision
+
+We will treat plugins as **trusted, in-process extensions registering into typed platform registries** — the trust boundary is installation, not a runtime sandbox.
+
+- A plugin extends `OpenKOS\Platform\Plugin\Plugin`, declares a `PluginManifest` (id, version, `coreVersion` constraint, dependencies), and registers into container-singleton registries via the `OpenKOSManager`. Enabled plugins are listed explicitly in `config/platform.php`.
+- Extension is **additive only**: plugins own their tables via their own migrations, declare their own permissions, and must not alter core schema or behavior.
+- Plugins react to core through **domain events** (`App\Events`, see [docs/domain-events.md](../../domain-events.md)) — the stable plugin API — never by patching core code.
+- The loader fail-fasts on incompatible core versions, missing dependencies, and cycles; a broken plugin never half-boots.
+- Dormant seams are interface-only until a real consumer forces their shape (e.g. `PaymentGateway` waits for the first real gateway; `PluginDiscovery` waits for Composer-based distribution).
+
+Full mechanics: [docs/platform.md](../../platform.md).
+
+## Consequences
+
+- Plugins get real types, IDE navigation, DI, and the whole framework — no capability API to design or maintain.
+- Users must vet plugins like Composer dependencies; there is no protection from a malicious plugin by design.
+- An untrusted-plugin marketplace would require sandboxing this architecture deliberately does not provide — that is a superseding ADR, not an increment.
+- **Revisit trigger:** demand for third-party plugins distributed outside the repo (the frontend bundling problem) or from untrusted authors (the sandbox problem).

--- a/docs/architecture/adr/006-api-strategy.md
+++ b/docs/architecture/adr/006-api-strategy.md
@@ -1,0 +1,29 @@
+# ADR-006: API Strategy
+
+**Status:** Accepted
+**Date:** 2026-07-08
+
+## Context
+
+The frontend needs data and mutations; third parties may eventually want programmatic access. The alternatives were:
+
+- **Public REST/GraphQL API from day one** — the SPA consumes the same versioned API third parties would; every internal change becomes a compatibility question.
+- **Inertia-first, no public API yet** — controllers return Inertia pages and redirects; the HTTP layer is an internal implementation detail.
+
+A premature public API is a contract guessed before any consumer exists — the same reasoning that keeps `PaymentGateway` interface-only ([ADR-005](005-plugin-philosophy.md)).
+
+## Decision
+
+We will keep the HTTP layer **Inertia-first with no public API**, until a real external consumer defines one.
+
+- All routes live in `routes/web.php` (plus `settings.php`), session-authenticated, returning Inertia responses or redirects. There is no `routes/api.php`, no token auth, no versioning.
+- These endpoints are **internal**: their shapes may change in any release. Nothing outside this repository may depend on them.
+- Extension happens through the plugin system ([ADR-005](005-plugin-philosophy.md)) — plugins run in-process and ship their own routes — and through domain events, not through HTTP scraping.
+- When a genuine external consumer appears (mobile app, tenant portal, integration), a public API will be introduced deliberately: versioned (`/api/v1`), token-authenticated, delegating to the same Actions the web controllers use — designed against that consumer's needs and recorded in a superseding ADR.
+
+## Consequences
+
+- Controllers stay thin and free to evolve; no API-compatibility tax on internal refactors.
+- The layer architecture (Controller → Action → Business/Repository) means a future API is a new thin HTTP skin over existing Actions, not a rewrite.
+- Anyone scripting against the web endpoints today is unsupported, by policy.
+- **Revisit trigger:** the first committed external consumer. Its concrete needs define `v1` — not speculation.

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -1,0 +1,29 @@
+# Architecture Decision Records
+
+Architectural decisions with real trade-offs are recorded here as ADRs, so future contributors can find the *why* without re-excavating old discussions and code reviews.
+
+## Index
+
+| ADR                                       | Title                   | Status   |
+| ----------------------------------------- | ----------------------- | -------- |
+| [001](001-single-tenant.md)               | Single Tenant           | Accepted |
+| [002](002-modular-monolith.md)            | Modular Monolith        | Accepted |
+| [003](003-cloud-separation.md)            | Cloud Separation        | Accepted |
+| [004](004-rental-unit-abstraction.md)     | Rental Unit Abstraction | Accepted |
+| [005](005-plugin-philosophy.md)           | Plugin Philosophy       | Accepted |
+| [006](006-api-strategy.md)                | API Strategy            | Accepted |
+
+Future ADR candidates: the Activity Log vs Audit Log split (`activity_logs` written by `RecordActivitySubscriber` from domain events; `audit_logs` written directly by actions like `UpdateSettings`) is a decision worth recording once it stabilizes.
+
+## Process
+
+1. Copy [template.md](template.md) to `NNN-short-kebab-title.md` — `NNN` is the next number in the index, zero-padded to three digits.
+2. Fill it in. Keep it short; an ADR records a decision, it is not a design doc.
+3. Add the ADR to the index table above.
+4. Open the ADR in the same PR as the change it justifies.
+
+**When to write one:** the change picks between real alternatives with lasting consequences (a boundary, a storage model, a dependency, a protocol). Routine implementation choices already covered by [docs/architecture.md](../../architecture.md) don't need one.
+
+**Changing a decision:** don't edit an accepted ADR's decision. Write a new ADR that supersedes it, set the old one's status to `Superseded by ADR-NNN`, and update the index.
+
+Statuses: `Proposed` → `Accepted` → (`Deprecated` | `Superseded by ADR-NNN`).

--- a/docs/architecture/adr/template.md
+++ b/docs/architecture/adr/template.md
@@ -1,0 +1,16 @@
+# ADR-NNN: Title
+
+**Status:** Proposed
+**Date:** YYYY-MM-DD
+
+## Context
+
+What forces this decision — the problem, the constraints, and the realistic alternatives considered.
+
+## Decision
+
+What we decided, stated actively ("We will …"). One or two paragraphs.
+
+## Consequences
+
+What becomes easier, what becomes harder, and what we deliberately give up. Include the revisit trigger: the concrete signal that should reopen this decision.


### PR DESCRIPTION
Adds docs/architecture/adr/ with a template, contributor process, and the six foundational ADRs: single tenant, modular monolith, cloud separation, rental unit abstraction, plugin philosophy, API strategy. Cross-references the ADR index from README and docs/architecture.md.

Refs OPE-67

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/senatroxx/OpenKos/pull/47?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

