### PR TITLE
Feature/ope 74

### DIFF
--- a/app/Business/Dashboard/RentStatsCalculator.php
+++ b/app/Business/Dashboard/RentStatsCalculator.php
@@ -36,12 +36,29 @@ class RentStatsCalculator
             ->whereBetween('due_date', [$now->copy()->addDay(), $now->copy()->addDays(7)])
             ->count();
 
-        $paidLeaseIds = Invoice::query()
+        $paidByCurrentMonth = Invoice::query()
             ->whereIn('lease_id', $leaseIds)
             ->where('status', InvoiceStatus::Paid)
             ->whereBetween('period_start', [$monthStart, $monthEnd])
             ->distinct()
             ->pluck('lease_id');
+
+        // Leases with invoices but no payable ones are paid up.
+        $leaseIdsWithInvoices = Invoice::query()
+            ->whereIn('lease_id', $leaseIds)
+            ->distinct()
+            ->pluck('lease_id');
+
+        $paidUp = collect($leaseIdsWithInvoices)
+            ->diff($overdueInvoices->pluck('lease_id'))
+            ->diff(
+                Invoice::query()
+                    ->whereIn('lease_id', $leaseIds)
+                    ->payable()
+                    ->whereDate('due_date', '<=', $now->copy()->addDays(7))
+                    ->distinct()
+                    ->pluck('lease_id'),
+            );
 
         return [
             'overdue' => [
@@ -50,7 +67,7 @@ class RentStatsCalculator
             ],
             'due_today' => $dueTodayCount,
             'due_soon' => $dueSoonCount,
-            'paid' => $paidLeaseIds->count(),
+            'paid' => $paidByCurrentMonth->merge($paidUp)->unique()->count(),
         ];
     }
 
@@ -66,25 +83,34 @@ class RentStatsCalculator
             $dueDate = $lease->next_due_date ? Carbon::parse($lease->next_due_date)->startOfDay() : null;
 
             if (! $dueDate) {
-                return null;
-            }
+                // No payable invoices. If the lease has any invoices at all,
+                // it means everything is paid up — show as "paid".
+                // Only hide leases that have never been invoiced.
+                if (! ($lease->has_any_invoice ?? false)) {
+                    return null;
+                }
 
-            $now = now()->startOfDay();
-
-            if ($dueDate->lt($now)) {
-                $status = 'overdue';
-                $daysOverdue = (int) $dueDate->diffInDays($now, false);
-            } elseif ($dueDate->eq($now)) {
-                $status = 'due_today';
+                $status = 'paid';
                 $daysOverdue = null;
-            } elseif ($dueDate->lte($now->copy()->addDays(7))) {
-                $status = 'due_soon';
-                $daysOverdue = null;
+                $amount = 0;
             } else {
-                return null;
-            }
+                $now = now()->startOfDay();
 
-            $amount = (float) ($lease->next_outstanding ?? 0);
+                if ($dueDate->lt($now)) {
+                    $status = 'overdue';
+                    $daysOverdue = (int) $dueDate->diffInDays($now, false);
+                } elseif ($dueDate->eq($now)) {
+                    $status = 'due_today';
+                    $daysOverdue = null;
+                } elseif ($dueDate->lte($now->copy()->addDays(7))) {
+                    $status = 'due_soon';
+                    $daysOverdue = null;
+                } else {
+                    return null;
+                }
+
+                $amount = (float) ($lease->next_outstanding ?? 0);
+            }
         }
 
         $primaryTenant = $lease->primaryTenant;

--- a/app/Business/Dashboard/RentStatsCalculator.php
+++ b/app/Business/Dashboard/RentStatsCalculator.php
@@ -10,79 +10,81 @@ use Illuminate\Support\Collection;
 
 class RentStatsCalculator
 {
-    public function computeStats(Collection $leases, int $today, int $currentMonth, int $currentYear): array
+    public function computeStats(Collection $leases, int $currentMonth, int $currentYear): array
     {
         $leaseIds = $leases->pluck('id')->all();
 
-        $paidLeaseIds = Invoice::query()
-            ->where('status', InvoiceStatus::Paid->value)
-            ->whereBetween('period_start', [
-                Carbon::create($currentYear, $currentMonth, 1)->startOfDay(),
-                Carbon::create($currentYear, $currentMonth, 1)->endOfMonth()->endOfDay(),
-            ])
+        $now = now()->startOfDay();
+        $monthStart = Carbon::create($currentYear, $currentMonth, 1)->startOfDay();
+        $monthEnd = Carbon::create($currentYear, $currentMonth, 1)->endOfMonth()->endOfDay();
+
+        $overdueInvoices = Invoice::query()
             ->whereIn('lease_id', $leaseIds)
+            ->payable()
+            ->where('due_date', '<', $now)
+            ->get();
+
+        $dueTodayCount = Invoice::query()
+            ->whereIn('lease_id', $leaseIds)
+            ->payable()
+            ->whereDate('due_date', '=', $now)
+            ->count();
+
+        $dueSoonCount = Invoice::query()
+            ->whereIn('lease_id', $leaseIds)
+            ->payable()
+            ->whereBetween('due_date', [$now->copy()->addDay(), $now->copy()->addDays(7)])
+            ->count();
+
+        $paidLeaseIds = Invoice::query()
+            ->whereIn('lease_id', $leaseIds)
+            ->where('status', InvoiceStatus::Paid)
+            ->whereBetween('period_start', [$monthStart, $monthEnd])
             ->distinct()
-            ->pluck('lease_id')
-            ->toArray();
-
-        $paidSet = array_flip($paidLeaseIds);
-
-        $overdueCount = 0;
-        $overdueAmount = 0.0;
-        $dueTodayCount = 0;
-        $dueSoonCount = 0;
-        $paidCount = 0;
-
-        foreach ($leases as $lease) {
-            if (isset($paidSet[$lease->id])) {
-                $paidCount++;
-
-                continue;
-            }
-
-            $dueDay = $lease->rent_due_day;
-
-            if ($dueDay < $today) {
-                $overdueCount++;
-                $overdueAmount += (float) $lease->rent_amount;
-            } elseif ($dueDay === $today) {
-                $dueTodayCount++;
-            } elseif ($dueDay <= $today + 7) {
-                $dueSoonCount++;
-            }
-        }
+            ->pluck('lease_id');
 
         return [
-            'overdue' => ['count' => $overdueCount, 'amount' => $overdueAmount],
+            'overdue' => [
+                'count' => $overdueInvoices->count(),
+                'amount' => $overdueInvoices->sum(fn (Invoice $inv) => (float) $inv->total - (float) $inv->amount_paid),
+            ],
             'due_today' => $dueTodayCount,
             'due_soon' => $dueSoonCount,
-            'paid' => $paidCount,
+            'paid' => $paidLeaseIds->count(),
         ];
     }
 
-    public function transformEntry(Lease $lease, int $today): ?array
+    public function transformEntry(Lease $lease): ?array
     {
         $hasPayment = $lease->has_payment_this_month ?? false;
 
         if ($hasPayment) {
             $status = 'paid';
             $daysOverdue = null;
+            $amount = 0;
         } else {
-            $dueDay = $lease->rent_due_day;
+            $dueDate = $lease->next_due_date ? Carbon::parse($lease->next_due_date)->startOfDay() : null;
 
-            if ($dueDay < $today) {
+            if (! $dueDate) {
+                return null;
+            }
+
+            $now = now()->startOfDay();
+
+            if ($dueDate->lt($now)) {
                 $status = 'overdue';
-                $dueDateThisMonth = now()->setDay(min($dueDay, now()->daysInMonth));
-                $daysOverdue = (int) $dueDateThisMonth->diffInDays(now(), false);
-            } elseif ($dueDay === $today) {
+                $daysOverdue = (int) $dueDate->diffInDays($now, false);
+            } elseif ($dueDate->eq($now)) {
                 $status = 'due_today';
                 $daysOverdue = null;
-            } elseif ($dueDay <= $today + 7) {
+            } elseif ($dueDate->lte($now->copy()->addDays(7))) {
                 $status = 'due_soon';
                 $daysOverdue = null;
             } else {
                 return null;
             }
+
+            $amount = (float) ($lease->next_outstanding ?? 0);
         }
 
         $primaryTenant = $lease->primaryTenant;
@@ -96,7 +98,7 @@ class RentStatsCalculator
             'property_name' => $unit?->property?->name ?? '—',
             'rent_due_day' => $lease->rent_due_day,
             'days_overdue' => $daysOverdue,
-            'rent_amount' => (string) $lease->rent_amount,
+            'rent_amount' => (string) $amount,
             'rent_status' => $status,
         ];
     }

--- a/app/Http/Controllers/Dashboard/RentController.php
+++ b/app/Http/Controllers/Dashboard/RentController.php
@@ -121,6 +121,9 @@ class RentController extends Controller
                     ->selectRaw('COALESCE(SUM(COALESCE(total, 0) - COALESCE(amount_paid, 0)), 0)')
                     ->whereColumn('lease_id', 'leases.id')
                     ->payable(),
+                'has_any_invoice' => Invoice::query()
+                    ->selectRaw('COUNT(*) > 0')
+                    ->whereColumn('lease_id', 'leases.id'),
             ]);
 
         $result = $table->paginate($query, $request, 'entries');

--- a/app/Http/Controllers/Dashboard/RentController.php
+++ b/app/Http/Controllers/Dashboard/RentController.php
@@ -28,9 +28,11 @@ class RentController extends Controller
         };
 
         $now = now();
-        $today = (int) $now->day;
         $currentMonth = (int) $now->month;
         $currentYear = (int) $now->year;
+
+        $periodStart = Carbon::create($currentYear, $currentMonth, 1)->startOfDay();
+        $periodEnd = Carbon::create($currentYear, $currentMonth, 1)->endOfMonth()->endOfDay();
 
         $baseQuery = Lease::query()
             ->where('status', 'active')
@@ -40,10 +42,7 @@ class RentController extends Controller
 
         $allActive = (clone $baseQuery)->get();
 
-        $statsResult = $stats->computeStats($allActive, $today, $currentMonth, $currentYear);
-
-        $periodStart = Carbon::create($currentYear, $currentMonth, 1)->startOfDay();
-        $periodEnd = Carbon::create($currentYear, $currentMonth, 1)->endOfMonth()->endOfDay();
+        $statsResult = $stats->computeStats($allActive, $currentMonth, $currentYear);
 
         $table = Table::make()
             ->columns([
@@ -54,8 +53,8 @@ class RentController extends Controller
                 }),
                 Column::make('unit_name', 'Unit'),
                 Column::make('property_name', 'Property'),
-                Column::make('rent_due_day', 'Due Date')->sortable(),
-                Column::make('rent_amount', 'Amount Due')->sortable(),
+                Column::make('next_due_date', 'Due Date')->sortable(),
+                Column::make('next_outstanding', 'Amount Due')->sortable(),
             ])
             ->filters([
                 Filter::select('status', 'Status', [
@@ -64,7 +63,7 @@ class RentController extends Controller
                     ['value' => 'due_soon', 'label' => 'Due Soon'],
                     ['value' => 'paid', 'label' => 'Paid'],
                 ])
-                    ->query(function (Builder $q, string $value) use ($today, $periodStart, $periodEnd): void {
+                    ->query(function (Builder $q, string $value) use ($periodStart, $periodEnd): void {
                         $hasPayment = fn (Builder $q) => $q->whereHas('invoices', fn (Builder $q) => $q
                             ->where('status', InvoiceStatus::Paid->value)
                             ->whereBetween('period_start', [$periodStart, $periodEnd]));
@@ -75,9 +74,15 @@ class RentController extends Controller
 
                         match ($value) {
                             'paid' => $hasPayment($q),
-                            'overdue' => $noPayment($q)->where('rent_due_day', '<', $today),
-                            'due_today' => $noPayment($q)->where('rent_due_day', '=', $today),
-                            'due_soon' => $noPayment($q)->whereBetween('rent_due_day', [$today + 1, min($today + 7, 31)]),
+                            'overdue' => $noPayment($q)->whereHas('invoices', fn (Builder $q) => $q
+                                ->payable()
+                                ->whereDate('due_date', '<', now())),
+                            'due_today' => $noPayment($q)->whereHas('invoices', fn (Builder $q) => $q
+                                ->payable()
+                                ->whereDate('due_date', '=', now())),
+                            'due_soon' => $noPayment($q)->whereHas('invoices', fn (Builder $q) => $q
+                                ->payable()
+                                ->whereBetween('due_date', [now()->addDay(), now()->addDays(7)])),
                         };
                     }),
                 Filter::select('properties', 'Property', function () use ($request): array {
@@ -96,21 +101,32 @@ class RentController extends Controller
                         fn (Builder $q) => $q->whereIn('property_id', explode(',', $value)),
                     )),
             ])
-            ->defaultSort('rent_due_day');
+            ->defaultSort('next_due_date');
 
         $query = (clone $baseQuery)
             ->with(['primaryTenant:id,name,phone', 'tenants:id,name,phone', 'unit:id,name,property_id', 'unit.property:id,name'])
-            ->addSelect(['has_payment_this_month' => Invoice::query()
-                ->selectRaw('COUNT(*) > 0')
-                ->whereColumn('lease_id', 'leases.id')
-                ->where('status', InvoiceStatus::Paid->value)
-                ->whereBetween('period_start', [$periodStart, $periodEnd]),
+            ->addSelect([
+                'has_payment_this_month' => Invoice::query()
+                    ->selectRaw('COUNT(*) > 0')
+                    ->whereColumn('lease_id', 'leases.id')
+                    ->where('status', InvoiceStatus::Paid->value)
+                    ->whereBetween('period_start', [$periodStart, $periodEnd]),
+                'next_due_date' => Invoice::query()
+                    ->select('due_date')
+                    ->whereColumn('lease_id', 'leases.id')
+                    ->payable()
+                    ->orderBy('due_date')
+                    ->limit(1),
+                'next_outstanding' => Invoice::query()
+                    ->selectRaw('COALESCE(SUM(COALESCE(total, 0) - COALESCE(amount_paid, 0)), 0)')
+                    ->whereColumn('lease_id', 'leases.id')
+                    ->payable(),
             ]);
 
         $result = $table->paginate($query, $request, 'entries');
 
         $entries = collect($result['entries']->items())
-            ->map(fn (Lease $lease) => $stats->transformEntry($lease, $today))
+            ->map(fn (Lease $lease) => $stats->transformEntry($lease))
             ->filter(fn (?array $entry) => $entry !== null)
             ->values();
 

--- a/tests/Feature/RentDashboardTest.php
+++ b/tests/Feature/RentDashboardTest.php
@@ -22,13 +22,21 @@ function createLeaseWithPayment(array $leaseOverrides = [], ?array $paymentData 
         'rent_due_day' => 5,
     ], $leaseOverrides));
 
+    $dueDay = min($lease->rent_due_day, now()->daysInMonth);
+    $dueDate = now()->startOfMonth()->setDay($dueDay);
+
+    $invoice = Invoice::factory()->create([
+        'lease_id' => $lease->id,
+        'period_start' => now()->startOfMonth(),
+        'period_end' => now()->endOfMonth(),
+        'due_date' => $dueDate,
+        'total' => 100000,
+        'amount_paid' => 0,
+        'status' => InvoiceStatus::Pending,
+    ]);
+
     if ($paymentData !== null) {
-        Invoice::factory()->create([
-            'lease_id' => $lease->id,
-            'period_start' => now()->startOfMonth(),
-            'period_end' => now()->endOfMonth(),
-            'due_date' => now()->startOfMonth()->addDays(4),
-            'total' => 100000,
+        $invoice->update([
             'amount_paid' => 100000,
             'status' => InvoiceStatus::Paid,
         ]);
@@ -108,16 +116,19 @@ test('rent dashboard shows due today correctly', function () {
 });
 
 test('rent dashboard shows due soon correctly', function () {
-    $today = now()->day;
-    Carbon::setTestNow(now()->setDay($today));
+    // Use a fixed date so we control due-day math precisely
+    Carbon::setTestNow(Carbon::parse('2026-07-05'));
 
     $user = User::factory()->owner()->create();
 
-    createLeaseWithPayment(['rent_due_day' => $today + 3]);
-    createLeaseWithPayment(['rent_due_day' => $today + 5]);
-    createLeaseWithPayment(['rent_due_day' => $today + 14]);
+    // due_day = 8 → due_date = July 8 → 3 days ahead → due_soon
+    createLeaseWithPayment(['rent_due_day' => 8]);
+    // due_day = 10 → due_date = July 10 → 5 days ahead → due_soon
+    createLeaseWithPayment(['rent_due_day' => 10]);
+    // due_day = 19 → due_date = July 19 → 14 days ahead → excluded
+    createLeaseWithPayment(['rent_due_day' => 19]);
     createLeaseWithPayment(
-        ['rent_due_day' => $today + 3],
+        ['rent_due_day' => 8],
         ['status' => 'confirmed'],
     );
 
@@ -164,17 +175,33 @@ test('rent dashboard search filters by tenant name', function () {
     $user = User::factory()->owner()->create();
 
     $tenantA = Tenant::factory()->create(['name' => 'Budi Santoso']);
-    Lease::factory()->create([
+    $leaseA = Lease::factory()->create([
         'primary_tenant_id' => $tenantA->id,
         'start_date' => now()->subMonths(2),
         'rent_due_day' => 5,
     ]);
+    Invoice::factory()->create([
+        'lease_id' => $leaseA->id,
+        'period_start' => now()->startOfMonth(),
+        'period_end' => now()->endOfMonth(),
+        'due_date' => now()->startOfMonth()->setDay(5),
+        'total' => 100000,
+        'status' => InvoiceStatus::Pending,
+    ]);
 
     $tenantB = Tenant::factory()->create(['name' => 'Siti Rahma']);
-    Lease::factory()->create([
+    $leaseB = Lease::factory()->create([
         'primary_tenant_id' => $tenantB->id,
         'start_date' => now()->subMonths(2),
         'rent_due_day' => 3,
+    ]);
+    Invoice::factory()->create([
+        'lease_id' => $leaseB->id,
+        'period_start' => now()->startOfMonth(),
+        'period_end' => now()->endOfMonth(),
+        'due_date' => now()->startOfMonth()->setDay(3),
+        'total' => 100000,
+        'status' => InvoiceStatus::Pending,
     ]);
 
     $this->actingAs($user)
@@ -201,7 +228,7 @@ test('rent dashboard requires dashboard.view permission', function () {
 });
 
 test('rent dashboard shows days overdue correctly', function () {
-    Carbon::setTestNow(now()->setDay(15));
+    Carbon::setTestNow(Carbon::parse('2026-07-15'));
 
     $user = User::factory()->owner()->create();
 
@@ -225,20 +252,36 @@ test('rent dashboard scopes to user properties for non-owner', function () {
 
     $propertyA = Property::factory()->create();
     $tenantA = Tenant::factory()->create();
-    Lease::factory()->create([
+    $leaseA = Lease::factory()->create([
         'unit_id' => Unit::factory()->create(['property_id' => $propertyA->id])->id,
         'primary_tenant_id' => $tenantA->id,
         'start_date' => now()->subMonths(2),
         'rent_due_day' => 5,
     ]);
+    Invoice::factory()->create([
+        'lease_id' => $leaseA->id,
+        'period_start' => now()->startOfMonth(),
+        'period_end' => now()->endOfMonth(),
+        'due_date' => now()->startOfMonth()->setDay(5),
+        'total' => 100000,
+        'status' => InvoiceStatus::Pending,
+    ]);
 
     $propertyB = Property::factory()->create();
     $tenantB = Tenant::factory()->create();
-    Lease::factory()->create([
+    $leaseB = Lease::factory()->create([
         'unit_id' => Unit::factory()->create(['property_id' => $propertyB->id])->id,
         'primary_tenant_id' => $tenantB->id,
         'start_date' => now()->subMonths(2),
         'rent_due_day' => 3,
+    ]);
+    Invoice::factory()->create([
+        'lease_id' => $leaseB->id,
+        'period_start' => now()->startOfMonth(),
+        'period_end' => now()->endOfMonth(),
+        'due_date' => now()->startOfMonth()->setDay(3),
+        'total' => 100000,
+        'status' => InvoiceStatus::Pending,
     ]);
 
     $propertyA->users()->attach($user->id);


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Replace rent-due-day logic with invoice-driven stats and table entries in the rent dashboard
- [`RentStatsCalculator`](https://github.com/senatroxx/OpenKos/pull/60/files#diff-7b408229125c0a5e68342d2ca87bc75e0b9f4272fafa3e854d462282e15f7e01) now computes overdue, due today, due soon, and paid counts from payable invoice `due_date` values and outstanding balances rather than the static `rent_due_day` and `rent_amount` lease fields.
- [`RentController`](https://github.com/senatroxx/OpenKos/pull/60/files#diff-c09b4a8275ee24c109d540f532e272584df397de5f79e6cad26ff9d5f8a51f75) adds subselect columns (`has_payment_this_month`, `next_due_date`, `next_outstanding`, `has_any_invoice`) to the base query; the table now sorts and filters by `next_due_date` and `next_outstanding`.
- Leases with no invoices are hidden from the dashboard; leases with invoices but no payable ones are shown as paid with amount 0.
- Tests in [`RentDashboardTest`](https://github.com/senatroxx/OpenKos/pull/60/files#diff-663270fb480e3ed1b1121716007a811d9d78dacb79b985aedd0a8622c1994c93) are updated to create invoices explicitly and assert against invoice-based fields.
- Behavioral Change: `rent_amount` shown in the table now reflects the outstanding invoice balance rather than the static lease rent amount, and leases without any invoices no longer appear in the dashboard.

<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 5905a6a. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
No issues evaluated.


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->