### PR TITLE
docs: audit and correct all docs to match implemented architecture

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,6 +28,7 @@ app/
 ├── Actions/          Single-responsibility operations (orchestration)
 ├── Business/         Pure domain logic, business rules
 ├── Data/             Typed DTOs / value objects
+├── Database/         PostgreSQL driver extensions
 ├── Results/          Typed result objects from action/business operations
 ├── Repositories/     Query abstraction over Eloquent
 ├── Models/           Eloquent models
@@ -35,6 +36,8 @@ app/
 ├── Contracts/        Interfaces
 ├── Services/         External integrations
 ├── Enums/            Type-safe domain constants
+├── Events/           Domain event classes
+├── Listeners/        Event subscribers and listeners
 ├── Http/             Controllers, Middleware, Form Requests
 ├── Policies/         Authorization per model
 ├── Concerns/         Reusable traits
@@ -112,9 +115,15 @@ Property (has a type — see below)
   ├── Regions / Cities (location)
   └── Units
        ├── UnitRates (pricing history)
+       ├── LeaseUnitHistory (unit transfer records)
+       ├── MaintenanceTickets
        └── Leases
             ├── Tenants (pivot: lease_tenant)
-            ├── Payments
+            ├── Invoices
+            │    ├── InvoiceLineItems
+            │    └── Payments
+            │         ├── PaymentAllocations (M:N pivot: payment_id, invoice_id, amount)
+            │         └── PaymentProofs
             └── ReminderLogs
 
 Tenant
@@ -124,11 +133,14 @@ Tenant
 User (staff / owner)
   ├── Properties (pivot: property_user)
   └── Roles / Permissions
+
+ActivityLog (records user-triggered activity across entities)
+AuditLog (records setting changes and sensitive operations)
 ```
 
 ### Property Type
 
-Every property has a `type` (`properties.type`), backed by the `App\Enums\PropertyType` string enum: `kos` (default), `apartment`, `villa`, `hostel`, `hotel`. The column defaults to `kos`, so existing properties and any created without an explicit type are boarding houses. The enum is cast on the `Property` model, validated on create/update, filterable on the properties index, and shown in the UI. It exists so future business logic can branch on the property type instead of assuming every property is a kos — no behaviour differs by type yet; it's the domain seam for that divergence.
+Every property has a `type` (`properties.type`), backed by the `App\Models\PropertyType` Eloquent model: `boarding_house` (default), `apartment`, `villa`, `hostel`, `hotel`. The column defaults to `boarding_house`, so existing properties and any created without an explicit type are boarding houses. The model is a user-managed CRUD resource (`Settings\PropertyTypeController`) with `slug`, `label`, `is_active`, and `sort_order` columns. Property types exist so future business logic can branch on the type instead of assuming every property is a kos — no behaviour differs by type yet; it's the domain seam for that divergence.
 
 ### Multi-Tenant Occupancy
 
@@ -136,7 +148,7 @@ A unit can hold multiple tenants on a single lease via the `lease_tenant` pivot 
 
 ### Payments & Rent Schedule
 
-Payments are tracked on the `payments` polymorphic table (morphs to `Lease`). The rent schedule is generated dynamically by `Lease::schedule()` — it is not stored. The schedule engine calculates periods from the lease's `start_date`, `end_date`, `billing_interval`, and `billing_unit`, then matches each period against payments to derive status (`paid`, `upcoming`, `due`, `overdue`).
+Payments settle invoices — `payments` has an `invoice_id` FK (not polymorphic). The rent schedule is generated dynamically by `Lease::schedule()` — it is not stored. The schedule engine feeds `invoices:generate` (daily 01:00, 2-month horizon), which materializes `Invoice` records with `total`, `amount_paid`, `status`, `period_start`, and `period_end`. Payments are recorded against a specific invoice via `RecordPayment`, and `Invoice::recalculateStatus()` recomputes status (Pending, Partial, Paid) from confirmed payment totals. See `docs/architecture/adr/007-invoice-aggregate.md`.
 
 ### Reminders
 
@@ -173,6 +185,7 @@ resources/js/
 ├── hooks/           Custom React hooks
 ├── lib/             Utility functions
 ├── types/           TypeScript type definitions
+├── plugins/         Plugin frontend entry points (side-effect imports)
 ├── actions/         Wayfinder-generated TS functions for controllers
 └── routes/          Wayfinder-generated TS functions for named routes
 ```
@@ -262,7 +275,7 @@ Occupied   ──→ Available       (all leases terminated)
 - Timestamps use `nullableTimestamps()` where appropriate (pivot tables).
 - Foreign keys use `constrained()` with explicit `cascadeOnDelete` / `nullOnDelete` / `restrictOnDelete`.
 - Unique constraints cover business-unique combinations (e.g., `lease_id + period_start + reminder_type + overdue_days` on `reminder_logs`).
-- Currency values are stored as integers (cents/sen). The frontend divides by 100 for display.
+- Currency values are stored as `decimal(12, 2)`. The frontend formats as-is for display.
 - The `settings` table is a singleton — one row with columns for each setting group. No key-value pattern.
 
 ### Foreign Key Delete Strategy
@@ -290,7 +303,6 @@ Composite indexes are added to support production query patterns (filtering and 
 
 | Table                  | Index                                     | Columns                                    | Query pattern                                                                                                                                                                                                                                              |
 | ---------------------- | ----------------------------------------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `payments`             | `idx_payments_type_id_status`             | `paymentable_type, paymentable_id, status` | Dashboard rent stats (`whereNotIn status`), overview finance (`where status = confirmed`), lease overdue checks. The previous morphs-only index `(paymentable_type, paymentable_id)` was a prefix — this superset covers it and status filtering together. |
 | `leases`               | `idx_leases_status_start_date`            | `status, start_date`                       | Dashboard base query `where(status='active', start_date <= now)`, overdue lease calculation.                                                                                                                                                               |
 | `maintenance_tickets`  | `idx_maintenance_tickets_property_status` | `property_id, status`                      | Property-scoped ticket filtering.                                                                                                                                                                                                                          |
 | `maintenance_tickets`  | `idx_maintenance_tickets_unit_status`     | `unit_id, status`                          | Unit-scoped maintenance history queries.                                                                                                                                                                                                                   |
@@ -301,7 +313,6 @@ Composite indexes are added to support production query patterns (filtering and 
 
 **Design decisions:**
 
-- `period_start` was intentionally excluded from the payments index. The original queries used `whereMonth()`/`whereYear()`, which wrap the column in `EXTRACT()` — a B-tree index cannot accelerate function-wrapped predicates. Those queries were rewritten to range conditions (`whereBetween`) so the index is usable.
 - Existing single-column indexes (`status`, `priority`) are preserved — they serve queries that filter on those columns alone without additional columns (e.g., global status filter on maintenance tickets).
 - The set of composite indexes is enforced by `tests/Feature/Schema/CompositeIndexTest.php`.
 
@@ -318,7 +329,7 @@ Composite indexes are added to support production query patterns (filtering and 
 ## Infrastructure
 
 - Queue driver is `database` — jobs are stored in the `jobs` table. Queue worker must be running for async notifications.
-- WhatsApp driver is pluggable via `config('services.whatsapp.driver')`. Default is `LogDriver` (writes to `storage/logs/whatsapp.log`).
+- WhatsApp driver is resolved from the platform `NotificationRegistry` (seeded by `config/services.php`). Default is `WhatsappLogDriver` (writes to `storage/logs/whatsapp.log`).
 - `Date` facade uses `CarbonImmutable` (configured in `AppServiceProvider`). All date type hints use `CarbonInterface` to accept both `Carbon` and `CarbonImmutable`.
 - Prohibits destructive DB commands (`DB::prohibitDestructiveCommands()`) in production.
 - Password defaults are strict in production (12 chars, mixed case, symbols, uncompromised).

--- a/docs/architecture/adr/003-cloud-separation.md
+++ b/docs/architecture/adr/003-cloud-separation.md
@@ -12,7 +12,7 @@ OpenKOS is open-source and self-hosted first. A hosted ("cloud") offering may ex
 We will keep the **open-source core fully functional and self-hostable, with cloud concerns strictly outside the core**.
 
 - The core must run on commodity infrastructure: PostgreSQL, the `database` queue driver, local/file storage, SMTP. No feature in core may hard-depend on a managed cloud service.
-- External integrations go behind pluggable drivers with a self-hosted default (e.g. the WhatsApp channel defaults to `LogDriver`; drivers are registered via the platform `NotificationRegistry`).
+- External integrations go behind pluggable drivers with a self-hosted default (e.g. the WhatsApp channel defaults to `WhatsappLogDriver`; drivers are registered via the platform `NotificationRegistry`).
 - Anything cloud-specific (managed hosting, billing, provisioning, telemetry) is built *around* the core — as separate services or plugins ([ADR-005](005-plugin-philosophy.md)) — never as conditional branches inside it.
 - A hosted offering provisions per-customer single-tenant installations ([ADR-001](001-single-tenant.md)); it does not get a privileged multi-tenant fork of the core.
 

--- a/docs/architecture/adr/004-rental-unit-abstraction.md
+++ b/docs/architecture/adr/004-rental-unit-abstraction.md
@@ -15,14 +15,14 @@ OpenKOS started as kos (boarding house) management, but properties come in flavo
 
 We will model everything rentable as a **Unit belonging to a typed Property**.
 
-- `Property` carries a `type` (`App\Enums\PropertyType`: `kos` default, `apartment`, `villa`, `hostel`, `hotel`). The enum is the *seam* for future divergence — no behavior branches on it yet, deliberately.
+- `Property` carries a `type` backed by the `App\Models\PropertyType` Eloquent model: `boarding_house` (default), `apartment`, `villa`, `hostel`, `hotel`. The model is the *seam* for future divergence — no behavior branches on it yet, deliberately. Property types are user-managed via `Settings\PropertyTypeController`.
 - `Unit` is the universal rentable thing: it owns pricing history (`UnitRates`), lifecycle status (`App\Enums\UnitStatus`), and `capacity`.
 - Leases attach to Units, tenants attach to Leases (`lease_tenant` pivot, multi-occupant with a `primary_tenant_id`), payments attach to Leases. None of this chain knows the property type.
 - Domain vocabulary: a **tenant** is a person renting; a **unit** is what they rent; a **property** groups units.
 
 ## Consequences
 
-- Supporting a new property type is a new enum case plus whatever behavior actually differs — no schema change.
+- Supporting a new property type is a new row in the `property_types` table plus whatever behavior actually differs — no schema change.
 - The lease/payment/reminder machinery is written once and works for all property types.
 - Kos-specific conveniences can't be hardcoded; they must branch on `PropertyType` when introduced, keeping the divergence visible in one place.
 - **Revisit trigger:** a property type whose rentable thing doesn't fit the Unit shape (e.g. time-slot bookings for hotel-style nightly rental). That likely means a booking abstraction *alongside* leases, recorded in a new ADR.

--- a/docs/business-workflows.md
+++ b/docs/business-workflows.md
@@ -124,7 +124,6 @@ app/
 │   ├── Leases/
 │   │   ├── CreateLease.php
 │   │   ├── MoveOutLease.php
-│   │   ├── RecordPayment.php
 │   │   └── RenewLease.php
 │   ├── Payments/
 │   │   └── RecordPayment.php
@@ -149,11 +148,11 @@ app/
 │       ├── ReminderEvent.php
 │       └── ReminderSettings.php
 ├── Results/
-│   └── Lease/
-│       ├── MoveOutLeaseResult.php
-│       └── RenewLeaseResult.php
-├── Payment/
-│   └── RecordPaymentResult.php
+│   ├── Lease/
+│   │   ├── MoveOutLeaseResult.php
+│   │   └── RenewLeaseResult.php
+│   └── Payment/
+│       └── RecordPaymentResult.php
 └── Repositories/
     └── ReminderRepository.php
 ```

--- a/docs/domain-events.md
+++ b/docs/domain-events.md
@@ -13,24 +13,25 @@
 
 ### Lease
 
-| Event                      | Payload                                            | Dispatched from                                                                                           |
-| -------------------------- | -------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| `Lease\LeaseCreated`       | `Lease $lease, array $tenantIds`                   | `LeaseController::store`                                                                                  |
-| `Lease\LeaseStatusChanged` | `Lease $lease, LeaseStatus $from, LeaseStatus $to` | `LeaseController::moveOut`, `LeaseController::move`, `LeaseController::renew`, `LeaseController::destroy` |
+| Event                      | Payload                                                               | Dispatched from                                                                                           |
+| -------------------------- | --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `Lease\LeaseCreated`       | `Lease $lease, array $tenantIds, ?int $actorId`                      | `LeaseController::store`                                                                                  |
+| `Lease\LeaseStatusChanged` | `Lease $lease, LeaseStatus $from, LeaseStatus $to, ?int $actorId`    | `LeaseController::moveOut`, `LeaseController::move`, `LeaseController::renew`, `LeaseController::destroy` |
 
 **Payload: `LeaseCreated`**
 
 ```php
 public readonly Lease $lease;
 public readonly array $tenantIds;   // IDs of attached tenants
+public readonly ?int $actorId;      // ID of the acting user, null for system-triggered
 ```
 
 ### Payment
 
-| Event                          | Payload                                                    | Dispatched from             |
-| ------------------------------ | ---------------------------------------------------------- | --------------------------- |
-| `Payment\PaymentRecorded`      | `Payment $payment`                                         | `PaymentController::store`  |
-| `Payment\PaymentStatusChanged` | `Payment $payment, PaymentStatus $from, PaymentStatus $to` | `PaymentController::verify` |
+| Event                          | Payload                                                                 | Dispatched from             |
+| ------------------------------ | ----------------------------------------------------------------------- | --------------------------- |
+| `Payment\PaymentRecorded`      | `Payment $payment, ?int $actorId`                                       | `PaymentController::store`  |
+| `Payment\PaymentStatusChanged` | `Payment $payment, PaymentStatus $from, PaymentStatus $to, ?int $actorId` | `PaymentController::verify` |
 
 Since [ADR-007](architecture/adr/007-invoice-aggregate.md) payments settle invoices; listeners reach the billing context via `$payment->invoice` (and `->invoice->lease`).
 
@@ -39,21 +40,24 @@ Since [ADR-007](architecture/adr/007-invoice-aggregate.md) payments settle invoi
 | Event                      | Payload            | Dispatched from                     |
 | -------------------------- | ------------------ | ----------------------------------- |
 | `Invoice\InvoiceGenerated` | `Invoice $invoice` | `GenerateInvoices` (post-commit)    |
+| `Invoice\InvoiceFullyPaid` | `Invoice $invoice` | `AllocatePayment`                   |
 
-`InvoiceGenerated` is the plugin hook for payment gateways, the tenant portal, and accounting — it fires once per invoice the generation engine creates, after the transaction commits, and never on reruns (generation is idempotent). Other invoice lifecycle events (status changed, cancelled) don't exist yet — add them when a consumer appears.
+`InvoiceGenerated` is the plugin hook for payment gateways, the tenant portal, and accounting — it fires once per invoice the generation engine creates, after the transaction commits, and never on reruns (generation is idempotent).
+
+`InvoiceFullyPaid` fires when an invoice's status transitions to `Paid` for the first time after a payment allocation. Other invoice lifecycle events (status changed, cancelled) don't exist yet — add them when a consumer appears.
 
 ### Maintenance
 
-| Event                                  | Payload                     | Dispatched from                       |
-| -------------------------------------- | --------------------------- | ------------------------------------- |
-| `Maintenance\MaintenanceTicketCreated` | `MaintenanceTicket $ticket` | `MaintenanceTicketController::store`  |
-| `Maintenance\MaintenanceResolved`      | `MaintenanceTicket $ticket` | `MaintenanceTicketController::update` |
+| Event                                  | Payload                               | Dispatched from                       |
+| -------------------------------------- | ------------------------------------- | ------------------------------------- |
+| `Maintenance\MaintenanceTicketCreated` | `MaintenanceTicket $ticket, ?int $actorId` | `MaintenanceTicketController::store`  |
+| `Maintenance\MaintenanceResolved`      | `MaintenanceTicket $ticket, ?int $actorId` | `MaintenanceTicketController::update` |
 
 ### Unit
 
-| Event                    | Payload                                        | Dispatched from                                                                                                                                                                        |
-| ------------------------ | ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Unit\UnitStatusChanged` | `Unit $unit, UnitStatus $from, UnitStatus $to` | `LeaseController::store`, `LeaseController::moveOut`, `LeaseController::move`, `LeaseController::destroy`, `MaintenanceTicketController::store`, `MaintenanceTicketController::update` |
+| Event                    | Payload                                                           | Dispatched from                                                                                                                                                                        |
+| ------------------------ | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Unit\UnitStatusChanged` | `Unit $unit, UnitStatus $from, UnitStatus $to, ?int $actorId`     | `LeaseController::store`, `LeaseController::moveOut`, `LeaseController::move`, `LeaseController::destroy`, `MaintenanceTicketController::store`, `MaintenanceTicketController::update` |
 
 **Payload: `UnitStatusChanged`**
 
@@ -61,13 +65,22 @@ Since [ADR-007](architecture/adr/007-invoice-aggregate.md) payments settle invoi
 public readonly Unit $unit;
 public readonly UnitStatus $from;   // previous status
 public readonly UnitStatus $to;     // new status
+public readonly ?int $actorId;      // ID of the acting user, null for system-triggered
 ```
+
+### Reminder
+
+| Event                                  | Payload                 | Dispatched from                       |
+| -------------------------------------- | ----------------------- | ------------------------------------- |
+| `Reminder\InvoiceReminderDispatched`   | `ReminderEvent $event`  | `SendRentReminders`, `ForceSendReminder` |
+
+`InvoiceReminderDispatched` fires when a rent reminder notification has been sent via WhatsApp — one event per reminder log entry created. Plugin consumers can use it for analytics, tenant-facing notification history, or cross-channel relay.
 
 ### Settings
 
-| Event                      | Payload                      | Dispatched from                                   |
-| -------------------------- | ---------------------------- | ------------------------------------------------- |
-| `Settings\SettingsUpdated` | `string $group, array $keys` | `UpdateSettings` action, `SettingsManager::set()` |
+| Event                      | Payload                                   | Dispatched from                                   |
+| -------------------------- | ----------------------------------------- | ------------------------------------------------- |
+| `Settings\SettingsUpdated` | `string $group, array $keys, ?int $actorId` | `UpdateSettings` action, `SettingsManager::set()` |
 
 **Payload: `SettingsUpdated`**
 

--- a/docs/domain-events.md
+++ b/docs/domain-events.md
@@ -74,7 +74,7 @@ public readonly ?int $actorId;      // ID of the acting user, null for system-tr
 | -------------------------------------- | ----------------------- | ------------------------------------- |
 | `Reminder\InvoiceReminderDispatched`   | `ReminderEvent $event`  | `SendRentReminders`, `ForceSendReminder` |
 
-`InvoiceReminderDispatched` fires when a rent reminder notification has been sent via WhatsApp — one event per reminder log entry created. Plugin consumers can use it for analytics, tenant-facing notification history, or cross-channel relay.
+`InvoiceReminderDispatched` fires to trigger a rent reminder notification — one event per reminder log entry created. The actual notification delivery (WhatsApp, mail, etc.) is handled by a listener in `AppServiceProvider`. Plugin consumers can use this event for analytics, tenant-facing notification history, or cross-channel relay, but should note it fires before delivery completes — it is not a delivery confirmation.
 
 ### Settings
 

--- a/docs/multi-tenant-occupancy.md
+++ b/docs/multi-tenant-occupancy.md
@@ -1,60 +1,15 @@
 # Multi-Tenant Unit Occupancy
 
-> **Status:** Design Document (not yet implemented)
+> **Status:** Implemented
 > **Issue:** [OPE-18](https://linear.app/openkos/issue/OPE-18)
-> **Decision:** Do NOT implement during MVP. Finish single-tenant leases, payments, and overdue tracking first.
 
 ## Context
 
-The kos (boarding house) market commonly requires shared units — multiple tenants occupying a single unit, splitting the rent. The current MVP architecture assumes:
+The kos (boarding house) market commonly requires shared units — multiple tenants occupying a single unit, splitting the rent.
 
-- One active lease per unit
-- One tenant per lease
-- One tenant per unit
+## Implementation
 
-The `units.capacity` column already exists (defaults to `1`) but is unused. This document describes the target architecture for multi-tenant support while preserving the path for future implementation.
-
-## Current State (MVP)
-
-### Schema
-
-```
-leases
-├── tenant_id (FK → tenants.id, NOT NULL)    ← one tenant only
-├── unit_id (FK → units.id, NOT NULL)
-├── rent_amount, billing_interval, billing_unit
-├── deposit_amount, deposit_paid_at, ...
-└── status
-
-units
-├── capacity (default 1)                      ← unused
-└── status
-
-tenants
-├── user_id (optional)
-├── name, phone, id_card_number, ...
-└── is_active
-```
-
-### Application-Level Constraints
-
-- `CreateLease::execute()` — checks unit capacity via `OccupancyCalculator::canAccommodate()`; aborts 422 if adding tenants would exceed capacity
-- `LeaseController@move` — same check on target unit via `OccupancyCalculator`
-- `TenantController@assignUnit` — same check via `CreateLease`
-- Unit listing queries filter out fully-occupied units via `scopeAvailableForAssignment()`
-- Unit status set to `occupied` when `count(active_tenants) >= capacity` (in `CreateLease`)
-
-### DB-Level Constraints
-
-There are **no unique constraints** on `leases.unit_id` or `(unit_id, tenant_id)` that would block multi-tenant. The enforcement is purely application-level. This means the DB schema is already forward-compatible.
-
-### Race Condition Risk
-
-The application-level checks are separate queries from the insert (not wrapped in a transaction with `FOR UPDATE` lock). Two concurrent requests could both pass the check and create two active leases on the same unit. Address this when implementing multi-tenant (or earlier if race conditions become a problem).
-
-## Target Architecture
-
-### Recommended Model: Shared Lease (Indonesia-First)
+### Model: Shared Lease (Indonesia-First)
 
 One lease per unit, multiple tenants on that lease. This matches how kos owners think about unit pricing — a unit costs X, not a bed costs X.
 
@@ -140,72 +95,6 @@ public function leases(): BelongsToMany
         ->withPivot('is_primary')
         ->withTimestamps();
 }
-```
-
-## Code Changes Required
-
-This is the exhaustive checklist of every location that needs modification when implementing multi-tenant support.
-
-### Backend
-
-| File                                           | Change                                                                                                                                                                                                             |
-| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `app/Models/Lease.php`                         | Replace `tenant(): BelongsTo` with `tenants(): BelongsToMany`, add `primaryTenant(): BelongsTo`. Remove `tenant_id` from `$fillable`, add `primary_tenant_id`.                                                     |
-| `app/Models/Tenant.php`                        | Change `leases(): HasMany` to `leases(): BelongsToMany`.                                                                                                                                                           |
-| `app/Http/Requests/StoreLeaseRequest.php`      | Replace `tenant_id` validation with `tenant_ids` (array). Remove `ensureUnitAvailable()`. Add capacity validation (`count(tenant_ids) <= unit.capacity`).                                                          |
-| `app/Http/Requests/UpdateLeaseRequest.php`     | Same tenant_id → tenant_ids changes.                                                                                                                                                                               |
-| `app/Http/Controllers/LeaseController.php`     | Store: accept `tenant_ids` array, create pivot records. Remove `ensureUnitAvailable()` call. Update `availableUnits` query to check capacity remaining. Move/moveOut: check capacity instead of "no active lease." |
-| `app/Http/Controllers/TenantController.php`    | `assignUnit`: accept multiple tenant IDs, check capacity. Update flash messages to plural.                                                                                                                         |
-| `app/Http/Controllers/UnitController.php`      | Update `occupied` status logic: check capacity vs active tenant count.                                                                                                                                             |
-| All `$lease->tenant` references in controllers | Change to `$lease->tenants` or `$lease->primaryTenant`.                                                                                                                                                            |
-
-### Queries (Affected)
-
-| Query                 | Current                                                      | Future                                                                                                             |
-| --------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
-| Available units       | `whereDoesntHave('leases', fn => status=active)`             | `withCount(['tenants' => fn => active])` + having `tenants_count < capacity`                                       |
-| Unit has active lease | `where('unit_id', $id)->where('status', 'active')->exists()` | `where('unit_id', $id)->where('status', 'active')->withCount('tenants')->having('tenants_count', '<', 'capacity')` |
-| Unit display status   | `occupied` if any active lease                               | `occupied` if `tenants_count >= capacity`, `partial` if `0 < tenants_count < capacity`                             |
-
-### Frontend
-
-All changes assume the backend now returns `tenants: TenantInfo[]` instead of `tenant: TenantInfo | null`.
-
-| File                                | Change                                                                                                                                                                               |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `lease-form-sheet.tsx`              | Replace single `SearchableSelect` for tenant with multi-select. Allow selecting up to `unit.capacity` tenants. Change button label to "Assign Tenants." Submit `tenant_ids[]` array. |
-| `lease-edit-sheet.tsx`              | Show list of tenants instead of single tenant name. Allow adding/removing tenants.                                                                                                   |
-| `lease-detail-sheet.tsx`            | Display tenant list (primary tenant highlighted). Show "Primary" badge on primary tenant.                                                                                            |
-| `unit-detail-sheet.tsx`             | Show all tenants currently on active lease, not just `leases[0].tenant`. Show capacity usage (e.g., "2/3 occupied").                                                                 |
-| `assign-unit-sheet.tsx`             | Accept single or multiple tenants.                                                                                                                                                   |
-| `move-unit-sheet.tsx`               | Handle partial move-out (moving one tenant out while others stay).                                                                                                                   |
-| `move-out-sheet.tsx`                | Handle partial move-out.                                                                                                                                                             |
-| `properties/units/index.tsx`        | Tenant column: show list of tenant names instead of single. Status column: show "Partial" for partially occupied units.                                                              |
-| `properties/units/leases/index.tsx` | Show multi-tenant occupancy on each lease row.                                                                                                                                       |
-| `leases/index.tsx`                  | Update tenant display to show multiple names. Update filters.                                                                                                                        |
-| `tenants/index.tsx`                 | Update "Active Lease" column to show unit + co-tenants.                                                                                                                              |
-| `tenant-detail-sheet.tsx`           | Show co-tenants on shared lease.                                                                                                                                                     |
-
-### TypeScript Types
-
-Update all local type definitions across components/pages:
-
-```typescript
-// Before
-type Lease = {
-    tenant: { id: number; name: string; phone: string | null } | null;
-};
-
-// After
-type Lease = {
-    tenants: Array<{
-        id: number;
-        name: string;
-        phone: string | null;
-        pivot: { is_primary: boolean };
-    }>;
-    primary_tenant: { id: number; name: string; phone: string | null } | null;
-};
 ```
 
 ## Business Rules

--- a/docs/platform.md
+++ b/docs/platform.md
@@ -18,7 +18,9 @@ src/
 ├── Platform/
 │   ├── OpenKOSManager.php    Central manager — the object plugins receive
 │   ├── PlatformServiceProvider.php
+│   ├── Console/
 │   ├── Facades/OpenKOS.php
+│   ├── Permission/           PermissionRegistry
 │   ├── Plugin/               Plugin base, PluginManifest, PluginLoader
 │   ├── Dashboard/            DashboardRegistry + DashboardPage
 │   ├── Navigation/           NavigationRegistry + NavigationItem
@@ -38,16 +40,19 @@ Core also dispatches domain events plugins can subscribe to, e.g. `App\Events\Pa
 
 ## The Registries
 
-Six registries, each bound as a **container singleton** (no static state) in `PlatformServiceProvider::register()`. All implement `Arrayable`, so exposing any of them to the frontend later is `->toArray()` in a shared Inertia prop.
+Nine singletons, each bound as a **container singleton** in `PlatformServiceProvider::register()`. All implement `Arrayable`, so exposing any of them to the frontend later is `->toArray()` in a shared Inertia prop.
 
 | Registry               | Registers                                        | Item shape                                                                                                                                                                                                                     |
 | ---------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `NavigationRegistry`   | Sidebar nav items, grouped (`main`, `footer`, …) | `NavigationItem(title, href?, icon?, permission?, children[])` — mirrors the TS `NavItem` type                                                                                                                                 |
 | `DashboardRegistry`    | Dashboard pages                                  | `DashboardPage(key, title, href, permission?)`                                                                                                                                                                                 |
 | `WorkspaceRegistry`    | Tabs on entity workspace pages                   | `WorkspaceTab(key, label, permission?, meta[])`                                                                                                                                                                                |
-| `SettingsRegistry`     | Settings pages                                   | `SettingsPage(key, title, href, permission?, group?, routeName?, order?)` — `group` renders under a nav section; `routeName` is resolved lazily in `toArray()` (safe for plugin `boot()`); pages sort by `order` (default 500) |
+| `SettingsRegistry`     | Settings pages + setting definitions             | `SettingsPage(key, title, href, permission?, group?, routeName?, order?)` — `group` renders under a nav section; `routeName` is resolved lazily in `toArray()` (safe for plugin `boot()`); pages sort by `order` (default 500) |
+| `SettingsManager`      | Settings storage (read/write by key)             | Injected class with `get(key)`, `set(key, value)`, `some(keys)` methods                                                                                                                                                        |
+| `PermissionRegistry`   | Plugin-declared permissions                      | `register(key, label)` — persisted to Spatie permissions table via `platform:permissions:sync`                                                                                                                                 |
 | `NotificationRegistry` | Notification drivers by name                     | `NotificationDriverRegistration(name, channel, driverClass, label, config[])`                                                                                                                                                  |
 | `PaymentRegistry`      | Payment gateways by key                          | class-string or instance of `PaymentGateway`                                                                                                                                                                                   |
+| `OpenKOSManager`       | Central manager — entry point for all registries | Injected into plugins; facade exposes `OpenKOS::navigation()->...`, `OpenKOS::dashboard()->...`, etc.                                                                                                                           |
 
 Conventions:
 

--- a/docs/rent-reminders.md
+++ b/docs/rent-reminders.md
@@ -11,7 +11,7 @@
 The kos management system needs automated rent reminders via WhatsApp to reduce late payments. Requirements:
 
 - Remind tenants before rent is due (upcoming), on the due date (due today), and when overdue
-- Derive reminder events from the existing rent schedule engine (`Lease::schedule()`)
+- Derive reminder events from payable invoices on each lease
 - Allow manual sending from lease detail sheet as a separate action from automated scheduling
 - Support custom message templates per installation
 - No payment gateway integration in scope
@@ -26,11 +26,11 @@ All reminder code lives in domain layers — `Actions/`, `Business/`, `Repositor
 
 Initially built with a feature folder (`app/Reminders/`), then refactored into layers during implementation.
 
-### 2. Concurrency Safety: Unique Constraint + Record-First
+### 2. Concurrency Safety: Unique Constraint + Select-Then-Insert
 
-`ReminderRepository::recordIfAbsent()` inserts into `reminder_logs` first (with a unique constraint on `lease_id + period_start + reminder_type + overdue_days`), catches integrity constraint violations (`SQLSTATE 23*`).
+`ReminderRepository::recordIfAbsent()` checks for an existing record first (SELECT), then inserts only if none exists. The unique constraint on `lease_id + period_start + reminder_type + overdue_days` is a safety net — it prevents duplicates from concurrent requests even if the SELECT race window is hit.
 
-**Rationale:** Avoids race conditions inherent in read-then-write patterns. The DB constraint guarantees at most one log per reminder, so the `catch` is the dedup check. Error code prefix check (`str_starts_with('23')`) is cross-database compatible (PostgreSQL uses `23505`, SQLite uses `23000`).
+**Rationale:** The unique constraint guarantees at most one log per reminder. Error code prefix check (`str_starts_with('23')`) is cross-database compatible (PostgreSQL uses `23505`, SQLite uses `23000`).
 
 ### 3. Scheduler Produces Events, Action Orchestrates
 
@@ -82,11 +82,11 @@ Scheduler methods accept `CarbonInterface` instead of `Carbon`.
 
 **Rationale:** Development-safe default — writes to `storage/logs/whatsapp.log` instead of requiring a real WhatsApp connection. The env var `WHATSAPP_DRIVER` lives in `config/services.php` (not `AppServiceProvider`) so omitting it doesn't crash with "Target class [] does not exist."
 
-### 11. Manual Send Is Independent of Scheduler
+### 11. Manual Send Goes Through ForceSendReminder Action
 
-`LeaseController::sendReminder()` finds the first unpaid period from `Lease::schedule()`, creates one `ReminderEvent`, sends synchronously via `$tenant->notifyNow()`, and logs. It bypasses the interval scheduler entirely.
+`LeaseController::sendReminder()` delegates to `ForceSendReminder` Action, which picks the first payable invoice, creates one `ReminderEvent`, sends synchronously via `$tenant->notifyNow()`, and logs via `ReminderRepository::recordIfAbsent()`. It bypasses the interval scheduler entirely.
 
-**Rationale:** Manual send is a one-off action for the landlord — send one reminder right now, regardless of whether the automated scheduler would have sent one. Using `notifyNow()` ensures the log file is written immediately (the sent_at timestamp is visible on refresh).
+**Rationale:** Manual send is a one-off action for the landlord — send one reminder right now, regardless of whether the automated scheduler would have sent one. Using `notifyNow()` ensures the log file is written immediately (the sent_at timestamp is visible on refresh). The `ForceSendReminder` action keeps the manual path consistent with the scheduled path, sharing the repository and notification logic.
 
 ### 12. Primary Tenant Only
 
@@ -101,7 +101,7 @@ Schedule (routes/console.php)
   └─ SendRentRemindersCommand
        └─ SendRentReminders (Action)
             ├─ PaymentReminderScheduler (Business)
-            │    └─ Lease::scheduleForReminder()
+            │    └─ $lease->invoices()->payable()
             ├─ ReminderRepository::recordIfAbsent() (Repositories)
             └─ Tenant::notify(new RentReminder)
                  └─ WhatsAppChannel
@@ -110,10 +110,11 @@ Schedule (routes/console.php)
 
 Manual Send (LeaseController)
   └─ LeaseController::sendReminder()
-       ├─ Lease::scheduleForReminder()
-       ├─ ReminderEvent
-       ├─ Tenant::notifyNow(new RentReminder)
-       └─ ReminderLog::create()
+       └─ ForceSendReminder (Action)
+            ├─ $lease->invoices()->payable()
+            ├─ ReminderEvent
+            ├─ Tenant::notifyNow(new RentReminder)
+            └─ ReminderRepository::recordIfAbsent()
 ```
 
 ### Directory Layout
@@ -121,6 +122,7 @@ Manual Send (LeaseController)
 ```
 app/
 ├── Actions/Reminders/
+│   ├── ForceSendReminder.php
 │   └── SendRentReminders.php
 ├── Business/Reminders/
 │   └── PaymentReminderScheduler.php
@@ -139,7 +141,7 @@ app/
 │   ├── Channels/
 │   │   └── WhatsAppChannel.php
 │   ├── Drivers/
-│   │   └── LogDriver.php
+│   │   └── WhatsappLogDriver.php
 │   └── RentReminder.php
 ├── Repositories/
 │   └── ReminderRepository.php

--- a/docs/rent-reminders.md
+++ b/docs/rent-reminders.md
@@ -84,9 +84,9 @@ Scheduler methods accept `CarbonInterface` instead of `Carbon`.
 
 ### 11. Manual Send Goes Through ForceSendReminder Action
 
-`LeaseController::sendReminder()` delegates to `ForceSendReminder` Action, which picks the first payable invoice, creates one `ReminderEvent`, sends synchronously via `$tenant->notifyNow()`, and logs via `ReminderRepository::recordIfAbsent()`. It bypasses the interval scheduler entirely.
+`LeaseController::sendReminder()` delegates to `ForceSendReminder` Action, which first tries `PaymentReminderScheduler::pendingFor()` to find already-scheduled but unlogged events. If none exist, it falls back to the first payable invoice and creates a one-off `ReminderEvent`. In either case it records the log via `ReminderRepository::recordIfAbsent()` and dispatches `InvoiceReminderDispatched`. A listener in `AppServiceProvider` picks up that event and performs the actual notification delivery.
 
-**Rationale:** Manual send is a one-off action for the landlord — send one reminder right now, regardless of whether the automated scheduler would have sent one. Using `notifyNow()` ensures the log file is written immediately (the sent_at timestamp is visible on refresh). The `ForceSendReminder` action keeps the manual path consistent with the scheduled path, sharing the repository and notification logic.
+**Rationale:** Manual send is a one-off action for the landlord — send one reminder right now, regardless of whether the automated scheduler would have sent one. The scheduled-path fallback ensures consistency: manual send reuses the same event types, dedup, and logging as the automated path. Dispatching `InvoiceReminderDispatched` instead of calling `notifyNow()` directly lets the same listener handle both scheduled and manual sends, keeping channel resolution in one place.
 
 ### 12. Primary Tenant Only
 
@@ -102,19 +102,20 @@ Schedule (routes/console.php)
        └─ SendRentReminders (Action)
             ├─ PaymentReminderScheduler (Business)
             │    └─ $lease->invoices()->payable()
-            ├─ ReminderRepository::recordIfAbsent() (Repositories)
-            └─ Tenant::notify(new RentReminder)
-                 └─ WhatsAppChannel
-                      └─ WhatsAppManager
-                           └─ WhatsAppDriver (LogDriver | Baileys)
+            ├─ ReminderRepository::recordIfAbsent()
+            └─ InvoiceReminderDispatched::dispatch()
+                 └─ AppServiceProvider listener
+                      └─ Notification delivery (WhatsApp, mail, etc.)
 
 Manual Send (LeaseController)
   └─ LeaseController::sendReminder()
        └─ ForceSendReminder (Action)
-            ├─ $lease->invoices()->payable()
-            ├─ ReminderEvent
-            ├─ Tenant::notifyNow(new RentReminder)
-            └─ ReminderRepository::recordIfAbsent()
+            ├─ PaymentReminderScheduler::pendingFor() (Business)
+            │    └─ $lease->invoices()->payable()
+            ├─ ReminderRepository::recordIfAbsent()
+            └─ InvoiceReminderDispatched::dispatch()
+                 └─ AppServiceProvider listener
+                      └─ Notification delivery (WhatsApp, mail, etc.)
 ```
 
 ### Directory Layout


### PR DESCRIPTION
## Summary

Audited all 17 docs against the codebase. Fixed 8 docs with 84 insertions / 165 deletions.

## Changes

### Critical fixes (OPE-91 scope)

| File | Fix |
|------|-----|
| `docs/multi-tenant-occupancy.md` | Status → "Implemented", removed stale MVP section + Code Changes checklist |
| `docs/architecture.md` | PropertyType: enum→model; Currency: integer→decimal(12,2); Payments: polymorphic→invoice-based; Domain model: added missing entities; Added Database/, Events/, Listeners/, plugins/ to trees; Removed stale composite index + design decision |
| `docs/rent-reminders.md` | Decision 2: Record-First→Select-Then-Insert; Decision 11: direct→ForceSendReminder; Diagrams use `$lease->invoices()->payable()`; `LogDriver`→`WhatsappLogDriver`; Added missing `ForceSendReminder.php` to directory layout |
| `docs/domain-events.md` | Added `InvoiceFullyPaid`, `InvoiceReminderDispatched`; Added `$actorId` to all event payloads |
| `docs/platform.md` | Added Console/, Permission/ to tree; Six→Nine singletons; Added SettingsManager, PermissionRegistry, OpenKOSManager |
| `docs/business-workflows.md` | Fixed RecordPayment path; Fixed RecordPaymentResult under Results/Payment/ |
| `docs/architecture/adr/003-cloud-separation.md` | `LogDriver`→`WhatsappLogDriver` |
| `docs/architecture/adr/004-rental-unit-abstraction.md` | PropertyType: enum case→model row |

### Verification

- All 10 acceptance criteria from OPE-91 met
- Triple-checked every claim against actual codebase (models, migrations, events, singletons, directory structures)
- Cross-referenced CompositeIndexTest.php for index accuracy

Fixes OPE-91

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Correct architecture docs to match implemented system design
> - Updates [architecture.md](https://github.com/senatroxx/OpenKos/pull/66/files#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782) to reflect invoice-centric payment flow, `App\Models\PropertyType` replacing enum-based property types, decimal(12,2) currency storage, and expanded entity relationships.
> - Updates ADRs [003](https://github.com/senatroxx/OpenKos/pull/66/files#diff-d96afaecd34c42d66e2e752a7ff5c26ec0c91fba92dc24804fb5760de1d0d000) and [004](https://github.com/senatroxx/OpenKos/pull/66/files#diff-c92b9a27e8961e7b7b16cd343c53aee5fcd9e70130a7a55c39ee607da5631a73) to reflect `WhatsappLogDriver` naming and database-backed property types.
> - Rewrites [domain-events.md](https://github.com/senatroxx/OpenKos/pull/66/files#diff-706b1ea4647f418f60a83c99d8dda294e1bc17b5a1a2df7dacab90e7b6d8fb0b) to add `InvoiceFullyPaid`, `InvoiceReminderDispatched`, and optional `actorId` fields across all event payloads.
> - Updates [rent-reminders.md](https://github.com/senatroxx/OpenKos/pull/66/files#diff-2a3daf4c47691944d51f8ba9a81d1130ed64e70d2d2bd5ee3a0d268a69f00f60) to reflect invoice-driven scheduling, `ForceSendReminder` action, and listener-based delivery via `InvoiceReminderDispatched`.
> - Marks [multi-tenant-occupancy.md](https://github.com/senatroxx/OpenKos/pull/66/files#diff-5e6bc6ff6a012d994c13bba4103a79cb7f37ad733cf121ade850b9d83def8b14) as implemented and removes design-phase checklists.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 15cf885.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->