### PR TITLE
feat: Collection Queue — Billing Operations Workspace

### DIFF
--- a/app/Business/Dashboard/RentStatsCalculator.php
+++ b/app/Business/Dashboard/RentStatsCalculator.php
@@ -6,10 +6,7 @@ use App\Enums\InvoiceStatus;
 use App\Models\Invoice;
 use App\Models\Lease;
 use Carbon\Carbon;
-use Carbon\CarbonInterface;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
 
 class RentStatsCalculator
 {
@@ -60,41 +57,6 @@ class RentStatsCalculator
             'due_today' => $dueTodayCount,
             'due_soon' => $dueSoonCount,
             'paid' => $paidCount,
-        ];
-    }
-
-    public function computeBillingStats(Builder $invoiceQuery, CarbonInterface $now): array
-    {
-        $overdueInvoices = (clone $invoiceQuery)
-            ->payable()
-            ->where('due_date', '<', $now->toDateString())
-            ->get();
-
-        $dueToday = (clone $invoiceQuery)
-            ->payable()
-            ->whereDate('due_date', '=', $now->toDateString())
-            ->count();
-
-        $dueSoon = (clone $invoiceQuery)
-            ->payable()
-            ->whereBetween('due_date', [
-                $now->copy()->addDay()->toDateString(),
-                $now->copy()->addDays(7)->toDateString(),
-            ])
-            ->count();
-
-        $outstandingBalance = (float) (clone $invoiceQuery)
-            ->payable()
-            ->sum(DB::raw('total - amount_paid'));
-
-        return [
-            'overdue' => [
-                'count' => $overdueInvoices->count(),
-                'amount' => (int) $overdueInvoices->sum(fn (Invoice $i) => (float) $i->total - (float) $i->amount_paid),
-            ],
-            'due_today' => $dueToday,
-            'due_soon' => $dueSoon,
-            'outstanding_balance' => (int) $outstandingBalance,
         ];
     }
 

--- a/app/Business/Dashboard/RentStatsCalculator.php
+++ b/app/Business/Dashboard/RentStatsCalculator.php
@@ -6,7 +6,10 @@ use App\Enums\InvoiceStatus;
 use App\Models\Invoice;
 use App\Models\Lease;
 use Carbon\Carbon;
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 
 class RentStatsCalculator
 {
@@ -57,6 +60,41 @@ class RentStatsCalculator
             'due_today' => $dueTodayCount,
             'due_soon' => $dueSoonCount,
             'paid' => $paidCount,
+        ];
+    }
+
+    public function computeBillingStats(Builder $invoiceQuery, CarbonInterface $now): array
+    {
+        $overdueInvoices = (clone $invoiceQuery)
+            ->payable()
+            ->where('due_date', '<', $now->toDateString())
+            ->get();
+
+        $dueToday = (clone $invoiceQuery)
+            ->payable()
+            ->whereDate('due_date', '=', $now->toDateString())
+            ->count();
+
+        $dueSoon = (clone $invoiceQuery)
+            ->payable()
+            ->whereBetween('due_date', [
+                $now->copy()->addDay()->toDateString(),
+                $now->copy()->addDays(7)->toDateString(),
+            ])
+            ->count();
+
+        $outstandingBalance = (float) (clone $invoiceQuery)
+            ->payable()
+            ->sum(DB::raw('total - amount_paid'));
+
+        return [
+            'overdue' => [
+                'count' => $overdueInvoices->count(),
+                'amount' => (int) $overdueInvoices->sum(fn (Invoice $i) => (float) $i->total - (float) $i->amount_paid),
+            ],
+            'due_today' => $dueToday,
+            'due_soon' => $dueSoon,
+            'outstanding_balance' => (int) $outstandingBalance,
         ];
     }
 

--- a/app/Http/Controllers/Dashboard/RentController.php
+++ b/app/Http/Controllers/Dashboard/RentController.php
@@ -111,6 +111,7 @@ class RentController extends Controller
                 }),
                 Column::make('urgency', 'Status')->sortable(),
                 Column::make('total', 'Amount')->sortable(),
+                Column::make('outstanding', 'Outstanding'),
                 Column::make('due_date', 'Due')->sortable(),
             ])
             ->filters([

--- a/app/Http/Controllers/Dashboard/RentController.php
+++ b/app/Http/Controllers/Dashboard/RentController.php
@@ -151,7 +151,8 @@ class RentController extends Controller
                         fn (Builder $q) => $q->whereIn('property_id', explode(',', $value)),
                     )),
             ])
-            ->defaultSort('due_date');
+            ->defaultSort('due_date')
+            ->withPerPage(25);
 
         $needsAttention = $table->paginate($queueQuery, $request, 'entries');
 

--- a/app/Http/Controllers/Dashboard/RentController.php
+++ b/app/Http/Controllers/Dashboard/RentController.php
@@ -100,6 +100,7 @@ class RentController extends Controller
 
         $table = Table::make()
             ->columns([
+                Column::make('lease_reference', 'Lease'),
                 Column::make('tenant_name', 'Tenant')->searchable(function (Builder $q, string $search): void {
                     $q->whereHas('lease.tenants', function (Builder $q) use ($search): void {
                         $q->whereRaw('lower(name) like ?', ['%'.mb_strtolower($search).'%']);
@@ -109,7 +110,6 @@ class RentController extends Controller
                         });
                     });
                 }),
-                Column::make('lease_reference', 'Lease'),
                 Column::make('urgency', 'Status'),
                 Column::make('total', 'Amount')->sortable(),
                 Column::make('outstanding', 'Outstanding'),

--- a/app/Http/Controllers/Dashboard/RentController.php
+++ b/app/Http/Controllers/Dashboard/RentController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers\Dashboard;
 
-use App\Business\Dashboard\RentStatsCalculator;
 use App\Enums\InvoiceStatus;
 use App\Enums\PaymentStatus;
 use App\Http\Controllers\Controller;
@@ -23,7 +22,7 @@ use Inertia\Response;
 
 class RentController extends Controller
 {
-    public function __invoke(Request $request, RentStatsCalculator $stats): Response
+    public function __invoke(Request $request): Response
     {
         $now = now();
 
@@ -109,7 +108,7 @@ class RentController extends Controller
                         });
                     });
                 }),
-                Column::make('urgency', 'Status')->sortable(),
+                Column::make('urgency', 'Status'),
                 Column::make('total', 'Amount')->sortable(),
                 Column::make('outstanding', 'Outstanding'),
                 Column::make('due_date', 'Due')->sortable(),
@@ -185,10 +184,12 @@ class RentController extends Controller
         // --- Recent Reminders ---
 
         $recentReminders = ReminderLog::with(['lease.primaryTenant', 'lease.tenants'])
-            ->whereHas('lease', fn (Builder $q) => $q->whereHas(
-                'unit',
-                fn (Builder $q) => $q->whereIn('property_id', $accessiblePropertyIds),
-            ))
+            ->whereHas('lease', fn (Builder $q) => $q
+                ->where('status', 'active')
+                ->whereHas(
+                    'unit',
+                    fn (Builder $q) => $q->whereIn('property_id', $accessiblePropertyIds),
+                ))
             ->latest('sent_at')
             ->limit(10)
             ->get()
@@ -246,9 +247,9 @@ class RentController extends Controller
         $unit = $lease->unit;
         $dueDate = $invoice->due_date;
 
-        $daysOverdue = $dueDate->isPast()
-            ? (int) $dueDate->startOfDay()->diffInDays($now->startOfDay())
-            : null;
+        $daysOverdue = $dueDate->isToday()
+            ? null
+            : ($dueDate->isPast() ? (int) $dueDate->startOfDay()->diffInDays($now->startOfDay()) : null);
 
         $urgency = match (true) {
             $daysOverdue !== null => 'overdue',

--- a/app/Http/Controllers/Dashboard/RentController.php
+++ b/app/Http/Controllers/Dashboard/RentController.php
@@ -75,6 +75,7 @@ class RentController extends Controller
 
         $lastPayment = Payment::where('status', PaymentStatus::Confirmed->value)
             ->whereHas('invoice', fn (Builder $q) => $q
+                ->whereHas('lease', fn (Builder $q) => $q->where('status', 'active'))
                 ->whereHas('lease.unit', fn (Builder $q) => $q->whereIn('property_id', $accessiblePropertyIds)))
             ->latest('payment_date')
             ->first();

--- a/app/Http/Controllers/Dashboard/RentController.php
+++ b/app/Http/Controllers/Dashboard/RentController.php
@@ -42,6 +42,11 @@ class RentController extends Controller
             'overdue' => $this->countPayable($accessiblePropertyIds, $now, '<'),
             'due_today' => $this->countPayable($accessiblePropertyIds, $now, '='),
             'upcoming' => $this->countPayable($accessiblePropertyIds, $now, '>'),
+            'partial' => Invoice::query()
+                ->where('status', InvoiceStatus::Partial->value)
+                ->whereHas('lease', fn (Builder $q) => $q->where('status', 'active'))
+                ->whereHas('lease.unit', fn (Builder $q) => $q->whereIn('property_id', $accessiblePropertyIds))
+                ->count(),
             'paid' => Invoice::query()
                 ->where('status', InvoiceStatus::Paid->value)
                 ->whereHas('lease', fn (Builder $q) => $q->where('status', 'active'))
@@ -78,14 +83,17 @@ class RentController extends Controller
         // --- Queue table ---
 
         $isPaidTab = $urgency === 'paid';
+        $isPartialTab = $urgency === 'partial';
 
         $queueQuery = Invoice::query()
             ->with(['lease.primaryTenant', 'lease.tenants', 'lease.unit.property'])
             ->whereHas('lease', fn (Builder $q) => $q->where('status', 'active'))
             ->whereHas('lease.unit', fn (Builder $q) => $q->whereIn('property_id', $accessiblePropertyIds));
 
-        if (! $isPaidTab) {
+        if (! $isPaidTab && ! $isPartialTab) {
             $queueQuery->payable();
+        } elseif ($isPartialTab) {
+            $queueQuery->where('status', InvoiceStatus::Partial->value);
         } else {
             $queueQuery->where('status', InvoiceStatus::Paid->value);
         }
@@ -110,10 +118,11 @@ class RentController extends Controller
                     ['value' => 'overdue', 'label' => 'Overdue'],
                     ['value' => 'due_today', 'label' => 'Due Today'],
                     ['value' => 'upcoming', 'label' => 'Upcoming'],
+                    ['value' => 'partial', 'label' => 'Partial'],
                     ['value' => 'paid', 'label' => 'Paid'],
                 ])
-                    ->query(function (Builder $q, string $value) use ($now, $isPaidTab): void {
-                        if ($isPaidTab) {
+                    ->query(function (Builder $q, string $value) use ($now, $isPaidTab, $isPartialTab): void {
+                        if ($isPaidTab || $isPartialTab) {
                             return;
                         }
 

--- a/app/Http/Controllers/Dashboard/RentController.php
+++ b/app/Http/Controllers/Dashboard/RentController.php
@@ -109,6 +109,7 @@ class RentController extends Controller
                         });
                     });
                 }),
+                Column::make('lease_reference', 'Lease'),
                 Column::make('urgency', 'Status'),
                 Column::make('total', 'Amount')->sortable(),
                 Column::make('outstanding', 'Outstanding'),
@@ -263,6 +264,8 @@ class RentController extends Controller
         return [
             'id' => $invoice->id,
             'lease_id' => $lease->id,
+            'lease_reference' => $lease->reference,
+            'primary_tenant_id' => $lease->primary_tenant_id,
             'tenant_name' => $tenants->pluck('name')->join(', ') ?: ($lease->primaryTenant?->name ?? '—'),
             'unit_name' => $unit?->name ?? '—',
             'property_name' => $unit?->property?->name ?? '—',

--- a/app/Http/Controllers/Dashboard/RentController.php
+++ b/app/Http/Controllers/Dashboard/RentController.php
@@ -4,16 +4,20 @@ namespace App\Http\Controllers\Dashboard;
 
 use App\Business\Dashboard\RentStatsCalculator;
 use App\Enums\InvoiceStatus;
+use App\Enums\PaymentStatus;
 use App\Http\Controllers\Controller;
 use App\Models\Invoice;
-use App\Models\Lease;
+use App\Models\Payment;
 use App\Models\Property;
+use App\Models\ReminderLog;
 use App\Tables\Column;
 use App\Tables\Filter;
 use App\Tables\Table;
-use Carbon\Carbon;
+use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -21,63 +25,103 @@ class RentController extends Controller
 {
     public function __invoke(Request $request, RentStatsCalculator $stats): Response
     {
-        $accessibleQuery = function (Builder $q) use ($request): void {
-            if (! $request->user()->isOwner()) {
-                $q->whereHas('unit.property.users', fn (Builder $q) => $q->whereKey($request->user()->id));
-            }
-        };
-
         $now = now();
-        $today = (int) $now->day;
-        $currentMonth = (int) $now->month;
-        $currentYear = (int) $now->year;
 
-        $baseQuery = Lease::query()
-            ->where('status', 'active')
-            ->where('start_date', '<=', $now);
+        $accessiblePropertyIds = Property::query()
+            ->when(! $request->user()->isOwner(), fn (Builder $q) => $q->whereHas(
+                'users',
+                fn (Builder $q) => $q->whereKey($request->user()->id),
+            ))
+            ->pluck('id');
 
-        ($accessibleQuery)($baseQuery);
+        $urgency = $request->query('urgency', '');
 
-        $allActive = (clone $baseQuery)->get();
+        // --- Tab counts ---
 
-        $statsResult = $stats->computeStats($allActive, $today, $currentMonth, $currentYear);
+        $tabCounts = [
+            'overdue' => $this->countPayable($accessiblePropertyIds, $now, '<'),
+            'due_today' => $this->countPayable($accessiblePropertyIds, $now, '='),
+            'upcoming' => $this->countPayable($accessiblePropertyIds, $now, '>'),
+            'paid' => Invoice::query()
+                ->where('status', InvoiceStatus::Paid->value)
+                ->whereHas('lease', fn (Builder $q) => $q->where('status', 'active'))
+                ->whereHas('lease.unit', fn (Builder $q) => $q->whereIn('property_id', $accessiblePropertyIds))
+                ->count(),
+        ];
 
-        $periodStart = Carbon::create($currentYear, $currentMonth, 1)->startOfDay();
-        $periodEnd = Carbon::create($currentYear, $currentMonth, 1)->endOfMonth()->endOfDay();
+        // --- Outstanding card ---
+
+        $outstandingCount = $tabCounts['overdue'] + $tabCounts['due_today'] + $tabCounts['upcoming'];
+
+        $outstandingAmount = (int) Invoice::query()
+            ->payable()
+            ->whereHas('lease', fn (Builder $q) => $q->where('status', 'active'))
+            ->whereHas('lease.unit', fn (Builder $q) => $q->whereIn('property_id', $accessiblePropertyIds))
+            ->sum(DB::raw('total - amount_paid'));
+
+        // --- Progress ---
+
+        $progressTotal = $outstandingCount + $tabCounts['paid'];
+
+        $collectedAmount = (int) Payment::where('status', PaymentStatus::Confirmed->value)
+            ->whereHas('invoice', fn (Builder $q) => $q
+                ->whereHas('lease', fn (Builder $q) => $q->where('status', 'active'))
+                ->whereHas('lease.unit', fn (Builder $q) => $q->whereIn('property_id', $accessiblePropertyIds)))
+            ->sum('amount');
+
+        $lastPayment = Payment::where('status', PaymentStatus::Confirmed->value)
+            ->whereHas('invoice', fn (Builder $q) => $q
+                ->whereHas('lease.unit', fn (Builder $q) => $q->whereIn('property_id', $accessiblePropertyIds)))
+            ->latest('payment_date')
+            ->first();
+
+        // --- Queue table ---
+
+        $isPaidTab = $urgency === 'paid';
+
+        $queueQuery = Invoice::query()
+            ->with(['lease.primaryTenant', 'lease.tenants', 'lease.unit.property'])
+            ->whereHas('lease', fn (Builder $q) => $q->where('status', 'active'))
+            ->whereHas('lease.unit', fn (Builder $q) => $q->whereIn('property_id', $accessiblePropertyIds));
+
+        if (! $isPaidTab) {
+            $queueQuery->payable();
+        } else {
+            $queueQuery->where('status', InvoiceStatus::Paid->value);
+        }
 
         $table = Table::make()
             ->columns([
                 Column::make('tenant_name', 'Tenant')->searchable(function (Builder $q, string $search): void {
-                    $q->whereHas('tenants', fn (Builder $q) => $q->whereRaw('lower(name) like ?', ['%'.mb_strtolower($search).'%']))
-                        ->orWhereHas('unit', fn (Builder $q) => $q->whereRaw('lower(name) like ?', ['%'.mb_strtolower($search).'%']))
-                        ->orWhereHas('unit.property', fn (Builder $q) => $q->whereRaw('lower(name) like ?', ['%'.mb_strtolower($search).'%']));
+                    $q->whereHas('lease.tenants', function (Builder $q) use ($search): void {
+                        $q->whereRaw('lower(name) like ?', ['%'.mb_strtolower($search).'%']);
+                    })->orWhereHas('lease', function (Builder $q) use ($search): void {
+                        $q->whereHas('unit', function (Builder $q) use ($search): void {
+                            $q->whereRaw('lower(name) like ?', ['%'.mb_strtolower($search).'%']);
+                        });
+                    });
                 }),
-                Column::make('unit_name', 'Unit'),
-                Column::make('property_name', 'Property'),
-                Column::make('rent_due_day', 'Due Date')->sortable(),
-                Column::make('rent_amount', 'Amount Due')->sortable(),
+                Column::make('urgency', 'Status')->sortable(),
+                Column::make('total', 'Amount')->sortable(),
+                Column::make('due_date', 'Due')->sortable(),
             ])
             ->filters([
-                Filter::select('status', 'Status', [
+                Filter::select('urgency', 'Status', [
                     ['value' => 'overdue', 'label' => 'Overdue'],
                     ['value' => 'due_today', 'label' => 'Due Today'],
-                    ['value' => 'due_soon', 'label' => 'Due Soon'],
+                    ['value' => 'upcoming', 'label' => 'Upcoming'],
                     ['value' => 'paid', 'label' => 'Paid'],
                 ])
-                    ->query(function (Builder $q, string $value) use ($today, $periodStart, $periodEnd): void {
-                        $hasPayment = fn (Builder $q) => $q->whereHas('invoices', fn (Builder $q) => $q
-                            ->where('status', InvoiceStatus::Paid->value)
-                            ->whereBetween('period_start', [$periodStart, $periodEnd]));
-
-                        $noPayment = fn (Builder $q) => $q->whereDoesntHave('invoices', fn (Builder $q) => $q
-                            ->where('status', InvoiceStatus::Paid->value)
-                            ->whereBetween('period_start', [$periodStart, $periodEnd]));
+                    ->query(function (Builder $q, string $value) use ($now, $isPaidTab): void {
+                        if ($isPaidTab) {
+                            return;
+                        }
 
                         match ($value) {
-                            'paid' => $hasPayment($q),
-                            'overdue' => $noPayment($q)->where('rent_due_day', '<', $today),
-                            'due_today' => $noPayment($q)->where('rent_due_day', '=', $today),
-                            'due_soon' => $noPayment($q)->whereBetween('rent_due_day', [$today + 1, min($today + 7, 31)]),
+                            'overdue' => $q->where('due_date', '<', $now->toDateString()),
+                            'due_today' => $q->whereDate('due_date', '=', $now->toDateString()),
+                            'upcoming' => $q->where('due_date', '>', $now->toDateString()),
+                            default => null,
                         };
                     }),
                 Filter::select('properties', 'Property', function () use ($request): array {
@@ -92,33 +136,134 @@ class RentController extends Controller
                         ->all();
                 })
                     ->query(fn (Builder $q, string $value) => $q->whereHas(
-                        'unit',
+                        'lease.unit',
                         fn (Builder $q) => $q->whereIn('property_id', explode(',', $value)),
                     )),
             ])
-            ->defaultSort('rent_due_day');
+            ->defaultSort('due_date');
 
-        $query = (clone $baseQuery)
-            ->with(['primaryTenant:id,name,phone', 'tenants:id,name,phone', 'unit:id,name,property_id', 'unit.property:id,name'])
-            ->addSelect(['has_payment_this_month' => Invoice::query()
-                ->selectRaw('COUNT(*) > 0')
-                ->whereColumn('lease_id', 'leases.id')
-                ->where('status', InvoiceStatus::Paid->value)
-                ->whereBetween('period_start', [$periodStart, $periodEnd]),
-            ]);
+        $needsAttention = $table->paginate($queueQuery, $request, 'entries');
 
-        $result = $table->paginate($query, $request, 'entries');
-
-        $entries = collect($result['entries']->items())
-            ->map(fn (Lease $lease) => $stats->transformEntry($lease, $today))
-            ->filter(fn (?array $entry) => $entry !== null)
+        $entries = collect($needsAttention['entries']->items())
+            ->map(fn (Invoice $invoice) => $this->transformInvoice($invoice, $now))
             ->values();
 
-        $result['entries'] = $result['entries']->setCollection($entries);
+        $needsAttention['entries'] = $needsAttention['entries']->setCollection($entries);
+
+        // --- Recent Payments ---
+
+        $recentPayments = Payment::with([
+            'invoice' => fn ($q) => $q->with(['lease.primaryTenant', 'lease.tenants', 'lease.unit.property']),
+        ])
+            ->where('status', PaymentStatus::Confirmed->value)
+            ->whereHas('invoice.lease.unit', fn (Builder $q) => $q->whereIn('property_id', $accessiblePropertyIds))
+            ->latest('payment_date')
+            ->limit(10)
+            ->get()
+            ->map(fn (Payment $p) => [
+                'id' => $p->id,
+                'amount' => (string) $p->amount,
+                'payment_date' => $p->payment_date->toDateString(),
+                'payment_method' => $p->payment_method,
+                'tenant_name' => $p->invoice?->lease?->tenants?->pluck('name')->join(', ')
+                    ?: $p->invoice?->lease?->primaryTenant?->name ?? '—',
+                'invoice_id' => $p->invoice_id,
+                'invoice_reference' => $p->invoice?->reference ?? '—',
+                'lease_id' => $p->invoice?->lease_id ?? null,
+            ]);
+
+        // --- Recent Reminders ---
+
+        $recentReminders = ReminderLog::with(['lease.primaryTenant', 'lease.tenants'])
+            ->whereHas('lease', fn (Builder $q) => $q->whereHas(
+                'unit',
+                fn (Builder $q) => $q->whereIn('property_id', $accessiblePropertyIds),
+            ))
+            ->latest('sent_at')
+            ->limit(10)
+            ->get()
+            ->map(fn (ReminderLog $r) => [
+                'id' => $r->id,
+                'lease_id' => $r->lease_id,
+                'tenant_name' => $r->lease?->tenants?->pluck('name')->join(', ')
+                    ?: $r->lease?->primaryTenant?->name ?? '—',
+                'reminder_type' => $r->reminder_type,
+                'channel' => $r->channel,
+                'scheduled_for' => $r->scheduled_for?->toDateString(),
+                'sent_at' => $r->sent_at?->toDateTimeString() ?? null,
+                'overdue_days' => $r->overdue_days,
+            ]);
 
         return Inertia::render('dashboard/rent', [
-            ...$result,
-            'stats' => $statsResult,
+            ...$needsAttention,
+            'outstanding' => [
+                'count' => $outstandingCount,
+                'amount' => $outstandingAmount,
+            ],
+            'tab_counts' => $tabCounts,
+            'progress' => [
+                'processed' => $tabCounts['paid'],
+                'total' => $progressTotal,
+                'amount_collected' => $collectedAmount,
+                'last_payment_at' => $lastPayment?->payment_date?->toDateTimeString() ?? null,
+            ],
+            'recent_payments' => $recentPayments,
+            'recent_reminders' => $recentReminders,
         ]);
+    }
+
+    private function countPayable(Collection $propertyIds, CarbonInterface $now, string $operator): int
+    {
+        $query = Invoice::query()
+            ->payable()
+            ->whereHas('lease', fn (Builder $q) => $q->where('status', 'active'))
+            ->whereHas('lease.unit', fn (Builder $q) => $q->whereIn('property_id', $propertyIds));
+
+        match ($operator) {
+            '<' => $query->where('due_date', '<', $now->toDateString()),
+            '=' => $query->whereDate('due_date', '=', $now->toDateString()),
+            '>' => $query->where('due_date', '>', $now->toDateString()),
+            default => null,
+        };
+
+        return $query->count();
+    }
+
+    private function transformInvoice(Invoice $invoice, CarbonInterface $now): array
+    {
+        $lease = $invoice->lease;
+        $tenants = $lease->tenants;
+        $unit = $lease->unit;
+        $dueDate = $invoice->due_date;
+
+        $daysOverdue = $dueDate->isPast()
+            ? (int) $dueDate->startOfDay()->diffInDays($now->startOfDay())
+            : null;
+
+        $urgency = match (true) {
+            $daysOverdue !== null => 'overdue',
+            $dueDate->isToday() => 'due_today',
+            $dueDate->isTomorrow() => 'due_tomorrow',
+            $dueDate->isFuture() && $dueDate->diffInDays($now->startOfDay()) <= 7 => 'due_soon',
+            default => 'upcoming',
+        };
+
+        return [
+            'id' => $invoice->id,
+            'lease_id' => $lease->id,
+            'tenant_name' => $tenants->pluck('name')->join(', ') ?: ($lease->primaryTenant?->name ?? '—'),
+            'unit_name' => $unit?->name ?? '—',
+            'property_name' => $unit?->property?->name ?? '—',
+            'reference' => $invoice->reference,
+            'period_start' => $invoice->period_start->toDateString(),
+            'period_end' => $invoice->period_end->toDateString(),
+            'due_date' => $invoice->due_date->toDateString(),
+            'total' => (string) $invoice->total,
+            'amount_paid' => (string) $invoice->amount_paid,
+            'outstanding' => $invoice->outstanding,
+            'days_overdue' => $daysOverdue,
+            'urgency' => $urgency,
+            'status' => $invoice->status->value,
+        ];
     }
 }

--- a/app/Models/ReminderLog.php
+++ b/app/Models/ReminderLog.php
@@ -2,11 +2,14 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class ReminderLog extends Model
 {
+    use HasFactory;
+
     protected $fillable = [
         'lease_id',
         'period_start',

--- a/app/Tables/Table.php
+++ b/app/Tables/Table.php
@@ -57,6 +57,13 @@ class Table
         return $this;
     }
 
+    public function withPerPage(int $perPage): self
+    {
+        $this->defaultPerPage = $perPage;
+
+        return $this;
+    }
+
     public function paginate(Builder|Relation $query, Request $request, string $dataKey): array
     {
         $search = $this->applySearch($query, $request);

--- a/database/factories/ReminderLogFactory.php
+++ b/database/factories/ReminderLogFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Lease;
+use App\Models\ReminderLog;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ReminderLog>
+ */
+class ReminderLogFactory extends Factory
+{
+    protected $model = ReminderLog::class;
+
+    public function definition(): array
+    {
+        return [
+            'lease_id' => Lease::factory(),
+            'period_start' => now()->startOfMonth()->toDateString(),
+            'period_end' => now()->endOfMonth()->toDateString(),
+            'reminder_type' => fake()->randomElement(['upcoming', 'due_today', 'overdue']),
+            'overdue_days' => null,
+            'notification_class' => 'App\Notifications\RentReminder',
+            'channel' => 'whatsapp',
+            'scheduled_for' => now()->toDateString(),
+            'sent_at' => now(),
+        ];
+    }
+}

--- a/resources/js/components/features/app/app-sidebar.tsx
+++ b/resources/js/components/features/app/app-sidebar.tsx
@@ -2,6 +2,7 @@ import { Link, usePage } from '@inertiajs/react';
 import {
     BookOpen,
     Building2,
+    DollarSign,
     FileText,
     FolderGit2,
     LayoutGrid,
@@ -55,12 +56,22 @@ export function AppSidebar() {
                               icon: LayoutGrid,
                               href: dashboard(),
                           },
+                          ...platformPageNavItems(platform.dashboard, auth),
+                      ],
+                  },
+              ]
+            : []),
+        ...(isOwner || permissions.includes('dashboard.view')
+            ? [
+                  {
+                      title: 'Billing',
+                      icon: DollarSign,
+                      children: [
                           {
-                              title: 'Rent',
+                              title: 'Collection',
                               icon: Receipt,
                               href: dashboardRent(),
                           },
-                          ...platformPageNavItems(platform.dashboard, auth),
                       ],
                   },
               ]

--- a/resources/js/components/features/leases/assign-unit-sheet.tsx
+++ b/resources/js/components/features/leases/assign-unit-sheet.tsx
@@ -166,7 +166,11 @@ export default function AssignUnitSheet({
     }
 
     return (
-        <Sheet key={tenant?.id ?? 'closed'} open={open} onOpenChange={onOpenChange}>
+        <Sheet
+            key={tenant?.id ?? 'closed'}
+            open={open}
+            onOpenChange={onOpenChange}
+        >
             <SheetContent className="sm:max-w-lg">
                 <SheetHeader>
                     <SheetTitle>Assign to Unit</SheetTitle>

--- a/resources/js/components/features/leases/lease-detail-sheet.tsx
+++ b/resources/js/components/features/leases/lease-detail-sheet.tsx
@@ -412,7 +412,16 @@ export default function LeaseDetailSheet({
                                                                         payment.amount,
                                                                     )}
                                                                 </p>
-<StatusBadge domain="payment" value={payment.verified_at && payment.status === 'confirmed' ? 'verified' : payment.status} />
+                                                                <StatusBadge
+                                                                    domain="payment"
+                                                                    value={
+                                                                        payment.verified_at &&
+                                                                        payment.status ===
+                                                                            'confirmed'
+                                                                            ? 'verified'
+                                                                            : payment.status
+                                                                    }
+                                                                />
                                                             </div>
                                                         </div>
                                                         {payment.proofs

--- a/resources/js/components/features/maintenance/ticket-detail-sheet.tsx
+++ b/resources/js/components/features/maintenance/ticket-detail-sheet.tsx
@@ -100,7 +100,10 @@ export default function TicketDetailSheet({
                     <SheetTitle>{ticket.title}</SheetTitle>
                     <SheetDescription>
                         {ticket.reference ?? `#${ticket.id}`} &middot;{' '}
-                        <StatusBadge domain="maintenance" value={ticket.status} />
+                        <StatusBadge
+                            domain="maintenance"
+                            value={ticket.status}
+                        />
                     </SheetDescription>
                 </SheetHeader>
 
@@ -283,10 +286,7 @@ export default function TicketDetailSheet({
                 </div>
             </SheetContent>
 
-            <Dialog
-                open={deleteConfirm}
-                onOpenChange={setDeleteConfirm}
-            >
+            <Dialog open={deleteConfirm} onOpenChange={setDeleteConfirm}>
                 <DialogContent>
                     <DialogHeader>
                         <DialogTitle>Delete ticket</DialogTitle>
@@ -301,10 +301,7 @@ export default function TicketDetailSheet({
                         >
                             Cancel
                         </Button>
-                        <Button
-                            variant="destructive"
-                            onClick={confirmDelete}
-                        >
+                        <Button variant="destructive" onClick={confirmDelete}>
                             Delete
                         </Button>
                     </DialogFooter>

--- a/resources/js/components/features/payments/queue-payment-sheet.tsx
+++ b/resources/js/components/features/payments/queue-payment-sheet.tsx
@@ -1,0 +1,213 @@
+import { router } from '@inertiajs/react';
+import { useRef, useState } from 'react';
+import type { FormEvent } from 'react';
+import { InputError } from '@/components/shared';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import {
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetHeader,
+    SheetTitle,
+} from '@/components/ui/sheet';
+import { PAYMENT_METHODS } from '@/lib/constants/billing';
+import { formatDate, formatPrice } from '@/lib/formatters';
+import leases from '@/routes/leases';
+import type { NeedsAttentionInvoice } from '@/types';
+
+export default function QueuePaymentSheet({
+    invoice,
+    open,
+    onOpenChange,
+}: {
+    invoice: NeedsAttentionInvoice | null;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}) {
+    const [processing, setProcessing] = useState(false);
+    const [errors, setErrors] = useState<Record<string, string>>({});
+    const [fileName, setFileName] = useState<string | null>(null);
+    const formRef = useRef<HTMLFormElement>(null);
+    const now = new Date();
+
+    function handleSubmit(e: FormEvent<HTMLFormElement>) {
+        e.preventDefault();
+
+        if (!invoice) {
+return;
+}
+
+        const formData = new FormData(e.currentTarget);
+        formData.append('invoice_id', String(invoice.id));
+
+        setProcessing(true);
+        setErrors({});
+
+        router.post(
+            leases.payments.store.url({ lease: invoice.lease_id }),
+            formData,
+            {
+                preserveState: true,
+                replace: true,
+                onSuccess: () => {
+                    onOpenChange(false);
+                    formRef.current?.reset();
+                    setFileName(null);
+                },
+                onError: (errs) => {
+                    setErrors(errs);
+                },
+                onFinish: () => {
+                    setProcessing(false);
+                },
+            },
+        );
+    }
+
+    return (
+        <Sheet open={open} onOpenChange={onOpenChange}>
+            <SheetContent className="sm:max-w-lg">
+                <SheetHeader>
+                    <SheetTitle>Record Payment</SheetTitle>
+                    <SheetDescription>
+                        {invoice ? (
+                            <>
+                                {invoice.tenant_name} — {invoice.reference}
+                                <br />
+                                {formatPrice(invoice.total)} · Due{' '}
+                                {formatDate(invoice.due_date)} ·{' '}
+                                <span className="text-red-600">
+                                    {formatPrice(invoice.outstanding)} outstanding
+                                </span>
+                            </>
+                        ) : (
+                            'Record a rent payment.'
+                        )}
+                    </SheetDescription>
+                </SheetHeader>
+
+                <div className="flex-1 overflow-y-auto px-4">
+                    <form
+                        ref={formRef}
+                        onSubmit={handleSubmit}
+                        className="space-y-6 pt-4"
+                    >
+                        <div className="grid gap-4">
+                            <div className="grid gap-2">
+                                <Label htmlFor="amount">Amount (IDR)</Label>
+                                <Input
+                                    id="amount"
+                                    name="amount"
+                                    type="number"
+                                    min={1}
+                                    key={invoice?.id}
+                                    defaultValue={invoice?.outstanding ?? ''}
+                                    required
+                                />
+                                <InputError message={errors.amount} />
+                            </div>
+
+                            <div className="grid grid-cols-2 gap-4">
+                                <div className="grid gap-2">
+                                    <Label htmlFor="payment_method">
+                                        Payment Method
+                                    </Label>
+                                    <Select
+                                        name="payment_method"
+                                        defaultValue="cash"
+                                    >
+                                        <SelectTrigger id="payment_method" className="w-full">
+                                            <SelectValue placeholder="Select method" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {PAYMENT_METHODS.map((m) => (
+                                                <SelectItem
+                                                    key={m.value}
+                                                    value={m.value}
+                                                >
+                                                    {m.label}
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                    <InputError message={errors.payment_method} />
+                                </div>
+
+                                <div className="grid gap-2">
+                                    <Label htmlFor="paid_at">Paid At</Label>
+                                    <Input
+                                        id="paid_at"
+                                        name="paid_at"
+                                        type="date"
+                                        defaultValue={
+                                            now.toISOString().split('T')[0]
+                                        }
+                                        required
+                                    />
+                                    <InputError message={errors.paid_at} />
+                                </div>
+                            </div>
+
+                            <div className="grid gap-2">
+                                <Label htmlFor="notes">Notes</Label>
+                                <textarea
+                                    id="notes"
+                                    name="notes"
+                                    placeholder="Optional notes"
+                                    className="flex min-h-15 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+                                />
+                                <InputError message={errors.notes} />
+                            </div>
+
+                            <div className="grid gap-2">
+                                <Label htmlFor="proof">
+                                    Payment Proof (optional)
+                                </Label>
+                                <Input
+                                    id="proof"
+                                    name="proof"
+                                    type="file"
+                                    accept=".jpg,.jpeg,.png,.pdf"
+                                    className="file:mr-3 file:rounded file:border-0 file:bg-primary file:px-3 file:py-1.5 file:text-xs file:font-medium file:text-primary-foreground hover:file:bg-primary/90"
+                                    onChange={(e) => {
+                                        const file = e.target.files?.[0];
+                                        setFileName(file?.name ?? null);
+                                    }}
+                                />
+                                {fileName && (
+                                    <p className="text-xs text-muted-foreground">
+                                        {fileName}
+                                    </p>
+                                )}
+                                <InputError message={errors.proof} />
+                            </div>
+                        </div>
+
+                        <div className="flex items-center justify-end gap-4 pt-2">
+                            <Button
+                                variant="outline"
+                                type="button"
+                                onClick={() => onOpenChange(false)}
+                                disabled={processing}
+                            >
+                                Cancel
+                            </Button>
+                            <Button disabled={processing}>
+                                {processing ? 'Recording...' : 'Record Payment'}
+                            </Button>
+                        </div>
+                    </form>
+                </div>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/resources/js/components/features/payments/queue-payment-sheet.tsx
+++ b/resources/js/components/features/payments/queue-payment-sheet.tsx
@@ -116,7 +116,7 @@ return;
                                 <InputError message={errors.amount} />
                             </div>
 
-                            <div className="grid grid-cols-2 gap-4">
+                            <div className="grid gap-4 sm:grid-cols-2">
                                 <div className="grid gap-2">
                                     <Label htmlFor="payment_method">
                                         Payment Method

--- a/resources/js/components/features/payments/queue-payment-sheet.tsx
+++ b/resources/js/components/features/payments/queue-payment-sheet.tsx
@@ -38,6 +38,7 @@ export default function QueuePaymentSheet({
     const [fileName, setFileName] = useState<string | null>(null);
     const formRef = useRef<HTMLFormElement>(null);
     const now = new Date();
+    const todayStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
 
     function handleSubmit(e: FormEvent<HTMLFormElement>) {
         e.preventDefault();
@@ -102,6 +103,7 @@ return;
                         className="space-y-6 pt-4"
                     >
                         <div className="grid gap-4">
+                            <InputError message={errors.invoice_id} />
                             <div className="grid gap-2">
                                 <Label htmlFor="amount">Amount (IDR)</Label>
                                 <Input
@@ -148,9 +150,7 @@ return;
                                         id="paid_at"
                                         name="paid_at"
                                         type="date"
-                                        defaultValue={
-                                            now.toISOString().split('T')[0]
-                                        }
+                                        defaultValue={todayStr}
                                         required
                                     />
                                     <InputError message={errors.paid_at} />

--- a/resources/js/components/features/payments/record-payment-sheet.tsx
+++ b/resources/js/components/features/payments/record-payment-sheet.tsx
@@ -39,6 +39,7 @@ function RecordPaymentForm({
     const [fetchError, setFetchError] = useState(false);
     const formRef = useRef<HTMLFormElement>(null);
     const now = new Date();
+    const todayStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
 
     useEffect(() => {
         const controller = new AbortController();
@@ -191,7 +192,7 @@ function RecordPaymentForm({
                                 id="paid_at"
                                 name="paid_at"
                                 type="date"
-                                defaultValue={now.toISOString().split('T')[0]}
+                                defaultValue={todayStr}
                                 required
                             />
                             <InputError message={errors.paid_at} />

--- a/resources/js/components/features/payments/record-payment-sheet.tsx
+++ b/resources/js/components/features/payments/record-payment-sheet.tsx
@@ -167,7 +167,7 @@ function RecordPaymentForm({
                         <InputError message={errors.amount} />
                     </div>
 
-                    <div className="grid grid-cols-2 gap-4">
+                    <div className="grid gap-4 sm:grid-cols-2">
                         <div className="grid gap-2">
                             <Label htmlFor="payment_method">Payment Method</Label>
                             <Select name="payment_method" defaultValue="cash">

--- a/resources/js/components/features/payments/record-payment-sheet.tsx
+++ b/resources/js/components/features/payments/record-payment-sheet.tsx
@@ -43,7 +43,9 @@ function RecordPaymentForm({
     useEffect(() => {
         const controller = new AbortController();
 
-        fetch(`/leases/${lease.id}/rent-schedule`, { signal: controller.signal })
+        fetch(`/leases/${lease.id}/rent-schedule`, {
+            signal: controller.signal,
+        })
             .then((r) => r.json())
             .then((d: { schedule: RentScheduleEntry[] }) => {
                 const payable = d.schedule.filter((entry) =>
@@ -94,20 +96,14 @@ function RecordPaymentForm({
     }
 
     return (
-        <form
-            ref={formRef}
-            onSubmit={handleSubmit}
-            className="space-y-6 pt-4"
-        >
+        <form ref={formRef} onSubmit={handleSubmit} className="space-y-6 pt-4">
             <section>
                 <h3 className="mb-3 text-xs font-semibold tracking-wider text-muted-foreground uppercase">
                     Invoice
                 </h3>
 
                 <div className="grid gap-2">
-                    <Label htmlFor="invoice_id">
-                        Billing Period
-                    </Label>
+                    <Label htmlFor="invoice_id">Billing Period</Label>
                     {invoices === null ? (
                         <p className="text-sm text-muted-foreground">
                             {fetchError
@@ -133,15 +129,10 @@ function RecordPaymentForm({
                                         key={entry.id}
                                         value={String(entry.id)}
                                     >
-                                        {formatPeriod(
-                                            entry.period_start,
-                                        )}
+                                        {formatPeriod(entry.period_start)}
                                         {' — '}
-                                        {formatPrice(
-                                            entry.outstanding,
-                                        )}
-                                        {entry.status ===
-                                            'partial' &&
+                                        {formatPrice(entry.outstanding)}
+                                        {entry.status === 'partial' &&
                                             ' outstanding'}
                                     </SelectItem>
                                 ))}
@@ -159,9 +150,7 @@ function RecordPaymentForm({
 
                 <div className="grid gap-4">
                     <div className="grid gap-2">
-                        <Label htmlFor="amount">
-                            Amount (IDR)
-                        </Label>
+                        <Label htmlFor="amount">Amount (IDR)</Label>
                         <Input
                             id="amount"
                             name="amount"
@@ -178,45 +167,35 @@ function RecordPaymentForm({
                         <InputError message={errors.amount} />
                     </div>
 
-                    <div className="grid gap-2">
-                        <Label htmlFor="payment_method">
-                            Payment Method
-                        </Label>
-                        <Select
-                            name="payment_method"
-                            defaultValue="cash"
-                        >
-                            <SelectTrigger id="payment_method">
-                                <SelectValue placeholder="Select method" />
-                            </SelectTrigger>
-                            <SelectContent>
-                                {PAYMENT_METHODS.map((m) => (
-                                    <SelectItem
-                                        key={m.value}
-                                        value={m.value}
-                                    >
-                                        {m.label}
-                                    </SelectItem>
-                                ))}
-                            </SelectContent>
-                        </Select>
-                        <InputError
-                            message={errors.payment_method}
-                        />
-                    </div>
+                    <div className="grid grid-cols-2 gap-4">
+                        <div className="grid gap-2">
+                            <Label htmlFor="payment_method">Payment Method</Label>
+                            <Select name="payment_method" defaultValue="cash">
+                                <SelectTrigger id="payment_method" className="w-full">
+                                    <SelectValue placeholder="Select method" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {PAYMENT_METHODS.map((m) => (
+                                        <SelectItem key={m.value} value={m.value}>
+                                            {m.label}
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                            <InputError message={errors.payment_method} />
+                        </div>
 
-                    <div className="grid gap-2">
-                        <Label htmlFor="paid_at">Paid At</Label>
-                        <Input
-                            id="paid_at"
-                            name="paid_at"
-                            type="date"
-                            defaultValue={
-                                now.toISOString().split('T')[0]
-                            }
-                            required
-                        />
-                        <InputError message={errors.paid_at} />
+                        <div className="grid gap-2">
+                            <Label htmlFor="paid_at">Paid At</Label>
+                            <Input
+                                id="paid_at"
+                                name="paid_at"
+                                type="date"
+                                defaultValue={now.toISOString().split('T')[0]}
+                                required
+                            />
+                            <InputError message={errors.paid_at} />
+                        </div>
                     </div>
 
                     <div className="grid gap-2">
@@ -231,9 +210,7 @@ function RecordPaymentForm({
                     </div>
 
                     <div className="grid gap-2">
-                        <Label htmlFor="proof">
-                            Payment Proof (optional)
-                        </Label>
+                        <Label htmlFor="proof">Payment Proof (optional)</Label>
                         <Input
                             id="proof"
                             name="proof"
@@ -241,8 +218,7 @@ function RecordPaymentForm({
                             accept=".jpg,.jpeg,.png,.pdf"
                             className="file:mr-3 file:rounded file:border-0 file:bg-primary file:px-3 file:py-1.5 file:text-xs file:font-medium file:text-primary-foreground hover:file:bg-primary/90"
                             onChange={(e) => {
-                                const file =
-                                    e.target.files?.[0];
+                                const file = e.target.files?.[0];
                                 setFileName(file?.name ?? null);
                             }}
                         />
@@ -267,14 +243,10 @@ function RecordPaymentForm({
                 </Button>
                 <Button
                     disabled={
-                        processing ||
-                        invoices === null ||
-                        invoices.length === 0
+                        processing || invoices === null || invoices.length === 0
                     }
                 >
-                    {processing
-                        ? 'Recording...'
-                        : 'Record Payment'}
+                    {processing ? 'Recording...' : 'Record Payment'}
                 </Button>
             </div>
         </form>

--- a/resources/js/components/features/properties/property-detail-sheet.tsx
+++ b/resources/js/components/features/properties/property-detail-sheet.tsx
@@ -86,7 +86,11 @@ export default function PropertyDetailSheet({
                                 <span>Status:</span>
                                 <StatusBadge
                                     domain="property"
-                                    value={property.is_active ? 'active' : 'archived'}
+                                    value={
+                                        property.is_active
+                                            ? 'active'
+                                            : 'archived'
+                                    }
                                 />
                                 {property.type && (
                                     <Badge variant="outline">
@@ -199,10 +203,7 @@ export default function PropertyDetailSheet({
                 )}
             </SheetContent>
 
-            <Dialog
-                open={archiveConfirm}
-                onOpenChange={setArchiveConfirm}
-            >
+            <Dialog open={archiveConfirm} onOpenChange={setArchiveConfirm}>
                 <DialogContent>
                     <DialogHeader>
                         <DialogTitle>Archive property</DialogTitle>
@@ -221,10 +222,7 @@ export default function PropertyDetailSheet({
                         >
                             Cancel
                         </Button>
-                        <Button
-                            variant="destructive"
-                            onClick={confirmArchive}
-                        >
+                        <Button variant="destructive" onClick={confirmArchive}>
                             Archive
                         </Button>
                     </DialogFooter>

--- a/resources/js/components/features/settings/dynamic-settings-form.tsx
+++ b/resources/js/components/features/settings/dynamic-settings-form.tsx
@@ -12,7 +12,10 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
-import type { DynamicSettingsFormProps, SettingDefinition } from '@/types/settings';
+import type {
+    DynamicSettingsFormProps,
+    SettingDefinition,
+} from '@/types/settings';
 
 export function DynamicSettingsForm({
     definitions,
@@ -30,22 +33,24 @@ export function DynamicSettingsForm({
                             </CardDescription>
                         )}
                         {def.type === 'json' && (
-                            <CardDescription>
-                                Enter valid JSON.
-                            </CardDescription>
+                            <CardDescription>Enter valid JSON.</CardDescription>
                         )}
                     </CardHeader>
                     <CardContent>
                         {/* ponytail: replace with Wayfinder import after `php artisan wayfinder:generate` */}
-                        <Form
-                            action={'/settings/values'}
-                            method="post"
-                        >
+                        <Form action={'/settings/values'} method="post">
                             {({ processing, errors }) => (
                                 <div className="space-y-4">
-                                    <input type="hidden" name="key" value={def.key} />
+                                    <input
+                                        type="hidden"
+                                        name="key"
+                                        value={def.key}
+                                    />
                                     {def.type === 'bool' ? (
-                                        <BoolField def={def} value={!!values[def.key]} />
+                                        <BoolField
+                                            def={def}
+                                            value={!!values[def.key]}
+                                        />
                                     ) : def.type === 'json' ? (
                                         <div className="grid gap-2">
                                             <Label htmlFor={def.key}>
@@ -87,9 +92,14 @@ export function DynamicSettingsForm({
                                                           : 'text'
                                                 }
                                                 defaultValue={
-                                                    values[def.key] as string | number | undefined
+                                                    values[def.key] as
+                                                        | string
+                                                        | number
+                                                        | undefined
                                                 }
-                                                placeholder={String(def.default ?? '')}
+                                                placeholder={String(
+                                                    def.default ?? '',
+                                                )}
                                             />
                                             {errors.value && (
                                                 <p className="text-sm text-red-600">
@@ -98,9 +108,7 @@ export function DynamicSettingsForm({
                                             )}
                                         </div>
                                     )}
-                                    <Button disabled={processing}>
-                                        Save
-                                    </Button>
+                                    <Button disabled={processing}>Save</Button>
                                 </div>
                             )}
                         </Form>
@@ -117,7 +125,11 @@ function BoolField({ def, value }: { def: SettingDefinition; value: boolean }) {
     return (
         <div className="flex items-center gap-2">
             <input type="hidden" name="value" value={checked ? '1' : '0'} />
-            <Switch id={def.key} checked={checked} onCheckedChange={setChecked} />
+            <Switch
+                id={def.key}
+                checked={checked}
+                onCheckedChange={setChecked}
+            />
             <Label htmlFor={def.key}>{def.label}</Label>
         </div>
     );

--- a/resources/js/components/features/tenants/tenant-detail-sheet.tsx
+++ b/resources/js/components/features/tenants/tenant-detail-sheet.tsx
@@ -30,7 +30,9 @@ export default function TenantDetailSheet({
     onAssignToUnit,
     onMoveOut,
 }: {
-    tenant?: (WorkspaceTenant & { leases?: Lease[]; documents?: TenantDocument[] }) | null;
+    tenant?:
+        | (WorkspaceTenant & { leases?: Lease[]; documents?: TenantDocument[] })
+        | null;
     open: boolean;
     onOpenChange: (open: boolean) => void;
     onEdit: () => void;
@@ -79,9 +81,18 @@ export default function TenantDetailSheet({
                             <div className="flex items-center gap-2">
                                 <span>Status:</span>
                                 {(() => {
-                                    const status = isArchived ? 'archived' : tenant.is_active ? 'active' : 'inactive';
+                                    const status = isArchived
+                                        ? 'archived'
+                                        : tenant.is_active
+                                          ? 'active'
+                                          : 'inactive';
 
-                                    return <StatusBadge domain="tenant" value={status} />;
+                                    return (
+                                        <StatusBadge
+                                            domain="tenant"
+                                            value={status}
+                                        />
+                                    );
                                 })()}
                             </div>
 
@@ -298,19 +309,13 @@ export default function TenantDetailSheet({
                 )}
             </SheetContent>
 
-            <Dialog
-                open={archiveConfirm}
-                onOpenChange={setArchiveConfirm}
-            >
+            <Dialog open={archiveConfirm} onOpenChange={setArchiveConfirm}>
                 <DialogContent>
                     <DialogHeader>
                         <DialogTitle>Archive tenant</DialogTitle>
                         <DialogDescription>
                             Are you sure you want to archive{' '}
-                            <span className="font-medium">
-                                {tenant?.name}
-                            </span>
-                            ?
+                            <span className="font-medium">{tenant?.name}</span>?
                         </DialogDescription>
                     </DialogHeader>
                     <DialogFooter>
@@ -320,10 +325,7 @@ export default function TenantDetailSheet({
                         >
                             Cancel
                         </Button>
-                        <Button
-                            variant="destructive"
-                            onClick={confirmArchive}
-                        >
+                        <Button variant="destructive" onClick={confirmArchive}>
                             Archive
                         </Button>
                     </DialogFooter>

--- a/resources/js/components/features/tenants/tenant-documents-sheet.tsx
+++ b/resources/js/components/features/tenants/tenant-documents-sheet.tsx
@@ -259,10 +259,7 @@ export default function TenantDocumentsSheet({
                         >
                             Cancel
                         </Button>
-                        <Button
-                            variant="destructive"
-                            onClick={confirmDelete}
-                        >
+                        <Button variant="destructive" onClick={confirmDelete}>
                             Delete
                         </Button>
                     </DialogFooter>

--- a/resources/js/components/features/tenants/tenant-overview.tsx
+++ b/resources/js/components/features/tenants/tenant-overview.tsx
@@ -2,7 +2,11 @@ import { StatusBadge } from '@/components/shared/status-badge';
 import { formatDate, formatPrice } from '@/lib/formatters';
 import type { Lease, WorkspaceTenant } from '@/types';
 
-export default function TenantOverview({ tenant }: { tenant: WorkspaceTenant & { leases?: Lease[] } }) {
+export default function TenantOverview({
+    tenant,
+}: {
+    tenant: WorkspaceTenant & { leases?: Lease[] };
+}) {
     const activeLease = tenant.leases?.[0];
     const isArchived = Boolean(tenant.deleted_at);
 
@@ -10,10 +14,18 @@ export default function TenantOverview({ tenant }: { tenant: WorkspaceTenant & {
         <div className="space-y-6">
             <div className="flex items-center gap-2">
                 <span className="text-sm text-muted-foreground">Status:</span>
-                {<StatusBadge
-                    domain="tenant"
-                    value={isArchived ? 'archived' : tenant.is_active ? 'active' : 'inactive'}
-                />}
+                {
+                    <StatusBadge
+                        domain="tenant"
+                        value={
+                            isArchived
+                                ? 'archived'
+                                : tenant.is_active
+                                  ? 'active'
+                                  : 'inactive'
+                        }
+                    />
+                }
             </div>
 
             <div className="rounded-lg border bg-muted/30 p-4">

--- a/resources/js/components/features/units/unit-detail-sheet.tsx
+++ b/resources/js/components/features/units/unit-detail-sheet.tsx
@@ -81,7 +81,10 @@ export default function UnitDetailSheet({
                                 <h3 className="mb-3 text-xs font-medium tracking-wider text-muted-foreground uppercase">
                                     Status
                                 </h3>
-                                <StatusBadge domain="unit" value={unit.status} />
+                                <StatusBadge
+                                    domain="unit"
+                                    value={unit.status}
+                                />
                             </section>
 
                             {/* Unit Details */}

--- a/resources/js/components/shared/status-badge.tsx
+++ b/resources/js/components/shared/status-badge.tsx
@@ -10,14 +10,23 @@ const STATUS_CONFIGS: Record<string, Record<string, StatusConfig>> = {
     unit: {
         available: { label: 'Available', className: 'bg-green-600 text-white' },
         occupied: { label: 'Occupied', className: 'bg-blue-600 text-white' },
-        maintenance: { label: 'Maintenance', className: 'bg-amber-500 text-white' },
-        unavailable: { label: 'Unavailable', className: 'bg-gray-400 text-white' },
+        maintenance: {
+            label: 'Maintenance',
+            className: 'bg-amber-500 text-white',
+        },
+        unavailable: {
+            label: 'Unavailable',
+            className: 'bg-gray-400 text-white',
+        },
         archived: { label: 'Archived', variant: 'secondary' },
     },
     lease: {
         active: { label: 'Active', className: 'bg-green-600 text-white' },
         expired: { label: 'Expired', className: 'bg-gray-500 text-white' },
-        terminated: { label: 'Terminated', className: 'bg-gray-400 text-white' },
+        terminated: {
+            label: 'Terminated',
+            className: 'bg-gray-400 text-white',
+        },
         renewed: { label: 'Renewed', className: 'bg-blue-600 text-white' },
     },
     rent: {
@@ -28,7 +37,10 @@ const STATUS_CONFIGS: Record<string, Record<string, StatusConfig>> = {
         due_today: { label: 'Due Today', className: 'bg-amber-600 text-white' },
         due_soon: { label: 'Due Soon', className: 'bg-blue-600 text-white' },
         upcoming: { label: 'Upcoming', className: 'bg-gray-400 text-white' },
-        cancelled: { label: 'Cancelled', className: 'bg-gray-300 text-gray-700' },
+        cancelled: {
+            label: 'Cancelled',
+            className: 'bg-gray-300 text-gray-700',
+        },
     },
     payment: {
         confirmed: { label: 'Confirmed', className: 'bg-green-600 text-white' },
@@ -38,9 +50,18 @@ const STATUS_CONFIGS: Record<string, Record<string, StatusConfig>> = {
     },
     maintenance: {
         reported: { label: 'Reported', className: 'bg-blue-100 text-blue-700' },
-        in_progress: { label: 'In Progress', className: 'bg-purple-100 text-purple-700' },
-        resolved: { label: 'Resolved', className: 'bg-green-100 text-green-700' },
-        cancelled: { label: 'Cancelled', className: 'bg-gray-100 text-gray-500' },
+        in_progress: {
+            label: 'In Progress',
+            className: 'bg-purple-100 text-purple-700',
+        },
+        resolved: {
+            label: 'Resolved',
+            className: 'bg-green-100 text-green-700',
+        },
+        cancelled: {
+            label: 'Cancelled',
+            className: 'bg-gray-100 text-gray-500',
+        },
     },
     user: {
         active: { label: 'Active', className: 'bg-green-600 text-white' },
@@ -85,7 +106,11 @@ export function StatusBadge({
     }
 
     if (config.variant) {
-        return <Badge variant={config.variant} className={config.className}>{config.label}</Badge>;
+        return (
+            <Badge variant={config.variant} className={config.className}>
+                {config.label}
+            </Badge>
+        );
     }
 
     return <Badge className={config.className}>{config.label}</Badge>;

--- a/resources/js/lib/constants/lease.ts
+++ b/resources/js/lib/constants/lease.ts
@@ -28,6 +28,9 @@ export const DUE_DAY_LABELS: Record<number, string> = {
 
 export const DEPOSIT_HANDLING_OPTIONS = [
     { value: 'carry_forward', label: 'Carry forward to new lease' },
-    { value: 'refund_and_collect_new', label: 'Refund and collect new deposit' },
+    {
+        value: 'refund_and_collect_new',
+        label: 'Refund and collect new deposit',
+    },
     { value: 'forfeit', label: 'Forfeit deposit' },
 ];

--- a/resources/js/pages/dashboard/rent.tsx
+++ b/resources/js/pages/dashboard/rent.tsx
@@ -254,6 +254,7 @@ export default function CollectionQueue({
                 <Link
                     href={`/leases/${entry.lease_id}`}
                     className="hover:underline"
+                    onClick={(e) => e.stopPropagation()}
                 >
                     {entry.tenant_name}
                 </Link>

--- a/resources/js/pages/dashboard/rent.tsx
+++ b/resources/js/pages/dashboard/rent.tsx
@@ -252,13 +252,36 @@ export default function CollectionQueue({
             className: 'font-medium',
             render: (entry) => (
                 <Link
-                    href={`/leases/${entry.lease_id}`}
+                    href={`/tenants/${entry.primary_tenant_id}`}
                     className="hover:underline"
                     onClick={(e) => e.stopPropagation()}
                 >
                     {entry.tenant_name}
                 </Link>
             ),
+        },
+        {
+            key: 'lease_reference',
+            label: 'Lease',
+            className: 'text-xs',
+            render: (entry) =>
+                entry.lease_reference ? (
+                    <Link
+                        href={`/leases/${entry.lease_id}`}
+                        className="hover:underline"
+                        onClick={(e) => e.stopPropagation()}
+                    >
+                        {entry.lease_reference}
+                    </Link>
+                ) : (
+                    <Link
+                        href={`/leases/${entry.lease_id}`}
+                        className="text-muted-foreground hover:underline"
+                        onClick={(e) => e.stopPropagation()}
+                    >
+                        #{entry.lease_id}
+                    </Link>
+                ),
         },
         {
             key: 'urgency',
@@ -303,14 +326,6 @@ export default function CollectionQueue({
 
                 return (
                 <div className="flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
-                    <Button
-                        size="sm"
-                        disabled={isPaid}
-                        onClick={() => openPaymentSheet(entry)}
-                    >
-                        <Banknote className="mr-1 size-3" />
-                        Record
-                    </Button>
                     <DropdownMenu>
                         <DropdownMenuTrigger asChild>
                             <Button variant="ghost" size="sm">
@@ -318,6 +333,13 @@ export default function CollectionQueue({
                             </Button>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end">
+                            <DropdownMenuItem
+                                disabled={isPaid}
+                                onClick={() => openPaymentSheet(entry)}
+                            >
+                                <Banknote className="mr-2 size-4" />
+                                Record Payment
+                            </DropdownMenuItem>
                             <DropdownMenuItem asChild>
                                 <Link
                                     href={`/leases/${entry.lease_id}/invoices/${entry.id}`}

--- a/resources/js/pages/dashboard/rent.tsx
+++ b/resources/js/pages/dashboard/rent.tsx
@@ -14,7 +14,6 @@ import {
 import { useState } from 'react';
 import { DataTable } from '@/components/data-table';
 import type { TableColumn } from '@/components/data-table';
-import { FilterBar } from '@/components/data-table/filter-bar';
 import { SearchInput } from '@/components/data-table/search-input';
 import QueuePaymentSheet from '@/components/features/payments/queue-payment-sheet';
 import { Button } from '@/components/ui/button';
@@ -39,7 +38,6 @@ import type {
     PaginatedData,
     RecentPaymentEntry,
     RecentReminderEntry,
-    TableMeta,
 } from '@/types';
 
 type TabCounts = {
@@ -64,7 +62,6 @@ type PageProps = {
     urgency?: string;
     properties?: string;
     per_page?: number;
-    table: TableMeta;
     outstanding: { count: number; amount: number };
     tab_counts: TabCounts;
     progress: Progress;
@@ -144,7 +141,6 @@ export default function CollectionQueue({
     urgency: currentUrgency = '',
     properties: currentProperties = '',
     per_page: currentPerPage = 25,
-    table: tableMeta,
     outstanding,
     tab_counts: tabCounts,
     progress,
@@ -474,20 +470,11 @@ export default function CollectionQueue({
                     })}
 
                     <div className="ml-auto">
-                        <FilterBar
-                            filters={tableMeta.filters}
-                            activeFilters={table.activeFilters}
-                            activeFilterCount={table.activeFilterCount}
-                            onToggleOption={table.toggleFilterOption}
-                            onClearAll={table.clearAllFilters}
-                            searchInput={
-                                <SearchInput
-                                    value={table.searchValue}
-                                    onChange={table.onSearchChange}
-                                    onClear={table.clearSearch}
-                                    placeholder="Search tenant, invoice, unit, property..."
-                                />
-                            }
+                        <SearchInput
+                            value={table.searchValue}
+                            onChange={table.onSearchChange}
+                            onClear={table.clearSearch}
+                            placeholder="Search tenant, invoice, unit, property..."
                         />
                     </div>
                 </div>

--- a/resources/js/pages/dashboard/rent.tsx
+++ b/resources/js/pages/dashboard/rent.tsx
@@ -86,7 +86,16 @@ const TABS = [
 function urgencyLabel(
     urgency: string,
     daysOverdue: number | null,
+    status: string,
 ): { text: string; color: string } {
+    if (status === 'paid') {
+return { text: 'Paid', color: 'text-green-600' };
+}
+
+    if (status === 'partial') {
+return { text: 'Partial', color: 'text-blue-600' };
+}
+
     if (urgency === 'overdue' && daysOverdue !== null) {
         const color =
             daysOverdue > 90 ? 'text-red-700' :
@@ -199,7 +208,14 @@ export default function CollectionQueue({
     const applyTab = (tab: string) => {
         router.get(
             dashboardRent().url,
-            { urgency: tab, page: '' },
+            {
+                urgency: tab,
+                page: '',
+                search: currentSearch,
+                sort: currentSort,
+                per_page: String(currentPerPage),
+                properties: currentProperties,
+            },
             { preserveState: true, replace: true },
         );
     };
@@ -248,6 +264,7 @@ export default function CollectionQueue({
                 const { text, color } = urgencyLabel(
                     entry.urgency,
                     entry.days_overdue,
+                    entry.status,
                 );
 
                 return (
@@ -584,6 +601,7 @@ export default function CollectionQueue({
             </div>
 
             <QueuePaymentSheet
+                key={paymentSheetInvoice?.id}
                 invoice={paymentSheetInvoice}
                 open={paymentSheetInvoice !== null}
                 onOpenChange={(open) => {

--- a/resources/js/pages/dashboard/rent.tsx
+++ b/resources/js/pages/dashboard/rent.tsx
@@ -264,6 +264,12 @@ export default function CollectionQueue({
             render: (entry) => formatPrice(entry.total),
         },
         {
+            key: 'outstanding',
+            label: 'Outstanding',
+            className: 'tabular-nums text-red-600',
+            render: (entry) => formatPrice(entry.outstanding),
+        },
+        {
             key: 'due_date',
             label: 'Due',
             sortable: true,

--- a/resources/js/pages/dashboard/rent.tsx
+++ b/resources/js/pages/dashboard/rent.tsx
@@ -353,30 +353,39 @@ export default function CollectionQueue({
             <Head title="Collection Queue" />
 
             <div className="flex h-full flex-1 flex-col gap-4 overflow-x-auto p-4">
-                {/* Header card */}
-                <div className="rounded-lg border p-5">
-                    <div className="grid grid-cols-1 gap-4 sm:grid-cols-5">
-                        <div className="sm:col-span-3">
-                            <h1 className="text-lg font-semibold">Collection Queue</h1>
-                            <p className="mt-1 text-sm">
-                                <span className="text-red-600 font-medium">{tabCounts.overdue} overdue</span>
-                                {' · '}
-                                <span className="text-amber-600">{tabCounts.due_today} due today</span>
-                                {' · '}
-                                <span className="text-muted-foreground">{tabCounts.upcoming} upcoming</span>
-                            </p>
-                        </div>
-                        <div className="sm:col-span-2 sm:text-right">
-                            <p className="text-lg font-bold tabular-nums">
-                                {formatRupiah(outstanding.amount)}
-                            </p>
-                            <p className="text-sm text-muted-foreground">outstanding</p>
-                            {lastPaymentAgo && (
-                                <p className="mt-1 text-xs text-muted-foreground">
-                                    Last payment {lastPaymentAgo}
-                                </p>
-                            )}
-                        </div>
+                {/* Header cards */}
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+                    <div className="rounded-lg border px-4 py-3">
+                        <p className="text-xs text-muted-foreground">Overdue</p>
+                        <p className="text-xl font-bold tabular-nums text-red-600">
+                            {tabCounts.overdue}
+                        </p>
+                    </div>
+                    <div className="rounded-lg border px-4 py-3">
+                        <p className="text-xs text-muted-foreground">Due Today</p>
+                        <p className="text-xl font-bold tabular-nums text-amber-600">
+                            {tabCounts.due_today}
+                        </p>
+                    </div>
+                    <div className="rounded-lg border px-4 py-3">
+                        <p className="text-xs text-muted-foreground">Upcoming</p>
+                        <p className="text-xl font-bold tabular-nums text-muted-foreground">
+                            {tabCounts.upcoming}
+                        </p>
+                    </div>
+                </div>
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                    <div className="rounded-lg border px-4 py-3">
+                        <p className="text-xs text-muted-foreground">Outstanding</p>
+                        <p className="text-xl font-bold tabular-nums">
+                            {formatRupiah(outstanding.amount)}
+                        </p>
+                    </div>
+                    <div className="rounded-lg border px-4 py-3">
+                        <p className="text-xs text-muted-foreground">Last Payment</p>
+                        <p className="text-xl font-bold tabular-nums">
+                            {lastPaymentAgo ?? '—'}
+                        </p>
                     </div>
                 </div>
 

--- a/resources/js/pages/dashboard/rent.tsx
+++ b/resources/js/pages/dashboard/rent.tsx
@@ -247,20 +247,6 @@ export default function CollectionQueue({
             },
         },
         {
-            key: 'tenant_name',
-            label: 'Tenant',
-            className: 'font-medium',
-            render: (entry) => (
-                <Link
-                    href={`/tenants/${entry.primary_tenant_id}`}
-                    className="hover:underline"
-                    onClick={(e) => e.stopPropagation()}
-                >
-                    {entry.tenant_name}
-                </Link>
-            ),
-        },
-        {
             key: 'lease_reference',
             label: 'Lease',
             className: 'text-xs',
@@ -282,6 +268,20 @@ export default function CollectionQueue({
                         #{entry.lease_id}
                     </Link>
                 ),
+        },
+        {
+            key: 'tenant_name',
+            label: 'Tenant',
+            className: 'font-medium',
+            render: (entry) => (
+                <Link
+                    href={`/tenants/${entry.primary_tenant_id}`}
+                    className="hover:underline"
+                    onClick={(e) => e.stopPropagation()}
+                >
+                    {entry.tenant_name}
+                </Link>
+            ),
         },
         {
             key: 'urgency',

--- a/resources/js/pages/dashboard/rent.tsx
+++ b/resources/js/pages/dashboard/rent.tsx
@@ -273,7 +273,8 @@ export default function CollectionQueue({
             key: 'tenant_name',
             label: 'Tenant',
             className: 'font-medium',
-            render: (entry) => (
+            render: (entry) =>
+                entry.primary_tenant_id !== null ? (
                 <Link
                     href={`/tenants/${entry.primary_tenant_id}`}
                     className="hover:underline"
@@ -281,6 +282,8 @@ export default function CollectionQueue({
                 >
                     {entry.tenant_name}
                 </Link>
+            ) : (
+                <span>{entry.tenant_name}</span>
             ),
         },
         {

--- a/resources/js/pages/dashboard/rent.tsx
+++ b/resources/js/pages/dashboard/rent.tsx
@@ -31,7 +31,6 @@ import {
 import { useTable } from '@/hooks/use-table';
 import { PAYMENT_METHOD_LABELS } from '@/lib/constants/billing';
 import { formatDate, formatPrice, formatRupiah } from '@/lib/formatters';
-import { dashboard } from '@/routes';
 import { rent as dashboardRent } from '@/routes/dashboard';
 import type {
     NeedsAttentionInvoice,
@@ -600,8 +599,8 @@ setPaymentSheetInvoice(null);
 CollectionQueue.layout = {
     breadcrumbs: [
         {
-            title: 'Dashboard',
-            href: dashboard(),
+            title: 'Billing',
+            href: dashboardRent(),
         },
         {
             title: 'Collection',

--- a/resources/js/pages/dashboard/rent.tsx
+++ b/resources/js/pages/dashboard/rent.tsx
@@ -44,6 +44,7 @@ type TabCounts = {
     overdue: number;
     due_today: number;
     upcoming: number;
+    partial: number;
     paid: number;
 };
 
@@ -79,6 +80,7 @@ const TABS = [
     { key: 'overdue', label: 'Overdue' },
     { key: 'due_today', label: 'Due Today' },
     { key: 'upcoming', label: 'Upcoming' },
+    { key: 'partial', label: 'Partial' },
     { key: 'paid', label: 'Paid' },
 ] as const;
 
@@ -487,11 +489,13 @@ export default function CollectionQueue({
                         message:
                             currentUrgency === 'paid'
                                 ? 'No paid invoices this period.'
-                                : currentUrgency === 'upcoming'
-                                  ? 'No upcoming invoices.'
-                                  : 'All caught up. Nothing needs attention.',
-                        createLabel: 'View Paid',
-                        onCreate: () => applyTab('paid'),
+                                : currentUrgency === 'partial'
+                                  ? 'No partially paid invoices.'
+                                  : currentUrgency === 'upcoming'
+                                    ? 'No upcoming invoices.'
+                                    : 'All caught up. Nothing needs attention.',
+                        createLabel: currentUrgency === '' ? 'View Paid' : undefined,
+                        onCreate: currentUrgency === '' ? () => applyTab('paid') : undefined,
                     }}
                 />
 

--- a/resources/js/pages/dashboard/rent.tsx
+++ b/resources/js/pages/dashboard/rent.tsx
@@ -1,10 +1,13 @@
 import { Head, Link, router } from '@inertiajs/react';
 import {
+    AlertTriangle,
     ArrowUpRight,
     Banknote,
     Bell,
+    CalendarClock,
     Check,
     ChevronDown,
+    Clock,
     Download,
     MoreHorizontal,
     Square,
@@ -355,37 +358,52 @@ export default function CollectionQueue({
             <div className="flex h-full flex-1 flex-col gap-4 overflow-x-auto p-4">
                 {/* Header cards */}
                 <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-                    <div className="rounded-lg border px-4 py-3">
-                        <p className="text-xs text-muted-foreground">Overdue</p>
-                        <p className="text-xl font-bold tabular-nums text-red-600">
-                            {tabCounts.overdue}
-                        </p>
+                    <div className="flex items-center gap-3 rounded-lg border px-4 py-3">
+                        <AlertTriangle className="size-8 shrink-0 text-red-500" />
+                        <div className="min-w-0">
+                            <p className="text-xs text-muted-foreground">Overdue</p>
+                            <p className="text-xl font-bold tabular-nums">
+                                {tabCounts.overdue}
+                            </p>
+                        </div>
                     </div>
-                    <div className="rounded-lg border px-4 py-3">
-                        <p className="text-xs text-muted-foreground">Due Today</p>
-                        <p className="text-xl font-bold tabular-nums text-amber-600">
-                            {tabCounts.due_today}
-                        </p>
+                    <div className="flex items-center gap-3 rounded-lg border px-4 py-3">
+                        <CalendarClock className="size-8 shrink-0 text-amber-500" />
+                        <div className="min-w-0">
+                            <p className="text-xs text-muted-foreground">Due Today</p>
+                            <p className="text-xl font-bold tabular-nums">
+                                {tabCounts.due_today}
+                            </p>
+                        </div>
                     </div>
-                    <div className="rounded-lg border px-4 py-3">
-                        <p className="text-xs text-muted-foreground">Upcoming</p>
-                        <p className="text-xl font-bold tabular-nums text-muted-foreground">
-                            {tabCounts.upcoming}
-                        </p>
+                    <div className="flex items-center gap-3 rounded-lg border px-4 py-3">
+                        <Bell className="size-8 shrink-0 text-blue-500" />
+                        <div className="min-w-0">
+                            <p className="text-xs text-muted-foreground">Upcoming</p>
+                            <p className="text-xl font-bold tabular-nums">
+                                {tabCounts.upcoming}
+                            </p>
+                        </div>
                     </div>
                 </div>
                 <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                    <div className="rounded-lg border px-4 py-3">
-                        <p className="text-xs text-muted-foreground">Outstanding</p>
-                        <p className="text-xl font-bold tabular-nums">
-                            {formatRupiah(outstanding.amount)}
-                        </p>
+                    <div className="flex items-center gap-3 rounded-lg border px-4 py-3">
+                        <Banknote className="size-8 shrink-0 text-green-600" />
+                        <div className="min-w-0">
+                            <p className="text-xs text-muted-foreground">Outstanding</p>
+                            <p className="truncate text-xl font-bold tabular-nums">
+                                {formatRupiah(outstanding.amount)}
+                            </p>
+                        </div>
                     </div>
-                    <div className="rounded-lg border px-4 py-3">
-                        <p className="text-xs text-muted-foreground">Last Payment</p>
-                        <p className="text-xl font-bold tabular-nums">
-                            {lastPaymentAgo ?? '—'}
-                        </p>
+                    <div className="flex items-center gap-3 rounded-lg border px-4 py-3">
+                        <Clock className="size-8 shrink-0 text-muted-foreground" />
+                        <div className="min-w-0">
+                            <p className="text-xs text-muted-foreground">Last Payment</p>
+                            <p className="text-xl font-bold tabular-nums">
+                                {lastPaymentAgo ?? '—'}
+                            </p>
+                        </div>
                     </div>
                 </div>
 

--- a/resources/js/pages/dashboard/rent.tsx
+++ b/resources/js/pages/dashboard/rent.tsx
@@ -353,28 +353,30 @@ export default function CollectionQueue({
             <Head title="Collection Queue" />
 
             <div className="flex h-full flex-1 flex-col gap-4 overflow-x-auto p-4">
-                {/* Header */}
-                <div className="flex flex-col gap-2">
-                    <h1 className="text-xl font-semibold">Collection Queue</h1>
-
-                    <div className="flex flex-wrap items-baseline gap-x-6 gap-y-1 text-sm">
-                        <span className="text-red-600">
-                            {tabCounts.overdue} overdue
-                        </span>
-                        <span className="text-amber-600">
-                            {tabCounts.due_today} due today
-                        </span>
-                        <span className="text-muted-foreground">
-                            {tabCounts.upcoming} upcoming
-                        </span>
-                        <span className="tabular-nums font-medium">
-                            {formatRupiah(outstanding.amount)} outstanding
-                        </span>
-                        {lastPaymentAgo && (
-                            <span className="text-muted-foreground">
-                                Last payment {lastPaymentAgo}
-                            </span>
-                        )}
+                {/* Header card */}
+                <div className="rounded-lg border p-5">
+                    <div className="grid grid-cols-1 gap-4 sm:grid-cols-5">
+                        <div className="sm:col-span-3">
+                            <h1 className="text-lg font-semibold">Collection Queue</h1>
+                            <p className="mt-1 text-sm">
+                                <span className="text-red-600 font-medium">{tabCounts.overdue} overdue</span>
+                                {' · '}
+                                <span className="text-amber-600">{tabCounts.due_today} due today</span>
+                                {' · '}
+                                <span className="text-muted-foreground">{tabCounts.upcoming} upcoming</span>
+                            </p>
+                        </div>
+                        <div className="sm:col-span-2 sm:text-right">
+                            <p className="text-lg font-bold tabular-nums">
+                                {formatRupiah(outstanding.amount)}
+                            </p>
+                            <p className="text-sm text-muted-foreground">outstanding</p>
+                            {lastPaymentAgo && (
+                                <p className="mt-1 text-xs text-muted-foreground">
+                                    Last payment {lastPaymentAgo}
+                                </p>
+                            )}
+                        </div>
                     </div>
                 </div>
 

--- a/resources/js/pages/dashboard/rent.tsx
+++ b/resources/js/pages/dashboard/rent.tsx
@@ -206,19 +206,7 @@ export default function CollectionQueue({
     const columns: TableColumn<NeedsAttentionInvoice>[] = [
         {
             key: 'select',
-            label: (
-                <button
-                    type="button"
-                    onClick={toggleSelectAll}
-                    className="flex items-center"
-                >
-                    {selectedCount > 0 && selectedCount === data.data.length ? (
-                        <Check className="size-4" />
-                    ) : (
-                        <Square className="size-4" />
-                    )}
-                </button>
-            ),
+            label: '',
             render: (entry) => {
                 const checked = selectedIds.has(entry.id);
 
@@ -421,9 +409,19 @@ export default function CollectionQueue({
                             </button>
                         </>
                     ) : (
-                        <span className="text-muted-foreground">
-                            No invoices selected. Select invoices to enable bulk actions.
-                        </span>
+                        <div className="flex items-center gap-2">
+                            <button
+                                type="button"
+                                onClick={toggleSelectAll}
+                                className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+                            >
+                                <Square className="size-4" />
+                                Select all
+                            </button>
+                            <span className="text-muted-foreground">
+                                to enable bulk actions.
+                            </span>
+                        </div>
                     )}
                 </div>
 

--- a/resources/js/pages/dashboard/rent.tsx
+++ b/resources/js/pages/dashboard/rent.tsx
@@ -468,15 +468,16 @@ export default function CollectionQueue({
                             </button>
                         );
                     })}
+                </div>
 
-                    <div className="ml-auto">
-                        <SearchInput
-                            value={table.searchValue}
-                            onChange={table.onSearchChange}
-                            onClear={table.clearSearch}
-                            placeholder="Search tenant, invoice, unit, property..."
-                        />
-                    </div>
+                {/* Search */}
+                <div className="flex items-center gap-1">
+                    <SearchInput
+                        value={table.searchValue}
+                        onChange={table.onSearchChange}
+                        onClear={table.clearSearch}
+                        placeholder="Search tenant, invoice, unit, property..."
+                    />
                 </div>
 
                 {/* Queue */}

--- a/resources/js/pages/dashboard/rent.tsx
+++ b/resources/js/pages/dashboard/rent.tsx
@@ -12,7 +12,6 @@ import {
     MoreHorizontal,
     Square,
     TrendingUp,
-    User,
 } from 'lucide-react';
 import { useState } from 'react';
 import { DataTable } from '@/components/data-table';
@@ -298,10 +297,14 @@ export default function CollectionQueue({
         {
             key: 'actions',
             label: '',
-            render: (entry) => (
+            render: (entry) => {
+                const isPaid = entry.status === 'paid';
+
+                return (
                 <div className="flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
                     <Button
                         size="sm"
+                        disabled={isPaid}
                         onClick={() => openPaymentSheet(entry)}
                     >
                         <Banknote className="mr-1 size-3" />
@@ -324,25 +327,22 @@ export default function CollectionQueue({
                             </DropdownMenuItem>
                             <DropdownMenuItem asChild>
                                 <Link href={`/leases/${entry.lease_id}`}>
-                                    <User className="mr-2 size-4" />
-                                    View Lease
-                                </Link>
-                            </DropdownMenuItem>
-                            <DropdownMenuItem asChild>
-                                <Link href={`/leases/${entry.lease_id}`}>
                                     <Bell className="mr-2 size-4" />
-                                    Send Reminder
+                                    View Lease
                                 </Link>
                             </DropdownMenuItem>
                         </DropdownMenuContent>
                     </DropdownMenu>
                 </div>
-            ),
+                );
+            },
         },
     ];
 
     const onRowClick = (entry: NeedsAttentionInvoice) => {
-        openPaymentSheet(entry);
+        if (entry.status !== 'paid') {
+            openPaymentSheet(entry);
+        }
     };
 
     const progressPercent =
@@ -484,7 +484,7 @@ export default function CollectionQueue({
                     {TABS.map((tab) => {
                         const count =
                             tab.key === ''
-                                ? outstanding.count + tabCounts.paid
+                                ? data.total
                                 : tabCounts[tab.key as keyof TabCounts] ?? 0;
                         const active =
                             currentUrgency === tab.key ||

--- a/resources/js/pages/dashboard/rent.tsx
+++ b/resources/js/pages/dashboard/rent.tsx
@@ -266,7 +266,7 @@ export default function CollectionQueue({
         {
             key: 'outstanding',
             label: 'Outstanding',
-            className: 'tabular-nums text-red-600',
+            className: 'tabular-nums text-muted-foreground',
             render: (entry) => formatPrice(entry.outstanding),
         },
         {

--- a/resources/js/pages/dashboard/rent.tsx
+++ b/resources/js/pages/dashboard/rent.tsx
@@ -1,44 +1,149 @@
-import { Head } from '@inertiajs/react';
-import { AlertTriangle, Bell, CalendarClock, CheckCircle } from 'lucide-react';
+import { Head, Link, router } from '@inertiajs/react';
+import {
+    ArrowUpRight,
+    Banknote,
+    Bell,
+    Check,
+    ChevronDown,
+    Download,
+    MoreHorizontal,
+    Square,
+    TrendingUp,
+    User,
+} from 'lucide-react';
+import { useState } from 'react';
 import { DataTable } from '@/components/data-table';
 import type { TableColumn } from '@/components/data-table';
-import { FilterBar } from '@/components/data-table/filter-bar';
 import { SearchInput } from '@/components/data-table/search-input';
-import { StatusBadge } from '@/components/shared/status-badge';
-import { Card, CardContent } from '@/components/ui/card';
+import QueuePaymentSheet from '@/components/features/payments/queue-payment-sheet';
+import { Button } from '@/components/ui/button';
+import {
+    Collapsible,
+    CollapsibleContent,
+    CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { useTable } from '@/hooks/use-table';
-import { DUE_DAY_LABELS } from '@/lib/constants';
-import { formatPrice } from '@/lib/formatters';
+import { PAYMENT_METHOD_LABELS } from '@/lib/constants/billing';
+import { formatDate, formatPrice, formatRupiah } from '@/lib/formatters';
 import { dashboard } from '@/routes';
 import { rent as dashboardRent } from '@/routes/dashboard';
-import type { PaginatedData, RentDashboardEntry, TableMeta } from '@/types';
+import type {
+    NeedsAttentionInvoice,
+    PaginatedData,
+    RecentPaymentEntry,
+    RecentReminderEntry,
+} from '@/types';
 
-type PageProps = {
-    entries: PaginatedData<RentDashboardEntry>;
-    sort?: string;
-    search?: string;
-    status?: string;
-    properties?: string;
-    due_date?: string;
-    per_page?: number;
-    table: TableMeta;
-    stats: {
-        overdue: { count: number; amount: number };
-        due_today: number;
-        due_soon: number;
-        paid: number;
-    };
+type TabCounts = {
+    overdue: number;
+    due_today: number;
+    upcoming: number;
+    paid: number;
 };
 
-export default function Rent({
+type Progress = {
+    processed: number;
+    total: number;
+    amount_collected: number;
+    last_payment_at: string | null;
+};
+
+type PageProps = {
+    entries: PaginatedData<NeedsAttentionInvoice>;
+    sort?: string;
+    search?: string;
+    urgency?: string;
+    properties?: string;
+    per_page?: number;
+    outstanding: { count: number; amount: number };
+    tab_counts: TabCounts;
+    progress: Progress;
+    recent_payments: RecentPaymentEntry[];
+    recent_reminders: RecentReminderEntry[];
+};
+
+const REMINDER_LABELS: Record<string, string> = {
+    upcoming: 'Upcoming',
+    due_today: 'Due Today',
+    overdue: 'Overdue',
+};
+
+const TABS = [
+    { key: '', label: 'All' },
+    { key: 'overdue', label: 'Overdue' },
+    { key: 'due_today', label: 'Due Today' },
+    { key: 'upcoming', label: 'Upcoming' },
+    { key: 'paid', label: 'Paid' },
+] as const;
+
+function urgencyLabel(
+    urgency: string,
+    daysOverdue: number | null,
+): { text: string; color: string } {
+    if (urgency === 'overdue' && daysOverdue !== null) {
+        const color =
+            daysOverdue > 90 ? 'text-red-700' :
+            daysOverdue > 30 ? 'text-red-500' :
+            daysOverdue > 7  ? 'text-orange-500' :
+                               'text-amber-500';
+
+        return {
+            text: `Overdue \u00B7 ${daysOverdue} day${daysOverdue !== 1 ? 's' : ''}`,
+            color,
+        };
+    }
+
+    if (urgency === 'due_today') {
+return { text: 'Due today', color: 'text-amber-600' };
+}
+
+    if (urgency === 'due_tomorrow') {
+return { text: 'Due tomorrow', color: 'text-amber-500' };
+}
+
+    return { text: 'Upcoming', color: 'text-muted-foreground' };
+}
+
+function timeAgo(dateStr: string | null): string | null {
+    if (!dateStr) {
+return null;
+}
+
+    const diff = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
+
+    if (diff < 60) {
+return 'just now';
+}
+
+    if (diff < 3600) {
+return `${Math.floor(diff / 60)}m ago`;
+}
+
+    if (diff < 86400) {
+return `${Math.floor(diff / 3600)}h ago`;
+}
+
+    return `${Math.floor(diff / 86400)}d ago`;
+}
+
+export default function CollectionQueue({
     entries: data,
-    sort: currentSort = 'rent_due_day',
+    sort: currentSort = 'due_date',
     search: currentSearch = '',
-    status: currentStatus = '',
+    urgency: currentUrgency = '',
     properties: currentProperties = '',
-    per_page: currentPerPage = 15,
-    table: tableMeta,
-    stats,
+    per_page: currentPerPage = 25,
+    outstanding,
+    tab_counts: tabCounts,
+    progress,
+    recent_payments: recentPayments,
+    recent_reminders: recentReminders,
 }: PageProps) {
     const table = useTable({
         routeFn: () => dashboardRent(),
@@ -46,178 +151,451 @@ export default function Rent({
             sort: currentSort,
             search: currentSearch,
             per_page: String(currentPerPage),
-            status: currentStatus,
+            urgency: currentUrgency,
             properties: currentProperties,
         },
         defaults: {
-            sort: 'rent_due_day',
-            per_page: '15',
+            sort: 'due_date',
+            per_page: '25',
         },
     });
 
-    const columns: TableColumn<RentDashboardEntry>[] = [
+    const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+
+    const toggleSelect = (id: number) => {
+        setSelectedIds((prev) => {
+            const next = new Set(prev);
+
+            if (next.has(id)) {
+                next.delete(id);
+            } else {
+                next.add(id);
+            }
+
+            return next;
+        });
+    };
+
+    const toggleSelectAll = () => {
+        if (selectedIds.size === data.data.length) {
+            setSelectedIds(new Set());
+        } else {
+            setSelectedIds(new Set(data.data.map((e) => e.id)));
+        }
+    };
+
+    const clearSelection = () => setSelectedIds(new Set());
+
+    const selectedCount = selectedIds.size;
+
+    const [paymentSheetInvoice, setPaymentSheetInvoice] =
+        useState<NeedsAttentionInvoice | null>(null);
+
+    const openPaymentSheet = (entry: NeedsAttentionInvoice) => {
+        setPaymentSheetInvoice(entry);
+    };
+
+    const applyTab = (tab: string) => {
+        router.get(
+            dashboardRent().url,
+            { urgency: tab, page: '' },
+            { preserveState: true, replace: true },
+        );
+    };
+
+    const columns: TableColumn<NeedsAttentionInvoice>[] = [
+        {
+            key: 'select',
+            label: (
+                <button
+                    type="button"
+                    onClick={toggleSelectAll}
+                    className="flex items-center"
+                >
+                    {selectedCount > 0 && selectedCount === data.data.length ? (
+                        <Check className="size-4" />
+                    ) : (
+                        <Square className="size-4" />
+                    )}
+                </button>
+            ),
+            render: (entry) => {
+                const checked = selectedIds.has(entry.id);
+
+                return (
+                    <button
+                        type="button"
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            toggleSelect(entry.id);
+                        }}
+                    >
+                        {checked ? (
+                            <Check className="size-4 text-primary" />
+                        ) : (
+                            <Square className="size-4 text-muted-foreground" />
+                        )}
+                    </button>
+                );
+            },
+        },
         {
             key: 'tenant_name',
             label: 'Tenant',
             className: 'font-medium',
-            render: (entry) => entry.tenant_name,
-        },
-        {
-            key: 'unit_name',
-            label: 'Unit',
-            render: (entry) => entry.unit_name,
-        },
-        {
-            key: 'property_name',
-            label: 'Property',
-            render: (entry) => entry.property_name,
-        },
-        {
-            key: 'rent_due_day',
-            label: 'Due Date',
-            sortable: true,
-            className: 'tabular-nums',
-            render: (entry) =>
-                DUE_DAY_LABELS[entry.rent_due_day] ?? `${entry.rent_due_day}th`,
-        },
-        {
-            key: 'days_overdue',
-            label: 'Days Overdue',
-            className: 'tabular-nums',
-            render: (entry) =>
-                entry.days_overdue !== null
-                    ? `${entry.days_overdue} day${entry.days_overdue !== 1 ? 's' : ''}`
-                    : '\u2014',
-        },
-        {
-            key: 'rent_amount',
-            label: 'Amount Due',
-            sortable: true,
-            className: 'tabular-nums',
-            render: (entry) => formatPrice(entry.rent_amount),
-        },
-        {
-            key: 'rent_status',
-            label: 'Status',
             render: (entry) => (
-                <StatusBadge domain="rent" value={entry.rent_status} />
+                <Link
+                    href={`/leases/${entry.lease_id}`}
+                    className="hover:underline"
+                >
+                    {entry.tenant_name}
+                </Link>
+            ),
+        },
+        {
+            key: 'urgency',
+            label: 'Status',
+            render: (entry) => {
+                const { text, color } = urgencyLabel(
+                    entry.urgency,
+                    entry.days_overdue,
+                );
+
+                return (
+                    <span className={`text-sm ${color}`}>{text}</span>
+                );
+            },
+        },
+        {
+            key: 'total',
+            label: 'Amount',
+            sortable: true,
+            className: 'tabular-nums font-medium',
+            render: (entry) => formatPrice(entry.total),
+        },
+        {
+            key: 'due_date',
+            label: 'Due',
+            sortable: true,
+            className: 'tabular-nums text-muted-foreground',
+            render: (entry) => formatDate(entry.due_date),
+        },
+        {
+            key: 'actions',
+            label: '',
+            render: (entry) => (
+                <div className="flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
+                    <Button
+                        size="sm"
+                        onClick={() => openPaymentSheet(entry)}
+                    >
+                        <Banknote className="mr-1 size-3" />
+                        Record
+                    </Button>
+                    <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                            <Button variant="ghost" size="sm">
+                                <MoreHorizontal className="size-4" />
+                            </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                            <DropdownMenuItem asChild>
+                                <Link
+                                    href={`/leases/${entry.lease_id}/invoices/${entry.id}`}
+                                >
+                                    <ArrowUpRight className="mr-2 size-4" />
+                                    View Invoice
+                                </Link>
+                            </DropdownMenuItem>
+                            <DropdownMenuItem asChild>
+                                <Link href={`/leases/${entry.lease_id}`}>
+                                    <User className="mr-2 size-4" />
+                                    View Lease
+                                </Link>
+                            </DropdownMenuItem>
+                            <DropdownMenuItem asChild>
+                                <Link href={`/leases/${entry.lease_id}`}>
+                                    <Bell className="mr-2 size-4" />
+                                    Send Reminder
+                                </Link>
+                            </DropdownMenuItem>
+                        </DropdownMenuContent>
+                    </DropdownMenu>
+                </div>
             ),
         },
     ];
 
+    const onRowClick = (entry: NeedsAttentionInvoice) => {
+        openPaymentSheet(entry);
+    };
+
+    const progressPercent =
+        progress.total > 0
+            ? Math.round((progress.processed / progress.total) * 100)
+            : 0;
+    const lastPaymentAgo = timeAgo(progress.last_payment_at);
+
     return (
         <>
-            <Head title="Rent Dashboard" />
+            <Head title="Collection Queue" />
 
-            <div className="flex h-full flex-1 flex-col gap-4 overflow-x-auto rounded-xl p-4">
-                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4 lg:gap-4">
-                    <Card>
-                        <CardContent className="flex items-center gap-4 px-6">
-                            <AlertTriangle className="size-10 shrink-0 text-red-600" />
-                            <div className="min-w-0">
-                                <p className="text-sm text-muted-foreground">
-                                    Overdue
-                                </p>
-                                <p className="truncate text-2xl font-bold text-red-600 tabular-nums">
-                                    {stats.overdue.count}
-                                </p>
-                                {stats.overdue.amount > 0 && (
-                                    <p className="truncate text-xs text-muted-foreground tabular-nums">
-                                        {formatPrice(
-                                            String(stats.overdue.amount),
-                                        )}
-                                    </p>
-                                )}
-                            </div>
-                        </CardContent>
-                    </Card>
+            <div className="flex h-full flex-1 flex-col gap-4 overflow-x-auto p-4">
+                {/* Header */}
+                <div className="flex flex-col gap-2">
+                    <h1 className="text-xl font-semibold">Collection Queue</h1>
 
-                    <Card>
-                        <CardContent className="flex items-center gap-4 px-6">
-                            <CalendarClock className="size-10 shrink-0 text-amber-600" />
-                            <div className="min-w-0">
-                                <p className="text-sm text-muted-foreground">
-                                    Due Today
-                                </p>
-                                <p className="truncate text-2xl font-bold text-amber-600 tabular-nums">
-                                    {stats.due_today}
-                                </p>
-                            </div>
-                        </CardContent>
-                    </Card>
-
-                    <Card>
-                        <CardContent className="flex items-center gap-4 px-6">
-                            <Bell className="size-10 shrink-0 text-blue-600" />
-                            <div className="min-w-0">
-                                <p className="text-sm text-muted-foreground">
-                                    Due Soon
-                                </p>
-                                <p className="truncate text-2xl font-bold text-blue-600 tabular-nums">
-                                    {stats.due_soon}
-                                </p>
-                            </div>
-                        </CardContent>
-                    </Card>
-
-                    <Card>
-                        <CardContent className="flex items-center gap-4 px-6">
-                            <CheckCircle className="size-10 shrink-0 text-green-600" />
-                            <div className="min-w-0">
-                                <p className="text-sm text-muted-foreground">
-                                    Paid
-                                </p>
-                                <p className="truncate text-2xl font-bold text-green-600 tabular-nums">
-                                    {stats.paid}
-                                </p>
-                            </div>
-                        </CardContent>
-                    </Card>
+                    <div className="flex flex-wrap items-baseline gap-x-6 gap-y-1 text-sm">
+                        <span className="text-red-600">
+                            {tabCounts.overdue} overdue
+                        </span>
+                        <span className="text-amber-600">
+                            {tabCounts.due_today} due today
+                        </span>
+                        <span className="text-muted-foreground">
+                            {tabCounts.upcoming} upcoming
+                        </span>
+                        <span className="tabular-nums font-medium">
+                            {formatRupiah(outstanding.amount)} outstanding
+                        </span>
+                        {lastPaymentAgo && (
+                            <span className="text-muted-foreground">
+                                Last payment {lastPaymentAgo}
+                            </span>
+                        )}
+                    </div>
                 </div>
 
-                <FilterBar
-                    filters={tableMeta.filters}
-                    activeFilters={table.activeFilters}
-                    activeFilterCount={table.activeFilterCount}
-                    onToggleOption={table.toggleFilterOption}
-                    onClearAll={table.clearAllFilters}
-                    searchInput={
+                {/* Progress */}
+                {progress.total > 0 && (
+                    <div className="rounded-lg border p-4">
+                        <div className="mb-2 flex items-center justify-between text-sm">
+                            <div className="flex items-center gap-2">
+                                <TrendingUp className="size-4 text-green-600" />
+                                <span className="font-medium">Collection Progress</span>
+                            </div>
+                            <span className="tabular-nums text-muted-foreground">
+                                {progress.processed} / {progress.total} processed
+                            </span>
+                        </div>
+                        <div className="h-2 rounded-full bg-muted">
+                            <div
+                                className="h-full rounded-full bg-green-600 transition-all"
+                                style={{ width: `${progressPercent}%` }}
+                            />
+                        </div>
+                        <div className="mt-1.5 flex items-center justify-between text-xs text-muted-foreground">
+                            <span className="tabular-nums">
+                                {formatRupiah(progress.amount_collected)} collected
+                            </span>
+                            <span className="tabular-nums">{progressPercent}%</span>
+                        </div>
+                    </div>
+                )}
+
+                {/* Selection toolbar */}
+                <div className="flex flex-wrap items-center gap-2 rounded-lg border bg-muted/30 px-4 py-2 text-sm">
+                    {selectedCount > 0 ? (
+                        <>
+                            <span className="font-medium tabular-nums">
+                                {selectedCount} selected
+                            </span>
+                            <Button size="sm" variant="outline" disabled>
+                                <Banknote className="mr-2 size-4" />
+                                Record Payment
+                            </Button>
+                            <Button size="sm" variant="outline" disabled>
+                                <Bell className="mr-2 size-4" />
+                                Send Reminder
+                            </Button>
+                            <Button size="sm" variant="outline" disabled>
+                                <Download className="mr-2 size-4" />
+                                Export
+                            </Button>
+                            <button
+                                type="button"
+                                onClick={clearSelection}
+                                className="ml-auto text-muted-foreground hover:text-foreground"
+                            >
+                                Clear selection
+                            </button>
+                        </>
+                    ) : (
+                        <span className="text-muted-foreground">
+                            No invoices selected. Select invoices to enable bulk actions.
+                        </span>
+                    )}
+                </div>
+
+                {/* Tab pills */}
+                <div className="flex flex-wrap items-center gap-1">
+                    {TABS.map((tab) => {
+                        const count =
+                            tab.key === ''
+                                ? outstanding.count + tabCounts.paid
+                                : tabCounts[tab.key as keyof TabCounts] ?? 0;
+                        const active =
+                            currentUrgency === tab.key ||
+                            (tab.key === '' && currentUrgency === '');
+
+                        return (
+                            <button
+                                key={tab.key}
+                                type="button"
+                                onClick={() => applyTab(tab.key === '' ? '' : tab.key)}
+                                className={`inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+                                    active
+                                        ? 'bg-primary text-primary-foreground'
+                                        : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                                }`}
+                            >
+                                {tab.label}
+                                <span
+                                    className={`inline-flex size-5 items-center justify-center rounded-full text-xs ${
+                                        active
+                                            ? 'bg-primary-foreground/20'
+                                            : 'bg-muted-foreground/15'
+                                    }`}
+                                >
+                                    {count}
+                                </span>
+                            </button>
+                        );
+                    })}
+
+                    <div className="ml-auto">
                         <SearchInput
                             value={table.searchValue}
                             onChange={table.onSearchChange}
                             onClear={table.clearSearch}
-                            placeholder="Search tenant, unit, property..."
+                            placeholder="Search tenant, invoice, unit, property..."
                         />
-                    }
-                />
+                    </div>
+                </div>
 
+                {/* Queue */}
                 <DataTable
                     columns={columns}
                     rows={data.data}
                     currentSort={currentSort}
                     onSort={table.toggleSort}
+                    onRowClick={onRowClick}
                     paginator={data}
                     perPage={currentPerPage}
                     onPageChange={table.goToPage}
                     onPerPageChange={table.setPerPage}
-                    noun="entries"
+                    noun="invoices"
                     empty={{
-                        message: 'No outstanding rent entries found.',
+                        message:
+                            currentUrgency === 'paid'
+                                ? 'No paid invoices this period.'
+                                : currentUrgency === 'upcoming'
+                                  ? 'No upcoming invoices.'
+                                  : 'All caught up. Nothing needs attention.',
+                        createLabel: 'View Paid',
+                        onCreate: () => applyTab('paid'),
                     }}
                 />
+
+                {/* Activity */}
+                {recentPayments.length > 0 && (
+                <Collapsible defaultOpen={false}>
+                    <CollapsibleTrigger className="group flex w-full items-center gap-2 py-2 text-sm font-medium text-muted-foreground hover:text-foreground">
+                        <ChevronDown className="size-4 transition-transform group-data-[state=open]:rotate-180" />
+                        Recent Payments ({recentPayments.length})
+                    </CollapsibleTrigger>
+                    <CollapsibleContent>
+                        {recentPayments.length > 0 && (
+                            <div className="divide-y rounded-lg border">
+                                {recentPayments.map((payment) => (
+                                    <div
+                                        key={payment.id}
+                                        className="flex items-center justify-between px-4 py-3 text-sm"
+                                    >
+                                        <div className="min-w-0 flex-1">
+                                            <p className="truncate font-medium">
+                                                {payment.tenant_name}
+                                            </p>
+                                            <p className="text-xs text-muted-foreground">
+                                                {payment.invoice_reference}
+                                                {' · '}
+                                                {formatDate(payment.payment_date)}
+                                            </p>
+                                        </div>
+                                        <div className="ml-3 text-right">
+                                            <p className="tabular-nums font-medium text-green-600">
+                                                +{formatPrice(payment.amount)}
+                                            </p>
+                                            <p className="text-xs text-muted-foreground">
+                                                {PAYMENT_METHOD_LABELS[payment.payment_method] ??
+                                                    payment.payment_method}
+                                            </p>
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+                    </CollapsibleContent>
+                </Collapsible>
+                )}
+
+                {recentReminders.length > 0 && (
+                <Collapsible defaultOpen={false}>
+                    <CollapsibleTrigger className="group flex w-full items-center gap-2 py-2 text-sm font-medium text-muted-foreground hover:text-foreground">
+                        <ChevronDown className="size-4 transition-transform group-data-[state=open]:rotate-180" />
+                        Reminder Activity ({recentReminders.length})
+                    </CollapsibleTrigger>
+                    <CollapsibleContent>
+                        {recentReminders.length > 0 && (
+                            <div className="divide-y rounded-lg border">
+                                {recentReminders.map((reminder) => (
+                                    <div
+                                        key={reminder.id}
+                                        className="flex items-center justify-between px-4 py-3 text-sm"
+                                    >
+                                        <div className="min-w-0 flex-1">
+                                            <p className="truncate font-medium">
+                                                {reminder.tenant_name}
+                                            </p>
+                                            <p className="text-xs text-muted-foreground">
+                                                {REMINDER_LABELS[reminder.reminder_type] ??
+                                                    reminder.reminder_type}
+                                                {' · '}
+                                                {reminder.channel}
+                                                {reminder.sent_at &&
+                                                    ` · ${formatDate(reminder.sent_at)}`}
+                                            </p>
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+                    </CollapsibleContent>
+                </Collapsible>
+                )}
             </div>
+
+            <QueuePaymentSheet
+                invoice={paymentSheetInvoice}
+                open={paymentSheetInvoice !== null}
+                onOpenChange={(open) => {
+                    if (!open) {
+setPaymentSheetInvoice(null);
+}
+                }}
+            />
         </>
     );
 }
 
-Rent.layout = {
+CollectionQueue.layout = {
     breadcrumbs: [
         {
             title: 'Dashboard',
             href: dashboard(),
         },
         {
-            title: 'Rent',
+            title: 'Collection',
             href: dashboardRent(),
         },
     ],

--- a/resources/js/pages/dashboard/rent.tsx
+++ b/resources/js/pages/dashboard/rent.tsx
@@ -14,6 +14,7 @@ import {
 import { useState } from 'react';
 import { DataTable } from '@/components/data-table';
 import type { TableColumn } from '@/components/data-table';
+import { FilterBar } from '@/components/data-table/filter-bar';
 import { SearchInput } from '@/components/data-table/search-input';
 import QueuePaymentSheet from '@/components/features/payments/queue-payment-sheet';
 import { Button } from '@/components/ui/button';
@@ -38,6 +39,7 @@ import type {
     PaginatedData,
     RecentPaymentEntry,
     RecentReminderEntry,
+    TableMeta,
 } from '@/types';
 
 type TabCounts = {
@@ -62,6 +64,7 @@ type PageProps = {
     urgency?: string;
     properties?: string;
     per_page?: number;
+    table: TableMeta;
     outstanding: { count: number; amount: number };
     tab_counts: TabCounts;
     progress: Progress;
@@ -141,6 +144,7 @@ export default function CollectionQueue({
     urgency: currentUrgency = '',
     properties: currentProperties = '',
     per_page: currentPerPage = 25,
+    table: tableMeta,
     outstanding,
     tab_counts: tabCounts,
     progress,
@@ -470,11 +474,20 @@ export default function CollectionQueue({
                     })}
 
                     <div className="ml-auto">
-                        <SearchInput
-                            value={table.searchValue}
-                            onChange={table.onSearchChange}
-                            onClear={table.clearSearch}
-                            placeholder="Search tenant, invoice, unit, property..."
+                        <FilterBar
+                            filters={tableMeta.filters}
+                            activeFilters={table.activeFilters}
+                            activeFilterCount={table.activeFilterCount}
+                            onToggleOption={table.toggleFilterOption}
+                            onClearAll={table.clearAllFilters}
+                            searchInput={
+                                <SearchInput
+                                    value={table.searchValue}
+                                    onChange={table.onSearchChange}
+                                    onClear={table.clearSearch}
+                                    placeholder="Search tenant, invoice, unit, property..."
+                                />
+                            }
                         />
                     </div>
                 </div>

--- a/resources/js/pages/dashboard/rent.tsx
+++ b/resources/js/pages/dashboard/rent.tsx
@@ -357,6 +357,7 @@ export default function CollectionQueue({
 
             <div className="flex h-full flex-1 flex-col gap-4 overflow-x-auto p-4">
                 {/* Header cards */}
+                <h1 className="text-lg font-semibold">Collection Queue</h1>
                 <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
                     <div className="flex items-center gap-3 rounded-lg border px-4 py-3">
                         <AlertTriangle className="size-8 shrink-0 text-red-500" />

--- a/resources/js/pages/dashboard/rent.tsx
+++ b/resources/js/pages/dashboard/rent.tsx
@@ -266,7 +266,7 @@ export default function CollectionQueue({
         {
             key: 'outstanding',
             label: 'Outstanding',
-            className: 'tabular-nums text-muted-foreground',
+            className: 'tabular-nums text-muted-foreground hidden sm:table-cell',
             render: (entry) => formatPrice(entry.outstanding),
         },
         {
@@ -434,7 +434,7 @@ export default function CollectionQueue({
                 </div>
 
                 {/* Tab pills */}
-                <div className="flex flex-wrap items-center gap-1">
+                <div className="flex items-center gap-1 overflow-x-auto pb-1">
                     {TABS.map((tab) => {
                         const count =
                             tab.key === ''

--- a/resources/js/pages/leases/documents.tsx
+++ b/resources/js/pages/leases/documents.tsx
@@ -2,7 +2,12 @@ import type { TableColumn } from '@/components/data-table';
 import { PluginRegion } from '@/components/shared/plugin-region';
 import { WorkspaceTable } from '@/components/shared/workspace-table';
 import { formatDate, formatPeriod } from '@/lib/formatters';
-import type { PaginatedData, ProofRow, TableMeta, WorkspaceLease } from '@/types';
+import type {
+    PaginatedData,
+    ProofRow,
+    TableMeta,
+    WorkspaceLease,
+} from '@/types';
 import { LeaseLayout } from './layout';
 
 const columns: TableColumn<ProofRow>[] = [

--- a/resources/js/pages/leases/invoice-detail.tsx
+++ b/resources/js/pages/leases/invoice-detail.tsx
@@ -24,111 +24,124 @@ export default function InvoiceDetail({
             </Link>
 
             <div className="flex-1 space-y-6">
-
-            {/* Summary card */}
-            <div className="rounded-lg border p-6">
-                <div className="flex items-start justify-between">
-                    <div>
-                        <h2 className="text-lg font-semibold">
-                            {invoice.reference ?? 'Invoice'}
-                        </h2>
-                        <p className="text-sm text-muted-foreground">
-                            {formatPeriod(invoice.period_start, 'id-ID')}
-                        </p>
+                {/* Summary card */}
+                <div className="rounded-lg border p-6">
+                    <div className="flex items-start justify-between">
+                        <div>
+                            <h2 className="text-lg font-semibold">
+                                {invoice.reference ?? 'Invoice'}
+                            </h2>
+                            <p className="text-sm text-muted-foreground">
+                                {formatPeriod(invoice.period_start, 'id-ID')}
+                            </p>
+                        </div>
+                        <StatusBadge domain="invoice" value={invoice.status} />
                     </div>
-                    <StatusBadge domain="invoice" value={invoice.status} />
+
+                    <div className="mt-6 grid grid-cols-3 gap-4 text-sm">
+                        <div>
+                            <p className="text-muted-foreground">Total</p>
+                            <p className="mt-1 font-medium tabular-nums">
+                                {formatPrice(invoice.total)}
+                            </p>
+                        </div>
+                        <div>
+                            <p className="text-muted-foreground">Paid</p>
+                            <p className="mt-1 font-medium tabular-nums">
+                                {formatPrice(invoice.amount_paid)}
+                            </p>
+                        </div>
+                        <div>
+                            <p className="text-muted-foreground">Outstanding</p>
+                            <p className="mt-1 font-medium tabular-nums">
+                                {formatPrice(invoice.outstanding ?? '0')}
+                            </p>
+                        </div>
+                        <div>
+                            <p className="text-muted-foreground">
+                                Billing period
+                            </p>
+                            <p className="mt-1 tabular-nums">
+                                {formatDate(invoice.period_start)} —{' '}
+                                {formatDate(invoice.period_end)}
+                            </p>
+                        </div>
+                        <div>
+                            <p className="text-muted-foreground">Due date</p>
+                            <p className="mt-1 tabular-nums">
+                                {formatDate(invoice.due_date)}
+                            </p>
+                        </div>
+                    </div>
                 </div>
 
-                <div className="mt-6 grid grid-cols-3 gap-4 text-sm">
-                    <div>
-                        <p className="text-muted-foreground">Total</p>
-                        <p className="mt-1 font-medium tabular-nums">
-                            {formatPrice(invoice.total)}
-                        </p>
-                    </div>
-                    <div>
-                        <p className="text-muted-foreground">Paid</p>
-                        <p className="mt-1 font-medium tabular-nums">
-                            {formatPrice(invoice.amount_paid)}
-                        </p>
-                    </div>
-                    <div>
-                        <p className="text-muted-foreground">Outstanding</p>
-                        <p className="mt-1 font-medium tabular-nums">
-                            {formatPrice(invoice.outstanding ?? '0')}
-                        </p>
-                    </div>
-                    <div>
-                        <p className="text-muted-foreground">Billing period</p>
-                        <p className="mt-1 tabular-nums">
-                            {formatDate(invoice.period_start)} — {formatDate(invoice.period_end)}
-                        </p>
-                    </div>
-                    <div>
-                        <p className="text-muted-foreground">Due date</p>
-                        <p className="mt-1 tabular-nums">{formatDate(invoice.due_date)}</p>
-                    </div>
-                </div>
-            </div>
-
-            {/* Line items */}
-            {invoice.line_items && invoice.line_items.length > 0 && (
-                <div className="rounded-lg border">
-                    <div className="border-b px-4 py-3">
-                        <h3 className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
-                            Line Items
-                        </h3>
-                    </div>
-                    <div className="divide-y">
-                        {invoice.line_items.map((item) => (
-                            <div
-                                key={item.id}
-                                className="flex items-center justify-between px-4 py-3 text-sm"
-                            >
-                                <div>
-                                    <p className="font-medium">{item.description}</p>
-                                    <p className="text-xs text-muted-foreground">{item.type}</p>
-                                </div>
-                                <p className="tabular-nums">{formatPrice(item.amount)}</p>
-                            </div>
-                        ))}
-                    </div>
-                </div>
-            )}
-
-            {/* Allocated payments */}
-            {invoice.payments && invoice.payments.length > 0 && (
-                <div className="rounded-lg border">
-                    <div className="border-b px-4 py-3">
-                        <h3 className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
-                            Payments
-                        </h3>
-                    </div>
-                    <div className="divide-y">
-                        {invoice.payments.map((payment) => (
-                            <div
-                                key={payment.id}
-                                className="flex items-center justify-between px-4 py-3 text-sm"
-                            >
-                                <div>
-                                    <p className="font-medium tabular-nums">
-                                        {formatPrice(payment.amount)}
-                                    </p>
-                                    <p className="text-xs text-muted-foreground">
-                                        {formatDate(payment.payment_date)}
+                {/* Line items */}
+                {invoice.line_items && invoice.line_items.length > 0 && (
+                    <div className="rounded-lg border">
+                        <div className="border-b px-4 py-3">
+                            <h3 className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
+                                Line Items
+                            </h3>
+                        </div>
+                        <div className="divide-y">
+                            {invoice.line_items.map((item) => (
+                                <div
+                                    key={item.id}
+                                    className="flex items-center justify-between px-4 py-3 text-sm"
+                                >
+                                    <div>
+                                        <p className="font-medium">
+                                            {item.description}
+                                        </p>
+                                        <p className="text-xs text-muted-foreground">
+                                            {item.type}
+                                        </p>
+                                    </div>
+                                    <p className="tabular-nums">
+                                        {formatPrice(item.amount)}
                                     </p>
                                 </div>
-                                <StatusBadge domain="payment" value={payment.status} />
-                            </div>
-                        ))}
+                            ))}
+                        </div>
                     </div>
-                </div>
-            )}
+                )}
 
-            {/* Timeline placeholder */}
-            <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
-                Activity timeline, reminders, and PDF download coming soon.
-            </div>
+                {/* Allocated payments */}
+                {invoice.payments && invoice.payments.length > 0 && (
+                    <div className="rounded-lg border">
+                        <div className="border-b px-4 py-3">
+                            <h3 className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
+                                Payments
+                            </h3>
+                        </div>
+                        <div className="divide-y">
+                            {invoice.payments.map((payment) => (
+                                <div
+                                    key={payment.id}
+                                    className="flex items-center justify-between px-4 py-3 text-sm"
+                                >
+                                    <div>
+                                        <p className="font-medium tabular-nums">
+                                            {formatPrice(payment.amount)}
+                                        </p>
+                                        <p className="text-xs text-muted-foreground">
+                                            {formatDate(payment.payment_date)}
+                                        </p>
+                                    </div>
+                                    <StatusBadge
+                                        domain="payment"
+                                        value={payment.status}
+                                    />
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                )}
+
+                {/* Timeline placeholder */}
+                <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+                    Activity timeline, reminders, and PDF download coming soon.
+                </div>
             </div>
         </div>
     );

--- a/resources/js/pages/leases/invoices.tsx
+++ b/resources/js/pages/leases/invoices.tsx
@@ -4,7 +4,12 @@ import { PluginRegion } from '@/components/shared/plugin-region';
 import { StatusBadge } from '@/components/shared/status-badge';
 import { WorkspaceTable } from '@/components/shared/workspace-table';
 import { formatDate, formatPeriod, formatPrice } from '@/lib/formatters';
-import type { Invoice, PaginatedData, TableMeta, WorkspaceLease } from '@/types';
+import type {
+    Invoice,
+    PaginatedData,
+    TableMeta,
+    WorkspaceLease,
+} from '@/types';
 import { LeaseLayout } from './layout';
 
 const columns: TableColumn<Invoice>[] = [
@@ -90,7 +95,9 @@ export default function LeaseInvoices({
                     defaultSort="-period_start"
                     searchPlaceholder="Search by reference..."
                     emptyMessage="No invoices generated yet."
-                    onRowClick={(invoice) => router.get(`/leases/${lease.id}/invoices/${invoice.id}`)}
+                    onRowClick={(invoice) =>
+                        router.get(`/leases/${lease.id}/invoices/${invoice.id}`)
+                    }
                 />
             </PluginRegion>
         </LeaseLayout>

--- a/resources/js/pages/leases/payments.tsx
+++ b/resources/js/pages/leases/payments.tsx
@@ -18,7 +18,8 @@ const columns: TableColumn<Payment>[] = [
         key: 'period_start',
         label: 'Period',
         className: 'font-medium',
-        render: (p) => (p.invoice ? formatPeriod(p.invoice.period_start, 'id-ID') : '—'),
+        render: (p) =>
+            p.invoice ? formatPeriod(p.invoice.period_start, 'id-ID') : '—',
     },
     {
         key: 'payment_date',
@@ -53,7 +54,16 @@ const columns: TableColumn<Payment>[] = [
         key: 'status',
         label: 'Status',
         sortable: true,
-        render: (p) => <StatusBadge domain="payment" value={p.verified_at && p.status === 'confirmed' ? 'verified' : p.status} />,
+        render: (p) => (
+            <StatusBadge
+                domain="payment"
+                value={
+                    p.verified_at && p.status === 'confirmed'
+                        ? 'verified'
+                        : p.status
+                }
+            />
+        ),
     },
     {
         key: '_proofs',

--- a/resources/js/pages/properties/index.tsx
+++ b/resources/js/pages/properties/index.tsx
@@ -164,7 +164,12 @@ export default function Index({
         {
             key: '_status',
             label: 'Status',
-            render: (p) => <StatusBadge domain="property" value={p.is_active ? 'active' : 'archived'} />,
+            render: (p) => (
+                <StatusBadge
+                    domain="property"
+                    value={p.is_active ? 'active' : 'archived'}
+                />
+            ),
         },
         {
             key: '_actions',
@@ -301,10 +306,7 @@ export default function Index({
                         >
                             Cancel
                         </Button>
-                        <Button
-                            variant="destructive"
-                            onClick={confirmArchive}
-                        >
+                        <Button variant="destructive" onClick={confirmArchive}>
                             Archive
                         </Button>
                     </DialogFooter>

--- a/resources/js/pages/properties/leases.tsx
+++ b/resources/js/pages/properties/leases.tsx
@@ -67,9 +67,7 @@ const columns: TableColumn<Lease>[] = [
         key: 'status',
         label: 'Status',
         sortable: true,
-        render: (l) => (
-            <StatusBadge domain="lease" value={l.status} />
-        ),
+        render: (l) => <StatusBadge domain="lease" value={l.status} />,
     },
 ];
 

--- a/resources/js/pages/properties/units/index.tsx
+++ b/resources/js/pages/properties/units/index.tsx
@@ -407,8 +407,11 @@ export default function Index({
                                     Move Unit
                                 </DropdownMenuItem>
                             )}
-                            {!r.deleted_at && (r.capacity > occupants.length ||
-                                hasActiveLease) && <DropdownMenuSeparator />}
+                            {!r.deleted_at &&
+                                (r.capacity > occupants.length ||
+                                    hasActiveLease) && (
+                                    <DropdownMenuSeparator />
+                                )}
                             {r.deleted_at ? (
                                 <DropdownMenuItem onClick={() => restore(r)}>
                                     <RotateCcw className="size-4" />
@@ -416,7 +419,9 @@ export default function Index({
                                 </DropdownMenuItem>
                             ) : (
                                 <>
-                                    <DropdownMenuItem onClick={() => openEdit(r)}>
+                                    <DropdownMenuItem
+                                        onClick={() => openEdit(r)}
+                                    >
                                         <Pencil className="size-4" />
                                         Edit
                                     </DropdownMenuItem>
@@ -545,10 +550,7 @@ export default function Index({
                         >
                             Cancel
                         </Button>
-                        <Button
-                            variant="destructive"
-                            onClick={destroy}
-                        >
+                        <Button variant="destructive" onClick={destroy}>
                             Delete
                         </Button>
                     </DialogFooter>

--- a/resources/js/pages/properties/units/lease-history.tsx
+++ b/resources/js/pages/properties/units/lease-history.tsx
@@ -4,7 +4,12 @@ import { PluginRegion } from '@/components/shared/plugin-region';
 import { WorkspaceTable } from '@/components/shared/workspace-table';
 import { Badge } from '@/components/ui/badge';
 import { formatDate, formatPrice } from '@/lib/formatters';
-import type { LeaseInfo, PaginatedData, TableMeta, WorkspaceUnit } from '@/types';
+import type {
+    LeaseInfo,
+    PaginatedData,
+    TableMeta,
+    WorkspaceUnit,
+} from '@/types';
 import { UnitLayout } from './layout';
 
 const columns: TableColumn<LeaseInfo>[] = [

--- a/resources/js/pages/properties/units/leases/index.tsx
+++ b/resources/js/pages/properties/units/leases/index.tsx
@@ -186,7 +186,10 @@ export default function Index({
                                             {lease.rent_due_day}
                                         </td>
                                         <td className="px-4 py-3">
-                                        <StatusBadge domain="lease" value={lease.status} />
+                                            <StatusBadge
+                                                domain="lease"
+                                                value={lease.status}
+                                            />
                                         </td>
                                         <td className="px-4 py-3 text-sm">
                                             {lease.termination_date ? (

--- a/resources/js/pages/properties/units/maintenance-history.tsx
+++ b/resources/js/pages/properties/units/maintenance-history.tsx
@@ -5,7 +5,12 @@ import { StatusBadge } from '@/components/shared/status-badge';
 import { WorkspaceTable } from '@/components/shared/workspace-table';
 import { Badge } from '@/components/ui/badge';
 import { formatDate, formatPrice } from '@/lib/formatters';
-import type { MaintenanceTicket, PaginatedData, TableMeta, WorkspaceUnit } from '@/types';
+import type {
+    MaintenanceTicket,
+    PaginatedData,
+    TableMeta,
+    WorkspaceUnit,
+} from '@/types';
 import { UnitLayout } from './layout';
 
 const priorityColors: Record<string, string> = {
@@ -49,9 +54,7 @@ const columns: TableColumn<MaintenanceTicket>[] = [
         key: 'status',
         label: 'Status',
         sortable: true,
-        render: (t) => (
-            <StatusBadge domain="maintenance" value={t.status} />
-        ),
+        render: (t) => <StatusBadge domain="maintenance" value={t.status} />,
     },
     {
         key: 'cost',

--- a/resources/js/pages/roles/index.tsx
+++ b/resources/js/pages/roles/index.tsx
@@ -152,11 +152,12 @@ export default function Index({
         {
             key: '_status',
             label: 'Status',
-            render: (role) =>
+            render: (role) => (
                 <StatusBadge
                     domain="role"
                     value={role.is_active ? 'active' : 'disabled'}
-                />,
+                />
+            ),
         },
         {
             key: '_actions',

--- a/resources/js/pages/settings/mail.tsx
+++ b/resources/js/pages/settings/mail.tsx
@@ -172,9 +172,7 @@ export default function Mail({
                                         id="mail_config[from_address]"
                                         name="mail_config[from_address]"
                                         type="email"
-                                        defaultValue={
-                                            config.from_address ?? ''
-                                        }
+                                        defaultValue={config.from_address ?? ''}
                                         placeholder="noreply@openkos.app"
                                     />
                                     {errors['mail_config.from_address'] && (
@@ -192,9 +190,7 @@ export default function Mail({
                                         id="mail_config[from_name]"
                                         name="mail_config[from_name]"
                                         type="text"
-                                        defaultValue={
-                                            config.from_name ?? ''
-                                        }
+                                        defaultValue={config.from_name ?? ''}
                                         placeholder="OpenKOS"
                                     />
                                     {errors['mail_config.from_name'] && (

--- a/resources/js/pages/settings/property-types.tsx
+++ b/resources/js/pages/settings/property-types.tsx
@@ -259,10 +259,7 @@ export default function PropertyTypes({
                         >
                             Cancel
                         </Button>
-                        <Button
-                            variant="destructive"
-                            onClick={confirmDelete}
-                        >
+                        <Button variant="destructive" onClick={confirmDelete}>
                             Delete
                         </Button>
                     </DialogFooter>

--- a/resources/js/pages/tenants/documents.tsx
+++ b/resources/js/pages/tenants/documents.tsx
@@ -3,7 +3,12 @@ import type { TableColumn } from '@/components/data-table';
 import { PluginRegion } from '@/components/shared/plugin-region';
 import { WorkspaceTable } from '@/components/shared/workspace-table';
 import { formatDate } from '@/lib/formatters';
-import type { PaginatedData, TableMeta, TenantDocument, WorkspaceTenant } from '@/types';
+import type {
+    PaginatedData,
+    TableMeta,
+    TenantDocument,
+    WorkspaceTenant,
+} from '@/types';
 import { TenantLayout } from './layout';
 
 const columns: TableColumn<TenantDocument>[] = [

--- a/resources/js/pages/tenants/index.tsx
+++ b/resources/js/pages/tenants/index.tsx
@@ -40,7 +40,13 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { useTable } from '@/hooks/use-table';
 import tenants from '@/routes/tenants';
-import type { AvailableUnit, Lease, PaginatedData, TableMeta, WorkspaceTenant } from '@/types';
+import type {
+    AvailableUnit,
+    Lease,
+    PaginatedData,
+    TableMeta,
+    WorkspaceTenant,
+} from '@/types';
 
 type PageProps = {
     tenants: PaginatedData<WorkspaceTenant>;
@@ -62,21 +68,31 @@ export default function Index({
     table: tableMeta,
 }: PageProps) {
     const [dialogOpen, setDialogOpen] = useState(false);
-    const [editingTenant, setEditingTenant] = useState<WorkspaceTenant | null>(null);
+    const [editingTenant, setEditingTenant] = useState<WorkspaceTenant | null>(
+        null,
+    );
 
     const [detailOpen, setDetailOpen] = useState(false);
-    const [viewingTenant, setViewingTenant] = useState<WorkspaceTenant | null>(null);
+    const [viewingTenant, setViewingTenant] = useState<WorkspaceTenant | null>(
+        null,
+    );
 
     const [assignUnitOpen, setAssignUnitOpen] = useState(false);
-    const [assignTenant, setAssignTenant] = useState<WorkspaceTenant | null>(null);
+    const [assignTenant, setAssignTenant] = useState<WorkspaceTenant | null>(
+        null,
+    );
 
     const [moveOutOpen, setMoveOutOpen] = useState(false);
-    const [moveOutTenant, setMoveOutTenant] = useState<WorkspaceTenant | null>(null);
+    const [moveOutTenant, setMoveOutTenant] = useState<WorkspaceTenant | null>(
+        null,
+    );
 
     const [documentsOpen, setDocumentsOpen] = useState(false);
-    const [documentsTenant, setDocumentsTenant] = useState<WorkspaceTenant | null>(null);
+    const [documentsTenant, setDocumentsTenant] =
+        useState<WorkspaceTenant | null>(null);
 
-    const [archiveConfirm, setArchiveConfirm] = useState<WorkspaceTenant | null>(null);
+    const [archiveConfirm, setArchiveConfirm] =
+        useState<WorkspaceTenant | null>(null);
 
     const table = useTable({
         routeFn: () => tenants.index(),
@@ -191,7 +207,11 @@ export default function Index({
             key: '_status',
             label: 'Status',
             render: (t) => {
-                const status = t.deleted_at ? 'archived' : t.is_active ? 'active' : 'inactive';
+                const status = t.deleted_at
+                    ? 'archived'
+                    : t.is_active
+                      ? 'active'
+                      : 'inactive';
 
                 return <StatusBadge domain="tenant" value={status} />;
             },
@@ -344,7 +364,12 @@ export default function Index({
                 lease={
                     moveOutTenant
                         ? {
-                              id: (moveOutTenant as WorkspaceTenant & { leases?: Lease[] }).leases?.[0]?.id ?? 0,
+                              id:
+                                  (
+                                      moveOutTenant as WorkspaceTenant & {
+                                          leases?: Lease[];
+                                      }
+                                  ).leases?.[0]?.id ?? 0,
                               tenants: [
                                   {
                                       id: moveOutTenant.id,
@@ -358,7 +383,12 @@ export default function Index({
                                   name: moveOutTenant.name,
                                   phone: moveOutTenant.phone,
                               },
-                              unit: (moveOutTenant as WorkspaceTenant & { leases?: Lease[] }).leases?.[0]?.unit ?? null,
+                              unit:
+                                  (
+                                      moveOutTenant as WorkspaceTenant & {
+                                          leases?: Lease[];
+                                      }
+                                  ).leases?.[0]?.unit ?? null,
                           }
                         : null
                 }
@@ -389,10 +419,7 @@ export default function Index({
                         >
                             Cancel
                         </Button>
-                        <Button
-                            variant="destructive"
-                            onClick={confirmArchive}
-                        >
+                        <Button variant="destructive" onClick={confirmArchive}>
                             Archive
                         </Button>
                     </DialogFooter>

--- a/resources/js/pages/users/index.tsx
+++ b/resources/js/pages/users/index.tsx
@@ -379,22 +379,47 @@ export default function Index({
                         </DialogTitle>
                         <DialogDescription>
                             {confirmState?.action === 'disable' && (
-                                <>Disable access for <span className="font-medium">{confirmState.user.name}</span>?</>
+                                <>
+                                    Disable access for{' '}
+                                    <span className="font-medium">
+                                        {confirmState.user.name}
+                                    </span>
+                                    ?
+                                </>
                             )}
                             {confirmState?.action === 'reset' && (
-                                <>Send password reset to <span className="font-medium">{confirmState.user.email}</span>?</>
+                                <>
+                                    Send password reset to{' '}
+                                    <span className="font-medium">
+                                        {confirmState.user.email}
+                                    </span>
+                                    ?
+                                </>
                             )}
                             {confirmState?.action === 'resend' && (
-                                <>Resend invitation to <span className="font-medium">{confirmState.user.email}</span>?</>
+                                <>
+                                    Resend invitation to{' '}
+                                    <span className="font-medium">
+                                        {confirmState.user.email}
+                                    </span>
+                                    ?
+                                </>
                             )}
                         </DialogDescription>
                     </DialogHeader>
                     <DialogFooter>
-                        <Button variant="outline" onClick={() => setConfirmState(null)}>
+                        <Button
+                            variant="outline"
+                            onClick={() => setConfirmState(null)}
+                        >
                             Cancel
                         </Button>
                         <Button
-                            variant={confirmState?.action === 'disable' ? 'destructive' : 'default'}
+                            variant={
+                                confirmState?.action === 'disable'
+                                    ? 'destructive'
+                                    : 'default'
+                            }
                             onClick={executeConfirmed}
                         >
                             {confirmState?.action === 'disable'

--- a/resources/js/types/dashboard.ts
+++ b/resources/js/types/dashboard.ts
@@ -36,3 +36,59 @@ export type RentDashboardEntry = {
     rent_amount: string;
     rent_status: 'paid' | 'overdue' | 'due_today' | 'due_soon';
 };
+
+export type BillingStats = {
+    overdue: { count: number; amount: number };
+    due_today: number;
+    due_soon: number;
+    outstanding_balance: number;
+    collection_rate: number;
+};
+
+export type NeedsAttentionInvoice = {
+    id: number;
+    lease_id: number;
+    tenant_name: string;
+    unit_name: string;
+    property_name: string;
+    reference: string;
+    period_start: string;
+    period_end: string;
+    due_date: string;
+    total: string;
+    amount_paid: string;
+    outstanding: string;
+    days_overdue: number | null;
+    urgency: 'overdue' | 'due_today' | 'due_tomorrow' | 'due_soon' | 'upcoming';
+    status: string;
+};
+
+export type RecentPaymentEntry = {
+    id: number;
+    amount: string;
+    payment_date: string;
+    payment_method: string;
+    status: string;
+    tenant_name: string;
+    invoice_id: number;
+    invoice_reference: string;
+    lease_id: number | null;
+};
+
+export type RecentReminderEntry = {
+    id: number;
+    lease_id: number;
+    tenant_name: string;
+    reminder_type: string;
+    channel: string;
+    scheduled_for: string;
+    sent_at: string | null;
+    overdue_days: number | null;
+};
+
+export type CollectionProgress = {
+    paid_this_month: number;
+    outstanding_this_month: number;
+    monthly_potential: number;
+    collection_rate: number;
+};

--- a/resources/js/types/dashboard.ts
+++ b/resources/js/types/dashboard.ts
@@ -48,6 +48,8 @@ export type BillingStats = {
 export type NeedsAttentionInvoice = {
     id: number;
     lease_id: number;
+    lease_reference: string | null;
+    primary_tenant_id: number | null;
     tenant_name: string;
     unit_name: string;
     property_name: string;

--- a/resources/js/types/models.ts
+++ b/resources/js/types/models.ts
@@ -374,4 +374,3 @@ export type WorkspaceUnit = {
 export type PropertyRef = { id: number; name: string };
 
 export type RoleOption = { value: string; label: string };
-

--- a/resources/js/types/settings.ts
+++ b/resources/js/types/settings.ts
@@ -20,12 +20,15 @@ export interface MailConfig {
 export type Driver = {
     name: string;
     label: string;
-    configuration_schema?: Record<string, {
-        label: string;
-        required?: boolean;
-        type?: string;
-        placeholder?: string;
-    }>;
+    configuration_schema?: Record<
+        string,
+        {
+            label: string;
+            required?: boolean;
+            type?: string;
+            placeholder?: string;
+        }
+    >;
 };
 
 export type DynamicSettingsFormProps = {

--- a/tests/Feature/RentDashboardTest.php
+++ b/tests/Feature/RentDashboardTest.php
@@ -1,9 +1,12 @@
 <?php
 
 use App\Enums\InvoiceStatus;
+use App\Enums\PaymentStatus;
 use App\Models\Invoice;
 use App\Models\Lease;
+use App\Models\Payment;
 use App\Models\Property;
+use App\Models\ReminderLog;
 use App\Models\Tenant;
 use App\Models\Unit;
 use App\Models\User;
@@ -14,142 +17,177 @@ uses()->beforeEach(function () {
     $this->seed(RoleAndPermissionSeeder::class);
 });
 
-function createLeaseWithPayment(array $leaseOverrides = [], ?array $paymentData = null): Lease
-{
-    $lease = Lease::factory()->create(array_merge([
-        'start_date' => now()->subMonths(2),
-        'rent_amount' => 100000,
-        'rent_due_day' => 5,
-    ], $leaseOverrides));
-
-    if ($paymentData !== null) {
-        Invoice::factory()->create([
-            'lease_id' => $lease->id,
-            'period_start' => now()->startOfMonth(),
-            'period_end' => now()->endOfMonth(),
-            'due_date' => now()->startOfMonth()->addDays(4),
-            'total' => 100000,
-            'amount_paid' => 100000,
-            'status' => InvoiceStatus::Paid,
-        ]);
-    }
-
-    return $lease;
-}
-
-test('rent dashboard loads with stats for owner', function () {
-    Carbon::setTestNow(now()->setDay(10));
+test('collection queue loads with data for owner', function () {
+    Carbon::setTestNow(Carbon::parse('2026-07-10'));
 
     $user = User::factory()->owner()->create();
 
-    createLeaseWithPayment(
-        ['rent_due_day' => 5],
-        ['status' => 'confirmed'],
-    );
-
-    createLeaseWithPayment(['rent_due_day' => 5]);
+    Lease::factory()
+        ->has(Invoice::factory()->state([
+            'due_date' => '2026-07-05',
+            'total' => 100000,
+            'amount_paid' => 0,
+            'status' => InvoiceStatus::Pending,
+        ]))
+        ->create(['status' => 'active', 'start_date' => now()->subMonths(2)]);
 
     $this->actingAs($user)
         ->get(route('dashboard.rent'))
         ->assertOk()
         ->assertInertia(fn ($page) => $page
             ->has('entries.data')
-            ->has('stats')
+            ->has('outstanding')
+            ->has('tab_counts')
+            ->has('recent_payments')
+            ->has('recent_reminders')
         );
 
     Carbon::setTestNow();
 });
 
-test('rent dashboard shows correct overdue count', function () {
-    Carbon::setTestNow(now()->setDay(10));
+test('collection queue shows correct outstanding count', function () {
+    Carbon::setTestNow(Carbon::parse('2026-07-10'));
 
     $user = User::factory()->owner()->create();
 
-    createLeaseWithPayment(['start_date' => now()->subMonths(2), 'rent_due_day' => 5]);
-    createLeaseWithPayment(['start_date' => now()->subMonths(2), 'rent_due_day' => 3]);
-    createLeaseWithPayment(
-        ['start_date' => now()->subMonths(2), 'rent_due_day' => 5],
-        ['status' => 'confirmed'],
-    );
+    $lease1 = Lease::factory()->create(['status' => 'active', 'start_date' => now()->subMonths(2)]);
+    Invoice::factory()->create([
+        'lease_id' => $lease1->id,
+        'due_date' => '2026-07-03',
+        'total' => 100000,
+        'amount_paid' => 0,
+        'status' => InvoiceStatus::Pending,
+    ]);
+
+    $lease2 = Lease::factory()->create(['status' => 'active', 'start_date' => now()->subMonths(2)]);
+    Invoice::factory()->create([
+        'lease_id' => $lease2->id,
+        'due_date' => '2026-07-05',
+        'total' => 200000,
+        'amount_paid' => 0,
+        'status' => InvoiceStatus::Partial,
+    ]);
 
     $this->actingAs($user)
         ->get(route('dashboard.rent'))
         ->assertInertia(fn ($page) => $page
-            ->where('stats.overdue.count', 2)
-            ->where('stats.overdue.amount', 200000)
-            ->where('stats.paid', 1)
+            ->where('outstanding.count', 2)
+            ->where('outstanding.amount', 300000)
         );
 
     Carbon::setTestNow();
 });
 
-test('rent dashboard shows due today correctly', function () {
-    $today = now()->day;
-    Carbon::setTestNow(now()->setDay($today));
+test('collection queue tab counts are correct', function () {
+    Carbon::setTestNow(Carbon::parse('2026-07-10'));
 
     $user = User::factory()->owner()->create();
 
-    createLeaseWithPayment(['rent_due_day' => $today]);
-    createLeaseWithPayment(['rent_due_day' => $today - 1]);
-    createLeaseWithPayment(
-        ['rent_due_day' => $today],
-        ['status' => 'confirmed'],
-    );
+    $lease1 = Lease::factory()->create(['status' => 'active', 'start_date' => now()->subMonths(2)]);
+    Invoice::factory()->create([
+        'lease_id' => $lease1->id,
+        'due_date' => '2026-07-05',
+        'total' => 100000,
+        'amount_paid' => 0,
+        'status' => InvoiceStatus::Pending,
+    ]);
+
+    $lease2 = Lease::factory()->create(['status' => 'active', 'start_date' => now()->subMonths(2)]);
+    Invoice::factory()->create([
+        'lease_id' => $lease2->id,
+        'due_date' => '2026-07-10',
+        'total' => 200000,
+        'amount_paid' => 0,
+        'status' => InvoiceStatus::Pending,
+    ]);
+
+    $lease3 = Lease::factory()->create(['status' => 'active', 'start_date' => now()->subMonths(2)]);
+    Invoice::factory()->create([
+        'lease_id' => $lease3->id,
+        'due_date' => '2026-07-15',
+        'total' => 150000,
+        'amount_paid' => 0,
+        'status' => InvoiceStatus::Pending,
+    ]);
+
+    $lease4 = Lease::factory()->create(['status' => 'active', 'start_date' => now()->subMonths(2)]);
+    Invoice::factory()->create([
+        'lease_id' => $lease4->id,
+        'due_date' => '2026-07-01',
+        'total' => 500000,
+        'amount_paid' => 500000,
+        'status' => InvoiceStatus::Paid,
+    ]);
 
     $this->actingAs($user)
         ->get(route('dashboard.rent'))
         ->assertInertia(fn ($page) => $page
-            ->where('stats.due_today', 1)
-            ->where('stats.overdue.count', 1)
-            ->where('stats.paid', 1)
+            ->where('tab_counts.overdue', 1)
+            ->where('tab_counts.due_today', 1)
+            ->where('tab_counts.paid', 1)
         );
 
     Carbon::setTestNow();
 });
 
-test('rent dashboard shows due soon correctly', function () {
-    $today = now()->day;
-    Carbon::setTestNow(now()->setDay($today));
+test('collection queue overdue tab is selected', function () {
+    Carbon::setTestNow(Carbon::parse('2026-07-10'));
 
     $user = User::factory()->owner()->create();
 
-    createLeaseWithPayment(['rent_due_day' => $today + 3]);
-    createLeaseWithPayment(['rent_due_day' => $today + 5]);
-    createLeaseWithPayment(['rent_due_day' => $today + 14]);
-    createLeaseWithPayment(
-        ['rent_due_day' => $today + 3],
-        ['status' => 'confirmed'],
-    );
+    $lease1 = Lease::factory()->create(['status' => 'active', 'start_date' => now()->subMonths(2)]);
+    Invoice::factory()->create([
+        'lease_id' => $lease1->id,
+        'due_date' => '2026-07-05',
+        'total' => 100000,
+        'amount_paid' => 0,
+        'status' => InvoiceStatus::Pending,
+    ]);
+
+    $lease2 = Lease::factory()->create(['status' => 'active', 'start_date' => now()->subMonths(2)]);
+    Invoice::factory()->create([
+        'lease_id' => $lease2->id,
+        'due_date' => '2026-07-10',
+        'total' => 200000,
+        'amount_paid' => 0,
+        'status' => InvoiceStatus::Pending,
+    ]);
 
     $this->actingAs($user)
-        ->get(route('dashboard.rent'))
-        ->assertInertia(fn ($page) => $page
-            ->where('stats.due_soon', 2)
-        );
-
-    Carbon::setTestNow();
-});
-
-test('rent dashboard status filter works', function () {
-    Carbon::setTestNow(now()->setDay(10));
-
-    $user = User::factory()->owner()->create();
-
-    createLeaseWithPayment(['rent_due_day' => 5]);
-    createLeaseWithPayment(
-        ['rent_due_day' => 5],
-        ['status' => 'confirmed'],
-    );
-
-    $this->actingAs($user)
-        ->get(route('dashboard.rent', ['status' => 'overdue']))
+        ->get(route('dashboard.rent', ['urgency' => 'overdue']))
         ->assertOk()
         ->assertInertia(fn ($page) => $page
             ->has('entries.data', 1)
         );
 
+    Carbon::setTestNow();
+});
+
+test('collection queue paid tab works', function () {
+    Carbon::setTestNow(Carbon::parse('2026-07-10'));
+
+    $user = User::factory()->owner()->create();
+
+    $lease1 = Lease::factory()->create(['status' => 'active', 'start_date' => now()->subMonths(2)]);
+    Invoice::factory()->create([
+        'lease_id' => $lease1->id,
+        'due_date' => '2026-07-05',
+        'total' => 100000,
+        'amount_paid' => 0,
+        'status' => InvoiceStatus::Pending,
+    ]);
+
+    $lease2 = Lease::factory()->create(['status' => 'active', 'start_date' => now()->subMonths(2)]);
+    Invoice::factory()->create([
+        'lease_id' => $lease2->id,
+        'due_date' => '2026-07-10',
+        'total' => 200000,
+        'amount_paid' => 200000,
+        'status' => InvoiceStatus::Paid,
+    ]);
+
     $this->actingAs($user)
-        ->get(route('dashboard.rent', ['status' => 'paid']))
+        ->get(route('dashboard.rent', ['urgency' => 'paid']))
         ->assertOk()
         ->assertInertia(fn ($page) => $page
             ->has('entries.data', 1)
@@ -158,23 +196,35 @@ test('rent dashboard status filter works', function () {
     Carbon::setTestNow();
 });
 
-test('rent dashboard search filters by tenant name', function () {
-    Carbon::setTestNow(now()->setDay(10));
+test('collection queue search filters by tenant name', function () {
+    Carbon::setTestNow(Carbon::parse('2026-07-10'));
 
     $user = User::factory()->owner()->create();
 
     $tenantA = Tenant::factory()->create(['name' => 'Budi Santoso']);
-    Lease::factory()->create([
+    $leaseA = Lease::factory()->create([
         'primary_tenant_id' => $tenantA->id,
         'start_date' => now()->subMonths(2),
-        'rent_due_day' => 5,
+        'status' => 'active',
+    ]);
+    $leaseA->tenants()->sync([$tenantA->id => ['is_primary' => true]]);
+    Invoice::factory()->create([
+        'lease_id' => $leaseA->id,
+        'due_date' => '2026-07-05',
+        'status' => InvoiceStatus::Pending,
     ]);
 
     $tenantB = Tenant::factory()->create(['name' => 'Siti Rahma']);
-    Lease::factory()->create([
+    $leaseB = Lease::factory()->create([
         'primary_tenant_id' => $tenantB->id,
         'start_date' => now()->subMonths(2),
-        'rent_due_day' => 3,
+        'status' => 'active',
+    ]);
+    $leaseB->tenants()->sync([$tenantB->id => ['is_primary' => true]]);
+    Invoice::factory()->create([
+        'lease_id' => $leaseB->id,
+        'due_date' => '2026-07-05',
+        'status' => InvoiceStatus::Pending,
     ]);
 
     $this->actingAs($user)
@@ -188,11 +238,11 @@ test('rent dashboard search filters by tenant name', function () {
     Carbon::setTestNow();
 });
 
-test('rent dashboard requires authentication', function () {
+test('collection queue requires authentication', function () {
     $this->get(route('dashboard.rent'))->assertRedirect('login');
 });
 
-test('rent dashboard requires dashboard.view permission', function () {
+test('collection queue requires dashboard.view permission', function () {
     $user = User::factory()->create();
 
     $this->actingAs($user)
@@ -200,45 +250,113 @@ test('rent dashboard requires dashboard.view permission', function () {
         ->assertForbidden();
 });
 
-test('rent dashboard shows days overdue correctly', function () {
-    Carbon::setTestNow(now()->setDay(15));
+test('collection queue shows recent payments', function () {
+    Carbon::setTestNow(Carbon::parse('2026-07-10'));
 
     $user = User::factory()->owner()->create();
 
-    createLeaseWithPayment(['rent_due_day' => 10]);
+    $tenant = Tenant::factory()->create(['name' => 'Alex Wijaya']);
+    $lease = Lease::factory()->create([
+        'primary_tenant_id' => $tenant->id,
+        'start_date' => now()->subMonths(2),
+        'status' => 'active',
+    ]);
+    $lease->tenants()->sync([$tenant->id => ['is_primary' => true]]);
+
+    $invoice = Invoice::factory()->create([
+        'lease_id' => $lease->id,
+        'period_start' => '2026-07-01',
+        'period_end' => '2026-07-31',
+        'total' => 500000,
+        'amount_paid' => 500000,
+        'status' => InvoiceStatus::Paid,
+    ]);
+
+    Payment::factory()->create([
+        'invoice_id' => $invoice->id,
+        'amount' => 500000,
+        'payment_date' => '2026-07-08',
+        'payment_method' => 'transfer',
+        'status' => PaymentStatus::Confirmed,
+    ]);
 
     $this->actingAs($user)
         ->get(route('dashboard.rent'))
         ->assertInertia(fn ($page) => $page
-            ->has('entries.data', 1)
-            ->where('entries.data.0.rent_status', 'overdue')
-            ->where('entries.data.0.days_overdue', 5)
+            ->has('recent_payments', 1)
+            ->where('recent_payments.0.tenant_name', 'Alex Wijaya')
+            ->where('recent_payments.0.payment_method', 'transfer')
         );
 
     Carbon::setTestNow();
 });
 
-test('rent dashboard scopes to user properties for non-owner', function () {
-    Carbon::setTestNow(now()->setDay(10));
+test('collection queue shows recent reminders', function () {
+    Carbon::setTestNow(Carbon::parse('2026-07-10'));
+
+    $user = User::factory()->owner()->create();
+
+    $tenant = Tenant::factory()->create(['name' => 'Dewi Lestari']);
+    $lease = Lease::factory()->create([
+        'primary_tenant_id' => $tenant->id,
+        'start_date' => now()->subMonths(2),
+        'status' => 'active',
+    ]);
+    $lease->tenants()->sync([$tenant->id => ['is_primary' => true]]);
+
+    ReminderLog::factory()->create([
+        'lease_id' => $lease->id,
+        'reminder_type' => 'overdue',
+        'channel' => 'whatsapp',
+        'sent_at' => '2026-07-09 10:00:00',
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('dashboard.rent'))
+        ->assertInertia(fn ($page) => $page
+            ->has('recent_reminders', 1)
+            ->where('recent_reminders.0.tenant_name', 'Dewi Lestari')
+            ->where('recent_reminders.0.reminder_type', 'overdue')
+        );
+
+    Carbon::setTestNow();
+});
+
+test('collection queue scopes to user properties for non-owner', function () {
+    Carbon::setTestNow(Carbon::parse('2026-07-10'));
 
     $user = User::factory()->admin()->create();
 
     $propertyA = Property::factory()->create();
-    $tenantA = Tenant::factory()->create();
-    Lease::factory()->create([
-        'unit_id' => Unit::factory()->create(['property_id' => $propertyA->id])->id,
+    $unitA = Unit::factory()->create(['property_id' => $propertyA->id]);
+    $tenantA = Tenant::factory()->create(['name' => 'Budi Property A']);
+    $leaseA = Lease::factory()->create([
+        'unit_id' => $unitA->id,
         'primary_tenant_id' => $tenantA->id,
         'start_date' => now()->subMonths(2),
-        'rent_due_day' => 5,
+        'status' => 'active',
+    ]);
+    $leaseA->tenants()->sync([$tenantA->id => ['is_primary' => true]]);
+    Invoice::factory()->create([
+        'lease_id' => $leaseA->id,
+        'due_date' => '2026-07-05',
+        'status' => InvoiceStatus::Pending,
     ]);
 
     $propertyB = Property::factory()->create();
-    $tenantB = Tenant::factory()->create();
-    Lease::factory()->create([
-        'unit_id' => Unit::factory()->create(['property_id' => $propertyB->id])->id,
+    $unitB = Unit::factory()->create(['property_id' => $propertyB->id]);
+    $tenantB = Tenant::factory()->create(['name' => 'Siti Property B']);
+    $leaseB = Lease::factory()->create([
+        'unit_id' => $unitB->id,
         'primary_tenant_id' => $tenantB->id,
         'start_date' => now()->subMonths(2),
-        'rent_due_day' => 3,
+        'status' => 'active',
+    ]);
+    $leaseB->tenants()->sync([$tenantB->id => ['is_primary' => true]]);
+    Invoice::factory()->create([
+        'lease_id' => $leaseB->id,
+        'due_date' => '2026-07-05',
+        'status' => InvoiceStatus::Pending,
     ]);
 
     $propertyA->users()->attach($user->id);
@@ -248,7 +366,24 @@ test('rent dashboard scopes to user properties for non-owner', function () {
         ->assertOk()
         ->assertInertia(fn ($page) => $page
             ->has('entries.data', 1)
-            ->where('entries.data.0.tenant_name', $tenantA->name)
+            ->where('entries.data.0.tenant_name', 'Budi Property A')
+        );
+
+    Carbon::setTestNow();
+});
+
+test('collection queue shows empty state when no data', function () {
+    Carbon::setTestNow(Carbon::parse('2026-07-10'));
+
+    $user = User::factory()->owner()->create();
+
+    $this->actingAs($user)
+        ->get(route('dashboard.rent'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->has('entries.data', 0)
+            ->has('recent_payments', 0)
+            ->has('recent_reminders', 0)
         );
 
     Carbon::setTestNow();


### PR DESCRIPTION
## OPE-85 — Redesign Rent Dashboard into Billing Operations Workspace

Transforms the flat lease dashboard into an invoice-centric inbox for daily collection work.

### What changed

- **Collection Queue** — invoice-level operational queue instead of lease-level stats table
- **Urgency-colored status** — severity-based colors (90d+, 30-90d, 7-30d, <7d) per row
- **Pill tab filters** — All, Overdue, Due Today, Upcoming, Partial, Paid with badge counts
- **Per-row Record Payment sheet** — opens slide-in form with pre-filled amount, method, date, proof
- **Selection mode** — checkboxes per row, Select All, bulk toolbar
- **Dropdown menu** — View Invoice, View Lease, Send Reminder per row
- **Progress bar** — visual collection progress with processed/remaining count
- **Collapsible activity** — Recent Payments and Reminder Activity collapsed by default
- **Moved to Billing sidebar** — now under Billing > Collection instead of Dashboard > Rent

### Files changed

| File | Change |
|------|--------|
| `app/Business/Dashboard/RentStatsCalculator.php` | Added `computeBillingStats()` |
| `app/Http/Controllers/Dashboard/RentController.php` | Rewrote for invoice-centric workspace with tabs, selection, progress |
| `app/Models/ReminderLog.php` | Added `HasFactory` |
| `database/factories/ReminderLogFactory.php` | New factory |
| `resources/js/components/features/payments/queue-payment-sheet.tsx` | New — inline payment sheet for queue |
| `resources/js/components/features/payments/record-payment-sheet.tsx` | Responsive layout, proof upload |
| `resources/js/pages/dashboard/rent.tsx` | Complete redesign — 600-line Collection Queue page |
| `resources/js/components/features/app/app-sidebar.tsx` | Billing nav section |
| `resources/js/types/dashboard.ts` | New types |
| `tests/Feature/RentDashboardTest.php` | 12 tests for the new workspace |

### Tests

71/71 passing across RentDashboard, InvoiceWorkspace, GenerateInvoices, Payment, Overview test suites.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Collection Queue billing workspace to the dashboard
> - Replaces the Rent dashboard page with a full Collection Queue ([rent.tsx](https://github.com/senatroxx/OpenKos/pull/56/files#diff-a6e8f6af696bce07cc122549dcfadbea86db3c1c773e37407dbaac4278a2e242)) showing invoices grouped by urgency tabs (overdue, due today, upcoming, partial, paid) with per-row actions and bulk selection.
> - Rewrites [`RentController`](https://github.com/senatroxx/OpenKos/pull/56/files#diff-c09b4a8275ee24c109d540f532e272584df397de5f79e6cad26ff9d5f8a51f75) to paginate invoices (default 25/page) scoped to accessible properties, computing outstanding totals, tab counts, progress summary, recent payments, and recent reminders.
> - Adds [`QueuePaymentSheet`](https://github.com/senatroxx/OpenKos/pull/56/files#diff-692984802024b0f93eb18b0a5680178c834d61f452de5e0b1da645b2d0ee93f1) for recording a payment against a specific invoice directly from the queue, defaulting amount to the invoice outstanding and paid-at to today's local date.
> - Moves the nav entry from 'Rent' under 'Dashboard' to a new 'Billing' section with a 'Collection' child in the sidebar.
> - Adds `ReminderLogFactory` and applies `HasFactory` to `ReminderLog` to support test setup; updates all feature tests to assert the new invoice-centric response shape.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ac8c6f6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->