### PR TITLE
feat(billing): replace Rent Schedule with Invoice workspace

### DIFF
--- a/app/Http/Controllers/LeaseController.php
+++ b/app/Http/Controllers/LeaseController.php
@@ -201,20 +201,13 @@ class LeaseController extends Controller
                 Filter::select('status', 'Status', [LeaseStatus::Active->value, LeaseStatus::Terminated->value])
                     ->query(fn (Builder $q, string $value) => $q->where('status', $value)),
                 Filter::select('payment_status', 'Payment', [
-                    ['value' => 'paid', 'label' => 'Paid'],
+                    ['value' => 'paid', 'label' => 'Current'],
                     ['value' => 'overdue', 'label' => 'Overdue'],
                 ])
                     ->query(function (Builder $q, string $value) {
-                        $periodStart = Carbon::now()->startOfMonth()->startOfDay();
-                        $periodEnd = Carbon::now()->endOfMonth()->endOfDay();
-
-                        return $value === 'paid'
-                            ? $q->whereHas('invoices', fn (Builder $q) => $q
-                                ->where('status', InvoiceStatus::Paid->value)
-                                ->whereBetween('period_start', [$periodStart, $periodEnd]))
-                            : $q->where('status', LeaseStatus::Active->value)->whereDoesntHave('invoices', fn (Builder $q) => $q
-                                ->where('status', InvoiceStatus::Paid->value)
-                                ->whereBetween('period_start', [$periodStart, $periodEnd]));
+                        return $value === 'overdue'
+                            ? $q->whereHas('invoices', fn (Builder $q) => $q->overdue())
+                            : $q->whereDoesntHave('invoices', fn (Builder $q) => $q->overdue());
                     }),
                 Filter::select('properties', 'Property', $allProperties->map(fn (Property $p) => [
                     'value' => (string) $p->id,
@@ -230,10 +223,10 @@ class LeaseController extends Controller
         $query = Lease::query()
             ->with(['primaryTenant:id,name,phone', 'tenants:id,name,phone', 'unit:id,slug,name,property_id', 'unit.property:id,slug,name'])
             ->addSelect(['payment_status' => Invoice::query()
-                ->selectRaw("CASE WHEN COUNT(*) > 0 THEN 'paid' ELSE 'overdue' END")
+                ->selectRaw("CASE WHEN COUNT(*) > 0 THEN 'overdue' ELSE 'paid' END")
                 ->whereColumn('lease_id', 'leases.id')
-                ->where('status', InvoiceStatus::Paid->value)
-                ->whereBetween('period_start', [Carbon::now()->startOfMonth()->startOfDay(), Carbon::now()->endOfMonth()->endOfDay()]),
+                ->whereIn('status', [InvoiceStatus::Pending->value, InvoiceStatus::Partial->value])
+                ->whereDate('due_date', '<', now()),
             ])
             ->when(! $request->user()->isOwner(), fn (Builder $q) => $q->whereHas(
                 'unit.property.users',

--- a/app/Http/Controllers/LeaseInvoiceController.php
+++ b/app/Http/Controllers/LeaseInvoiceController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Invoice;
+use App\Models\Lease;
+use App\Tables\Column;
+use App\Tables\Filter;
+use App\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class LeaseInvoiceController extends Controller
+{
+    public function index(Request $request, Lease $lease): Response
+    {
+        $this->authorize('view', $lease);
+
+        $table = Table::make()
+            ->columns([
+                Column::make('reference', 'Reference')->searchable(fn (Builder $q, string $search) => $q->where('reference', 'like', "%{$search}%")),
+                Column::make('period_start', 'Period')->sortable(),
+                Column::make('due_date', 'Due date')->sortable(),
+                Column::make('total', 'Total')->sortable(),
+                Column::make('amount_paid', 'Paid')->sortable(),
+                Column::make('outstanding', 'Outstanding'),
+                Column::make('status', 'Status')->sortable(),
+            ])
+            ->filters([
+                Filter::select('status', 'Status', ['pending', 'partial', 'paid', 'cancelled', 'void'])
+                    ->query(fn (Builder $q, string $value) => $q->where('status', $value)),
+            ])
+            ->defaultSort('-period_start');
+
+        $result = $table->paginate(
+            $lease->invoices(),
+            $request,
+            'invoices',
+        );
+
+        return Inertia::render('leases/invoices', [
+            ...$result,
+            'lease' => $lease->only('id', 'reference', 'status'),
+        ]);
+    }
+
+    public function show(Lease $lease, Invoice $invoice): Response
+    {
+        abort_if($invoice->lease_id !== $lease->id, 404);
+
+        $this->authorize('view', $lease);
+
+        $invoice->load(['lineItems', 'payments.confirmedBy:id,name', 'payments.proofs', 'allocations']);
+
+        return Inertia::render('leases/invoice-detail', [
+            'lease' => $lease->only('id', 'reference', 'status'),
+            'invoice' => $invoice,
+        ]);
+    }
+}

--- a/app/Http/Controllers/LeaseInvoiceController.php
+++ b/app/Http/Controllers/LeaseInvoiceController.php
@@ -35,7 +35,7 @@ class LeaseInvoiceController extends Controller
             ->defaultSort('-period_start');
 
         $result = $table->paginate(
-            $lease->invoices(),
+            $lease->invoices()->select('invoices.*')->selectRaw('(COALESCE(total, 0) - COALESCE(amount_paid, 0)) as outstanding'),
             $request,
             'invoices',
         );
@@ -52,7 +52,8 @@ class LeaseInvoiceController extends Controller
 
         $this->authorize('view', $lease);
 
-        $invoice->load(['lineItems', 'payments.confirmedBy:id,name', 'payments.proofs', 'allocations']);
+        $invoice->load(['lineItems', 'payments']);
+        $invoice->append('outstanding');
 
         return Inertia::render('leases/invoice-detail', [
             'lease' => $lease->only('id', 'reference', 'status'),

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -26,8 +26,6 @@ class Invoice extends Model
 {
     use Auditable, HasFactory;
 
-    protected $appends = ['outstanding'];
-
     protected static function boot(): void
     {
         parent::boot();

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -26,6 +26,8 @@ class Invoice extends Model
 {
     use Auditable, HasFactory;
 
+    protected $appends = ['outstanding'];
+
     protected static function boot(): void
     {
         parent::boot();

--- a/resources/js/components/features/leases/lease-detail-sheet.tsx
+++ b/resources/js/components/features/leases/lease-detail-sheet.tsx
@@ -1,6 +1,6 @@
 import { router, usePage } from '@inertiajs/react';
-import { Banknote, ChevronDown, FileText, Loader2 } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { Banknote, ChevronDown, FileText } from 'lucide-react';
+import { useState } from 'react';
 import { RecordPaymentSheet } from '@/components/features';
 import { DocumentPreview } from '@/components/shared';
 import { StatusBadge } from '@/components/shared/status-badge';
@@ -21,7 +21,7 @@ import { DUE_DAY_LABELS } from '@/lib/constants';
 import { PAYMENT_METHOD_LABELS } from '@/lib/constants/billing';
 import { formatDate, formatPeriod, formatPrice } from '@/lib/formatters';
 import leases from '@/routes/leases';
-import type { Lease, Payment, RentScheduleEntry } from '@/types';
+import type { Lease, Payment } from '@/types';
 
 export default function LeaseDetailSheet({
     lease,
@@ -40,8 +40,6 @@ export default function LeaseDetailSheet({
 }) {
     const { auth } = usePage<{ auth: { permissions: string[] } }>().props;
     const [recordPaymentOpen, setRecordPaymentOpen] = useState(false);
-    const [schedule, setSchedule] = useState<RentScheduleEntry[] | null>(null);
-    const [loadingSchedule, setLoadingSchedule] = useState(false);
     const [verifyingId, setVerifyingId] = useState<number | null>(null);
     const [previewProof, setPreviewProof] = useState<{
         src: string;
@@ -65,16 +63,6 @@ export default function LeaseDetailSheet({
             },
         );
     }
-
-    useEffect(() => {
-        if (open && lease) {
-            Promise.resolve().then(() => setLoadingSchedule(true));
-            fetch(`/leases/${lease.id}/rent-schedule`)
-                .then((r) => r.json())
-                .then((d) => setSchedule(d.schedule))
-                .finally(() => setLoadingSchedule(false));
-        }
-    }, [open, lease]);
 
     const unitLabel = lease?.unit?.name ?? '—';
     const propertyName = lease?.unit?.property?.name ?? '—';
@@ -514,73 +502,6 @@ export default function LeaseDetailSheet({
                                     </CollapsibleContent>
                                 </section>
                             </Collapsible>
-
-                            {/* Rent Schedule */}
-                            {isActive && (
-                                <Collapsible defaultOpen>
-                                    <section>
-                                        <CollapsibleTrigger className="flex w-full cursor-pointer items-center justify-between gap-2">
-                                            <h3 className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
-                                                Rent Schedule
-                                            </h3>
-                                            <ChevronDown className="ui-open:rotate-180 size-3 text-muted-foreground transition-transform" />
-                                        </CollapsibleTrigger>
-                                        <CollapsibleContent className="mt-3">
-                                            {loadingSchedule ? (
-                                                <div className="flex items-center justify-center gap-2 rounded-lg border p-6 text-sm text-muted-foreground">
-                                                    <Loader2 className="size-4 animate-spin" />
-                                                    Loading schedule...
-                                                </div>
-                                            ) : schedule &&
-                                              schedule.length > 0 ? (
-                                                <div className="space-y-2">
-                                                    {schedule.map(
-                                                        (entry, i) => {
-                                                                return (
-                                                                <div
-                                                                    key={i}
-                                                                    className="flex items-center justify-between rounded-lg border p-3 text-sm"
-                                                                >
-                                                                    <div>
-                                                                        <p className="font-medium">
-                                                                            {formatPeriod(
-                                                                                entry.period_start,
-                                                                            )}
-                                                                        </p>
-                                                                        <p className="text-xs text-muted-foreground">
-                                                                            Due{' '}
-                                                                            {formatDate(
-                                                                                entry.due_date,
-                                                                            )}
-                                                                        </p>
-                                                                    </div>
-                                                                    <div className="text-right">
-                                                                        <p className="font-medium tabular-nums">
-                                                                            {formatPrice(
-                                                                                entry.amount,
-                                                                            )}
-                                                                        </p>
-                                                                        <StatusBadge
-                                                                            domain="rent"
-                                                                            value={
-                                                                                entry.status
-                                                                            }
-                                                                        />
-                                                                    </div>
-                                                                </div>
-                                                            );
-                                                        },
-                                                    )}
-                                                </div>
-                                            ) : (
-                                                <p className="rounded-lg border p-4 text-sm text-muted-foreground">
-                                                    No schedule data available.
-                                                </p>
-                                            )}
-                                        </CollapsibleContent>
-                                    </section>
-                                </Collapsible>
-                            )}
 
                             {/* Notes */}
                             {lease.notes && (

--- a/resources/js/components/shared/status-badge.tsx
+++ b/resources/js/components/shared/status-badge.tsx
@@ -62,6 +62,13 @@ const STATUS_CONFIGS: Record<string, Record<string, StatusConfig>> = {
         system: { label: 'System', variant: 'secondary' },
         custom: { label: 'Custom', variant: 'outline' },
     },
+    invoice: {
+        pending: { label: 'Pending', className: 'bg-yellow-500 text-white' },
+        partial: { label: 'Partial', className: 'bg-blue-600 text-white' },
+        paid: { label: 'Paid', className: 'bg-green-600 text-white' },
+        cancelled: { label: 'Cancelled', className: 'bg-gray-400 text-white' },
+        void: { label: 'Void', className: 'bg-gray-300 text-gray-700' },
+    },
 };
 
 export function StatusBadge({

--- a/resources/js/pages/leases/invoice-detail.tsx
+++ b/resources/js/pages/leases/invoice-detail.tsx
@@ -3,7 +3,6 @@ import { ChevronLeft } from 'lucide-react';
 import { StatusBadge } from '@/components/shared/status-badge';
 import { formatDate, formatPeriod, formatPrice } from '@/lib/formatters';
 import type { Invoice, WorkspaceLease } from '@/types';
-import { LeaseLayout } from './layout';
 
 export default function InvoiceDetail({
     lease,
@@ -13,18 +12,18 @@ export default function InvoiceDetail({
     invoice: Invoice;
 }) {
     return (
-        <LeaseLayout lease={lease} activeTab="invoices">
+        <div className="workspace-enter flex h-full flex-1 flex-col gap-6 overflow-x-auto rounded-xl p-4">
             <Head title={`Invoice ${invoice.reference} — Lease #${lease.id}`} />
 
             <Link
                 href={`/leases/${lease.id}/invoices`}
-                className="mb-6 inline-flex items-center gap-1 text-sm text-muted-foreground hover:underline"
+                className="mb-2 inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
             >
-                <ChevronLeft className="size-4" />
+                <ChevronLeft className="size-3" />
                 Back to invoices
             </Link>
 
-            <div className="space-y-6">
+            <div className="flex-1 space-y-6">
 
             {/* Summary card */}
             <div className="rounded-lg border p-6">
@@ -131,6 +130,6 @@ export default function InvoiceDetail({
                 Activity timeline, reminders, and PDF download coming soon.
             </div>
             </div>
-        </LeaseLayout>
+        </div>
     );
 }

--- a/resources/js/pages/leases/invoice-detail.tsx
+++ b/resources/js/pages/leases/invoice-detail.tsx
@@ -3,6 +3,7 @@ import { ChevronLeft } from 'lucide-react';
 import { StatusBadge } from '@/components/shared/status-badge';
 import { formatDate, formatPeriod, formatPrice } from '@/lib/formatters';
 import type { Invoice, WorkspaceLease } from '@/types';
+import { LeaseLayout } from './layout';
 
 export default function InvoiceDetail({
     lease,
@@ -12,16 +13,18 @@ export default function InvoiceDetail({
     invoice: Invoice;
 }) {
     return (
-        <div className="space-y-6">
+        <LeaseLayout lease={lease} activeTab="invoices">
             <Head title={`Invoice ${invoice.reference} — Lease #${lease.id}`} />
 
             <Link
                 href={`/leases/${lease.id}/invoices`}
-                className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:underline"
+                className="mb-6 inline-flex items-center gap-1 text-sm text-muted-foreground hover:underline"
             >
                 <ChevronLeft className="size-4" />
                 Back to invoices
             </Link>
+
+            <div className="space-y-6">
 
             {/* Summary card */}
             <div className="rounded-lg border p-6">
@@ -127,6 +130,7 @@ export default function InvoiceDetail({
             <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
                 Activity timeline, reminders, and PDF download coming soon.
             </div>
-        </div>
+            </div>
+        </LeaseLayout>
     );
 }

--- a/resources/js/pages/leases/invoice-detail.tsx
+++ b/resources/js/pages/leases/invoice-detail.tsx
@@ -1,0 +1,132 @@
+import { Head, Link } from '@inertiajs/react';
+import { ChevronLeft } from 'lucide-react';
+import { StatusBadge } from '@/components/shared/status-badge';
+import { formatDate, formatPeriod, formatPrice } from '@/lib/formatters';
+import type { Invoice, WorkspaceLease } from '@/types';
+
+export default function InvoiceDetail({
+    lease,
+    invoice,
+}: {
+    lease: WorkspaceLease;
+    invoice: Invoice;
+}) {
+    return (
+        <div className="space-y-6">
+            <Head title={`Invoice ${invoice.reference} — Lease #${lease.id}`} />
+
+            <Link
+                href={`/leases/${lease.id}/invoices`}
+                className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:underline"
+            >
+                <ChevronLeft className="size-4" />
+                Back to invoices
+            </Link>
+
+            {/* Summary card */}
+            <div className="rounded-lg border p-6">
+                <div className="flex items-start justify-between">
+                    <div>
+                        <h2 className="text-lg font-semibold">
+                            {invoice.reference ?? 'Invoice'}
+                        </h2>
+                        <p className="text-sm text-muted-foreground">
+                            {formatPeriod(invoice.period_start, 'id-ID')}
+                        </p>
+                    </div>
+                    <StatusBadge domain="invoice" value={invoice.status} />
+                </div>
+
+                <div className="mt-6 grid grid-cols-3 gap-4 text-sm">
+                    <div>
+                        <p className="text-muted-foreground">Total</p>
+                        <p className="mt-1 font-medium tabular-nums">
+                            {formatPrice(invoice.total)}
+                        </p>
+                    </div>
+                    <div>
+                        <p className="text-muted-foreground">Paid</p>
+                        <p className="mt-1 font-medium tabular-nums">
+                            {formatPrice(invoice.amount_paid)}
+                        </p>
+                    </div>
+                    <div>
+                        <p className="text-muted-foreground">Outstanding</p>
+                        <p className="mt-1 font-medium tabular-nums">
+                            {formatPrice(invoice.outstanding ?? '0')}
+                        </p>
+                    </div>
+                    <div>
+                        <p className="text-muted-foreground">Billing period</p>
+                        <p className="mt-1 tabular-nums">
+                            {formatDate(invoice.period_start)} — {formatDate(invoice.period_end)}
+                        </p>
+                    </div>
+                    <div>
+                        <p className="text-muted-foreground">Due date</p>
+                        <p className="mt-1 tabular-nums">{formatDate(invoice.due_date)}</p>
+                    </div>
+                </div>
+            </div>
+
+            {/* Line items */}
+            {invoice.line_items && invoice.line_items.length > 0 && (
+                <div className="rounded-lg border">
+                    <div className="border-b px-4 py-3">
+                        <h3 className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
+                            Line Items
+                        </h3>
+                    </div>
+                    <div className="divide-y">
+                        {invoice.line_items.map((item) => (
+                            <div
+                                key={item.id}
+                                className="flex items-center justify-between px-4 py-3 text-sm"
+                            >
+                                <div>
+                                    <p className="font-medium">{item.description}</p>
+                                    <p className="text-xs text-muted-foreground">{item.type}</p>
+                                </div>
+                                <p className="tabular-nums">{formatPrice(item.amount)}</p>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            )}
+
+            {/* Allocated payments */}
+            {invoice.payments && invoice.payments.length > 0 && (
+                <div className="rounded-lg border">
+                    <div className="border-b px-4 py-3">
+                        <h3 className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
+                            Payments
+                        </h3>
+                    </div>
+                    <div className="divide-y">
+                        {invoice.payments.map((payment) => (
+                            <div
+                                key={payment.id}
+                                className="flex items-center justify-between px-4 py-3 text-sm"
+                            >
+                                <div>
+                                    <p className="font-medium tabular-nums">
+                                        {formatPrice(payment.amount)}
+                                    </p>
+                                    <p className="text-xs text-muted-foreground">
+                                        {formatDate(payment.payment_date)}
+                                    </p>
+                                </div>
+                                <StatusBadge domain="payment" value={payment.status} />
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            )}
+
+            {/* Timeline placeholder */}
+            <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+                Activity timeline, reminders, and PDF download coming soon.
+            </div>
+        </div>
+    );
+}

--- a/resources/js/pages/leases/invoices.tsx
+++ b/resources/js/pages/leases/invoices.tsx
@@ -1,3 +1,4 @@
+import { router } from '@inertiajs/react';
 import type { TableColumn } from '@/components/data-table';
 import { PluginRegion } from '@/components/shared/plugin-region';
 import { StatusBadge } from '@/components/shared/status-badge';
@@ -89,6 +90,7 @@ export default function LeaseInvoices({
                     defaultSort="-period_start"
                     searchPlaceholder="Search by reference..."
                     emptyMessage="No invoices generated yet."
+                    onRowClick={(invoice) => router.get(`/leases/${lease.id}/invoices/${invoice.id}`)}
                 />
             </PluginRegion>
         </LeaseLayout>

--- a/resources/js/pages/leases/invoices.tsx
+++ b/resources/js/pages/leases/invoices.tsx
@@ -1,0 +1,96 @@
+import type { TableColumn } from '@/components/data-table';
+import { PluginRegion } from '@/components/shared/plugin-region';
+import { StatusBadge } from '@/components/shared/status-badge';
+import { WorkspaceTable } from '@/components/shared/workspace-table';
+import { formatDate, formatPeriod, formatPrice } from '@/lib/formatters';
+import type { Invoice, PaginatedData, TableMeta, WorkspaceLease } from '@/types';
+import { LeaseLayout } from './layout';
+
+const columns: TableColumn<Invoice>[] = [
+    {
+        key: 'reference',
+        label: 'Reference',
+        sortable: true,
+        className: 'font-medium font-mono text-xs',
+        render: (inv) => inv.reference ?? '—',
+    },
+    {
+        key: 'period_start',
+        label: 'Period',
+        sortable: true,
+        className: 'text-muted-foreground',
+        render: (inv) => formatPeriod(inv.period_start, 'id-ID'),
+    },
+    {
+        key: 'due_date',
+        label: 'Due date',
+        sortable: true,
+        className: 'text-muted-foreground tabular-nums',
+        render: (inv) => formatDate(inv.due_date),
+    },
+    {
+        key: 'total',
+        label: 'Total',
+        sortable: true,
+        className: 'tabular-nums',
+        render: (inv) => formatPrice(inv.total),
+    },
+    {
+        key: 'amount_paid',
+        label: 'Paid',
+        sortable: true,
+        className: 'tabular-nums text-muted-foreground',
+        render: (inv) => formatPrice(inv.amount_paid),
+    },
+    {
+        key: 'outstanding',
+        label: 'Outstanding',
+        className: 'tabular-nums',
+        render: (inv) => formatPrice(inv.outstanding ?? '0'),
+    },
+    {
+        key: 'status',
+        label: 'Status',
+        sortable: true,
+        render: (inv) => <StatusBadge domain="invoice" value={inv.status} />,
+    },
+];
+
+export default function LeaseInvoices({
+    lease,
+    invoices,
+    sort = '-period_start',
+    search = '',
+    status = '',
+    per_page = 15,
+    table,
+}: {
+    lease: WorkspaceLease;
+    invoices: PaginatedData<Invoice>;
+    sort?: string;
+    search?: string;
+    status?: string;
+    per_page?: number;
+    table: TableMeta;
+}) {
+    return (
+        <LeaseLayout lease={lease} activeTab="invoices">
+            <PluginRegion name="workspace-tab-invoices">
+                <WorkspaceTable
+                    url={`/leases/${lease.id}/invoices`}
+                    noun="invoices"
+                    rows={invoices}
+                    columns={columns}
+                    tableMeta={table}
+                    sort={sort}
+                    search={search}
+                    perPage={per_page}
+                    filterValues={{ status }}
+                    defaultSort="-period_start"
+                    searchPlaceholder="Search by reference..."
+                    emptyMessage="No invoices generated yet."
+                />
+            </PluginRegion>
+        </LeaseLayout>
+    );
+}

--- a/resources/js/pages/leases/layout.tsx
+++ b/resources/js/pages/leases/layout.tsx
@@ -33,6 +33,11 @@ export function LeaseLayout({
                         href: `/leases/${lease.id}`,
                     },
                     {
+                        key: 'invoices',
+                        label: 'Invoices',
+                        href: `/leases/${lease.id}/invoices`,
+                    },
+                    {
                         key: 'payments',
                         label: 'Payments',
                         href: `/leases/${lease.id}/payments`,

--- a/resources/js/pages/leases/payments.tsx
+++ b/resources/js/pages/leases/payments.tsx
@@ -1,5 +1,4 @@
 import { FileText } from 'lucide-react';
-import { useEffect, useState } from 'react';
 import type { TableColumn } from '@/components/data-table';
 import { PluginRegion } from '@/components/shared/plugin-region';
 import { StatusBadge } from '@/components/shared/status-badge';
@@ -9,7 +8,6 @@ import { formatDate, formatPeriod, formatPrice } from '@/lib/formatters';
 import type {
     PaginatedData,
     Payment,
-    RentScheduleEntry,
     TableMeta,
     WorkspaceLease,
 } from '@/types';
@@ -72,70 +70,6 @@ const columns: TableColumn<Payment>[] = [
     },
 ];
 
-function RentSchedule({ lease }: { lease: WorkspaceLease }) {
-    const [schedule, setSchedule] = useState<RentScheduleEntry[] | null>(null);
-
-    useEffect(() => {
-        let cancelled = false;
-        fetch(`/leases/${lease.id}/rent-schedule`)
-            .then((r) => r.json())
-            .then((d) => {
-                if (!cancelled) {
-                    setSchedule(d.schedule);
-                }
-            });
-
-        return () => {
-            cancelled = true;
-        };
-    }, [lease.id]);
-
-    if (schedule === null) {
-        return (
-            <p className="text-sm text-muted-foreground">Loading schedule...</p>
-        );
-    }
-
-    if (schedule.length === 0) {
-        return (
-            <p className="text-sm text-muted-foreground">
-                No schedule data available.
-            </p>
-        );
-    }
-
-    return (
-        <div className="space-y-2">
-            {schedule.map((entry, i) => {
-                return (
-                    <div
-                        key={i}
-                        className="flex items-center justify-between rounded-lg border p-3 text-sm"
-                    >
-                        <div>
-                            <p className="font-medium">
-                                {formatPeriod(entry.period_start, 'id-ID')}
-                            </p>
-                            <p className="text-xs text-muted-foreground">
-                                Due {formatDate(entry.due_date)}
-                            </p>
-                        </div>
-                        <div className="text-right">
-                            <p className="font-medium tabular-nums">
-                                {formatPrice(entry.amount)}
-                            </p>
-                            <StatusBadge
-                                domain="rent"
-                                value={entry.status}
-                            />
-                        </div>
-                    </div>
-                );
-            })}
-        </div>
-    );
-}
-
 export default function LeasePayments({
     lease,
     payments,
@@ -172,15 +106,6 @@ export default function LeasePayments({
                     searchPlaceholder="Search by reference..."
                     emptyMessage="No payments recorded yet."
                 />
-
-                {lease.status === 'active' && (
-                    <div className="mt-6">
-                        <h3 className="mb-3 text-xs font-medium tracking-wider text-muted-foreground uppercase">
-                            Rent Schedule
-                        </h3>
-                        <RentSchedule lease={lease} />
-                    </div>
-                )}
             </PluginRegion>
         </LeaseLayout>
     );

--- a/resources/js/types/models.ts
+++ b/resources/js/types/models.ts
@@ -202,6 +202,21 @@ export type PaymentProof = {
     created_at: string;
 };
 
+export type InvoiceLineItem = {
+    id: number;
+    invoice_id: number;
+    type: string;
+    description: string;
+    amount: string;
+};
+
+export type PaymentAllocation = {
+    id: number;
+    payment_id: number;
+    invoice_id: number;
+    amount: string;
+};
+
 export type Invoice = {
     id: number;
     lease_id: number;
@@ -213,6 +228,9 @@ export type Invoice = {
     total: string;
     amount_paid: string;
     outstanding?: string;
+    line_items?: InvoiceLineItem[];
+    payments?: Payment[];
+    allocations?: PaymentAllocation[];
 };
 
 export type Payment = {

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Dashboard\OverviewController;
 use App\Http\Controllers\Dashboard\RentController;
 use App\Http\Controllers\LeaseController;
+use App\Http\Controllers\LeaseInvoiceController;
 use App\Http\Controllers\LeaseRentScheduleController;
 use App\Http\Controllers\MaintenanceTicketController;
 use App\Http\Controllers\PaymentController;
@@ -98,6 +99,8 @@ Route::middleware(['auth', 'verified', 'permission:dashboard.view'])->group(func
         Route::prefix('{lease}')->whereNumber('lease')->group(function () {
             Route::get('/', [LeaseController::class, 'show'])->name('show')->middleware('permission:leases.view');
             Route::get('documents', [LeaseController::class, 'documents'])->name('workspace.documents')->middleware('permission:leases.view');
+            Route::get('invoices', [LeaseInvoiceController::class, 'index'])->name('workspace.invoices')->middleware('permission:leases.view');
+            Route::get('invoices/{invoice}', [LeaseInvoiceController::class, 'show'])->name('workspace.invoices.show')->middleware('permission:leases.view');
             Route::get('rent-schedule', LeaseRentScheduleController::class)->name('rent-schedule')->middleware('permission:leases.view');
             Route::post('move-out', [LeaseController::class, 'moveOut'])->name('move-out')->middleware('permission:leases.move_out');
             Route::post('renew', [LeaseController::class, 'renew'])->name('renew')->middleware('permission:leases.renew');

--- a/tests/Feature/InvoiceWorkspaceTest.php
+++ b/tests/Feature/InvoiceWorkspaceTest.php
@@ -1,0 +1,85 @@
+<?php
+
+use App\Models\Invoice;
+use App\Models\InvoiceLineItem;
+use App\Models\Lease;
+use App\Models\User;
+use Database\Seeders\RegionAndCitySeeder;
+use Database\Seeders\RoleAndPermissionSeeder;
+
+uses()->beforeEach(function () {
+    $this->seed([RoleAndPermissionSeeder::class, RegionAndCitySeeder::class]);
+    $this->owner = User::factory()->owner()->create();
+});
+
+describe('invoice workspace index', function () {
+    it('lists invoices for a lease', function () {
+        $lease = Lease::factory()->create();
+        $invoices = Invoice::factory()
+            ->count(3)
+            ->sequence(
+                ['period_start' => '2026-05-01'],
+                ['period_start' => '2026-06-01'],
+                ['period_start' => '2026-07-01'],
+            )
+            ->create(['lease_id' => $lease->id]);
+
+        $this->actingAs($this->owner)
+            ->get(route('leases.workspace.invoices', $lease))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('leases/invoices')
+                ->where('lease.id', $lease->id)
+                ->has('invoices.data', 3));
+    });
+
+    it('returns empty state when lease has no invoices', function () {
+        $lease = Lease::factory()->create();
+
+        $this->actingAs($this->owner)
+            ->get(route('leases.workspace.invoices', $lease))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->has('invoices.data', 0));
+    });
+
+    it('denies users without leases.view permission', function () {
+        $user = User::factory()->create();
+        $lease = Lease::factory()->create();
+
+        $this->actingAs($user)
+            ->get(route('leases.workspace.invoices', $lease))
+            ->assertForbidden();
+    });
+});
+
+describe('invoice workspace show', function () {
+    it('renders invoice detail with line items and payments', function () {
+        $lease = Lease::factory()->create();
+        $invoice = Invoice::factory()->create(['lease_id' => $lease->id]);
+        InvoiceLineItem::factory()->create([
+            'invoice_id' => $invoice->id,
+            'description' => 'Monthly rent',
+            'amount' => $invoice->total,
+        ]);
+
+        $this->actingAs($this->owner)
+            ->get(route('leases.workspace.invoices.show', [$lease, $invoice]))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('leases/invoice-detail')
+                ->where('lease.id', $lease->id)
+                ->where('invoice.id', $invoice->id)
+                ->has('invoice.line_items', 1));
+    });
+
+    it('denies access to invoice from another lease', function () {
+        $lease = Lease::factory()->create();
+        $otherLease = Lease::factory()->create();
+        $invoice = Invoice::factory()->create(['lease_id' => $otherLease->id]);
+
+        $this->actingAs($this->owner)
+            ->get(route('leases.workspace.invoices.show', [$lease, $invoice]))
+            ->assertNotFound();
+    });
+});

--- a/tests/Feature/WorkspaceRoutesTest.php
+++ b/tests/Feature/WorkspaceRoutesTest.php
@@ -43,6 +43,7 @@ describe('lease workspace', function () {
                 ->where('lease.id', $lease->id));
     })->with([
         ['leases.show', 'leases/show'],
+        ['leases.workspace.invoices', 'leases/invoices'],
         ['leases.workspace.payments', 'leases/payments'],
         ['leases.workspace.documents', 'leases/documents'],
     ]);


### PR DESCRIPTION
## Changes

- **New Invoices tab** in lease workspace (between Overview and Payments)
- **Invoice list** with sortable/filterable DataTable (reference, period, due date, total, paid, outstanding, status)
- **Invoice detail view** with summary card, line items, allocated payments, and timeline placeholder
- Replaced derived Rent Schedule UI with persisted Invoice data
- Removed Rent Schedule from Payments tab and LeaseDetailSheet

## Bug fix

- **payment_status column** on leases listing now checks for actual overdue invoices (Pending/Partial past due) instead of checking if the current month has a paid invoice. Previously, paying all overdue invoices still showed "overdue" if the current month's invoice hadn't been generated yet.

## Files

**New:**
- `app/Http/Controllers/LeaseInvoiceController.php` — index + show for invoice workspace
- `resources/js/pages/leases/invoices.tsx` — invoice list page
- `resources/js/pages/leases/invoice-detail.tsx` — invoice detail page
- `tests/Feature/InvoiceWorkspaceTest.php` — 5 tests

**Modified:**
- `routes/web.php` — 2 new invoice routes
- `app/Http/Controllers/LeaseController.php` — fix payment_status logic
- `resources/js/pages/leases/layout.tsx` — add Invoices tab
- `resources/js/pages/leases/payments.tsx` — remove Rent Schedule
- `resources/js/components/features/leases/lease-detail-sheet.tsx` — remove Rent Schedule
- `resources/js/components/shared/status-badge.tsx` — add invoice domain
- `resources/js/types/models.ts` — add InvoiceLineItem, PaymentAllocation types
- `tests/Feature/WorkspaceRoutesTest.php` — add invoices tab route test

Closes OPE-73

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace Rent Schedule with an Invoice workspace for lease billing
> - Adds `LeaseInvoiceController` with `index` and `show` actions, backed by two new routes under `/leases/{lease}/invoices`, protected by `permission:leases.view`.
> - Adds [invoices.tsx](https://github.com/senatroxx/OpenKos/pull/54/files#diff-cf26300fa9362178d8ebbbccb288778ca15ccbd9797113abea62e5cff17cbcca) and [invoice-detail.tsx](https://github.com/senatroxx/OpenKos/pull/54/files#diff-04ec2e17aee3118935adfdf7f612b154ad66ec7efdf4cd561305edc3cc4b4cf1) pages with sorting, filtering, and navigation; extends `StatusBadge` with an `invoice` domain.
> - Adds an Invoices tab to the lease workspace layout in [layout.tsx](https://github.com/senatroxx/OpenKos/pull/54/files#diff-1d6898a2e96e4eb192875908036e2fe6b2a72261efdcae63ec5feca31e9f556e) and removes the Rent Schedule section from the payments page and lease detail sheet.
> - Reworks the `payment_status` filter in `LeaseController.globalIndex` to mark leases overdue when any invoice with status pending/partial has a past due date, replacing the prior logic that checked for a paid invoice in the current month. The filter label changes from 'Paid' to 'Current'.
> - Behavioral Change: the global leases table Payment filter now reflects overdue status based on unpaid past-due invoices rather than presence of a current-month paid invoice.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f30a6f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->