### PR TITLE
feat(tenants): add app access invite and acceptance flow

### DIFF
--- a/app/Actions/Reminders/ForceSendReminder.php
+++ b/app/Actions/Reminders/ForceSendReminder.php
@@ -21,11 +21,11 @@ class ForceSendReminder
 
     public function execute(Lease $lease): string
     {
-        $lease->load(['primaryTenant']);
+        $lease->load(['primaryTenant.user']);
         $tenant = $lease->primaryTenant;
 
         $channels = Setting::get('reminder_channels') ?? ['log'];
-        $hasContact = $tenant?->phone || ($tenant?->email && in_array('mail', $channels));
+        $hasContact = $tenant?->phone || ($tenant?->user?->email && in_array('mail', $channels));
 
         if (! $hasContact) {
             return 'no_contact';

--- a/app/Actions/Reminders/SendRentReminders.php
+++ b/app/Actions/Reminders/SendRentReminders.php
@@ -32,8 +32,8 @@ class SendRentReminders
         }
 
         $leases = $lease
-            ? [$lease->load(['primaryTenant'])]
-            : Lease::active()->with(['primaryTenant'])->get();
+            ? [$lease->load(['primaryTenant.user'])]
+            : Lease::active()->with(['primaryTenant.user'])->get();
 
         $sent = collect();
 
@@ -41,7 +41,7 @@ class SendRentReminders
 
         foreach ($leases as $lease) {
             $tenant = $lease->primaryTenant;
-            $hasContact = $tenant?->phone || ($tenant?->email && in_array('mail', $channels));
+            $hasContact = $tenant?->phone || ($tenant?->user?->email && in_array('mail', $channels));
             if (! $hasContact) {
                 continue;
             }

--- a/app/Actions/Tenants/DisableTenantAccess.php
+++ b/app/Actions/Tenants/DisableTenantAccess.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Actions\Tenants;
+
+use App\Models\Tenant;
+use Illuminate\Support\Facades\DB;
+
+class DisableTenantAccess
+{
+    public function execute(Tenant $tenant): void
+    {
+        $user = $tenant->user;
+
+        if (! $user) {
+            return;
+        }
+
+        $user->update([
+            'is_active' => false,
+            'invited_at' => null,
+        ]);
+
+        DB::table('sessions')->where('user_id', $user->id)->delete();
+    }
+}

--- a/app/Actions/Tenants/InviteTenant.php
+++ b/app/Actions/Tenants/InviteTenant.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Actions\Tenants;
+
+use App\Models\Tenant;
+use App\Models\User;
+use App\Notifications\TenantInvitation;
+use Illuminate\Auth\Passwords\PasswordBroker;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Password;
+use Illuminate\Support\Str;
+
+class InviteTenant
+{
+    public function execute(Tenant $tenant, string $email, bool $sendInvite = true): User
+    {
+        $user = User::create([
+            'name' => $tenant->name,
+            'email' => $email,
+            'password' => Hash::make(Str::password(64)),
+            'is_active' => false,
+            // invited_at marks a pending activation; skip it when only registering
+            // the email for notifications (no portal invite sent).
+            'invited_at' => $sendInvite ? now() : null,
+        ]);
+
+        $tenant->user()->associate($user)->save();
+
+        if ($sendInvite) {
+            /** @var PasswordBroker $broker */
+            $broker = Password::broker();
+            $token = $broker->createToken($user);
+
+            $user->notify(new TenantInvitation(
+                route('tenants.invitations.accept', ['token' => $token, 'email' => $user->email]),
+            ));
+        }
+
+        return $user;
+    }
+}

--- a/app/Enums/Permission.php
+++ b/app/Enums/Permission.php
@@ -34,6 +34,7 @@ enum Permission: string
     case TenantsUpdate = 'tenants.update';
     case TenantsDelete = 'tenants.delete';
     case TenantsExport = 'tenants.export';
+    case TenantsInvite = 'tenants.invite';
 
     case LeasesView = 'leases.view';
     case LeasesCreate = 'leases.create';
@@ -70,6 +71,7 @@ enum Permission: string
             'reset_password' => 'Reset Password',
             'resend_invitation' => 'Resend Invitation',
             'export' => 'Export',
+            'invite' => 'Invite',
             'move' => 'Move Unit',
             'move_out' => 'Move Out',
             'renew' => 'Renew Lease',
@@ -113,6 +115,7 @@ enum Permission: string
             self::TenantsUpdate => 'Edit existing tenant information.',
             self::TenantsDelete => 'Archive tenant records.',
             self::TenantsExport => 'Export tenant data.',
+            self::TenantsInvite => 'Invite tenants to access the app.',
 
             self::LeasesView => 'View lease agreements and history.',
             self::LeasesCreate => 'Create new leases and assign tenants to units.',

--- a/app/Http/Controllers/TenantController.php
+++ b/app/Http/Controllers/TenantController.php
@@ -3,21 +3,27 @@
 namespace App\Http\Controllers;
 
 use App\Actions\Leases\CreateLease;
+use App\Actions\Tenants\DisableTenantAccess;
+use App\Actions\Tenants\InviteTenant;
 use App\Data\Lease\CreateLeaseData;
 use App\Enums\LeaseStatus;
 use App\Enums\TenantDocumentType;
 use App\Http\Requests\Tenant\AssignUnitRequest;
+use App\Http\Requests\Tenant\InviteTenantRequest;
 use App\Http\Requests\Tenant\StoreTenantRequest;
 use App\Http\Requests\Tenant\UpdateTenantRequest;
 use App\Models\Tenant;
 use App\Models\Unit;
+use App\Notifications\TenantInvitation;
 use App\Tables\Column;
 use App\Tables\Filter;
 use App\Tables\Table;
+use Illuminate\Auth\Passwords\PasswordBroker;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Password;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -28,6 +34,7 @@ class TenantController extends Controller
         $this->authorize('view', $tenant);
 
         $tenant->load([
+            'user:id,email,email_verified_at,last_login_at,is_active,invited_at',
             'documents',
             'leases' => fn ($q) => $q->where('status', 'active')
                 ->with(['unit.property', 'tenants:id,name,phone', 'primaryTenant:id,name,phone']),
@@ -215,6 +222,66 @@ class TenantController extends Controller
         $tenant->restore();
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Tenant restored.')]);
+
+        return back();
+    }
+
+    public function invite(InviteTenantRequest $request, Tenant $tenant, InviteTenant $action): RedirectResponse
+    {
+        $this->authorize('invite', $tenant);
+
+        if ($tenant->user_id) {
+            Inertia::flash('toast', ['type' => 'error', 'message' => __('Tenant already has app access.')]);
+
+            return back();
+        }
+
+        $sendInvite = $request->boolean('send_invite', true);
+
+        $action->execute($tenant, $request->validated('email'), $sendInvite);
+
+        Inertia::flash('toast', [
+            'type' => 'success',
+            'message' => $sendInvite ? __('Tenant invited.') : __('Tenant email saved.'),
+        ]);
+
+        return back();
+    }
+
+    public function resendInvitation(Tenant $tenant): RedirectResponse
+    {
+        $this->authorize('invite', $tenant);
+
+        $user = $tenant->user;
+
+        if (! $user) {
+            return back()->withErrors(['invite' => __('Tenant has no user account. Invite them first.')]);
+        }
+
+        if (! $user->invited_at) {
+            $user->update(['invited_at' => now()]);
+        }
+
+        /** @var PasswordBroker $broker */
+        $broker = Password::broker();
+        $token = $broker->createToken($user);
+
+        $user->notify(new TenantInvitation(
+            route('tenants.invitations.accept', ['token' => $token, 'email' => $user->email]),
+        ));
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Invitation resent.')]);
+
+        return back();
+    }
+
+    public function disableAccess(Tenant $tenant, DisableTenantAccess $action): RedirectResponse
+    {
+        $this->authorize('invite', $tenant);
+
+        $action->execute($tenant);
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Tenant access disabled.')]);
 
         return back();
     }

--- a/app/Http/Controllers/TenantController.php
+++ b/app/Http/Controllers/TenantController.php
@@ -258,7 +258,9 @@ class TenantController extends Controller
             return back()->withErrors(['invite' => __('Tenant has no user account. Invite them first.')]);
         }
 
-        if (! $user->invited_at) {
+        // Active users can already sign in, so a resend is just a fresh access link —
+        // don't flag them as "pending invite". Only mark genuinely un-activated users.
+        if (! $user->is_active && ! $user->invited_at) {
             $user->update(['invited_at' => now()]);
         }
 

--- a/app/Http/Controllers/TenantInvitationController.php
+++ b/app/Http/Controllers/TenantInvitationController.php
@@ -29,9 +29,11 @@ class TenantInvitationController extends Controller
 
         $user = User::where('email', $validated['email'])->first();
 
-        // Scope strictly to tenant invitations — this endpoint must never be able to
-        // activate a staff/owner account via its password-reset token.
-        if (! $user?->invited_at || ! $user->tenant()->exists()) {
+        // Scope strictly to tenant users who currently have access: a pending invite
+        // (invited_at) or an already-active account (a resend acts as a password reset).
+        // A disabled/un-invited tenant (inactive with no pending invite) is rejected, so
+        // this endpoint can never activate a staff account or revive disabled access.
+        if (! $user || ! $user->tenant()->exists() || (! $user->is_active && ! $user->invited_at)) {
             return back()->withErrors(['email' => __('This invitation is invalid or inactive.')]);
         }
 

--- a/app/Http/Controllers/TenantInvitationController.php
+++ b/app/Http/Controllers/TenantInvitationController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\Tenant\CompleteTenantInvitationRequest;
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Password;
+use Illuminate\Validation\Rules\Password as PasswordRule;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class TenantInvitationController extends Controller
+{
+    public function acceptInvitation(Request $request, string $token): Response
+    {
+        return Inertia::render('auth/tenant-accept-invitation', [
+            'email' => $request->query('email', ''),
+            'token' => $token,
+            'passwordRules' => PasswordRule::defaults()->toPasswordRulesString(),
+        ]);
+    }
+
+    public function completeInvitation(CompleteTenantInvitationRequest $request): RedirectResponse
+    {
+        $validated = $request->validated();
+
+        $user = User::where('email', $validated['email'])->first();
+
+        // Scope strictly to tenant invitations — this endpoint must never be able to
+        // activate a staff/owner account via its password-reset token.
+        if (! $user?->invited_at || ! $user->tenant()->exists()) {
+            return back()->withErrors(['email' => __('This invitation is invalid or inactive.')]);
+        }
+
+        $status = Password::broker()->reset($validated, function (User $user, string $password): void {
+            $user->forceFill([
+                'password' => Hash::make($password),
+                'email_verified_at' => now(),
+                'invited_at' => null,
+                'is_active' => true,
+            ])->save();
+        });
+
+        if ($status !== Password::PASSWORD_RESET) {
+            return back()->withErrors(['email' => __('This invitation link is invalid or has expired.')]);
+        }
+
+        return to_route('login')->with('status', __('Invitation accepted. You can now log in.'));
+    }
+}

--- a/app/Http/Requests/Tenant/CompleteTenantInvitationRequest.php
+++ b/app/Http/Requests/Tenant/CompleteTenantInvitationRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Requests\Tenant;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Password;
+
+class CompleteTenantInvitationRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'email'],
+            'token' => ['required', 'string'],
+            'password' => ['required', 'confirmed', Password::defaults()],
+        ];
+    }
+}

--- a/app/Http/Requests/Tenant/InviteTenantRequest.php
+++ b/app/Http/Requests/Tenant/InviteTenantRequest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Requests\Tenant;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class InviteTenantRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'email', 'max:255', 'unique:users,email'],
+            'send_invite' => ['nullable', 'boolean'],
+        ];
+    }
+}

--- a/app/Http/Requests/Tenant/StoreTenantRequest.php
+++ b/app/Http/Requests/Tenant/StoreTenantRequest.php
@@ -15,7 +15,6 @@ class StoreTenantRequest extends FormRequest
         return [
             'name' => ['required', 'string', 'max:255'],
             'phone' => ['nullable', 'string', 'max:20', 'regex:/^\+[1-9]\d{6,14}$/'],
-            'email' => ['nullable', 'email', 'max:255'],
             'id_card_number' => ['nullable', 'string', 'max:50'],
             'emergency_contact_name' => ['nullable', 'string', 'max:255'],
             'emergency_contact_phone' => ['nullable', 'string', 'max:20', 'regex:/^\+[1-9]\d{6,14}$/'],

--- a/app/Http/Requests/Tenant/UpdateTenantRequest.php
+++ b/app/Http/Requests/Tenant/UpdateTenantRequest.php
@@ -15,7 +15,6 @@ class UpdateTenantRequest extends FormRequest
         return [
             'name' => ['required', 'string', 'max:255'],
             'phone' => ['nullable', 'string', 'max:20', 'regex:/^\+[1-9]\d{6,14}$/'],
-            'email' => ['nullable', 'email', 'max:255'],
             'id_card_number' => ['nullable', 'string', 'max:50'],
             'emergency_contact_name' => ['nullable', 'string', 'max:255'],
             'emergency_contact_phone' => ['nullable', 'string', 'max:20', 'regex:/^\+[1-9]\d{6,14}$/'],

--- a/app/Models/Tenant.php
+++ b/app/Models/Tenant.php
@@ -17,7 +17,6 @@ use Illuminate\Notifications\Notification;
     'user_id',
     'name',
     'phone',
-    'email',
     'id_card_number',
     'emergency_contact_name',
     'emergency_contact_phone',
@@ -28,7 +27,7 @@ class Tenant extends Model
 {
     use Auditable, HasFactory, Notifiable, SoftDeletes;
 
-    protected array $auditableMask = ['phone', 'email', 'id_card_number', 'emergency_contact_phone'];
+    protected array $auditableMask = ['phone', 'id_card_number', 'emergency_contact_phone'];
 
     protected function casts(): array
     {
@@ -44,7 +43,9 @@ class Tenant extends Model
 
     public function routeNotificationForMail(Notification $notification): array
     {
-        return [$this->email => $this->name];
+        $email = $this->user?->email;
+
+        return $email ? [$email => $this->name] : [];
     }
 
     public function user(): BelongsTo

--- a/app/Notifications/TenantInvitation.php
+++ b/app/Notifications/TenantInvitation.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class TenantInvitation extends Notification
+{
+    use Queueable;
+
+    public function __construct(private readonly string $url) {}
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject(__('notifications.tenant_invitation.subject'))
+            ->greeting(__('notifications.tenant_invitation.greeting'))
+            ->line(__('notifications.tenant_invitation.intro'))
+            ->line(__('notifications.tenant_invitation.instruction'))
+            ->action(__('notifications.tenant_invitation.action'), $this->url)
+            ->line(__('notifications.tenant_invitation.outro'));
+    }
+
+    public function toArray(object $notifiable): array
+    {
+        return ['url' => $this->url];
+    }
+}

--- a/app/Policies/TenantPolicy.php
+++ b/app/Policies/TenantPolicy.php
@@ -39,6 +39,13 @@ class TenantPolicy
         return $this->delete($user, $tenant);
     }
 
+    public function invite(User $user, Tenant $tenant): bool
+    {
+        return $tenant->leases()
+            ->whereHas('unit.property.users', fn ($q) => $q->whereKey($user->id))
+            ->exists();
+    }
+
     public function assignUnit(User $user, Unit $unit): bool
     {
         return $user->properties->contains($unit->property_id);

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -96,11 +96,11 @@ class AppServiceProvider extends ServiceProvider
     {
         Event::listen(InvoiceReminderDispatched::class, function (InvoiceReminderDispatched $event): void {
             $lease = $event->event->lease;
-            $lease->loadMissing('primaryTenant');
+            $lease->loadMissing('primaryTenant.user');
             $tenant = $lease->primaryTenant;
 
             $channels = Setting::get('reminder_channels') ?? ['log'];
-            $hasContact = $tenant?->phone || ($tenant?->email && in_array('mail', $channels));
+            $hasContact = $tenant?->phone || ($tenant?->user?->email && in_array('mail', $channels));
 
             if (! $hasContact) {
                 return;

--- a/database/migrations/2026_07_18_000000_drop_email_from_tenants_table.php
+++ b/database/migrations/2026_07_18_000000_drop_email_from_tenants_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Tenant::query()
+            ->whereNotNull('email')
+            ->whereNull('user_id')
+            ->each(function (Tenant $tenant): void {
+                // firstOrCreate: two tenants sharing an email, or an email that already
+                // belongs to a user, must not abort the migration.
+                $user = User::firstOrCreate(
+                    ['email' => $tenant->email],
+                    [
+                        'name' => $tenant->name,
+                        'password' => Hash::make(Str::password(64)),
+                        'is_active' => false,
+                    ],
+                );
+
+                $tenant->user()->associate($user)->save();
+            });
+
+        Schema::table('tenants', function (Blueprint $table) {
+            $table->dropColumn('email');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tenants', function (Blueprint $table) {
+            $table->string('email')->nullable()->after('phone');
+        });
+    }
+};

--- a/database/migrations/2026_07_18_000000_drop_email_from_tenants_table.php
+++ b/database/migrations/2026_07_18_000000_drop_email_from_tenants_table.php
@@ -16,19 +16,43 @@ return new class extends Migration
             ->whereNotNull('email')
             ->whereNull('user_id')
             ->each(function (Tenant $tenant): void {
-                // firstOrCreate: two tenants sharing an email, or an email that already
-                // belongs to a user, must not abort the migration.
-                $user = User::firstOrCreate(
-                    ['email' => $tenant->email],
-                    [
-                        'name' => $tenant->name,
-                        'password' => Hash::make(Str::password(64)),
-                        'is_active' => false,
-                    ],
-                );
+                // users.email and tenants.user_id are both unique (1:1), so an email
+                // that's already taken — by another tenant's backfilled user or by an
+                // existing account — can only back one tenant. Link the first; leave the
+                // rest unlinked (user_id null) rather than abort or hijack an account.
+                if (User::where('email', $tenant->email)->exists()) {
+                    return;
+                }
+
+                $user = User::create([
+                    'name' => $tenant->name,
+                    'email' => $tenant->email,
+                    'password' => Hash::make(Str::password(64)),
+                    'is_active' => false,
+                ]);
 
                 $tenant->user()->associate($user)->save();
             });
+
+        // Tripwire: dropping email is irreversible. Nothing populated tenants.user_id
+        // before this feature, so already-linked rows shouldn't exist — but if one has
+        // a contact email that differs from its user's (unique, NOT NULL) login email,
+        // dropping would silently destroy it. user.email can't be safely overwritten
+        // (it's the login identity), so surface it for manual resolution instead.
+        $orphanedEmails = Tenant::query()
+            ->whereNotNull('user_id')
+            ->whereNotNull('email')
+            ->with('user:id,email')
+            ->get()
+            ->filter(fn (Tenant $tenant): bool => $tenant->email !== $tenant->user?->email);
+
+        if ($orphanedEmails->isNotEmpty()) {
+            throw new RuntimeException(
+                "Refusing to drop tenants.email: {$orphanedEmails->count()} linked tenant(s) have a contact "
+                .'email that differs from their user login email (ids: '.$orphanedEmails->pluck('id')->join(', ')
+                .'). Reconcile these before migrating.'
+            );
+        }
 
         Schema::table('tenants', function (Blueprint $table) {
             $table->dropColumn('email');

--- a/lang/en/notifications.php
+++ b/lang/en/notifications.php
@@ -6,4 +6,12 @@ return [
         'due_today' => "Hi :name,\n\nRent for :unit is due today.\n\nAmount: :amount",
         'overdue' => "Hi :name,\n\nRent for :unit is overdue by :days day(s).\n\nAmount: :amount",
     ],
+    'tenant_invitation' => [
+        'subject' => 'You have been invited to OpenKos',
+        'greeting' => 'Welcome to OpenKos',
+        'intro' => 'You have been given access to your tenant portal.',
+        'instruction' => 'Set your password to activate your account and access payments, invoices, and lease details.',
+        'action' => 'Accept Invitation',
+        'outro' => 'If you did not expect this invitation, you may ignore this email.',
+    ],
 ];

--- a/lang/id/notifications.php
+++ b/lang/id/notifications.php
@@ -6,4 +6,12 @@ return [
         'due_today' => "Halo :name,\n\nSewa kamar :unit jatuh tempo hari ini.\n\nJumlah: :amount",
         'overdue' => "Halo :name,\n\nPembayaran sewa kamar :unit terlambat :days hari.\n\nJumlah: :amount",
     ],
+    'tenant_invitation' => [
+        'subject' => 'Anda diundang ke OpenKos',
+        'greeting' => 'Selamat datang di OpenKos',
+        'intro' => 'Anda telah diberikan akses ke portal penyewa Anda.',
+        'instruction' => 'Atur kata sandi Anda untuk mengaktifkan akun dan mengakses pembayaran, tagihan, dan detail sewa.',
+        'action' => 'Terima Undangan',
+        'outro' => 'Jika Anda tidak mengharapkan undangan ini, Anda dapat mengabaikan email ini.',
+    ],
 ];

--- a/resources/js/components/features/tenants/invite-to-app-sheet.tsx
+++ b/resources/js/components/features/tenants/invite-to-app-sheet.tsx
@@ -1,0 +1,139 @@
+import { router } from '@inertiajs/react';
+import { useState } from 'react';
+import { InputError } from '@/components/shared';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetHeader,
+    SheetTitle,
+} from '@/components/ui/sheet';
+import { Switch } from '@/components/ui/switch';
+import tenants from '@/routes/tenants';
+
+export default function InviteToAppSheet({
+    tenantId,
+    open,
+    onOpenChange,
+}: {
+    tenantId: number | null;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}) {
+    const [email, setEmail] = useState('');
+    const [error, setError] = useState('');
+    const [sending, setSending] = useState(false);
+    const [sendInvite, setSendInvite] = useState(true);
+
+    function close(next: boolean) {
+        if (!next) {
+            setEmail('');
+            setError('');
+            setSending(false);
+            setSendInvite(true);
+        }
+
+        onOpenChange(next);
+    }
+
+    function handleSend() {
+        if (tenantId === null) {
+            return;
+        }
+
+        if (!email) {
+            setError('Email is required');
+
+            return;
+        }
+
+        setSending(true);
+        router.post(
+            tenants.invite(tenantId).url,
+            { email, send_invite: sendInvite },
+            {
+                onSuccess: () => close(false),
+                onError: (errors) => {
+                    setError(errors.email ?? 'Failed to send invitation');
+                    setSending(false);
+                },
+            },
+        );
+    }
+
+    return (
+        <Sheet open={open} onOpenChange={close}>
+            <SheetContent className="sm:max-w-lg">
+                <SheetHeader>
+                    <SheetTitle>Invite to App</SheetTitle>
+                    <SheetDescription>
+                        Add an email to send this tenant notifications. Optionally
+                        invite them to activate a portal account for payments,
+                        invoices, and lease details.
+                    </SheetDescription>
+                </SheetHeader>
+
+                <div className="flex flex-1 flex-col justify-between gap-6 overflow-y-auto px-4 pt-4 pb-6">
+                    <div className="grid gap-4">
+                        <div className="grid gap-2">
+                            <Label htmlFor="invite-email">Email</Label>
+                            <Input
+                                id="invite-email"
+                                type="email"
+                                value={email}
+                                onChange={(e) => {
+                                    setEmail(e.target.value);
+                                    setError('');
+                                }}
+                                placeholder="e.g. tenant@example.com"
+                            />
+                            <InputError message={error} />
+                        </div>
+
+                        <div className="flex items-start justify-between gap-4">
+                            <div className="grid gap-1">
+                                <Label htmlFor="invite-send">
+                                    Send activation invite
+                                </Label>
+                                <p className="text-xs text-muted-foreground">
+                                    Emails the tenant a link to set a password and
+                                    access the portal. Leave off to only save the
+                                    email for notifications.
+                                </p>
+                            </div>
+                            <Switch
+                                id="invite-send"
+                                checked={sendInvite}
+                                onCheckedChange={setSendInvite}
+                            />
+                        </div>
+                    </div>
+
+                    <div className="flex items-center justify-end gap-4">
+                        <Button
+                            variant="outline"
+                            type="button"
+                            onClick={() => close(false)}
+                            disabled={sending}
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            disabled={sending || !email}
+                            onClick={handleSend}
+                        >
+                            {sending
+                                ? 'Saving...'
+                                : sendInvite
+                                  ? 'Send Invitation'
+                                  : 'Save Email'}
+                        </Button>
+                    </div>
+                </div>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/resources/js/components/features/tenants/invite-to-app-sheet.tsx
+++ b/resources/js/components/features/tenants/invite-to-app-sheet.tsx
@@ -28,12 +28,21 @@ export default function InviteToAppSheet({
     const [sending, setSending] = useState(false);
     const [sendInvite, setSendInvite] = useState(true);
 
+    function reset() {
+        setEmail('');
+        setError('');
+        setSendInvite(true);
+    }
+
     function close(next: boolean) {
+        // Block dismissal (X, Esc, overlay) while a request is in flight so the
+        // sheet can't be reopened and re-submitted before the first completes.
+        if (sending) {
+            return;
+        }
+
         if (!next) {
-            setEmail('');
-            setError('');
-            setSending(false);
-            setSendInvite(true);
+            reset();
         }
 
         onOpenChange(next);
@@ -55,7 +64,11 @@ export default function InviteToAppSheet({
             tenants.invite(tenantId).url,
             { email, send_invite: sendInvite },
             {
-                onSuccess: () => close(false),
+                onSuccess: () => {
+                    setSending(false);
+                    reset();
+                    onOpenChange(false);
+                },
                 onError: (errors) => {
                     setError(errors.email ?? 'Failed to send invitation');
                     setSending(false);

--- a/resources/js/components/features/tenants/tenant-app-access-section.tsx
+++ b/resources/js/components/features/tenants/tenant-app-access-section.tsx
@@ -1,0 +1,152 @@
+import { router } from '@inertiajs/react';
+import { useState } from 'react';
+import InviteToAppSheet from '@/components/features/tenants/invite-to-app-sheet';
+import { StatusBadge } from '@/components/shared/status-badge';
+import { Button } from '@/components/ui/button';
+import { formatDate } from '@/lib/formatters';
+import tenants from '@/routes/tenants';
+import type { Tenant } from '@/types';
+
+type TenantWithUser = Tenant & {
+    user?: {
+        id: number;
+        email: string;
+        email_verified_at: string | null;
+        last_login_at: string | null;
+        is_active: boolean;
+        invited_at: string | null;
+    } | null;
+};
+
+export default function TenantAppAccessSection({
+    tenant,
+}: {
+    tenant: TenantWithUser;
+}) {
+    const [inviteOpen, setInviteOpen] = useState(false);
+
+    const user = tenant.user;
+    const isActivated = user?.is_active && user?.email_verified_at;
+    const isInvited = user && !isActivated && user.invited_at;
+    const isEmailOnly = user && !isActivated && !user.invited_at;
+
+    function handleResend() {
+        router.post(tenants.resendInvitation(tenant.id).url);
+    }
+
+    function handleDisable() {
+        router.post(tenants.disableAccess(tenant.id).url);
+    }
+
+    return (
+        <div className="rounded-lg border bg-muted/30 p-4">
+            <p className="mb-3 text-xs font-medium tracking-wider text-muted-foreground uppercase">
+                App Access
+            </p>
+
+            {!user && (
+                <div className="space-y-3">
+                    <div className="flex items-center gap-2">
+                        <span className="text-sm text-muted-foreground">
+                            Not activated
+                        </span>
+                        <StatusBadge domain="user" value="disabled" />
+                    </div>
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setInviteOpen(true)}
+                    >
+                        Invite to App
+                    </Button>
+                </div>
+            )}
+
+            {isEmailOnly && (
+                <div className="space-y-3">
+                    <div className="flex items-center gap-2">
+                        <span className="text-sm text-muted-foreground">
+                            {user.email}
+                        </span>
+                        <StatusBadge domain="user" value="notified" />
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                        Receives notifications. No portal access yet.
+                    </p>
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={handleResend}
+                    >
+                        Send Invitation
+                    </Button>
+                </div>
+            )}
+
+            {isInvited && (
+                <div className="space-y-3">
+                    <div className="flex items-center gap-2">
+                        <span className="text-sm text-muted-foreground">
+                            {user.email}
+                        </span>
+                        <StatusBadge domain="user" value="invited" />
+                    </div>
+                    <div className="flex gap-2">
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={handleResend}
+                        >
+                            Resend Invitation
+                        </Button>
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={handleDisable}
+                        >
+                            Disable Access
+                        </Button>
+                    </div>
+                </div>
+            )}
+
+            {isActivated && (
+                <div className="space-y-3">
+                    <div className="flex items-center gap-2">
+                        <span className="text-sm text-muted-foreground">
+                            {user.email}
+                        </span>
+                        <StatusBadge domain="user" value="active" />
+                    </div>
+                    {user.last_login_at && (
+                        <p className="text-xs text-muted-foreground">
+                            Last login: {formatDate(user.last_login_at)}
+                        </p>
+                    )}
+                    <div className="flex gap-2">
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={handleResend}
+                        >
+                            Resend Invitation
+                        </Button>
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={handleDisable}
+                        >
+                            Disable Access
+                        </Button>
+                    </div>
+                </div>
+            )}
+
+            <InviteToAppSheet
+                tenantId={tenant.id}
+                open={inviteOpen}
+                onOpenChange={setInviteOpen}
+            />
+        </div>
+    );
+}

--- a/resources/js/components/features/tenants/tenant-detail-sheet.tsx
+++ b/resources/js/components/features/tenants/tenant-detail-sheet.tsx
@@ -1,4 +1,5 @@
 import { router } from '@inertiajs/react';
+import { MailPlus } from 'lucide-react';
 import { useState } from 'react';
 import { StatusBadge } from '@/components/shared/status-badge';
 import { Button } from '@/components/ui/button';
@@ -29,6 +30,7 @@ export default function TenantDetailSheet({
     onDocuments,
     onAssignToUnit,
     onMoveOut,
+    onInvite,
 }: {
     tenant?:
         | (WorkspaceTenant & { leases?: Lease[]; documents?: TenantDocument[] })
@@ -39,6 +41,7 @@ export default function TenantDetailSheet({
     onDocuments: () => void;
     onAssignToUnit?: () => void;
     onMoveOut?: () => void;
+    onInvite?: () => void;
 }) {
     const [archiveConfirm, setArchiveConfirm] = useState(false);
 
@@ -278,6 +281,15 @@ export default function TenantDetailSheet({
                             </Button>
                             {!isArchived && tenant && (
                                 <>
+                                    {!tenant.user_id && onInvite && (
+                                        <Button
+                                            variant="outline"
+                                            onClick={onInvite}
+                                        >
+                                            <MailPlus className="size-4" />
+                                            Invite to App
+                                        </Button>
+                                    )}
                                     {!activeLease && onAssignToUnit && (
                                         <Button onClick={onAssignToUnit}>
                                             Assign to Unit

--- a/resources/js/components/features/tenants/tenant-form-sheet.tsx
+++ b/resources/js/components/features/tenants/tenant-form-sheet.tsx
@@ -29,7 +29,6 @@ export default function TenantFormSheet({
         useForm({
             name: tenant?.name ?? '',
             phone: tenant?.phone ?? '',
-            email: tenant?.email ?? '',
             id_card_number: tenant?.id_card_number ?? '',
             emergency_contact_phone: tenant?.emergency_contact_phone ?? '',
             emergency_contact_name: tenant?.emergency_contact_name ?? '',
@@ -98,20 +97,6 @@ export default function TenantFormSheet({
                                 placeholder="e.g. 81234567890"
                             />
                             <InputError message={errors.phone} />
-                        </div>
-
-                        <div className="grid gap-2">
-                            <Label htmlFor="email">Email</Label>
-                            <Input
-                                id="email"
-                                type="email"
-                                value={data.email}
-                                onChange={(e) =>
-                                    setData('email', e.target.value)
-                                }
-                                placeholder="e.g. john@example.com"
-                            />
-                            <InputError message={errors.email} />
                         </div>
 
                         <div className="grid gap-2">

--- a/resources/js/components/features/tenants/tenant-overview.tsx
+++ b/resources/js/components/features/tenants/tenant-overview.tsx
@@ -1,3 +1,4 @@
+import TenantAppAccessSection from '@/components/features/tenants/tenant-app-access-section';
 import { StatusBadge } from '@/components/shared/status-badge';
 import { formatDate, formatPrice } from '@/lib/formatters';
 import type { Lease, WorkspaceTenant } from '@/types';
@@ -27,6 +28,8 @@ export default function TenantOverview({
                     />
                 }
             </div>
+
+            <TenantAppAccessSection tenant={tenant} />
 
             <div className="rounded-lg border bg-muted/30 p-4">
                 <p className="mb-2 text-xs font-medium tracking-wider text-muted-foreground uppercase">

--- a/resources/js/components/shared/status-badge.tsx
+++ b/resources/js/components/shared/status-badge.tsx
@@ -66,6 +66,7 @@ const STATUS_CONFIGS: Record<string, Record<string, StatusConfig>> = {
     user: {
         active: { label: 'Active', className: 'bg-green-600 text-white' },
         invited: { label: 'Invited', variant: 'outline' },
+        notified: { label: 'Email only', variant: 'outline' },
         disabled: { label: 'Disabled', variant: 'secondary' },
     },
     tenant: {

--- a/resources/js/pages/auth/tenant-accept-invitation.tsx
+++ b/resources/js/pages/auth/tenant-accept-invitation.tsx
@@ -1,0 +1,80 @@
+import { Form, Head } from '@inertiajs/react';
+import { InputError, PasswordInput } from '@/components/shared';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Spinner } from '@/components/ui/spinner';
+import { complete } from '@/routes/tenants/invitations';
+
+type Props = {
+    token: string;
+    email: string;
+    passwordRules: string;
+};
+
+export default function TenantAcceptInvitation({
+    token,
+    email,
+    passwordRules,
+}: Props) {
+    return (
+        <>
+            <Head title="Accept invitation" />
+
+            <Form
+                {...complete.form()}
+                transform={(data) => ({ ...data, token, email })}
+                resetOnSuccess={['password', 'password_confirmation']}
+            >
+                {({ processing, errors }) => (
+                    <div className="grid gap-6">
+                        <div className="grid gap-2">
+                            <Label htmlFor="email">Email</Label>
+                            <Input id="email" value={email} readOnly />
+                            <InputError message={errors.email} />
+                        </div>
+
+                        <div className="grid gap-2">
+                            <Label htmlFor="password">Password</Label>
+                            <PasswordInput
+                                id="password"
+                                name="password"
+                                autoComplete="new-password"
+                                autoFocus
+                                placeholder="Password"
+                                passwordrules={passwordRules}
+                            />
+                            <InputError message={errors.password} />
+                        </div>
+
+                        <div className="grid gap-2">
+                            <Label htmlFor="password_confirmation">
+                                Confirm password
+                            </Label>
+                            <PasswordInput
+                                id="password_confirmation"
+                                name="password_confirmation"
+                                autoComplete="new-password"
+                                placeholder="Confirm password"
+                                passwordrules={passwordRules}
+                            />
+                            <InputError
+                                message={errors.password_confirmation}
+                            />
+                        </div>
+
+                        <Button className="mt-4 w-full" disabled={processing}>
+                            {processing && <Spinner />}
+                            Accept invitation
+                        </Button>
+                    </div>
+                )}
+            </Form>
+        </>
+    );
+}
+
+TenantAcceptInvitation.layout = {
+    title: 'Accept invitation',
+    description: 'Set your password to activate your tenant account',
+};

--- a/resources/js/pages/tenants/index.tsx
+++ b/resources/js/pages/tenants/index.tsx
@@ -4,6 +4,7 @@ import {
     EllipsisVertical,
     ExternalLink,
     Eye,
+    MailPlus,
     Pencil,
     RotateCcw,
     Trash2,
@@ -20,6 +21,7 @@ import {
     TenantDocumentsSheet,
     TenantFormSheet,
 } from '@/components/features';
+import InviteToAppSheet from '@/components/features/tenants/invite-to-app-sheet';
 import { Heading } from '@/components/shared';
 import { StatusBadge } from '@/components/shared/status-badge';
 import { Badge } from '@/components/ui/badge';
@@ -93,6 +95,10 @@ export default function Index({
 
     const [archiveConfirm, setArchiveConfirm] =
         useState<WorkspaceTenant | null>(null);
+
+    const [inviteTenant, setInviteTenant] = useState<WorkspaceTenant | null>(
+        null,
+    );
 
     const table = useTable({
         routeFn: () => tenants.index(),
@@ -240,6 +246,14 @@ export default function Index({
                             <ExternalLink className="size-4" />
                             Open Workspace
                         </DropdownMenuItem>
+                        {!t.deleted_at && !t.user_id && (
+                            <DropdownMenuItem
+                                onClick={() => setInviteTenant(t)}
+                            >
+                                <MailPlus className="size-4" />
+                                Invite to App
+                            </DropdownMenuItem>
+                        )}
                         <DropdownMenuItem onClick={() => openDetail(t)}>
                             <Eye className="size-4" />
                             View
@@ -338,6 +352,14 @@ export default function Index({
                 onAssignToUnit={openAssignUnit}
                 onMoveOut={openMoveOut}
                 onDocuments={openDocuments}
+                onInvite={
+                    viewingTenant?.user_id ? undefined : () => {
+                        if (viewingTenant) {
+                            setDetailOpen(false);
+                            setInviteTenant(viewingTenant);
+                        }
+                    }
+                }
             />
 
             <TenantFormSheet
@@ -397,6 +419,12 @@ export default function Index({
                 availableUnits={_availableUnits}
                 open={moveOutOpen}
                 onOpenChange={setMoveOutOpen}
+            />
+
+            <InviteToAppSheet
+                tenantId={inviteTenant?.id ?? null}
+                open={inviteTenant !== null}
+                onOpenChange={(open) => !open && setInviteTenant(null)}
             />
 
             <Dialog

--- a/resources/js/types/models.ts
+++ b/resources/js/types/models.ts
@@ -1,8 +1,8 @@
 export type Tenant = {
     id: number;
+    user_id: number | null;
     name: string;
     phone: string | null;
-    email: string | null;
     id_card_number: string | null;
     emergency_contact_name: string | null;
     emergency_contact_phone: string | null;
@@ -11,6 +11,14 @@ export type Tenant = {
     deleted_at?: string | null;
     active_leases_count?: number;
     documents?: TenantDocument[];
+    user?: {
+        id: number;
+        email: string;
+        email_verified_at: string | null;
+        last_login_at: string | null;
+        is_active: boolean;
+        invited_at: string | null;
+    } | null;
 };
 
 export type TenantInfo = {

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,6 +13,7 @@ use App\Http\Controllers\PropertyLeasesController;
 use App\Http\Controllers\RoleController;
 use App\Http\Controllers\TenantController;
 use App\Http\Controllers\TenantDocumentController;
+use App\Http\Controllers\TenantInvitationController;
 use App\Http\Controllers\UnitController;
 use App\Http\Controllers\UserController;
 use Illuminate\Support\Facades\Route;
@@ -84,6 +85,9 @@ Route::middleware(['auth', 'verified', 'permission:dashboard.view'])->group(func
             Route::get('leases', [TenantController::class, 'leases'])->name('workspace.leases')->middleware('permission:tenants.view');
             Route::get('documents', [TenantController::class, 'documents'])->name('workspace.documents')->middleware('permission:tenants.view');
             Route::post('assign-unit', [TenantController::class, 'assignUnit'])->name('assign-unit')->middleware('permission:tenants.update');
+            Route::post('invite', [TenantController::class, 'invite'])->name('invite')->middleware('permission:tenants.invite');
+            Route::post('resend-invitation', [TenantController::class, 'resendInvitation'])->name('resend-invitation')->middleware('permission:tenants.invite');
+            Route::post('disable-access', [TenantController::class, 'disableAccess'])->name('disable-access')->middleware('permission:tenants.invite');
 
             Route::prefix('documents')->name('documents.')->group(function () {
                 Route::post('/', [TenantDocumentController::class, 'store'])->name('store')->middleware('permission:tenants.update');
@@ -91,6 +95,11 @@ Route::middleware(['auth', 'verified', 'permission:dashboard.view'])->group(func
                 Route::delete('{document}', [TenantDocumentController::class, 'destroy'])->name('destroy')->middleware('permission:tenants.update');
             });
         });
+    });
+
+    Route::prefix('tenants/invitations')->name('tenants.invitations.')->middleware('guest')->group(function () {
+        Route::get('{token}', [TenantInvitationController::class, 'acceptInvitation'])->name('accept');
+        Route::post('accept', [TenantInvitationController::class, 'completeInvitation'])->name('complete');
     });
 
     Route::prefix('leases')->name('leases.')->group(function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,6 +25,11 @@ Route::prefix('invitations')->name('users.invitations.')->middleware('guest')->g
     Route::post('accept', [UserController::class, 'completeInvitation'])->name('complete');
 });
 
+Route::prefix('tenants/invitations')->name('tenants.invitations.')->middleware('guest')->group(function () {
+    Route::get('{token}', [TenantInvitationController::class, 'acceptInvitation'])->name('accept');
+    Route::post('accept', [TenantInvitationController::class, 'completeInvitation'])->name('complete');
+});
+
 Route::middleware(['auth', 'verified', 'permission:dashboard.view'])->group(function () {
     Route::prefix('dashboard')->group(function () {
         Route::get('/', OverviewController::class)->name('dashboard');
@@ -95,11 +100,6 @@ Route::middleware(['auth', 'verified', 'permission:dashboard.view'])->group(func
                 Route::delete('{document}', [TenantDocumentController::class, 'destroy'])->name('destroy')->middleware('permission:tenants.update');
             });
         });
-    });
-
-    Route::prefix('tenants/invitations')->name('tenants.invitations.')->middleware('guest')->group(function () {
-        Route::get('{token}', [TenantInvitationController::class, 'acceptInvitation'])->name('accept');
-        Route::post('accept', [TenantInvitationController::class, 'completeInvitation'])->name('complete');
     });
 
     Route::prefix('leases')->name('leases.')->group(function () {

--- a/tests/Feature/AuditLogTest.php
+++ b/tests/Feature/AuditLogTest.php
@@ -114,13 +114,11 @@ describe('PII handling', function () {
     it('masks sensitive fields on Tenant', function () {
         Tenant::factory()->create([
             'phone' => '08123456789',
-            'email' => 'tenant@example.com',
             'id_card_number' => '1234567890123456',
         ]);
 
         $log = AuditLog::first();
         expect($log->after['phone'])->toBe('***MASKED***');
-        expect($log->after['email'])->toBe('***MASKED***');
         expect($log->after['id_card_number'])->toBe('***MASKED***');
         expect($log->after['name'])->not->toBe('***MASKED***');
     });

--- a/tests/Feature/SendRentRemindersTest.php
+++ b/tests/Feature/SendRentRemindersTest.php
@@ -204,6 +204,42 @@ describe('SendRentRemindersAction', function () {
 
         Carbon::setTestNow();
     });
+
+    it('emails an invited but unverified tenant', function () {
+        Carbon::setTestNow(Carbon::parse('2026-07-01'));
+        Setting::set('reminder_channels', ['mail'], 'array');
+        Notification::fake();
+
+        $property = Property::factory()->create();
+        $unit = Unit::factory()->for($property)->create();
+        $user = User::factory()->create([
+            'email' => 'tenant@example.com',
+            'is_active' => false,
+            'email_verified_at' => null,
+            'invited_at' => now(),
+        ]);
+        $tenant = Tenant::factory()->create(['phone' => null, 'user_id' => $user->id]);
+
+        $lease = Lease::factory()->create([
+            'unit_id' => $unit->id,
+            'primary_tenant_id' => $tenant->id,
+            'start_date' => '2026-06-01',
+            'rent_amount' => 1500000.00,
+            'rent_due_day' => 1,
+            'billing_interval' => 1,
+            'billing_unit' => 'month',
+            'status' => 'active',
+        ]);
+        app(GenerateInvoices::class)->execute($lease);
+        $lease->load(['primaryTenant']);
+
+        $sent = app(SendRentReminders::class)->execute($lease);
+
+        expect($sent)->not->toBeEmpty();
+        Notification::assertSentTo($lease->primaryTenant, RentReminder::class);
+
+        Carbon::setTestNow();
+    });
 });
 
 describe('Command', function () {

--- a/tests/Feature/TenantInviteTest.php
+++ b/tests/Feature/TenantInviteTest.php
@@ -1,0 +1,259 @@
+<?php
+
+use App\Models\Lease;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Notifications\TenantInvitation;
+use App\Policies\TenantPolicy;
+use Database\Seeders\RoleAndPermissionSeeder;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Password;
+
+uses()->beforeEach(function () {
+    $this->seed(RoleAndPermissionSeeder::class);
+});
+
+describe('invite tenant', function () {
+    it('creates a user and links to tenant', function () {
+        Notification::fake();
+
+        $owner = User::factory()->owner()->create();
+        $tenant = Tenant::factory()->create();
+
+        $this->actingAs($owner)
+            ->from(route('tenants.show', $tenant))
+            ->post(route('tenants.invite', $tenant), [
+                'email' => 'tenant@example.com',
+            ])
+            ->assertRedirect(route('tenants.show', $tenant));
+
+        $tenant->refresh();
+
+        expect($tenant->user)->not->toBeNull();
+        expect($tenant->user->email)->toBe('tenant@example.com');
+        expect($tenant->user->is_active)->toBeFalse();
+        expect($tenant->user->invited_at)->not->toBeNull();
+
+        Notification::assertSentTo($tenant->user, TenantInvitation::class);
+    });
+
+    it('saves the email without sending when send_invite is false', function () {
+        Notification::fake();
+
+        $owner = User::factory()->owner()->create();
+        $tenant = Tenant::factory()->create();
+
+        $this->actingAs($owner)
+            ->from(route('tenants.show', $tenant))
+            ->post(route('tenants.invite', $tenant), [
+                'email' => 'tenant@example.com',
+                'send_invite' => false,
+            ])
+            ->assertRedirect(route('tenants.show', $tenant));
+
+        $tenant->refresh();
+
+        expect($tenant->user)->not->toBeNull();
+        expect($tenant->user->email)->toBe('tenant@example.com');
+        expect($tenant->user->is_active)->toBeFalse();
+        expect($tenant->user->invited_at)->toBeNull();
+
+        Notification::assertNotSentTo($tenant->user, TenantInvitation::class);
+    });
+
+    it('returns 403 for user without tenants.invite permission', function () {
+        $user = User::factory()->create();
+        $tenant = Tenant::factory()->create();
+
+        $this->actingAs($user)
+            ->post(route('tenants.invite', $tenant), [
+                'email' => 'tenant@example.com',
+            ])
+            ->assertForbidden();
+    });
+
+    it('validates email is required', function () {
+        $owner = User::factory()->owner()->create();
+        $tenant = Tenant::factory()->create();
+
+        $this->actingAs($owner)
+            ->post(route('tenants.invite', $tenant), [])
+            ->assertSessionHasErrors('email');
+    });
+
+    it('validates email is unique in users table', function () {
+        $owner = User::factory()->owner()->create();
+        User::factory()->create(['email' => 'existing@example.com']);
+        $tenant = Tenant::factory()->create();
+
+        $this->actingAs($owner)
+            ->post(route('tenants.invite', $tenant), [
+                'email' => 'existing@example.com',
+            ])
+            ->assertSessionHasErrors('email');
+    });
+
+    it('returns error when tenant already has a linked user', function () {
+        $owner = User::factory()->owner()->create();
+        $tenant = Tenant::factory()->withUser()->create();
+
+        $this->actingAs($owner)
+            ->from(route('tenants.show', $tenant))
+            ->post(route('tenants.invite', $tenant), [
+                'email' => 'another@example.com',
+            ])
+            ->assertRedirect(route('tenants.show', $tenant));
+    });
+});
+
+describe('resend invitation', function () {
+    it('resends to an invited tenant', function () {
+        Notification::fake();
+
+        $owner = User::factory()->owner()->create();
+        $user = User::factory()->create([
+            'email' => 'tenant@example.com',
+            'invited_at' => now(),
+            'is_active' => false,
+        ]);
+        $tenant = Tenant::factory()->create(['user_id' => $user->id]);
+
+        $this->actingAs($owner)
+            ->post(route('tenants.resend-invitation', $tenant))
+            ->assertSessionHasNoErrors();
+
+        Notification::assertSentTo($user, TenantInvitation::class);
+    });
+
+    it('sets invited_at if null before resending', function () {
+        Notification::fake();
+
+        $owner = User::factory()->owner()->create();
+        $user = User::factory()->create([
+            'email' => 'tenant@example.com',
+            'invited_at' => null,
+            'is_active' => false,
+        ]);
+        $tenant = Tenant::factory()->create(['user_id' => $user->id]);
+
+        $this->actingAs($owner)
+            ->post(route('tenants.resend-invitation', $tenant))
+            ->assertSessionHasNoErrors();
+
+        expect($user->fresh()->invited_at)->not->toBeNull();
+
+        Notification::assertSentTo($user, TenantInvitation::class);
+    });
+
+    it('returns error if tenant has no user account', function () {
+        $owner = User::factory()->owner()->create();
+        $tenant = Tenant::factory()->create();
+
+        $this->actingAs($owner)
+            ->post(route('tenants.resend-invitation', $tenant))
+            ->assertSessionHasErrors('invite');
+    });
+});
+
+describe('disable access', function () {
+    it('deactivates the linked user', function () {
+        $owner = User::factory()->owner()->create();
+        $user = User::factory()->create([
+            'email' => 'tenant@example.com',
+            'invited_at' => now(),
+            'is_active' => false,
+        ]);
+        $tenant = Tenant::factory()->create(['user_id' => $user->id]);
+
+        $this->actingAs($owner)
+            ->post(route('tenants.disable-access', $tenant))
+            ->assertSessionHasNoErrors();
+
+        $user->refresh();
+
+        expect($user->is_active)->toBeFalse();
+        expect($user->invited_at)->toBeNull();
+    });
+
+    // Regression: policy must still grant invite/disable/resend for scoped staff
+    // once the tenant's user is active (post-activation lifecycle).
+    it('lets scoped staff manage access after the tenant user is active', function () {
+        $staff = User::factory()->staff()->create();
+        $tenant = Tenant::factory()->withUser()->create();
+        $lease = Lease::factory()->create(['primary_tenant_id' => $tenant->id]);
+        $lease->unit->property->users()->attach($staff);
+
+        expect($tenant->user->is_active)->toBeTrue();
+        expect(app(TenantPolicy::class)->invite($staff, $tenant))->toBeTrue();
+    });
+});
+
+describe('invitation acceptance', function () {
+    it('accepts a valid invitation and sets password', function () {
+        $user = User::factory()->create([
+            'email' => 'tenant@example.com',
+            'invited_at' => now(),
+            'is_active' => false,
+        ]);
+        Tenant::factory()->create(['user_id' => $user->id]);
+
+        $token = Password::broker()->createToken($user);
+
+        $this->withoutMiddleware()
+            ->post(route('tenants.invitations.complete'), [
+                'email' => 'tenant@example.com',
+                'token' => $token,
+                'password' => 'NewPassword123!',
+                'password_confirmation' => 'NewPassword123!',
+            ])
+            ->assertRedirect('/login')
+            ->assertSessionHas('status');
+
+        $user->refresh();
+
+        expect($user->email_verified_at)->not->toBeNull();
+        expect($user->is_active)->toBeTrue();
+        expect($user->invited_at)->toBeNull();
+    });
+
+    it('rejects an invalid token', function () {
+        $user = User::factory()->create([
+            'email' => 'tenant@example.com',
+            'invited_at' => now(),
+            'is_active' => false,
+        ]);
+        Tenant::factory()->create(['user_id' => $user->id]);
+
+        $this->withoutMiddleware()
+            ->withSession(['_previous' => ['url' => route('tenants.invitations.accept', ['token' => 'invalid-token', 'email' => 'tenant@example.com'])]])
+            ->post(route('tenants.invitations.complete'), [
+                'email' => 'tenant@example.com',
+                'token' => 'invalid-token',
+                'password' => 'NewPassword123!',
+                'password_confirmation' => 'NewPassword123!',
+            ])
+            ->assertSessionHasErrors(['email']);
+    });
+
+    it('rejects completion for a user without a tenant profile', function () {
+        $user = User::factory()->create([
+            'email' => 'staff@example.com',
+            'invited_at' => now(),
+            'is_active' => false,
+        ]);
+
+        $token = Password::broker()->createToken($user);
+
+        $this->withoutMiddleware()
+            ->withSession(['_previous' => ['url' => route('tenants.invitations.accept', ['token' => $token, 'email' => 'staff@example.com'])]])
+            ->post(route('tenants.invitations.complete'), [
+                'email' => 'staff@example.com',
+                'token' => $token,
+                'password' => 'NewPassword123!',
+                'password_confirmation' => 'NewPassword123!',
+            ])
+            ->assertSessionHasErrors(['email']);
+
+        expect($user->fresh()->is_active)->toBeFalse();
+    });
+});

--- a/tests/Feature/TenantInviteTest.php
+++ b/tests/Feature/TenantInviteTest.php
@@ -145,6 +145,27 @@ describe('resend invitation', function () {
         Notification::assertSentTo($user, TenantInvitation::class);
     });
 
+    it('resends to an active tenant without re-flagging invited_at', function () {
+        Notification::fake();
+
+        $owner = User::factory()->owner()->create();
+        $user = User::factory()->create([
+            'email' => 'tenant@example.com',
+            'invited_at' => null,
+            'is_active' => true,
+            'email_verified_at' => now(),
+        ]);
+        $tenant = Tenant::factory()->create(['user_id' => $user->id]);
+
+        $this->actingAs($owner)
+            ->post(route('tenants.resend-invitation', $tenant))
+            ->assertSessionHasNoErrors();
+
+        // Still emails a fresh link, but the active account stays "not pending".
+        Notification::assertSentTo($user, TenantInvitation::class);
+        expect($user->fresh()->invited_at)->toBeNull();
+    });
+
     it('returns error if tenant has no user account', function () {
         $owner = User::factory()->owner()->create();
         $tenant = Tenant::factory()->create();
@@ -189,6 +210,12 @@ describe('disable access', function () {
 });
 
 describe('invitation acceptance', function () {
+    it('serves the accept page to a guest', function () {
+        $this->get(route('tenants.invitations.accept', ['token' => 'some-token', 'email' => 'tenant@example.com']))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page->component('auth/tenant-accept-invitation'));
+    });
+
     it('accepts a valid invitation and sets password', function () {
         $user = User::factory()->create([
             'email' => 'tenant@example.com',
@@ -199,8 +226,7 @@ describe('invitation acceptance', function () {
 
         $token = Password::broker()->createToken($user);
 
-        $this->withoutMiddleware()
-            ->post(route('tenants.invitations.complete'), [
+        $this->post(route('tenants.invitations.complete'), [
                 'email' => 'tenant@example.com',
                 'token' => $token,
                 'password' => 'NewPassword123!',
@@ -224,8 +250,7 @@ describe('invitation acceptance', function () {
         ]);
         Tenant::factory()->create(['user_id' => $user->id]);
 
-        $this->withoutMiddleware()
-            ->withSession(['_previous' => ['url' => route('tenants.invitations.accept', ['token' => 'invalid-token', 'email' => 'tenant@example.com'])]])
+        $this->withSession(['_previous' => ['url' => route('tenants.invitations.accept', ['token' => 'invalid-token', 'email' => 'tenant@example.com'])]])
             ->post(route('tenants.invitations.complete'), [
                 'email' => 'tenant@example.com',
                 'token' => 'invalid-token',
@@ -244,10 +269,53 @@ describe('invitation acceptance', function () {
 
         $token = Password::broker()->createToken($user);
 
-        $this->withoutMiddleware()
-            ->withSession(['_previous' => ['url' => route('tenants.invitations.accept', ['token' => $token, 'email' => 'staff@example.com'])]])
+        $this->withSession(['_previous' => ['url' => route('tenants.invitations.accept', ['token' => $token, 'email' => 'staff@example.com'])]])
             ->post(route('tenants.invitations.complete'), [
                 'email' => 'staff@example.com',
+                'token' => $token,
+                'password' => 'NewPassword123!',
+                'password_confirmation' => 'NewPassword123!',
+            ])
+            ->assertSessionHasErrors(['email']);
+
+        expect($user->fresh()->is_active)->toBeFalse();
+    });
+
+    it('lets an active tenant reset password via a resend link', function () {
+        $user = User::factory()->create([
+            'email' => 'tenant@example.com',
+            'invited_at' => null,
+            'is_active' => true,
+            'email_verified_at' => now(),
+        ]);
+        Tenant::factory()->create(['user_id' => $user->id]);
+
+        $token = Password::broker()->createToken($user);
+
+        $this->post(route('tenants.invitations.complete'), [
+            'email' => 'tenant@example.com',
+            'token' => $token,
+            'password' => 'ResetPassword123!',
+            'password_confirmation' => 'ResetPassword123!',
+        ])->assertRedirect('/login');
+
+        expect($user->fresh()->is_active)->toBeTrue();
+    });
+
+    it('rejects completion for a disabled tenant', function () {
+        $user = User::factory()->create([
+            'email' => 'tenant@example.com',
+            'invited_at' => null,
+            'is_active' => false,
+            'email_verified_at' => now(),
+        ]);
+        Tenant::factory()->create(['user_id' => $user->id]);
+
+        $token = Password::broker()->createToken($user);
+
+        $this->withSession(['_previous' => ['url' => route('tenants.invitations.accept', ['token' => $token, 'email' => 'tenant@example.com'])]])
+            ->post(route('tenants.invitations.complete'), [
+                'email' => 'tenant@example.com',
                 'token' => $token,
                 'password' => 'NewPassword123!',
                 'password_confirmation' => 'NewPassword123!',

--- a/tests/Feature/TenantTest.php
+++ b/tests/Feature/TenantTest.php
@@ -69,7 +69,6 @@ describe('CRUD', function () {
         $this->actingAs($user)->post(route('tenants.store'), [
             'name' => 'Budi Santoso',
             'phone' => '+6281234567890',
-            'email' => 'budi@example.com',
             'id_card_number' => '3273010203040005',
         ]);
 


### PR DESCRIPTION
## Summary

Add tenant app access flow: admins invite tenants via email, tenants accept and set a password, then log in with limited access (payments, invoices, lease visibility).

## What's included

- **Migration** — drops `tenants.email`, migrates existing values to `users` via `user_id` FK
- **Backend** — `InviteTenant`/`DisableTenantAccess` actions, `TenantInvitationController` (guest accept/complete with password broker), `TenantInvitation` mail notification, `TenantsInvite` permission
- **Frontend** — App Access section on tenant workspace, invite button in detail sheet & table dropdown, `TenantAcceptInvitation` page for guest password setup
- **Auth** — `EnsureUserIsActive` middleware + Fortify `authenticateUsing` blocks inactive tenant login
- **Tests** — `TenantInviteTest` covers invite, resend, disable, and invitation acceptance flow
- **Housekeeping** — patched 3 reminder files for `email`→`user.email`, fixed `AuditLogTest` PII assertions

## Known issues (post-PR)

These need follow-up:
1. Policy `invite()` blocks `disableAccess`/`resendInvitation` for activated tenants (non-owners)
2. Tenant list index missing `user` eager-load — "Invite" shown for already-linked tenants
3. Migration uses `User::create()` instead of `firstOrCreate`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tenant app access invite and acceptance flow
> - Adds `InviteTenant`, `DisableTenantAccess` actions and a `TenantInvitationController` to manage the full lifecycle: creating a linked user account, sending an invitation email, accepting the invite via a token, and disabling access.
> - Removes `email` from the `Tenant` model, requests, and form UI; tenant email is now owned by the linked `User` record. A migration backfills users for existing tenants with emails before dropping the `tenants.email` column.
> - Adds `tenants.invite` permission and policy, new routes for `invite`, `resend-invitation`, `disable-access`, and guest routes for invitation acceptance.
> - Adds frontend components (`TenantAppAccessSection`, `InviteToAppSheet`, `TenantAcceptInvitation` page) to surface access status and invite actions.
> - Risk: `tenants.email` is a destructive schema change — the migration includes a tripwire that throws if a tenant's existing `user_id` points to a user with a conflicting email, but the column drop is irreversible without a rollback.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bdbd236.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->