### PR TITLE
fix(payment): scope verify to assigned properties

### DIFF
--- a/app/Policies/PaymentPolicy.php
+++ b/app/Policies/PaymentPolicy.php
@@ -41,6 +41,6 @@ class PaymentPolicy
             return false;
         }
 
-        return true;
+        return $user->isOwner() || $user->properties->contains($payment->invoice->lease->unit->property_id);
     }
 }

--- a/tests/Feature/PaymentTest.php
+++ b/tests/Feature/PaymentTest.php
@@ -2,6 +2,7 @@
 
 use App\Enums\InvoiceStatus;
 use App\Enums\PaymentStatus;
+use App\Enums\Permission;
 use App\Models\Invoice;
 use App\Models\Lease;
 use App\Models\Payment;
@@ -82,6 +83,52 @@ describe('authorization', function () {
         ]);
 
         expect($admin->can('view', $payment))->toBeFalse();
+    });
+
+    it('allows owner to verify payment', function () {
+        $user = User::factory()->owner()->create();
+        $lease = createLeaseForProperty();
+        $payment = Payment::factory()->pending()->create([
+            'invoice_id' => createInvoiceFor($lease)->id,
+        ]);
+
+        expect($user->can('verify', $payment))->toBeTrue();
+    });
+
+    it('allows user with permission assigned to property to verify payment', function () {
+        $user = User::factory()->create();
+        $user->givePermissionTo(Permission::PaymentsVerify->value);
+        $property = Property::factory()->create();
+        $user->properties()->sync([$property->id]);
+        $lease = createLeaseForProperty($property);
+        $payment = Payment::factory()->pending()->create([
+            'invoice_id' => createInvoiceFor($lease)->id,
+        ]);
+
+        expect($user->can('verify', $payment))->toBeTrue();
+    });
+
+    it('denies user with permission not assigned to property from verifying payment', function () {
+        $user = User::factory()->create();
+        $user->givePermissionTo(Permission::PaymentsVerify->value);
+        $propertyA = Property::factory()->create();
+        $user->properties()->sync([$propertyA->id]);
+        $lease = createLeaseForProperty();
+        $payment = Payment::factory()->pending()->create([
+            'invoice_id' => createInvoiceFor($lease)->id,
+        ]);
+
+        expect($user->can('verify', $payment))->toBeFalse();
+    });
+
+    it('denies user without payments.verify permission', function () {
+        $user = User::factory()->create();
+        $lease = createLeaseForProperty();
+        $payment = Payment::factory()->pending()->create([
+            'invoice_id' => createInvoiceFor($lease)->id,
+        ]);
+
+        expect($user->can('verify', $payment))->toBeFalse();
     });
 });
 


### PR DESCRIPTION
## Problem

`PaymentPolicy::verify()` checked the `payments.verify` permission and payment status, but did not verify that non-owner users can access the property associated with the payment. A staff user with `payments.verify` could confirm/reject payments for unassigned properties.

## Fix

Added the same property-scoping check used in `view()` and `create()` — `$user->properties->contains($payment->invoice->lease->unit->property_id)` — with an `isOwner()` bypass for owners.

## Tests

- Owner can verify any payment
- User with `payments.verify` + property assignment can verify
- User with `payments.verify` but wrong property gets denied
- User without `payments.verify` gets denied

Closes #67

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope `PaymentPolicy::verify` to users assigned to the payment's property
> - Previously, `verify()` allowed any user with the `payments.verify` permission and a Pending payment to proceed. Now the user must also be an owner or have the payment's property in their assigned properties (resolved via `payment->invoice->lease->unit->property_id`).
> - Adds feature tests covering: owner can verify, assigned user can verify, user assigned to a different property is denied, user without permission is denied.
> - Risk: Users who previously passed verification by permission and Pending status alone will now be denied if not assigned to the relevant property.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 52b13c1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->