### PR TITLE
feat: payment allocation engine (OPE-72)

### DIFF
--- a/app/Actions/Invoices/AllocatePayment.php
+++ b/app/Actions/Invoices/AllocatePayment.php
@@ -24,7 +24,10 @@ class AllocatePayment
             // Track invoices previously affected so we can reset their
             // amount_paid before re-computing from new allocations.
             $previousIds = $payment->allocations()->pluck('invoice_id');
-            Invoice::whereIn('id', $previousIds)->update(['amount_paid' => 0]);
+            Invoice::whereIn('id', $previousIds)->update([
+                'amount_paid' => 0,
+                'status' => InvoiceStatus::Pending,
+            ]);
 
             $payment->allocations()->delete();
 

--- a/app/Actions/Invoices/AllocatePayment.php
+++ b/app/Actions/Invoices/AllocatePayment.php
@@ -39,9 +39,15 @@ class AllocatePayment
             $remaining = (float) $payment->amount;
             $affected = collect();
 
+            // ponytail: orderBy('id') ensures consistent lock ordering and
+            // reduces deadlock risk with concurrent payments on the same
+            // lease. The caller (RecordPayment) already holds a lock on the
+            // primary invoice, which creates an implicit lock outside this
+            // ordered set — a true fix would move all locking into this query.
             $invoices = Invoice::where('lease_id', $payment->invoice->lease_id)
                 ->payable()
                 ->orderBy('due_date')
+                ->orderBy('id')
                 ->lockForUpdate()
                 ->get();
 

--- a/app/Actions/Invoices/AllocatePayment.php
+++ b/app/Actions/Invoices/AllocatePayment.php
@@ -21,6 +21,7 @@ class AllocatePayment
     {
         DB::transaction(function () use ($payment) {
             $remaining = (float) $payment->amount;
+            $affected = collect();
 
             $invoices = Invoice::where('lease_id', $payment->invoice->lease_id)
                 ->payable()
@@ -47,14 +48,16 @@ class AllocatePayment
                 ]);
 
                 $remaining -= $allocated;
+                $affected->push($invoice);
             }
 
-            // Recalculate status for the payment's primary invoice
-            $payment->invoice->recalculateStatus();
+            // Recalculate status on every invoice that received an allocation
+            foreach ($affected as $invoice) {
+                $invoice->recalculateStatus();
 
-            // If fully paid, fire domain event
-            if ($payment->invoice->status === InvoiceStatus::Paid) {
-                InvoiceFullyPaid::dispatch($payment->invoice);
+                if ($invoice->status === InvoiceStatus::Paid) {
+                    InvoiceFullyPaid::dispatch($invoice);
+                }
             }
         });
     }

--- a/app/Actions/Invoices/AllocatePayment.php
+++ b/app/Actions/Invoices/AllocatePayment.php
@@ -21,6 +21,9 @@ class AllocatePayment
     public function execute(Payment $payment): void
     {
         DB::transaction(function () use ($payment) {
+            // Lock payment row so concurrent execute() calls serialize
+            $payment = Payment::lockForUpdate()->findOrFail($payment->id);
+
             // Track invoices previously affected so we can reset their
             // amount_paid before re-computing from new allocations.
             $previousIds = $payment->allocations()->pluck('invoice_id');
@@ -63,6 +66,10 @@ class AllocatePayment
                 $remaining -= $allocated;
                 $affected->push($invoice);
             }
+
+            // ponytail: if $remaining > 0 after allocating all payable
+            // invoices, the excess is unallocated overpayment. Credit
+            // balance/refund handling is a future enhancement.
 
             // Update invoice balances from allocations (not from payments
             // by invoice_id, which would miss cross-invoice allocations).

--- a/app/Actions/Invoices/AllocatePayment.php
+++ b/app/Actions/Invoices/AllocatePayment.php
@@ -3,6 +3,7 @@
 namespace App\Actions\Invoices;
 
 use App\Enums\InvoiceStatus;
+use App\Enums\PaymentStatus;
 use App\Events\Invoice\InvoiceFullyPaid;
 use App\Models\Invoice;
 use App\Models\Payment;
@@ -20,6 +21,9 @@ class AllocatePayment
     public function execute(Payment $payment): void
     {
         DB::transaction(function () use ($payment) {
+            // Clear any prior allocations for idempotency
+            $payment->allocations()->delete();
+
             $remaining = (float) $payment->amount;
             $affected = collect();
 
@@ -51,12 +55,28 @@ class AllocatePayment
                 $affected->push($invoice);
             }
 
-            // Recalculate status on every invoice that received an allocation
+            // Update invoice balances from allocations (not from payments
+            // by invoice_id, which would miss cross-invoice allocations).
             foreach ($affected as $invoice) {
-                $invoice->recalculateStatus();
+                $paid = (float) $invoice->allocations()
+                    ->whereHas('payment', fn ($q) => $q->where('status', PaymentStatus::Confirmed->value))
+                    ->sum('amount');
 
-                if ($invoice->status === InvoiceStatus::Paid) {
-                    InvoiceFullyPaid::dispatch($invoice);
+                $status = match (true) {
+                    $paid >= (float) $invoice->total => InvoiceStatus::Paid,
+                    $paid > 0 => InvoiceStatus::Partial,
+                    default => InvoiceStatus::Pending,
+                };
+
+                $invoice->update([
+                    'amount_paid' => $paid,
+                    'status' => $status,
+                ]);
+
+                if ($status === InvoiceStatus::Paid) {
+                    // ponytail: dispatched via afterCommit so listeners
+                    // never see uncommitted data.
+                    DB::afterCommit(fn () => InvoiceFullyPaid::dispatch($invoice));
                 }
             }
         });

--- a/app/Actions/Invoices/AllocatePayment.php
+++ b/app/Actions/Invoices/AllocatePayment.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Actions\Invoices;
+
+use App\Enums\InvoiceStatus;
+use App\Events\Invoice\InvoiceFullyPaid;
+use App\Models\Invoice;
+use App\Models\Payment;
+use App\Models\PaymentAllocation;
+use Illuminate\Support\Facades\DB;
+
+class AllocatePayment
+{
+    /**
+     * Allocate a payment to outstanding invoices.
+     *
+     * Default strategy: oldest due-date first. The engine creates
+     * allocation records, updates invoice amounts, and fires events.
+     */
+    public function execute(Payment $payment): void
+    {
+        DB::transaction(function () use ($payment) {
+            $remaining = (float) $payment->amount;
+
+            $invoices = Invoice::where('lease_id', $payment->invoice->lease_id)
+                ->payable()
+                ->orderBy('due_date')
+                ->lockForUpdate()
+                ->get();
+
+            foreach ($invoices as $invoice) {
+                if ($remaining <= 0) {
+                    break;
+                }
+
+                $outstanding = (float) $invoice->total - (float) $invoice->amount_paid;
+                $allocated = min($remaining, $outstanding);
+
+                if ($allocated <= 0) {
+                    continue;
+                }
+
+                PaymentAllocation::create([
+                    'payment_id' => $payment->id,
+                    'invoice_id' => $invoice->id,
+                    'amount' => $allocated,
+                ]);
+
+                $remaining -= $allocated;
+            }
+
+            // Recalculate status for the payment's primary invoice
+            $payment->invoice->recalculateStatus();
+
+            // If fully paid, fire domain event
+            if ($payment->invoice->status === InvoiceStatus::Paid) {
+                InvoiceFullyPaid::dispatch($payment->invoice);
+            }
+        });
+    }
+}

--- a/app/Actions/Invoices/AllocatePayment.php
+++ b/app/Actions/Invoices/AllocatePayment.php
@@ -24,6 +24,8 @@ class AllocatePayment
             // Track invoices previously affected so we can reset their
             // amount_paid before re-computing from new allocations.
             $previousIds = $payment->allocations()->pluck('invoice_id');
+            $priorStatuses = Invoice::whereIn('id', $previousIds)
+                ->pluck('status', 'id');
             Invoice::whereIn('id', $previousIds)->update([
                 'amount_paid' => 0,
                 'status' => InvoiceStatus::Pending,
@@ -80,7 +82,9 @@ class AllocatePayment
                     'status' => $status,
                 ]);
 
-                if ($status === InvoiceStatus::Paid) {
+                if ($status === InvoiceStatus::Paid
+                    && ($priorStatuses[$invoice->id] ?? null) !== InvoiceStatus::Paid
+                ) {
                     // ponytail: dispatched via afterCommit so listeners
                     // never see uncommitted data.
                     DB::afterCommit(fn () => InvoiceFullyPaid::dispatch($invoice));

--- a/app/Actions/Invoices/AllocatePayment.php
+++ b/app/Actions/Invoices/AllocatePayment.php
@@ -21,7 +21,11 @@ class AllocatePayment
     public function execute(Payment $payment): void
     {
         DB::transaction(function () use ($payment) {
-            // Clear any prior allocations for idempotency
+            // Track invoices previously affected so we can reset their
+            // amount_paid before re-computing from new allocations.
+            $previousIds = $payment->allocations()->pluck('invoice_id');
+            Invoice::whereIn('id', $previousIds)->update(['amount_paid' => 0]);
+
             $payment->allocations()->delete();
 
             $remaining = (float) $payment->amount;

--- a/app/Actions/Payments/RecordPayment.php
+++ b/app/Actions/Payments/RecordPayment.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Payments;
 
+use App\Actions\Invoices\AllocatePayment;
 use App\Data\Payment\RecordPaymentData;
 use App\Enums\PaymentStatus;
 use App\Exceptions\PaymentOverflowException;
@@ -13,6 +14,10 @@ use Illuminate\Support\Str;
 
 class RecordPayment
 {
+    public function __construct(
+        private AllocatePayment $allocatePayment,
+    ) {}
+
     public function execute(Invoice $invoice, RecordPaymentData $data, User $user): RecordPaymentResult
     {
         $hasProof = $data->proof !== null;
@@ -55,7 +60,9 @@ class RecordPayment
                 ]);
             }
 
-            $locked->recalculateStatus();
+            if ($payment->status === PaymentStatus::Confirmed) {
+                $this->allocatePayment->execute($payment);
+            }
 
             return $payment;
         });

--- a/app/Events/Invoice/InvoiceFullyPaid.php
+++ b/app/Events/Invoice/InvoiceFullyPaid.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Events\Invoice;
+
+use App\Models\Invoice;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class InvoiceFullyPaid
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly Invoice $invoice,
+    ) {}
+}

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Actions\Invoices\AllocatePayment;
 use App\Actions\Payments\RecordPayment;
 use App\Business\Payments\PaymentStatusValidator;
 use App\Data\Payment\RecordPaymentData;
@@ -78,6 +79,7 @@ class PaymentController extends Controller
 
     public function __construct(
         private PaymentStatusValidator $paymentStatusValidator,
+        private AllocatePayment $allocatePayment,
     ) {}
 
     public function verify(Request $request, Payment $payment): RedirectResponse
@@ -122,7 +124,7 @@ class PaymentController extends Controller
                     'verified_at' => now(),
                 ]);
 
-                $invoice->recalculateStatus();
+                $this->allocatePayment->execute($lockedPayment);
             } else {
                 $invoice = Invoice::lockForUpdate()->findOrFail($payment->invoice_id);
 

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -79,6 +79,11 @@ class Invoice extends Model
         return $this->hasMany(Payment::class);
     }
 
+    public function allocations(): HasMany
+    {
+        return $this->hasMany(PaymentAllocation::class);
+    }
+
     public function getOutstandingAttribute(): string
     {
         return number_format((float) $this->total - (float) $this->amount_paid, 2, '.', '');

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -41,6 +41,11 @@ class Payment extends Model
         return $this->belongsTo(Invoice::class);
     }
 
+    public function allocations(): HasMany
+    {
+        return $this->hasMany(PaymentAllocation::class);
+    }
+
     public function proofs(): HasMany
     {
         return $this->hasMany(PaymentProof::class);

--- a/app/Models/PaymentAllocation.php
+++ b/app/Models/PaymentAllocation.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PaymentAllocation extends Model
+{
+    protected $fillable = [
+        'payment_id',
+        'invoice_id',
+        'amount',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'amount' => 'decimal:2',
+        ];
+    }
+
+    public function payment(): BelongsTo
+    {
+        return $this->belongsTo(Payment::class);
+    }
+
+    public function invoice(): BelongsTo
+    {
+        return $this->belongsTo(Invoice::class);
+    }
+}

--- a/database/factories/PaymentAllocationFactory.php
+++ b/database/factories/PaymentAllocationFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Invoice;
+use App\Models\Payment;
+use App\Models\PaymentAllocation;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class PaymentAllocationFactory extends Factory
+{
+    protected $model = PaymentAllocation::class;
+
+    public function definition(): array
+    {
+        return [
+            'payment_id' => Payment::factory(),
+            'invoice_id' => Invoice::factory(),
+            'amount' => fake()->numberBetween(100_000, 1_000_000),
+        ];
+    }
+}

--- a/database/migrations/2026_07_11_133727_create_payment_allocations_table.php
+++ b/database/migrations/2026_07_11_133727_create_payment_allocations_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('payment_allocations', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('payment_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('invoice_id')->constrained()->cascadeOnDelete();
+            $table->decimal('amount', 12, 2);
+            $table->timestamps();
+            $table->unique(['payment_id', 'invoice_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('payment_allocations');
+    }
+};

--- a/tests/Feature/PaymentAllocationTest.php
+++ b/tests/Feature/PaymentAllocationTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use App\Actions\Invoices\AllocatePayment;
+use App\Enums\InvoiceStatus;
+use App\Models\Invoice;
+use App\Models\Lease;
+use App\Models\Payment;
+use App\Models\Tenant;
+use App\Models\Unit;
+use App\Models\User;
+use Database\Seeders\RoleAndPermissionSeeder;
+
+uses()->beforeEach(function () {
+    $this->seed(RoleAndPermissionSeeder::class);
+});
+
+it('creates allocation records when recording a confirmed payment', function () {
+    $user = User::factory()->owner()->create();
+    $lease = Lease::factory()->create();
+    $invoice = Invoice::factory()->create([
+        'lease_id' => $lease->id,
+        'total' => 1_000_000,
+        'amount_paid' => 0,
+        'status' => InvoiceStatus::Pending,
+    ]);
+
+    $payment = Payment::factory()->create([
+        'invoice_id' => $invoice->id,
+        'amount' => 500_000,
+        'status' => \App\Enums\PaymentStatus::Confirmed,
+    ]);
+
+    app(AllocatePayment::class)->execute($payment);
+
+    expect($payment->allocations()->count())->toBe(1);
+    expect($payment->allocations->first()->amount)->toBe('500000.00');
+});
+
+it('marks invoice as partial after partial payment', function () {
+    $lease = Lease::factory()->create();
+    $invoice = Invoice::factory()->create([
+        'lease_id' => $lease->id,
+        'total' => 1_000_000,
+        'amount_paid' => 0,
+        'status' => InvoiceStatus::Pending,
+    ]);
+    $payment = Payment::factory()->create([
+        'invoice_id' => $invoice->id,
+        'amount' => 500_000,
+        'status' => \App\Enums\PaymentStatus::Confirmed,
+    ]);
+
+    app(AllocatePayment::class)->execute($payment);
+
+    $invoice->refresh();
+
+    expect($invoice->status)->toBe(InvoiceStatus::Partial);
+    expect((float) $invoice->amount_paid)->toBe(500000.0);
+});
+
+it('marks invoice as paid after full payment', function () {
+    $lease = Lease::factory()->create();
+    $invoice = Invoice::factory()->create([
+        'lease_id' => $lease->id,
+        'total' => 1_000_000,
+        'amount_paid' => 0,
+        'status' => InvoiceStatus::Pending,
+    ]);
+    $payment = Payment::factory()->create([
+        'invoice_id' => $invoice->id,
+        'amount' => 1_000_000,
+        'status' => \App\Enums\PaymentStatus::Confirmed,
+    ]);
+
+    app(AllocatePayment::class)->execute($payment);
+
+    $invoice->refresh();
+
+    expect($invoice->status)->toBe(InvoiceStatus::Paid);
+});


### PR DESCRIPTION
## Changes

### Payment Allocation Engine

Introduces a dedicated `AllocatePayment` action that separates payment recording from invoice settlement.

- **Migration:** `payment_allocations` table linking payments to invoices with allocation amounts
- **Model:** `PaymentAllocation` with `payment()` and `invoice()` relationships
- **Engine:** `AllocatePayment` — oldest-due-date-first strategy, creates allocation records, recalculates invoice status via `recalculateStatus()`
- **Integration:** Called from `RecordPayment` (confirmed payments) and `PaymentController::verify` (on confirm)
- **Events:** `InvoiceFullyPaid` dispatched when invoice reaches `Paid` status
- **Tests:** 3 tests covering allocation record creation, partial payment, full payment

All 509 tests pass.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add payment allocation engine to distribute confirmed payments across lease invoices
> - Introduces [`AllocatePayment`](https://github.com/senatroxx/OpenKos/pull/52/files#diff-6cda2bdd73e187abc0539b894ea7c919af0979a63eeda6cb8e6a8d50083c89a0) action that locks the payment row, resets prior allocations, then distributes the payment amount across payable invoices for the same lease ordered by due date.
> - Creates a new [`PaymentAllocation`](https://github.com/senatroxx/OpenKos/pull/52/files#diff-0aca550615f0052a961a313756ef27e172e12c664b1af8d7faa193ada4af28b8) model and [`payment_allocations`](https://github.com/senatroxx/OpenKos/pull/52/files#diff-d254e5b24907b1b2379562345511ee52d8a5185005efe756827c312d9ea60b78) table (with a unique constraint on `payment_id`/`invoice_id`) to persist per-invoice allocation records.
> - Recomputes each affected invoice's `amount_paid` by summing confirmed allocations and sets status to Pending/Partial/Paid; dispatches `InvoiceFullyPaid` event after commit when an invoice transitions to Paid.
> - Replaces direct `invoice->recalculateStatus()` calls in [`RecordPayment`](https://github.com/senatroxx/OpenKos/pull/52/files#diff-09327a6f3d02843f71268cd8b6fa1a954a81d2ed38a0d997671c499dd99afa76) and [`PaymentController::verify`](https://github.com/senatroxx/OpenKos/pull/52/files#diff-fb7868e87ce53611024c953e45b102576be65cd32247df19b463ca9b13e60773) with `AllocatePayment::execute` for confirmed payments.
> - Behavioral Change: confirming or recording a payment now affects all payable invoices on the lease, not just the single invoice tied to the payment.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3d7c475.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->