### PR TITLE
fix(tenants): harden invite lifecycle, remove test workarounds, wrap sheet actions

### DIFF
--- a/resources/js/components/features/leases/lease-edit-sheet.tsx
+++ b/resources/js/components/features/leases/lease-edit-sheet.tsx
@@ -258,7 +258,7 @@ export default function LeaseEditSheet({
                             </div>
                         </section>
 
-                        <div className="flex items-center justify-end gap-4 pt-2">
+                        <div className="flex flex-wrap items-center justify-end gap-4 pt-2">
                             <Button
                                 variant="outline"
                                 type="button"

--- a/resources/js/components/features/leases/move-out-sheet.tsx
+++ b/resources/js/components/features/leases/move-out-sheet.tsx
@@ -389,7 +389,7 @@ export default function MoveOutSheet({
                             <InputError message={errors.notes} />
                         </div>
                     </div>
-                    <div className="flex items-center justify-end gap-4">
+                    <div className="flex flex-wrap items-center justify-end gap-4">
                         <Button
                             variant="outline"
                             type="button"

--- a/resources/js/components/features/leases/move-unit-sheet.tsx
+++ b/resources/js/components/features/leases/move-unit-sheet.tsx
@@ -109,7 +109,7 @@ export default function MoveUnitSheet({
                             deposit will be transferred.
                         </p>
                     </div>
-                    <div className="flex items-center justify-end gap-4">
+                    <div className="flex flex-wrap items-center justify-end gap-4">
                         <Button
                             variant="outline"
                             type="button"

--- a/resources/js/components/features/leases/renew-lease-sheet.tsx
+++ b/resources/js/components/features/leases/renew-lease-sheet.tsx
@@ -212,7 +212,7 @@ export default function RenewLeaseSheet({
                             </Alert>
                         )}
                     </div>
-                    <div className="flex items-center justify-end gap-4">
+                    <div className="flex flex-wrap items-center justify-end gap-4">
                         <Button
                             variant="outline"
                             type="button"

--- a/resources/js/components/features/maintenance/ticket-form-sheet.tsx
+++ b/resources/js/components/features/maintenance/ticket-form-sheet.tsx
@@ -474,7 +474,7 @@ export default function TicketFormSheet({
                                     );
                                 })()}
                         </div>
-                        <div className="flex items-center justify-end gap-4">
+                        <div className="flex flex-wrap items-center justify-end gap-4">
                             <Button
                                 variant="outline"
                                 type="button"

--- a/resources/js/components/features/payments/queue-payment-sheet.tsx
+++ b/resources/js/components/features/payments/queue-payment-sheet.tsx
@@ -193,7 +193,7 @@ export default function QueuePaymentSheet({
                         </div>
                     </div>
 
-                    <div className="flex items-center justify-end gap-4">
+                    <div className="flex flex-wrap items-center justify-end gap-4">
                         <Button
                             variant="outline"
                             type="button"

--- a/resources/js/components/features/payments/record-payment-sheet.tsx
+++ b/resources/js/components/features/payments/record-payment-sheet.tsx
@@ -249,7 +249,7 @@ function RecordPaymentForm({
                     </div>
                 </section>
             </div>
-            <div className="flex items-center justify-end gap-4">
+            <div className="flex flex-wrap items-center justify-end gap-4">
                 <Button
                     variant="outline"
                     type="button"

--- a/resources/js/components/features/properties/property-detail-sheet.tsx
+++ b/resources/js/components/features/properties/property-detail-sheet.tsx
@@ -180,7 +180,7 @@ export default function PropertyDetailSheet({
 
                         <div className="flex-1"></div>
 
-                        <div className="flex items-center justify-end gap-4">
+                        <div className="flex flex-wrap items-center justify-end gap-4">
                             <Button
                                 variant="outline"
                                 onClick={() => onOpenChange(false)}

--- a/resources/js/components/features/properties/property-form-sheet.tsx
+++ b/resources/js/components/features/properties/property-form-sheet.tsx
@@ -213,7 +213,7 @@ export default function PropertyFormSheet({
                             <InputError message={errors.phone} />
                         </div>
                     </div>
-                    <div className="flex items-center justify-end gap-4">
+                    <div className="flex flex-wrap items-center justify-end gap-4">
                         <Button
                             variant="outline"
                             type="button"

--- a/resources/js/components/features/tenants/assign-unit-sheet.tsx
+++ b/resources/js/components/features/tenants/assign-unit-sheet.tsx
@@ -559,7 +559,7 @@ export default function AssignUnitSheet({
                             <InputError message={errors.notes} />
                         </div>
                     </div>
-                    <div className="flex items-center justify-end gap-4">
+                    <div className="flex flex-wrap items-center justify-end gap-4">
                         <Button
                             variant="outline"
                             type="button"

--- a/resources/js/components/features/tenants/invite-to-app-sheet.tsx
+++ b/resources/js/components/features/tenants/invite-to-app-sheet.tsx
@@ -125,7 +125,7 @@ export default function InviteToAppSheet({
                         </div>
                     </div>
 
-                    <div className="flex items-center justify-end gap-4">
+                    <div className="flex flex-wrap items-center justify-end gap-4">
                         <Button
                             variant="outline"
                             type="button"

--- a/resources/js/components/features/tenants/tenant-detail-sheet.tsx
+++ b/resources/js/components/features/tenants/tenant-detail-sheet.tsx
@@ -272,7 +272,7 @@ export default function TenantDetailSheet({
                             )}
                         </div>
 
-                        <div className="flex items-center justify-end gap-4">
+                        <div className="flex flex-wrap items-center justify-end gap-4">
                             <Button
                                 variant="outline"
                                 onClick={() => onOpenChange(false)}

--- a/resources/js/components/features/tenants/tenant-form-sheet.tsx
+++ b/resources/js/components/features/tenants/tenant-form-sheet.tsx
@@ -176,7 +176,7 @@ export default function TenantFormSheet({
                             <Label htmlFor="is_active">Active</Label>
                         </div>
                     </div>
-                    <div className="flex items-center justify-end gap-4">
+                    <div className="flex flex-wrap items-center justify-end gap-4">
                         <Button
                             variant="outline"
                             type="button"

--- a/resources/js/components/features/units/assign-tenant-sheet.tsx
+++ b/resources/js/components/features/units/assign-tenant-sheet.tsx
@@ -504,7 +504,7 @@ export default function AssignTenantSheet({
                             <InputError message={errors.notes} />
                         </div>
                     </div>
-                    <div className="flex items-center justify-end gap-4">
+                    <div className="flex flex-wrap items-center justify-end gap-4">
                         <Button
                             variant="outline"
                             type="button"

--- a/resources/js/components/features/units/unit-form-sheet.tsx
+++ b/resources/js/components/features/units/unit-form-sheet.tsx
@@ -360,7 +360,7 @@ export default function UnitFormSheet({
                             <InputError message={errors.notes} />
                         </div>
                     </div>
-                    <div className="flex items-center justify-end gap-4">
+                    <div className="flex flex-wrap items-center justify-end gap-4">
                         <Button
                             variant="outline"
                             type="button"


### PR DESCRIPTION
## Changes since last merge (#78)

- **`resendInvitation`** — skips `invited_at` flag for active tenants (they aren't pending)
- **`completeInvitation`** — allows active tenants to reset password via resend link; rejects disabled tenants with no pending invite
- **`invite-to-app-sheet.tsx`** — blocks dismiss (X/Esc) while request is in flight, fixes close-vs-reset state management
- **Migration** — adds `firstOrCreate` guard and tripwire for orphaned contact emails before drop column
- **Tests** — added coverage for active tenant resend, password reset, disabled tenant rejection; removed `withoutMiddleware()` workarounds now the tenant routes are outside the auth group
- **Style** — `flex-wrap` on all 15 sheet footer action rows to prevent button overflow

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `flex-wrap` to action button containers across all sheet components
> Adds `flex-wrap` to the action button footer containers in all sheet components (leases, payments, properties, tenants, units, maintenance). This ensures action buttons reflow onto multiple lines on narrow screens instead of overflowing horizontally.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b822349.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->