### PR TITLE
fix: import PaymentProof, scope route binding, use Storage facade

### DIFF
--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -14,10 +14,12 @@ use App\Http\Requests\Payment\StorePaymentRequest;
 use App\Models\Invoice;
 use App\Models\Lease;
 use App\Models\Payment;
+use App\Models\PaymentProof;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
 use Inertia\Inertia;
 
 class PaymentController extends Controller
@@ -68,13 +70,11 @@ class PaymentController extends Controller
     {
         $this->authorize('view', $payment);
 
-        $path = storage_path('app/private/'.$proof->path);
-
-        if (! file_exists($path)) {
+        if (! Storage::disk('local')->exists($proof->path)) {
             abort(404);
         }
 
-        return response()->file($path);
+        return Storage::disk('local')->response($proof->path);
     }
 
     public function __construct(

--- a/app/Models/PaymentProof.php
+++ b/app/Models/PaymentProof.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
@@ -14,6 +15,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 ])]
 class PaymentProof extends Model
 {
+    use HasFactory;
+
     public function payment(): BelongsTo
     {
         return $this->belongsTo(Payment::class);

--- a/database/factories/PaymentProofFactory.php
+++ b/database/factories/PaymentProofFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Models\Payment;
 use App\Models\PaymentProof;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -18,7 +19,10 @@ class PaymentProofFactory extends Factory
     public function definition(): array
     {
         return [
-            //
+            'payment_id' => Payment::factory(),
+            'path' => 'proofs/'.fake()->uuid().'.pdf',
+            'original_name' => fake()->word().'.pdf',
+            'mime_type' => 'application/pdf',
         ];
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -112,7 +112,7 @@ Route::middleware(['auth', 'verified', 'permission:dashboard.view'])->group(func
         });
     });
 
-    Route::prefix('payments/{payment}')->name('payments.')->group(function () {
+    Route::prefix('payments/{payment}')->name('payments.')->scopeBindings()->group(function () {
         Route::get('proof/{proof}', [PaymentController::class, 'proof'])->name('proof');
         Route::post('verify', [PaymentController::class, 'verify'])->name('verify')->middleware('permission:payments.verify');
     });

--- a/tests/Feature/PaymentTest.php
+++ b/tests/Feature/PaymentTest.php
@@ -5,12 +5,14 @@ use App\Enums\PaymentStatus;
 use App\Models\Invoice;
 use App\Models\Lease;
 use App\Models\Payment;
+use App\Models\PaymentProof;
 use App\Models\Property;
 use App\Models\Tenant;
 use App\Models\Unit;
 use App\Models\User;
 use Database\Seeders\RegionAndCitySeeder;
 use Database\Seeders\RoleAndPermissionSeeder;
+use Illuminate\Support\Facades\File;
 
 uses()->beforeEach(function () {
     $this->seed(RoleAndPermissionSeeder::class);
@@ -270,5 +272,89 @@ describe('invoice settlement', function () {
 
         expect($payment2->fresh()->status)->toBe(PaymentStatus::Cancelled)
             ->and($payment2->invoice->fresh()->status)->toBe(InvoiceStatus::Pending);
+    });
+});
+
+describe('proof download', function () {
+    it('allows authorized user to download a valid proof', function () {
+        $user = User::factory()->owner()->create();
+        $lease = createLeaseForProperty();
+        $invoice = createInvoiceFor($lease);
+        $payment = Payment::factory()->create(['invoice_id' => $invoice->id]);
+        $proofPath = 'proofs/test-proof.pdf';
+        $fullPath = storage_path('app/private/'.$proofPath);
+        File::makeDirectory(dirname($fullPath), 0755, true, true);
+        File::put($fullPath, 'fake-pdf-content');
+        $proof = PaymentProof::factory()->create([
+            'payment_id' => $payment->id,
+            'path' => $proofPath,
+            'original_name' => 'proof.pdf',
+            'mime_type' => 'application/pdf',
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('payments.proof', [$payment, $proof]))
+            ->assertOk();
+
+        File::delete($fullPath);
+    });
+
+    it('returns 404 when proof belongs to another payment', function () {
+        $user = User::factory()->owner()->create();
+        $lease = createLeaseForProperty();
+        $invoice = createInvoiceFor($lease);
+        $payment = Payment::factory()->create(['invoice_id' => $invoice->id]);
+        $otherPayment = Payment::factory()->create(['invoice_id' => $invoice->id]);
+
+        $proofPath = 'proofs/test-proof.pdf';
+        $fullPath = storage_path('app/private/'.$proofPath);
+        File::makeDirectory(dirname($fullPath), 0755, true, true);
+        File::put($fullPath, 'fake-pdf-content');
+        $proof = PaymentProof::factory()->create([
+            'payment_id' => $otherPayment->id,
+            'path' => $proofPath,
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('payments.proof', [$payment, $proof]))
+            ->assertNotFound();
+
+        File::delete($fullPath);
+    });
+
+    it('returns 403 for user without access to the property', function () {
+        $user = User::factory()->admin()->create();
+        $lease = createLeaseForProperty();
+        $invoice = createInvoiceFor($lease);
+        $payment = Payment::factory()->create(['invoice_id' => $invoice->id]);
+        $proofPath = 'proofs/test-proof.pdf';
+        $fullPath = storage_path('app/private/'.$proofPath);
+        File::makeDirectory(dirname($fullPath), 0755, true, true);
+        File::put($fullPath, 'fake-pdf-content');
+        $proof = PaymentProof::factory()->create([
+            'payment_id' => $payment->id,
+            'path' => $proofPath,
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('payments.proof', [$payment, $proof]))
+            ->assertForbidden();
+
+        File::delete($fullPath);
+    });
+
+    it('returns 404 when proof file is missing from disk', function () {
+        $user = User::factory()->owner()->create();
+        $lease = createLeaseForProperty();
+        $invoice = createInvoiceFor($lease);
+        $payment = Payment::factory()->create(['invoice_id' => $invoice->id]);
+        $proof = PaymentProof::factory()->create([
+            'payment_id' => $payment->id,
+            'path' => 'proofs/nonexistent.pdf',
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('payments.proof', [$payment, $proof]))
+            ->assertNotFound();
     });
 });


### PR DESCRIPTION
## Summary

Security fix for the payment proof download endpoint. Two issues:

1. **Missing import** — `PaymentProof` was type-hinted without an import, causing PHP to resolve the wrong class.
2. **No ownership check** — proofs were served without verifying they belonged to the requested payment.
3. **Path traversal risk** — `$proof->path` was concatenated into `storage_path()` directly instead of going through Filesystem.

## Changes

- Added `use App\Models\PaymentProof` import
- Added `scopeBindings()` to the payments route — proofs not belonging to the payment now return 404
- Replaced manual `storage_path()` + `response()->file()` with `Storage::disk('local')` to prevent path traversal
- Added `HasFactory` to `PaymentProof` and populated the factory
- 4 new feature tests covering all acceptance criteria

## Acceptance criteria

- Valid proof downloads for authorized users → 200
- Proof belonging to another payment → 404
- User without property access → 403
- Missing file on disk → 404

Closes #68

## Testing

```bash
php artisan test --compact --filter=PaymentTest
# 20 passed, 35 assertions
```

All 542 tests pass with zero regressions.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix proof file serving in `PaymentController` to use Storage facade and scope route bindings
> - Replaces direct `storage_path()` + `file_exists()` calls in `PaymentController::proof` with `Storage::disk('local')->exists()` and `Storage::disk('local')->response()`, and adds missing `use` imports for `PaymentProof` and `Storage`.
> - Adds `scopeBindings()` to the `payments/{payment}` route group so that `{proof}` is scoped to its parent payment, returning 404 when the proof does not belong to the given payment.
> - Implements `PaymentProofFactory` with PDF defaults and adds `HasFactory` to the `PaymentProof` model to support factory usage.
> - Adds a feature test suite covering authorized download, mismatched payment 404, unauthorized 403, and missing-file 404 cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c7ccfdf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->