### PR TITLE
fix: verify owner email

### DIFF
--- a/app/Console/Commands/InstallCommand.php
+++ b/app/Console/Commands/InstallCommand.php
@@ -89,8 +89,8 @@ class InstallCommand extends Command
             'name' => $name,
             'email' => $email,
             'password' => Hash::make($password),
-            'email_verified_at' => now(),
         ]);
+        $user->markEmailAsVerified();
 
         $role = SpatieRole::findOrCreate(Role::Owner->value);
         $user->assignRole($role);

--- a/app/Console/Commands/InstallCommand.php
+++ b/app/Console/Commands/InstallCommand.php
@@ -89,6 +89,7 @@ class InstallCommand extends Command
             'name' => $name,
             'email' => $email,
             'password' => Hash::make($password),
+            'email_verified_at' => now(),
         ]);
 
         $role = SpatieRole::findOrCreate(Role::Owner->value);


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Mark owner email as verified during installation
Calls `markEmailAsVerified()` on the owner user record created by `InstallCommand` so the owner is not required to verify their email after installation.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff2efee.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->