### PR TITLE
feat: surface billing strategy in lease UI

### DIFF
--- a/app/Http/Controllers/LeaseController.php
+++ b/app/Http/Controllers/LeaseController.php
@@ -335,6 +335,8 @@ class LeaseController extends Controller
     {
         $this->authorize('update', $lease);
 
+        abort(403, 'Lease editing is temporarily disabled.');
+
         $lease->update($request->validated());
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Lease updated.')]);

--- a/resources/js/components/features/leases/assign-unit-sheet.tsx
+++ b/resources/js/components/features/leases/assign-unit-sheet.tsx
@@ -25,6 +25,7 @@ import {
     SheetTitle,
 } from '@/components/ui/sheet';
 import { DUE_DAY_OPTIONS } from '@/lib/constants';
+import { BILLING_STRATEGIES } from '@/lib/constants/billing';
 import { computeMonthlyEquivalent, formatPrice } from '@/lib/formatters';
 import tenants from '@/routes/tenants';
 import type { AvailableUnit, UnitRate, Tenant } from '@/types';
@@ -47,6 +48,7 @@ export default function AssignUnitSheet({
     );
     const [selectedUnitId, setSelectedUnitId] = useState<number | null>(null);
     const [dueDay, setDueDay] = useState('1');
+    const [billingStrategy, setBillingStrategy] = useState('advance');
     const [hasDeposit, setHasDeposit] = useState(false);
     const dueDayInitialized = useRef(false);
 
@@ -432,6 +434,23 @@ export default function AssignUnitSheet({
                                                 message={errors.rent_due_day}
                                             />
                                         </div>
+                                    </div>
+                                    <div className="mt-4 grid gap-2">
+                                        <Label htmlFor="billing_strategy">Billing Strategy</Label>
+                                        <input type="hidden" name="billing_strategy" value={billingStrategy} />
+                                        <Select value={billingStrategy} onValueChange={setBillingStrategy}>
+                                            <SelectTrigger id="billing_strategy">
+                                                <SelectValue placeholder="Select billing strategy" />
+                                            </SelectTrigger>
+                                            <SelectContent>
+                                                {BILLING_STRATEGIES.map((s) => (
+                                                    <SelectItem key={s.value} value={s.value}>
+                                                        {s.label}
+                                                    </SelectItem>
+                                                ))}
+                                            </SelectContent>
+                                        </Select>
+                                        <InputError message={errors.billing_strategy} />
                                     </div>
                                 </section>
 

--- a/resources/js/components/features/leases/lease-detail-sheet.tsx
+++ b/resources/js/components/features/leases/lease-detail-sheet.tsx
@@ -18,7 +18,7 @@ import {
     SheetTitle,
 } from '@/components/ui/sheet';
 import { DUE_DAY_LABELS } from '@/lib/constants';
-import { PAYMENT_METHOD_LABELS } from '@/lib/constants/billing';
+import { BILLING_STRATEGIES, PAYMENT_METHOD_LABELS } from '@/lib/constants/billing';
 import { formatDate, formatPeriod, formatPrice } from '@/lib/formatters';
 import leases from '@/routes/leases';
 import type { Lease, Payment } from '@/types';
@@ -274,6 +274,14 @@ export default function LeaseDetailSheet({
                                                         lease.rent_amount,
                                                     )}
                                                     {lease.billing_label}
+                                                </span>
+                                            </div>
+                                            <div className="flex items-center justify-between text-sm">
+                                                <span className="text-muted-foreground">
+                                                    Billing strategy
+                                                </span>
+                                                <span className="text-xs font-medium">
+                                                    {BILLING_STRATEGIES.find((s) => s.value === lease.billing_strategy)?.label ?? 'Advance (due within period)'}
                                                 </span>
                                             </div>
                                             <div className="flex items-center justify-between text-sm">

--- a/resources/js/components/features/leases/lease-detail-sheet.tsx
+++ b/resources/js/components/features/leases/lease-detail-sheet.tsx
@@ -29,14 +29,12 @@ export default function LeaseDetailSheet({
     onOpenChange,
     onMoveOut,
     onMoveUnit,
-    onEdit,
 }: {
     lease?: Lease | null;
     open: boolean;
     onOpenChange: (open: boolean) => void;
     onMoveOut?: () => void;
     onMoveUnit?: () => void;
-    onEdit?: () => void;
 }) {
     const { auth } = usePage<{ auth: { permissions: string[] } }>().props;
     const [recordPaymentOpen, setRecordPaymentOpen] = useState(false);
@@ -625,11 +623,7 @@ export default function LeaseDetailSheet({
                         </div>
 
                         <div className="flex flex-wrap items-center justify-end gap-4">
-                            {onEdit && (
-                                <Button variant="outline" onClick={onEdit}>
-                                    Edit
-                                </Button>
-                            )}
+
                             {isActive && (
                                 <Button
                                     variant="default"

--- a/resources/js/components/features/leases/lease-form-sheet.tsx
+++ b/resources/js/components/features/leases/lease-form-sheet.tsx
@@ -25,6 +25,7 @@ import {
     SheetTitle,
 } from '@/components/ui/sheet';
 import { DUE_DAY_OPTIONS } from '@/lib/constants';
+import { BILLING_STRATEGIES } from '@/lib/constants/billing';
 import { computeMonthlyEquivalent, formatPrice } from '@/lib/formatters';
 import properties from '@/routes/properties';
 import type { Property, Unit, UnitRate } from '@/types';
@@ -45,6 +46,7 @@ export default function LeaseFormSheet({
     }>().props;
     const [selectedTenantIds, setSelectedTenantIds] = useState<number[]>([]);
     const [dueDay, setDueDay] = useState('1');
+    const [billingStrategy, setBillingStrategy] = useState('advance');
     const [hasDeposit, setHasDeposit] = useState(false);
     const dueDayInitialized = useRef(false);
 
@@ -408,6 +410,23 @@ export default function LeaseFormSheet({
                                                 message={errors.rent_due_day}
                                             />
                                         </div>
+                                    </div>
+                                    <div className="mt-4 grid gap-2">
+                                        <Label htmlFor="billing_strategy">Billing Strategy</Label>
+                                        <input type="hidden" name="billing_strategy" value={billingStrategy} />
+                                        <Select value={billingStrategy} onValueChange={setBillingStrategy}>
+                                            <SelectTrigger id="billing_strategy">
+                                                <SelectValue placeholder="Select billing strategy" />
+                                            </SelectTrigger>
+                                            <SelectContent>
+                                                {BILLING_STRATEGIES.map((s) => (
+                                                    <SelectItem key={s.value} value={s.value}>
+                                                        {s.label}
+                                                    </SelectItem>
+                                                ))}
+                                            </SelectContent>
+                                        </Select>
+                                        <InputError message={errors.billing_strategy} />
                                     </div>
                                 </section>
 

--- a/resources/js/components/features/leases/lease-overview.tsx
+++ b/resources/js/components/features/leases/lease-overview.tsx
@@ -6,6 +6,7 @@ import {
     CollapsibleTrigger,
 } from '@/components/ui/collapsible';
 import { DUE_DAY_LABELS } from '@/lib/constants';
+import { BILLING_STRATEGIES } from '@/lib/constants/billing';
 import { formatDate, formatPrice } from '@/lib/formatters';
 import type { Lease } from '@/types';
 
@@ -182,6 +183,14 @@ export default function LeaseOverview({ lease }: { lease: Lease }) {
                                 <span className="tabular-nums">
                                     {formatPrice(lease.rent_amount)}
                                     {lease.billing_label}
+                                </span>
+                            </div>
+                            <div className="flex items-center justify-between text-sm">
+                                <span className="text-muted-foreground">
+                                    Billing strategy
+                                </span>
+                                <span className="text-xs font-medium">
+                                    {BILLING_STRATEGIES.find((s) => s.value === lease.billing_strategy)?.label ?? 'Advance (due within period)'}
                                 </span>
                             </div>
                             <div className="flex items-center justify-between text-sm">

--- a/resources/js/components/ui/switch.tsx
+++ b/resources/js/components/ui/switch.tsx
@@ -13,6 +13,7 @@ function Switch({
   checked?: boolean
   onCheckedChange?: (checked: boolean) => void
   disabled?: boolean
+  id?: string
 }) {
   return (
     <button

--- a/resources/js/pages/leases/index.tsx
+++ b/resources/js/pages/leases/index.tsx
@@ -17,7 +17,7 @@ import { FilterBar } from '@/components/data-table/filter-bar';
 import { SearchInput } from '@/components/data-table/search-input';
 import {
     LeaseDetailSheet,
-    LeaseEditSheet,
+    // LeaseEditSheet,
     MoveOutSheet,
     RenewLeaseSheet,
 } from '@/components/features';
@@ -70,7 +70,7 @@ export default function Index({
 }: PageProps) {
     const [detailLease, setDetailLease] = useState<Lease | null>(null);
     const [detailOpen, setDetailOpen] = useState(false);
-    const [editOpen, setEditOpen] = useState(false);
+    // const [editOpen, setEditOpen] = useState(false);
     const [moveOutOpen, setMoveOutOpen] = useState(false);
     const [renewOpen, setRenewOpen] = useState(false);
 
@@ -98,11 +98,6 @@ export default function Index({
     function openMoveOutFromDetail() {
         setDetailOpen(false);
         setMoveOutOpen(true);
-    }
-
-    function openEditFromDetail() {
-        setDetailOpen(false);
-        setEditOpen(true);
     }
 
     const columns: TableColumn<Lease>[] = [
@@ -230,7 +225,7 @@ export default function Index({
                             <Eye className="size-4" />
                             View
                         </DropdownMenuItem>
-                        <DropdownMenuItem
+                        {/* <DropdownMenuItem
                             onClick={() => {
                                 setDetailLease(lease);
                                 setDetailOpen(false);
@@ -239,7 +234,7 @@ export default function Index({
                         >
                             <Pencil className="size-4" />
                             Edit
-                        </DropdownMenuItem>
+                        </DropdownMenuItem> */}
                         {lease.status === 'active' && (
                             <>
                                 <DropdownMenuItem

--- a/resources/js/pages/leases/index.tsx
+++ b/resources/js/pages/leases/index.tsx
@@ -375,13 +375,6 @@ export default function Index({
                         ? openMoveOutFromDetail
                         : undefined
                 }
-                onEdit={detailLease ? openEditFromDetail : undefined}
-            />
-
-            <LeaseEditSheet
-                lease={detailLease}
-                open={editOpen}
-                onOpenChange={setEditOpen}
             />
 
             <MoveOutSheet

--- a/resources/js/pages/leases/index.tsx
+++ b/resources/js/pages/leases/index.tsx
@@ -4,7 +4,6 @@ import {
     Eye,
     LogOut,
     EllipsisVertical,
-    Pencil,
     RefreshCw,
     Building2,
     Banknote,

--- a/resources/js/pages/properties/units/leases/index.tsx
+++ b/resources/js/pages/properties/units/leases/index.tsx
@@ -1,4 +1,4 @@
-import { Head, Link, router } from '@inertiajs/react';
+import { Head, Link } from '@inertiajs/react';
 import { useState } from 'react';
 import { LeaseDetailSheet, MoveOutSheet } from '@/components/features';
 import { Heading } from '@/components/shared';
@@ -35,15 +35,6 @@ export default function Index({
     function openMoveOutFromDetail() {
         setDetailOpen(false);
         setMoveOutOpen(true);
-    }
-
-    function openEditFromDetail() {
-        if (!detailLease) {
-            return;
-        }
-
-        setDetailOpen(false);
-        router.get(backUrl);
     }
 
     return (

--- a/resources/js/pages/properties/units/leases/index.tsx
+++ b/resources/js/pages/properties/units/leases/index.tsx
@@ -230,7 +230,6 @@ export default function Index({
                         ? openMoveOutFromDetail
                         : undefined
                 }
-                onEdit={detailLease ? openEditFromDetail : undefined}
             />
 
             <MoveOutSheet

--- a/resources/js/types/models.ts
+++ b/resources/js/types/models.ts
@@ -320,6 +320,7 @@ export type WorkspaceLease = {
     start_date: string;
     end_date: string | null;
     rent_amount: string | null;
+    billing_strategy?: string;
     status: string;
 };
 

--- a/tests/Feature/LeaseTest.php
+++ b/tests/Feature/LeaseTest.php
@@ -180,11 +180,8 @@ describe('CRUD', function () {
         $this->actingAs($user)
             ->put(route('properties.units.leases.update', [$property, $unit, $lease]), [
                 'rent_amount' => 2_000_000,
-            ]);
-
-        $lease->refresh();
-
-        expect($lease->rent_amount)->toBe('2000000.00');
+            ])
+            ->assertForbidden();
     });
 });
 


### PR DESCRIPTION
## Changes

- **Lease create forms** (`lease-form-sheet.tsx`, `assign-unit-sheet.tsx`) — added billing strategy selector (advance/arrears) using existing `BILLING_STRATEGIES` constant
- **Lease detail views** (`lease-overview.tsx`, `lease-detail-sheet.tsx`) — display billing strategy label next to billing rate
- **`WorkspaceLease` type** — added `billing_strategy?: string` field
- **Edit lease temporarily disabled** — removed Edit button from detail sheet, blocked `LeaseController@update` with 403 guard, commented out edit sheet usage on workspace lease index
- **`Switch` component** — added `id` prop to type definition (fixes pre-existing TS error)

Closes OPE-96

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface billing strategy in lease UI and disable lease editing
> - Adds a billing strategy select field to the lease creation form ([lease-form-sheet.tsx](https://github.com/senatroxx/OpenKos/pull/71/files#diff-92fce0d7db5757245532a4a81ae95f3457481cb05ff9840c06ad6fecb1e990f6)) and assign-unit form ([assign-unit-sheet.tsx](https://github.com/senatroxx/OpenKos/pull/71/files#diff-a2d16177e20eddce794d3b99dfdcaf9aa0999b6a46629df05ff2bdf6e302046f)), submitting the value as `billing_strategy`.
> - Displays the resolved billing strategy label in the lease detail sheet ([lease-detail-sheet.tsx](https://github.com/senatroxx/OpenKos/pull/71/files#diff-2c42f3cee2a481a015c0ccb3c969d335af134d035c3da98eb48cada37331757a)) and lease overview ([lease-overview.tsx](https://github.com/senatroxx/OpenKos/pull/71/files#diff-d6b8d0f2a7e83a880c96ddfe78388f6805b26e866c6a5f00513a5a928bb1aa10)).
> - Removes the Edit lease action from the leases index and unit leases pages, and removes the `onEdit` prop from `LeaseDetailSheet`.
> - Behavioral Change: `LeaseController.update` now always returns HTTP 403, making the lease update endpoint non-functional until the abort is removed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4b08efc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->