### PR TITLE
feat(OPE-84): redesign overview dashboard as operational command center

### DIFF
--- a/app/Http/Controllers/Dashboard/OverviewController.php
+++ b/app/Http/Controllers/Dashboard/OverviewController.php
@@ -4,10 +4,20 @@ namespace App\Http\Controllers\Dashboard;
 
 use App\Business\Dashboard\OverviewStatsCalculator;
 use App\Enums\LeaseStatus;
+use App\Enums\MaintenanceStatus;
 use App\Enums\UnitStatus;
 use App\Http\Controllers\Controller;
+use App\Models\AuditLog;
+use App\Models\Invoice;
 use App\Models\Lease;
+use App\Models\LeaseUnitHistory;
+use App\Models\MaintenanceTicket;
 use App\Models\Property;
+use App\Models\PropertyType;
+use App\Models\Region;
+use App\Models\Setting;
+use App\Models\Unit;
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
@@ -54,9 +64,84 @@ class OverviewController extends Controller
         $activeLeases = Lease::where('status', LeaseStatus::Active->value)
             ->whereHas('unit.property', fn (Builder $q) => $q->whereIn('id', $accessibleProperties));
 
+        $invoiceScope = Invoice::whereHas('lease', fn (Builder $q) => $q
+            ->where('status', LeaseStatus::Active->value)
+            ->whereHas('unit.property', fn (Builder $q) => $q->whereIn('id', $accessibleProperties)));
+
+        $overdueInvoices = (clone $invoiceScope)
+            ->payable()
+            ->whereDate('due_date', '<', now())
+            ->selectRaw('COUNT(*) as count, COALESCE(SUM(total - amount_paid), 0) as amount')
+            ->first();
+
+        $dueTodayInvoices = (clone $invoiceScope)
+            ->payable()
+            ->whereDate('due_date', now())
+            ->count();
+
+        $openMaintenance = MaintenanceTicket::whereIn('property_id', $accessibleProperties)
+            ->whereIn('status', [MaintenanceStatus::Reported->value, MaintenanceStatus::InProgress->value])
+            ->count();
+
+        $leasesEndingSoon = (clone $activeLeases)
+            ->whereDate('end_date', '<=', Carbon::today()->addDays(30))
+            ->whereDate('end_date', '>', Carbon::today())
+            ->count();
+
+        $attention = [
+            'overdue_invoices' => [
+                'count' => (int) ($overdueInvoices->count ?? 0),
+                'amount' => (int) ($overdueInvoices->amount ?? 0),
+            ],
+            'due_today' => $dueTodayInvoices,
+            'open_maintenance' => $openMaintenance,
+            'leases_ending_soon' => $leasesEndingSoon,
+        ];
+
+        $recentActivity = AuditLog::with('auditable')
+            ->latest()
+            ->take(10)
+            ->get()
+            ->map(fn (AuditLog $log) => [
+                'id' => $log->id,
+                'description' => $this->describeAudit($log),
+                'created_at' => $log->created_at->toISOString(),
+                'subject_type' => $log->auditable_type,
+            ])
+            ->values()
+            ->toArray();
+
+        $ticketFormUnits = Unit::query()
+            ->select(['id', 'slug', 'name', 'property_id', 'status'])
+            ->withCount(['leases as active_lease_count' => fn (Builder $q) => $q->where('status', LeaseStatus::Active->value)])
+            ->with(['leases' => fn ($q) => $q->where('status', LeaseStatus::Active->value)->with('tenants:id,name')])
+            ->addSelect([
+                'has_maintenance_transfer' => LeaseUnitHistory::query()
+                    ->selectRaw('1')
+                    ->whereColumn('from_unit_id', 'units.id')
+                    ->where('reason', 'maintenance')
+                    ->limit(1),
+            ])
+            ->whereIn('property_id', $accessibleProperties)
+            ->orderBy('name')
+            ->get();
+
+        $ticketFormProperties = Property::query()
+            ->whereIn('id', $accessibleProperties)
+            ->orderBy('name')
+            ->get(['id', 'name']);
+
+        $countryCode = Setting::get('country_code', 'ID');
+        $regions = Region::where('country_code', $countryCode)
+            ->orderBy('name')
+            ->get(['id', 'name']);
+
+        $propertyTypes = PropertyType::active()->ordered()->get(['slug', 'label']);
+
         $financeResult = $finance->computeFinance($activeLeases);
 
         return Inertia::render('dashboard/overview', [
+            'attention' => $attention,
             'finance' => $financeResult,
             'stats' => [
                 'total_units' => $totalUnits,
@@ -80,6 +165,28 @@ class OverviewController extends Controller
                         : 0,
                 ])->values()->toArray(),
             ],
+            'recent_activity' => $recentActivity,
+            'properties' => $ticketFormProperties,
+            'units' => $ticketFormUnits,
+            'regions' => $regions,
+            'propertyTypes' => $propertyTypes,
         ]);
+    }
+
+    private function describeAudit(AuditLog $log): string
+    {
+        $model = class_basename($log->auditable_type);
+        $op = match ($log->operation) {
+            'created' => 'created',
+            'updated' => 'updated',
+            'deleted' => 'deleted',
+            default => $log->operation,
+        };
+
+        if ($model) {
+            return ucfirst($model).' '.$op;
+        }
+
+        return ucfirst($log->operation);
     }
 }

--- a/app/Http/Controllers/Dashboard/OverviewController.php
+++ b/app/Http/Controllers/Dashboard/OverviewController.php
@@ -180,7 +180,7 @@ class OverviewController extends Controller
 
     private function describeAudit(AuditLog $log): string
     {
-        $model = class_basename($log->auditable_type);
+        $model = $log->auditable_type ? class_basename($log->auditable_type) : null;
         $op = match ($log->operation) {
             'create' => 'created',
             'update' => 'updated',

--- a/app/Http/Controllers/Dashboard/OverviewController.php
+++ b/app/Http/Controllers/Dashboard/OverviewController.php
@@ -47,7 +47,7 @@ class OverviewController extends Controller
                     ->whereDoesntHave('leases', fn (Builder $q) => $q->where('status', LeaseStatus::Active->value)),
             ])
             ->orderBy('name')
-            ->get(['id', 'name']);
+            ->get(['id', 'name', 'slug']);
 
         $totalUnits = $properties->sum('units_count');
         $occupiedUnits = $properties->sum('occupied_units_count');
@@ -98,7 +98,11 @@ class OverviewController extends Controller
             'leases_ending_soon' => $leasesEndingSoon,
         ];
 
-        $recentActivity = AuditLog::with('auditable')
+        $recentActivity = AuditLog::query()
+            ->when(! $request->user()->isOwner(), fn (Builder $q) => $q
+                ->where('actor_type', $request->user()->getMorphClass())
+                ->where('actor_id', $request->user()->id),
+            )
             ->latest()
             ->take(10)
             ->get()
@@ -155,6 +159,7 @@ class OverviewController extends Controller
                 'properties' => $properties->map(fn (Property $p) => [
                     'id' => $p->id,
                     'name' => $p->name,
+                    'slug' => $p->slug,
                     'total_units' => $p->units_count,
                     'occupied_units' => $p->occupied_units_count,
                     'available_units' => $p->units_count - $p->occupied_units_count - $p->maintenance_units_count - $p->unavailable_units_count,
@@ -177,9 +182,9 @@ class OverviewController extends Controller
     {
         $model = class_basename($log->auditable_type);
         $op = match ($log->operation) {
-            'created' => 'created',
-            'updated' => 'updated',
-            'deleted' => 'deleted',
+            'create' => 'created',
+            'update' => 'updated',
+            'delete' => 'deleted',
             default => $log->operation,
         };
 

--- a/resources/js/pages/dashboard/overview.tsx
+++ b/resources/js/pages/dashboard/overview.tsx
@@ -288,7 +288,7 @@ function StatCard({
 function PropertyCard({ property }: { property: PropertyStats }) {
     return (
         <Link
-            href={`/properties/${property.id}`}
+            href={`/properties/${property.slug}`}
             className="block rounded-xl border border-sidebar-border/70 p-5 transition-colors hover:bg-accent dark:border-sidebar-border"
         >
             <h3 className="truncate text-sm font-semibold">{property.name}</h3>

--- a/resources/js/pages/dashboard/overview.tsx
+++ b/resources/js/pages/dashboard/overview.tsx
@@ -1,70 +1,140 @@
-import { Head } from '@inertiajs/react';
+import { Head, Link } from '@inertiajs/react';
+import { useState } from 'react';
+import { PropertyFormSheet, TenantFormSheet, TicketFormSheet } from '@/components/features';
 import { formatRupiah } from '@/lib/formatters';
 import { dashboard } from '@/routes';
-import type { Finance, PropertyStats, Stats } from '@/types';
+import type { Finance, PropertyStats, RecentActivityEntry, Stats } from '@/types';
+
+interface Attention {
+    overdue_invoices: { count: number; amount: number };
+    due_today: number;
+    open_maintenance: number;
+    leases_ending_soon: number;
+}
+
+type MaintenanceProperty = { id: number; name: string };
+type MaintenanceUnit = {
+    id: number;
+    slug: string;
+    name: string;
+    property_id: number;
+    status: string;
+    active_lease_count: number;
+    has_maintenance_transfer?: number;
+    leases?: { tenants: { id: number; name: string }[] }[];
+};
 
 export default function Overview({
+    attention,
     finance,
     stats,
+    recent_activity,
+    properties,
+    units,
 }: {
+    attention: Attention;
     finance: Finance;
     stats: Stats;
+    recent_activity: RecentActivityEntry[];
+    properties: MaintenanceProperty[];
+    units: MaintenanceUnit[];
 }) {
+    const [tenantSheetOpen, setTenantSheetOpen] = useState(false);
+    const [propertySheetOpen, setPropertySheetOpen] = useState(false);
+    const [ticketSheetOpen, setTicketSheetOpen] = useState(false);
+
     return (
         <>
             <Head title="Dashboard" />
             <div className="flex h-full flex-1 flex-col gap-6 overflow-x-auto rounded-xl p-4">
-                <div className="grid gap-4 md:grid-cols-4">
-                    <StatCard
-                        label="Occupied Units"
-                        value={stats.occupied_units}
-                        bgColor="bg-blue-50 dark:bg-blue-950/20"
-                    />
-                    <StatCard
-                        label="Available Units"
-                        value={stats.available_units}
-                        bgColor="bg-green-50 dark:bg-green-950/20"
-                    />
-                    <StatCard
-                        label="Maintenance"
-                        value={stats.maintenance_units}
-                        bgColor="bg-amber-50 dark:bg-amber-950/20"
-                    />
-                    <StatCard
-                        label="Occupancy Rate"
-                        value={stats.occupancy_percentage}
-                        bgColor="bg-indigo-50 dark:bg-indigo-950/20"
-                        isPercentage
-                    />
-                </div>
 
-                <div className="grid gap-4 md:grid-cols-4">
-                    <StatCard
-                        label="Revenue This Month"
-                        value={formatRupiah(finance.revenue_this_month)}
-                        bgColor="bg-emerald-50 dark:bg-emerald-950/20"
-                    />
-                    <StatCard
-                        label="Monthly Potential"
-                        value={formatRupiah(finance.monthly_potential)}
-                        bgColor="bg-violet-50 dark:bg-violet-950/20"
-                    />
-                    <StatCard
-                        label="Outstanding"
-                        value={formatRupiah(finance.outstanding)}
-                        bgColor="bg-rose-50 dark:bg-rose-950/20"
-                    />
-                    <StatCard
-                        label="Collection Rate"
-                        value={finance.collection_rate}
-                        bgColor="bg-cyan-50 dark:bg-cyan-950/20"
-                        isPercentage
-                    />
-                </div>
-
-                <div>
+                <section>
                     <h2 className="mb-4 text-sm font-medium tracking-wider text-muted-foreground uppercase">
-                        Per Property
+                        Today&apos;s Attention
+                    </h2>
+                    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                        <AttentionCard
+                            label="Overdue Invoices"
+                            count={attention.overdue_invoices.count}
+                            amount={attention.overdue_invoices.amount}
+                            bgColor="bg-rose-50 dark:bg-rose-950/20"
+                            textColor="text-rose-600 dark:text-rose-400"
+                        />
+                        <AttentionCard
+                            label="Due Today"
+                            count={attention.due_today}
+                            bgColor="bg-amber-50 dark:bg-amber-950/20"
+                            textColor="text-amber-600 dark:text-amber-400"
+                        />
+                        <AttentionCard
+                            label="Open Maintenance"
+                            count={attention.open_maintenance}
+                            bgColor="bg-orange-50 dark:bg-orange-950/20"
+                            textColor="text-orange-600 dark:text-orange-400"
+                        />
+                        <AttentionCard
+                            label="Leases Ending Soon"
+                            count={attention.leases_ending_soon}
+                            bgColor="bg-sky-50 dark:bg-sky-950/20"
+                            textColor="text-sky-600 dark:text-sky-400"
+                        />
+                    </div>
+                </section>
+
+                <section>
+                    <h2 className="mb-4 text-sm font-medium tracking-wider text-muted-foreground uppercase">
+                        Quick Access
+                    </h2>
+                    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+                        <QuickAccessButton
+                            label="Add Tenant"
+                            onClick={() => setTenantSheetOpen(true)}
+                        />
+                        <QuickAccessButton
+                            label="Add Property"
+                            onClick={() => setPropertySheetOpen(true)}
+                        />
+                        <QuickAccessButton
+                            label="Report Maintenance"
+                            onClick={() => setTicketSheetOpen(true)}
+                        />
+                        <QuickAccessLink label="Assign Tenant" href="/tenants" />
+                        <QuickAccessLink label="Collect Rent" href="/dashboard/rent" />
+                    </div>
+                </section>
+
+                <section>
+                    <h2 className="mb-4 text-sm font-medium tracking-wider text-muted-foreground uppercase">
+                        Business Health
+                    </h2>
+                    <div className="grid gap-4 md:grid-cols-4">
+                        <StatCard
+                            label="Revenue This Month"
+                            value={formatRupiah(finance.revenue_this_month)}
+                            bgColor="bg-emerald-50 dark:bg-emerald-950/20"
+                        />
+                        <StatCard
+                            label="Monthly Potential"
+                            value={formatRupiah(finance.monthly_potential)}
+                            bgColor="bg-violet-50 dark:bg-violet-950/20"
+                        />
+                        <StatCard
+                            label="Outstanding"
+                            value={formatRupiah(finance.outstanding)}
+                            bgColor="bg-rose-50 dark:bg-rose-950/20"
+                        />
+                        <StatCard
+                            label="Collection Rate"
+                            value={finance.collection_rate}
+                            bgColor="bg-cyan-50 dark:bg-cyan-950/20"
+                            isPercentage
+                        />
+                    </div>
+                </section>
+
+                <section>
+                    <h2 className="mb-4 text-sm font-medium tracking-wider text-muted-foreground uppercase">
+                        Property Overview
                     </h2>
                     <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
                         {stats.properties.map((property) => (
@@ -74,9 +144,109 @@ export default function Overview({
                             />
                         ))}
                     </div>
-                </div>
+                </section>
+
+                {recent_activity.length > 0 && (
+                    <section>
+                        <h2 className="mb-4 text-sm font-medium tracking-wider text-muted-foreground uppercase">
+                            Recent Activity
+                        </h2>
+                        <div className="rounded-xl border border-sidebar-border/70 p-4 dark:border-sidebar-border">
+                            <div className="space-y-3">
+                                {recent_activity.map((entry) => (
+                                    <div
+                                        key={entry.id}
+                                        className="flex items-center gap-3 text-sm"
+                                    >
+                                        <div className="h-2 w-2 shrink-0 rounded-full bg-muted-foreground/40" />
+                                        <span className="text-foreground">{entry.description}</span>
+                                        <span className="ml-auto shrink-0 text-xs text-muted-foreground tabular-nums">
+                                            {relativeTime(entry.created_at)}
+                                        </span>
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    </section>
+                )}
             </div>
+
+            <TenantFormSheet
+                open={tenantSheetOpen}
+                onOpenChange={setTenantSheetOpen}
+            />
+            <PropertyFormSheet
+                open={propertySheetOpen}
+                onOpenChange={setPropertySheetOpen}
+            />
+            <TicketFormSheet
+                open={ticketSheetOpen}
+                onOpenChange={setTicketSheetOpen}
+                properties={properties}
+                units={units}
+            />
         </>
+    );
+}
+
+function AttentionCard({
+    label,
+    count,
+    amount,
+    bgColor,
+    textColor,
+}: {
+    label: string;
+    count: number;
+    amount?: number;
+    bgColor: string;
+    textColor: string;
+}) {
+    return (
+        <div
+            className={`rounded-xl border border-sidebar-border/70 p-5 dark:border-sidebar-border ${bgColor}`}
+        >
+            <p className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
+                {label}
+            </p>
+            <p className={`mt-2 text-3xl font-bold tabular-nums ${textColor}`}>
+                {count}
+            </p>
+            {amount !== undefined && amount > 0 && (
+                <p className="mt-1 text-sm text-muted-foreground">
+                    {formatRupiah(amount)}
+                </p>
+            )}
+        </div>
+    );
+}
+
+function QuickAccessButton({
+    label,
+    onClick,
+}: {
+    label: string;
+    onClick: () => void;
+}) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className="flex cursor-pointer items-center justify-center rounded-xl border border-sidebar-border/70 p-4 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground dark:border-sidebar-border"
+        >
+            {label}
+        </button>
+    );
+}
+
+function QuickAccessLink({ label, href }: { label: string; href: string }) {
+    return (
+        <Link
+            href={href}
+            className="flex items-center justify-center rounded-xl border border-sidebar-border/70 p-4 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground dark:border-sidebar-border"
+        >
+            {label}
+        </Link>
     );
 }
 
@@ -117,7 +287,10 @@ function StatCard({
 
 function PropertyCard({ property }: { property: PropertyStats }) {
     return (
-        <div className="rounded-xl border border-sidebar-border/70 p-5 dark:border-sidebar-border">
+        <Link
+            href={`/properties/${property.id}`}
+            className="block rounded-xl border border-sidebar-border/70 p-5 transition-colors hover:bg-accent dark:border-sidebar-border"
+        >
             <h3 className="truncate text-sm font-semibold">{property.name}</h3>
 
             <div className="mt-4 grid grid-cols-2 gap-4">
@@ -161,8 +334,32 @@ function PropertyCard({ property }: { property: PropertyStats }) {
                     />
                 </div>
             </div>
-        </div>
+        </Link>
     );
+}
+
+function relativeTime(iso: string): string {
+    const then = new Date(iso).getTime();
+    const now = Date.now();
+    const diff = Math.floor((now - then) / 1000);
+
+    if (diff < 60) {
+        return 'just now';
+    }
+
+    if (diff < 3600) {
+        return `${Math.floor(diff / 60)}m ago`;
+    }
+
+    if (diff < 86400) {
+        return `${Math.floor(diff / 3600)}h ago`;
+    }
+
+    if (diff < 2592000) {
+        return `${Math.floor(diff / 86400)}d ago`;
+    }
+
+    return `${Math.floor(diff / 2592000)}mo ago`;
 }
 
 Overview.layout = {

--- a/resources/js/types/dashboard.ts
+++ b/resources/js/types/dashboard.ts
@@ -94,3 +94,17 @@ export type CollectionProgress = {
     monthly_potential: number;
     collection_rate: number;
 };
+
+export type AttentionItem = {
+    label: string;
+    count: number;
+    amount?: number;
+    href: string;
+};
+
+export type RecentActivityEntry = {
+    id: number;
+    description: string;
+    created_at: string;
+    subject_type: string | null;
+};

--- a/resources/js/types/dashboard.ts
+++ b/resources/js/types/dashboard.ts
@@ -1,6 +1,7 @@
 export type PropertyStats = {
     id: number;
     name: string;
+    slug: string;
     total_units: number;
     occupied_units: number;
     available_units: number;

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -197,9 +197,9 @@ test('dashboard shows overdue invoice count and amount in attention', function (
         'status' => InvoiceStatus::Partial,
     ]);
 
-    Lease::factory()->create(['status' => LeaseStatus::Active->value, 'start_date' => now()->subMonths(2)]);
+    $lease2 = Lease::factory()->create(['status' => LeaseStatus::Active->value, 'start_date' => now()->subMonths(2)]);
     Invoice::factory()->create([
-        'lease_id' => $lease->id,
+        'lease_id' => $lease2->id,
         'due_date' => '2026-07-05',
         'total' => 200000,
         'amount_paid' => 0,

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -1,8 +1,14 @@
 <?php
 
+use App\Enums\InvoiceStatus;
+use App\Enums\LeaseStatus;
+use App\Models\Invoice;
+use App\Models\Lease;
+use App\Models\MaintenanceTicket;
 use App\Models\Property;
 use App\Models\Unit;
 use App\Models\User;
+use Carbon\Carbon;
 use Database\Seeders\RegionAndCitySeeder;
 use Database\Seeders\RoleAndPermissionSeeder;
 
@@ -175,4 +181,167 @@ test('dashboard requires dashboard.view permission', function () {
     $this->actingAs($user)
         ->get(route('dashboard'))
         ->assertForbidden();
+});
+
+test('dashboard shows overdue invoice count and amount in attention', function () {
+    Carbon::setTestNow(Carbon::parse('2026-07-10'));
+
+    $user = User::factory()->owner()->create();
+
+    $lease = Lease::factory()->create(['status' => LeaseStatus::Active->value, 'start_date' => now()->subMonths(2)]);
+    Invoice::factory()->create([
+        'lease_id' => $lease->id,
+        'due_date' => '2026-07-03',
+        'total' => 500000,
+        'amount_paid' => 100000,
+        'status' => InvoiceStatus::Partial,
+    ]);
+
+    Lease::factory()->create(['status' => LeaseStatus::Active->value, 'start_date' => now()->subMonths(2)]);
+    Invoice::factory()->create([
+        'lease_id' => $lease->id,
+        'due_date' => '2026-07-05',
+        'total' => 200000,
+        'amount_paid' => 0,
+        'status' => InvoiceStatus::Pending,
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('attention.overdue_invoices.count', 2)
+            ->where('attention.overdue_invoices.amount', 600000)
+        );
+
+    Carbon::setTestNow();
+});
+
+test('dashboard shows due today count in attention', function () {
+    Carbon::setTestNow(Carbon::parse('2026-07-10'));
+
+    $user = User::factory()->owner()->create();
+
+    $lease = Lease::factory()->create(['status' => LeaseStatus::Active->value, 'start_date' => now()->subMonths(2)]);
+    Invoice::factory()->create([
+        'lease_id' => $lease->id,
+        'due_date' => '2026-07-10',
+        'total' => 300000,
+        'amount_paid' => 0,
+        'status' => InvoiceStatus::Pending,
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('attention.due_today', 1)
+        );
+
+    Carbon::setTestNow();
+});
+
+test('dashboard shows open maintenance count in attention', function () {
+    $user = User::factory()->owner()->create();
+
+    $property = Property::factory()->create();
+    $unit = Unit::factory()->create(['property_id' => $property->id]);
+    MaintenanceTicket::factory()->create([
+        'property_id' => $property->id,
+        'unit_id' => $unit->id,
+        'status' => 'reported',
+    ]);
+    MaintenanceTicket::factory()->create([
+        'property_id' => $property->id,
+        'unit_id' => $unit->id,
+        'status' => 'in_progress',
+    ]);
+    MaintenanceTicket::factory()->create([
+        'property_id' => $property->id,
+        'unit_id' => $unit->id,
+        'status' => 'resolved',
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('attention.open_maintenance', 2)
+        );
+});
+
+test('dashboard shows leases ending soon count in attention', function () {
+    Carbon::setTestNow(Carbon::parse('2026-07-10'));
+
+    $user = User::factory()->owner()->create();
+
+    Lease::factory()->create([
+        'status' => LeaseStatus::Active->value,
+        'start_date' => now()->subMonths(6),
+        'end_date' => '2026-07-20',
+    ]);
+    Lease::factory()->create([
+        'status' => LeaseStatus::Active->value,
+        'start_date' => now()->subMonths(6),
+        'end_date' => '2026-08-05',
+    ]);
+    Lease::factory()->create([
+        'status' => LeaseStatus::Active->value,
+        'start_date' => now()->subMonths(6),
+        'end_date' => '2026-09-01',
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('attention.leases_ending_soon', 2)
+        );
+
+    Carbon::setTestNow();
+});
+
+test('dashboard includes recent activity from audit log', function () {
+    Carbon::setTestNow(Carbon::parse('2026-07-10'));
+
+    $user = User::factory()->owner()->create();
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->has('recent_activity')
+        );
+
+    Carbon::setTestNow();
+});
+
+test('dashboard attention shows zeros when no actionable items exist', function () {
+    $user = User::factory()->owner()->create();
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('attention.overdue_invoices.count', 0)
+            ->where('attention.overdue_invoices.amount', 0)
+            ->where('attention.due_today', 0)
+            ->where('attention.open_maintenance', 0)
+            ->where('attention.leases_ending_soon', 0)
+        );
+});
+
+test('dashboard returns properties and units for maintenance sheet', function () {
+    $user = User::factory()->owner()->create();
+
+    $property = Property::factory()->create();
+    Unit::factory()->create(['property_id' => $property->id, 'status' => 'available']);
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->has('properties')
+            ->has('units')
+        );
 });


### PR DESCRIPTION
## What

Redesigns the Overview Dashboard from a KPI-oriented page into an operational Command Center that answers "What should I do today?" before "How is my business performing?"

### Sections (ordered by priority)

1. **Today's Attention** — overdue invoice count/amount, due today count, open maintenance count, leases ending soon count
2. **Quick Access** — sheet-based creation (Add Tenant, Add Property, Report Maintenance) + workspace navigation (Assign Tenant → /tenants, Collect Rent → /dashboard/rent)
3. **Business Health** — 4 KPIs (revenue, potential, outstanding, collection rate)
4. **Property Overview** — per-property cards (now clickable, link to property workspace)
5. **Recent Activity** — timeline of last 10 audit log entries with relative timestamps

### Files changed
- `app/Http/Controllers/Dashboard/OverviewController.php` — added queries for attention data, recent activity, properties/units/regions/propertyTypes for sheet components
- `resources/js/pages/dashboard/overview.tsx` — restructured into 5 sections with sheets and navigation links
- `resources/js/types/dashboard.ts` — added `AttentionItem`, `RecentActivityEntry` types
- `tests/Feature/DashboardTest.php` — 7 new tests for attention counts, zero state, and new props

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Redesign overview dashboard as an operational command center with attention metrics and quick access actions
> - Adds a "Today's Attention" section to the dashboard with overdue invoices (count + amount), due-today invoices, open maintenance tickets, and active leases ending within 30 days, computed in [`OverviewController`](https://github.com/senatroxx/OpenKos/pull/57/files#diff-e6eb2e310bc741b9d12ca147838c3dc3ff6de09bf2d5258467528864366807de).
> - Adds a "Quick Access" section with buttons/links to open tenant, property, and ticket creation sheets directly from the dashboard.
> - Adds a "Recent Activity" feed derived from audit logs, with human-readable descriptions and relative timestamps (e.g. '5m ago').
> - Clicking a property card now navigates to `/properties/{slug}`.
> - Covers the new metrics with feature tests in [`DashboardTest.php`](https://github.com/senatroxx/OpenKos/pull/57/files#diff-71491292b9092a8a2b6800d7e69a10bc281450d09e8797956f4f6cd2029fd14d) using deterministic dates via `Carbon::setTestNow`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 012caf4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->