### PR TITLE
feat(tenants): email-only access state, inline invite actions, notification banner

### DIFF
--- a/app/Actions/Tenants/InviteTenant.php
+++ b/app/Actions/Tenants/InviteTenant.php
@@ -19,23 +19,35 @@ class InviteTenant
             'email' => $email,
             'password' => Hash::make(Str::password(64)),
             'is_active' => false,
-            // invited_at marks a pending activation; skip it when only registering
-            // the email for notifications (no portal invite sent).
-            'invited_at' => $sendInvite ? now() : null,
         ]);
 
         $tenant->user()->associate($user)->save();
 
         if ($sendInvite) {
-            /** @var PasswordBroker $broker */
-            $broker = Password::broker();
-            $token = $broker->createToken($user);
-
-            $user->notify(new TenantInvitation(
-                route('tenants.invitations.accept', ['token' => $token, 'email' => $user->email]),
-            ));
+            $this->sendInvitation($user);
         }
 
         return $user;
+    }
+
+    /**
+     * Issue a fresh activation link and email it to the linked user. Shared by the
+     * invite, resend, and tenant create/edit flows.
+     */
+    public function sendInvitation(User $user): void
+    {
+        // Active users can already sign in, so a resend is just a fresh link — don't
+        // re-flag them as pending. Only mark genuinely un-activated users.
+        if (! $user->is_active && ! $user->invited_at) {
+            $user->update(['invited_at' => now()]);
+        }
+
+        /** @var PasswordBroker $broker */
+        $broker = Password::broker();
+        $token = $broker->createToken($user);
+
+        $user->notify(new TenantInvitation(
+            route('tenants.invitations.accept', ['token' => $token, 'email' => $user->email]),
+        ));
     }
 }

--- a/app/Http/Controllers/TenantController.php
+++ b/app/Http/Controllers/TenantController.php
@@ -14,16 +14,13 @@ use App\Http\Requests\Tenant\StoreTenantRequest;
 use App\Http\Requests\Tenant\UpdateTenantRequest;
 use App\Models\Tenant;
 use App\Models\Unit;
-use App\Notifications\TenantInvitation;
 use App\Tables\Column;
 use App\Tables\Filter;
 use App\Tables\Table;
-use Illuminate\Auth\Passwords\PasswordBroker;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Password;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -127,6 +124,33 @@ class TenantController extends Controller
                         'archived' => $q->onlyTrashed(),
                         default => $q,
                     }),
+                Filter::select('app_access', 'App Access', [
+                    ['value' => 'active', 'label' => 'Has access'],
+                    ['value' => 'invited', 'label' => 'Invite pending'],
+                    ['value' => 'email_only', 'label' => 'Email only'],
+                    ['value' => 'disabled', 'label' => 'Access disabled'],
+                    ['value' => 'none', 'label' => 'No access'],
+                ])
+                    // Buckets mirror appAccessStatus() on the frontend.
+                    ->query(fn (Builder $q, string $value) => match ($value) {
+                        'none' => $q->whereNull('user_id'),
+                        'active' => $q->whereHas('user', fn (Builder $u) => $u
+                            ->where('is_active', true)
+                            ->whereNotNull('email_verified_at')),
+                        'invited' => $q->whereHas('user', fn (Builder $u) => $u
+                            ->whereNotNull('invited_at')
+                            ->where(fn (Builder $a) => $a
+                                ->where('is_active', false)
+                                ->orWhereNull('email_verified_at'))),
+                        'disabled' => $q->whereHas('user', fn (Builder $u) => $u
+                            ->where('is_active', false)
+                            ->whereNull('invited_at')
+                            ->whereNotNull('email_verified_at')),
+                        'email_only' => $q->whereHas('user', fn (Builder $u) => $u
+                            ->whereNull('invited_at')
+                            ->whereNull('email_verified_at')),
+                        default => $q,
+                    }),
             ])
             ->defaultSort('name');
 
@@ -135,7 +159,7 @@ class TenantController extends Controller
             : null;
 
         $query = Tenant::query()
-            ->with(['documents', 'leases' => fn ($q) => $q->where('status', 'active')->with(['unit.property', 'tenants:id,name,phone', 'primaryTenant:id,name,phone'])])
+            ->with(['user:id,email,email_verified_at,last_login_at,is_active,invited_at', 'documents', 'leases' => fn ($q) => $q->where('status', 'active')->with(['unit.property', 'tenants:id,name,phone', 'primaryTenant:id,name,phone'])])
             ->withCount(['leases as active_leases_count' => fn ($q) => $q->where('status', 'active')])
             ->when($assignedPropertyIds !== null, fn (Builder $q) => $q->whereHas(
                 'leases',
@@ -195,20 +219,45 @@ class TenantController extends Controller
         return back();
     }
 
-    public function store(StoreTenantRequest $request): RedirectResponse
+    public function store(StoreTenantRequest $request, InviteTenant $invite): RedirectResponse
     {
-        $tenant = Tenant::create($request->validated());
+        $tenant = Tenant::create($request->safe()->except(['email', 'send_invite']));
+
+        if ($email = $request->validated('email')) {
+            $invite->execute($tenant, $email, $request->boolean('send_invite'));
+        }
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Tenant created.')]);
 
         return back();
     }
 
-    public function update(UpdateTenantRequest $request, Tenant $tenant): RedirectResponse
+    public function update(UpdateTenantRequest $request, Tenant $tenant, InviteTenant $invite): RedirectResponse
     {
         $this->authorize('update', $tenant);
 
-        $tenant->update($request->validated());
+        $tenant->update($request->safe()->except(['email', 'send_invite']));
+
+        $email = $request->validated('email');
+
+        if ($email) {
+            $user = $tenant->user;
+            $sendInvite = $request->boolean('send_invite');
+
+            if (! $user) {
+                $invite->execute($tenant, $email, $sendInvite);
+            } elseif (! ($user->is_active && $user->email_verified_at)) {
+                // Non-active account: email is editable here. Active accounts are
+                // read-only in the form and their login email is ignored server-side.
+                if ($user->email !== $email) {
+                    $user->update(['email' => $email]);
+                }
+
+                if ($sendInvite) {
+                    $invite->sendInvitation($user);
+                }
+            }
+        }
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Tenant updated.')]);
 
@@ -248,7 +297,7 @@ class TenantController extends Controller
         return back();
     }
 
-    public function resendInvitation(Tenant $tenant): RedirectResponse
+    public function resendInvitation(Tenant $tenant, InviteTenant $action): RedirectResponse
     {
         $this->authorize('invite', $tenant);
 
@@ -258,19 +307,7 @@ class TenantController extends Controller
             return back()->withErrors(['invite' => __('Tenant has no user account. Invite them first.')]);
         }
 
-        // Active users can already sign in, so a resend is just a fresh access link —
-        // don't flag them as "pending invite". Only mark genuinely un-activated users.
-        if (! $user->is_active && ! $user->invited_at) {
-            $user->update(['invited_at' => now()]);
-        }
-
-        /** @var PasswordBroker $broker */
-        $broker = Password::broker();
-        $token = $broker->createToken($user);
-
-        $user->notify(new TenantInvitation(
-            route('tenants.invitations.accept', ['token' => $token, 'email' => $user->email]),
-        ));
+        $action->sendInvitation($user);
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Invitation resent.')]);
 

--- a/app/Http/Controllers/TenantController.php
+++ b/app/Http/Controllers/TenantController.php
@@ -221,11 +221,15 @@ class TenantController extends Controller
 
     public function store(StoreTenantRequest $request, InviteTenant $invite): RedirectResponse
     {
-        $tenant = Tenant::create($request->safe()->except(['email', 'send_invite']));
+        $tenant = DB::transaction(function () use ($request, $invite) {
+            $tenant = Tenant::create($request->safe()->except(['email', 'send_invite']));
 
-        if ($email = $request->validated('email')) {
-            $invite->execute($tenant, $email, $request->boolean('send_invite'));
-        }
+            if ($email = $request->validated('email')) {
+                $invite->execute($tenant, $email, $request->boolean('send_invite'));
+            }
+
+            return $tenant;
+        });
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Tenant created.')]);
 

--- a/app/Http/Controllers/TenantController.php
+++ b/app/Http/Controllers/TenantController.php
@@ -254,7 +254,7 @@ class TenantController extends Controller
                 // Non-active account: email is editable here. Active accounts are
                 // read-only in the form and their login email is ignored server-side.
                 if ($user->email !== $email) {
-                    $user->update(['email' => $email]);
+                    $user->update(['email' => $email, 'invited_at' => null]);
                 }
 
                 if ($sendInvite) {

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -33,7 +33,16 @@ class HandleInertiaRequests extends Middleware
         return [
             ...parent::share($request),
             'name' => config('app.name'),
-            'setting' => fn () => Setting::get(),
+            // Integration configs (mail_config, whatsapp_config) hold secrets — SMTP
+            // password, API tokens — so they never go into the app-wide share. Their
+            // own settings pages load them (masked) separately.
+            'setting' => fn () => collect(Setting::get())
+                ->except(['mail_config', 'whatsapp_config'])
+                ->all(),
+            'notificationChannels' => fn () => [
+                'mail' => filled(data_get(Setting::get('mail_config'), 'host')),
+                'whatsapp' => filled(Setting::get('whatsapp_driver')),
+            ],
             'auth' => [
                 'user' => $request->user(),
                 'role' => $request->user()?->getRoleNames()->first(),

--- a/app/Http/Requests/Tenant/StoreTenantRequest.php
+++ b/app/Http/Requests/Tenant/StoreTenantRequest.php
@@ -15,6 +15,8 @@ class StoreTenantRequest extends FormRequest
         return [
             'name' => ['required', 'string', 'max:255'],
             'phone' => ['nullable', 'string', 'max:20', 'regex:/^\+[1-9]\d{6,14}$/'],
+            'email' => ['nullable', 'email', 'max:255', 'unique:users,email'],
+            'send_invite' => ['nullable', 'boolean'],
             'id_card_number' => ['nullable', 'string', 'max:50'],
             'emergency_contact_name' => ['nullable', 'string', 'max:255'],
             'emergency_contact_phone' => ['nullable', 'string', 'max:20', 'regex:/^\+[1-9]\d{6,14}$/'],

--- a/app/Http/Requests/Tenant/UpdateTenantRequest.php
+++ b/app/Http/Requests/Tenant/UpdateTenantRequest.php
@@ -4,6 +4,7 @@ namespace App\Http\Requests\Tenant;
 
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UpdateTenantRequest extends FormRequest
 {
@@ -15,6 +16,8 @@ class UpdateTenantRequest extends FormRequest
         return [
             'name' => ['required', 'string', 'max:255'],
             'phone' => ['nullable', 'string', 'max:20', 'regex:/^\+[1-9]\d{6,14}$/'],
+            'email' => ['nullable', 'email', 'max:255', Rule::unique('users', 'email')->ignore($this->route('tenant')?->user_id)],
+            'send_invite' => ['nullable', 'boolean'],
             'id_card_number' => ['nullable', 'string', 'max:50'],
             'emergency_contact_name' => ['nullable', 'string', 'max:255'],
             'emergency_contact_phone' => ['nullable', 'string', 'max:20', 'regex:/^\+[1-9]\d{6,14}$/'],

--- a/resources/js/components/features/app/notification-setup-banner.tsx
+++ b/resources/js/components/features/app/notification-setup-banner.tsx
@@ -1,0 +1,50 @@
+import { Link } from '@inertiajs/react';
+import { TriangleAlert, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import mail from '@/routes/settings/mail';
+
+// Fixed full-width bar pinned to the very top of the viewport (above the sidebar).
+// Its height must match --app-banner-height set on the layout wrapper so the sidebar
+// and page content are offset by the same amount.
+export function NotificationSetupBanner({
+    visible,
+    dismiss,
+    dontShowAgain,
+}: {
+    visible: boolean;
+    dismiss: () => void;
+    dontShowAgain: () => void;
+}) {
+    if (!visible) {
+        return null;
+    }
+
+    return (
+        <div className="fixed inset-x-0 top-0 z-50 flex h-11 items-center gap-3 border-b border-amber-500/40 bg-amber-50 px-4 text-sm text-amber-900 dark:bg-amber-950 dark:text-amber-100">
+            <TriangleAlert className="size-4 shrink-0" />
+            <p className="flex-1 truncate">
+                Set up email or WhatsApp so tenants can receive rent reminders
+                and invitations.
+            </p>
+            <Button asChild size="sm" variant="outline">
+                <Link href={mail.edit.url()}>Set up</Link>
+            </Button>
+            <button
+                type="button"
+                onClick={dontShowAgain}
+                className="hidden shrink-0 text-xs underline underline-offset-2 opacity-80 transition-opacity hover:opacity-100 sm:inline"
+            >
+                Don't show again
+            </button>
+            <button
+                type="button"
+                onClick={dismiss}
+                aria-label="Dismiss"
+                title="Hide until next visit"
+                className="rounded p-1 text-amber-900/70 transition-colors hover:bg-amber-500/20 hover:text-amber-900 dark:text-amber-100/70 dark:hover:text-amber-100"
+            >
+                <X className="size-4" />
+            </button>
+        </div>
+    );
+}

--- a/resources/js/components/features/tenants/tenant-app-access-section.tsx
+++ b/resources/js/components/features/tenants/tenant-app-access-section.tsx
@@ -3,6 +3,15 @@ import { useState } from 'react';
 import InviteToAppSheet from '@/components/features/tenants/invite-to-app-sheet';
 import { StatusBadge } from '@/components/shared/status-badge';
 import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { appAccessStatus } from '@/lib/app-access';
 import { formatDate } from '@/lib/formatters';
 import tenants from '@/routes/tenants';
 import type { Tenant } from '@/types';
@@ -24,18 +33,18 @@ export default function TenantAppAccessSection({
     tenant: TenantWithUser;
 }) {
     const [inviteOpen, setInviteOpen] = useState(false);
+    const [disableConfirm, setDisableConfirm] = useState(false);
 
     const user = tenant.user;
-    const isActivated = user?.is_active && user?.email_verified_at;
-    const isInvited = user && !isActivated && user.invited_at;
-    const isEmailOnly = user && !isActivated && !user.invited_at;
+    const status = appAccessStatus(user);
 
     function handleResend() {
         router.post(tenants.resendInvitation(tenant.id).url);
     }
 
-    function handleDisable() {
+    function confirmDisable() {
         router.post(tenants.disableAccess(tenant.id).url);
+        setDisableConfirm(false);
     }
 
     return (
@@ -44,13 +53,13 @@ export default function TenantAppAccessSection({
                 App Access
             </p>
 
-            {!user && (
+            {status === 'none' && (
                 <div className="space-y-3">
                     <div className="flex items-center gap-2">
                         <span className="text-sm text-muted-foreground">
                             Not activated
                         </span>
-                        <StatusBadge domain="user" value="disabled" />
+                        <StatusBadge domain="app_access" value="none" />
                     </div>
                     <Button
                         variant="outline"
@@ -62,13 +71,13 @@ export default function TenantAppAccessSection({
                 </div>
             )}
 
-            {isEmailOnly && (
+            {status === 'email_only' && user && (
                 <div className="space-y-3">
                     <div className="flex items-center gap-2">
                         <span className="text-sm text-muted-foreground">
                             {user.email}
                         </span>
-                        <StatusBadge domain="user" value="notified" />
+                        <StatusBadge domain="app_access" value="email_only" />
                     </div>
                     <p className="text-xs text-muted-foreground">
                         Receives notifications. No portal access yet.
@@ -83,13 +92,13 @@ export default function TenantAppAccessSection({
                 </div>
             )}
 
-            {isInvited && (
+            {status === 'invited' && user && (
                 <div className="space-y-3">
                     <div className="flex items-center gap-2">
                         <span className="text-sm text-muted-foreground">
                             {user.email}
                         </span>
-                        <StatusBadge domain="user" value="invited" />
+                        <StatusBadge domain="app_access" value="invited" />
                     </div>
                     <div className="flex gap-2">
                         <Button
@@ -102,7 +111,7 @@ export default function TenantAppAccessSection({
                         <Button
                             variant="outline"
                             size="sm"
-                            onClick={handleDisable}
+                            onClick={() => setDisableConfirm(true)}
                         >
                             Disable Access
                         </Button>
@@ -110,13 +119,34 @@ export default function TenantAppAccessSection({
                 </div>
             )}
 
-            {isActivated && (
+            {status === 'disabled' && user && (
                 <div className="space-y-3">
                     <div className="flex items-center gap-2">
                         <span className="text-sm text-muted-foreground">
                             {user.email}
                         </span>
-                        <StatusBadge domain="user" value="active" />
+                        <StatusBadge domain="app_access" value="disabled" />
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                        Access disabled. Still receives notifications.
+                    </p>
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={handleResend}
+                    >
+                        Re-invite
+                    </Button>
+                </div>
+            )}
+
+            {status === 'active' && user && (
+                <div className="space-y-3">
+                    <div className="flex items-center gap-2">
+                        <span className="text-sm text-muted-foreground">
+                            {user.email}
+                        </span>
+                        <StatusBadge domain="app_access" value="active" />
                     </div>
                     {user.last_login_at && (
                         <p className="text-xs text-muted-foreground">
@@ -134,7 +164,7 @@ export default function TenantAppAccessSection({
                         <Button
                             variant="outline"
                             size="sm"
-                            onClick={handleDisable}
+                            onClick={() => setDisableConfirm(true)}
                         >
                             Disable Access
                         </Button>
@@ -147,6 +177,32 @@ export default function TenantAppAccessSection({
                 open={inviteOpen}
                 onOpenChange={setInviteOpen}
             />
+
+            <Dialog open={disableConfirm} onOpenChange={setDisableConfirm}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Disable app access</DialogTitle>
+                        <DialogDescription>
+                            This signs{' '}
+                            <span className="font-medium">{tenant.name}</span>{' '}
+                            out and revokes their portal access. They'll still
+                            receive notifications, and you can re-invite them
+                            later.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                        <Button
+                            variant="outline"
+                            onClick={() => setDisableConfirm(false)}
+                        >
+                            Cancel
+                        </Button>
+                        <Button variant="destructive" onClick={confirmDisable}>
+                            Disable Access
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
         </div>
     );
 }

--- a/resources/js/components/features/tenants/tenant-detail-sheet.tsx
+++ b/resources/js/components/features/tenants/tenant-detail-sheet.tsx
@@ -1,5 +1,5 @@
 import { router } from '@inertiajs/react';
-import { MailPlus } from 'lucide-react';
+import { MailPlus, Send, UserX } from 'lucide-react';
 import { useState } from 'react';
 import { StatusBadge } from '@/components/shared/status-badge';
 import { Button } from '@/components/ui/button';
@@ -18,6 +18,7 @@ import {
     SheetHeader,
     SheetTitle,
 } from '@/components/ui/sheet';
+import { appAccessStatus, inviteActionLabel } from '@/lib/app-access';
 import { formatDate, formatPrice } from '@/lib/formatters';
 import tenants from '@/routes/tenants';
 import type { Lease, TenantDocument, WorkspaceTenant } from '@/types';
@@ -31,6 +32,8 @@ export default function TenantDetailSheet({
     onAssignToUnit,
     onMoveOut,
     onInvite,
+    onResend,
+    onDisableAccess,
 }: {
     tenant?:
         | (WorkspaceTenant & { leases?: Lease[]; documents?: TenantDocument[] })
@@ -42,6 +45,8 @@ export default function TenantDetailSheet({
     onAssignToUnit?: () => void;
     onMoveOut?: () => void;
     onInvite?: () => void;
+    onResend?: () => void;
+    onDisableAccess?: () => void;
 }) {
     const [archiveConfirm, setArchiveConfirm] = useState(false);
 
@@ -81,7 +86,7 @@ export default function TenantDetailSheet({
                 {tenant && (
                     <div className="flex flex-1 flex-col justify-between gap-6 overflow-y-auto px-4 pt-4 pb-6">
                         <div className="space-y-5">
-                            <div className="flex items-center gap-2">
+                            <div className="flex flex-wrap items-center gap-2">
                                 <span>Status:</span>
                                 {(() => {
                                     const status = isArchived
@@ -97,6 +102,11 @@ export default function TenantDetailSheet({
                                         />
                                     );
                                 })()}
+                                <span className="ml-2">App access:</span>
+                                <StatusBadge
+                                    domain="app_access"
+                                    value={appAccessStatus(tenant.user)}
+                                />
                             </div>
 
                             <div className="rounded-lg border bg-muted/30 p-4">
@@ -290,6 +300,32 @@ export default function TenantDetailSheet({
                                             Invite to App
                                         </Button>
                                     )}
+                                    {inviteActionLabel(
+                                        appAccessStatus(tenant.user),
+                                    ) &&
+                                        onResend && (
+                                            <Button
+                                                variant="outline"
+                                                onClick={onResend}
+                                            >
+                                                <Send className="size-4" />
+                                                {inviteActionLabel(
+                                                    appAccessStatus(tenant.user),
+                                                )}
+                                            </Button>
+                                        )}
+                                    {['invited', 'active'].includes(
+                                        appAccessStatus(tenant.user),
+                                    ) &&
+                                        onDisableAccess && (
+                                            <Button
+                                                variant="outline"
+                                                onClick={onDisableAccess}
+                                            >
+                                                <UserX className="size-4" />
+                                                Disable Access
+                                            </Button>
+                                        )}
                                     {!activeLease && onAssignToUnit && (
                                         <Button onClick={onAssignToUnit}>
                                             Assign to Unit

--- a/resources/js/components/features/tenants/tenant-form-sheet.tsx
+++ b/resources/js/components/features/tenants/tenant-form-sheet.tsx
@@ -10,7 +10,9 @@ import {
     SheetHeader,
     SheetTitle,
 } from '@/components/ui/sheet';
+import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
+import { appAccessStatus } from '@/lib/app-access';
 import tenants from '@/routes/tenants';
 import type { Tenant } from '@/types';
 
@@ -25,10 +27,16 @@ export default function TenantFormSheet({
 }) {
     const isEdit = Boolean(tenant);
 
+    // App access lives on the linked user. Its login email is read-only here once the
+    // account is active — changing it goes through the App Access section instead.
+    const emailLocked = isEdit && appAccessStatus(tenant?.user) === 'active';
+
     const { data, setData, transform, submit, reset, processing, errors } =
         useForm({
             name: tenant?.name ?? '',
             phone: tenant?.phone ?? '',
+            email: tenant?.user?.email ?? '',
+            send_invite: false,
             id_card_number: tenant?.id_card_number ?? '',
             emergency_contact_phone: tenant?.emergency_contact_phone ?? '',
             emergency_contact_name: tenant?.emergency_contact_name ?? '',
@@ -46,7 +54,11 @@ export default function TenantFormSheet({
 
     function handleSubmit(e: React.FormEvent) {
         e.preventDefault();
-        transform((d) => ({ ...d, is_active: d.is_active ? '1' : '0' }));
+        transform((d) => ({
+            ...d,
+            is_active: d.is_active ? '1' : '0',
+            send_invite: d.send_invite ? '1' : '0',
+        }));
         submit(isEdit ? tenants.update(tenant!.id) : tenants.store(), {
             onSuccess: () => handleOpenChange(false),
         });
@@ -98,6 +110,48 @@ export default function TenantFormSheet({
                             />
                             <InputError message={errors.phone} />
                         </div>
+
+                        <div className="grid gap-2">
+                            <Label htmlFor="email">Email</Label>
+                            <Input
+                                id="email"
+                                type="email"
+                                value={data.email}
+                                disabled={emailLocked}
+                                onChange={(e) =>
+                                    setData('email', e.target.value)
+                                }
+                                placeholder="e.g. tenant@example.com"
+                            />
+                            <p className="text-xs text-muted-foreground">
+                                {emailLocked
+                                    ? 'This tenant signs in with this email. To change it, disable their app access first, then edit.'
+                                    : 'Used for app access and notifications. Optional.'}
+                            </p>
+                            <InputError message={errors.email} />
+                        </div>
+
+                        {!emailLocked && data.email !== '' && (
+                            <div className="flex items-start justify-between gap-4">
+                                <div className="grid gap-1">
+                                    <Label htmlFor="send_invite">
+                                        Send activation invite
+                                    </Label>
+                                    <p className="text-xs text-muted-foreground">
+                                        Emails a link to set a password and access
+                                        the portal. Leave off to only save the email
+                                        for notifications.
+                                    </p>
+                                </div>
+                                <Switch
+                                    id="send_invite"
+                                    checked={data.send_invite}
+                                    onCheckedChange={(v) =>
+                                        setData('send_invite', v)
+                                    }
+                                />
+                            </div>
+                        )}
 
                         <div className="grid gap-2">
                             <Label htmlFor="id_card_number">

--- a/resources/js/components/shared/status-badge.tsx
+++ b/resources/js/components/shared/status-badge.tsx
@@ -69,6 +69,13 @@ const STATUS_CONFIGS: Record<string, Record<string, StatusConfig>> = {
         notified: { label: 'Email only', variant: 'outline' },
         disabled: { label: 'Disabled', variant: 'secondary' },
     },
+    app_access: {
+        active: { label: 'App access', className: 'bg-green-600 text-white' },
+        invited: { label: 'Invite pending', className: 'bg-amber-500 text-white' },
+        email_only: { label: 'Email only', variant: 'outline' },
+        disabled: { label: 'Access disabled', variant: 'secondary' },
+        none: { label: 'No access', variant: 'secondary' },
+    },
     tenant: {
         active: { label: 'Active', className: 'bg-green-600 text-white' },
         inactive: { label: 'Inactive', className: 'bg-gray-400 text-white' },

--- a/resources/js/components/ui/sidebar.tsx
+++ b/resources/js/components/ui/sidebar.tsx
@@ -303,7 +303,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
       data-slot="sidebar-inset"
       className={cn(
         "bg-background relative flex max-w-full min-h-[calc(100svh_-_var(--app-banner-height,0px))] flex-1 flex-col",
-        "peer-data-[variant=inset]:min-h-[calc(100svh-(--spacing(4)))] md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-0",
+        "peer-data-[variant=inset]:min-h-[calc(100svh_-_var(--app-banner-height,0px))-(--spacing(4))] md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-0",
         className
       )}
       {...props}

--- a/resources/js/components/ui/sidebar.tsx
+++ b/resources/js/components/ui/sidebar.tsx
@@ -136,7 +136,7 @@ function SidebarProvider({
           } as React.CSSProperties
         }
         className={cn(
-          "group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-svh w-full",
+          "group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-[calc(100svh_-_var(--app-banner-height,0px))] w-full pt-[var(--app-banner-height,0px)]",
           className
         )}
         {...props}
@@ -213,7 +213,7 @@ function Sidebar({
       {/* This is what handles the sidebar gap on desktop */}
       <div
         className={cn(
-          "relative h-svh w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear",
+          "relative h-[calc(100svh_-_var(--app-banner-height,0px))] w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear",
           "group-data-[collapsible=offcanvas]:w-0",
           "group-data-[side=right]:rotate-180",
           variant === "floating" || variant === "inset"
@@ -223,7 +223,7 @@ function Sidebar({
       />
       <div
         className={cn(
-          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
+          "fixed top-[var(--app-banner-height,0px)] z-10 hidden h-[calc(100svh_-_var(--app-banner-height,0px))] w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
           side === "left"
             ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
             : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
@@ -302,7 +302,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
     <main
       data-slot="sidebar-inset"
       className={cn(
-        "bg-background relative flex max-w-full min-h-svh flex-1 flex-col",
+        "bg-background relative flex max-w-full min-h-[calc(100svh_-_var(--app-banner-height,0px))] flex-1 flex-col",
         "peer-data-[variant=inset]:min-h-[calc(100svh-(--spacing(4)))] md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-0",
         className
       )}

--- a/resources/js/hooks/use-notification-banner.ts
+++ b/resources/js/hooks/use-notification-banner.ts
@@ -13,13 +13,13 @@ export function useNotificationBanner() {
         notificationChannels: { mail: boolean; whatsapp: boolean };
     }>().props;
 
-    const [hidden, setHidden] = useState(
-        () =>
-            localStorage.getItem(PERMANENT_KEY) === '1' ||
-            sessionStorage.getItem(SESSION_KEY) === '1',
+    const [hidden, setHidden] = useState(() =>
+        typeof window === 'undefined'
+            ? false
+            : localStorage.getItem(PERMANENT_KEY) === '1' ||
+              sessionStorage.getItem(SESSION_KEY) === '1',
     );
 
-    // Only owners can reach the mail/WhatsApp settings, so only they see the nudge.
     const visible =
         auth.role === 'owner' &&
         !notificationChannels?.mail &&
@@ -27,11 +27,19 @@ export function useNotificationBanner() {
         !hidden;
 
     function dismiss() {
+        if (typeof window === 'undefined') {
+            return;
+        }
+
         sessionStorage.setItem(SESSION_KEY, '1');
         setHidden(true);
     }
 
     function dontShowAgain() {
+        if (typeof window === 'undefined') {
+            return;
+        }
+
         localStorage.setItem(PERMANENT_KEY, '1');
         setHidden(true);
     }

--- a/resources/js/hooks/use-notification-banner.ts
+++ b/resources/js/hooks/use-notification-banner.ts
@@ -1,0 +1,40 @@
+import { usePage } from '@inertiajs/react';
+import { useState } from 'react';
+import type { Auth } from '@/types';
+
+// Permanent opt-out (localStorage) vs. this-session dismissal (sessionStorage, so it
+// stays hidden while navigating/reloading in this tab but returns on the next visit).
+const PERMANENT_KEY = 'notif-setup-banner-hidden';
+const SESSION_KEY = 'notif-setup-banner-dismissed';
+
+export function useNotificationBanner() {
+    const { auth, notificationChannels } = usePage<{
+        auth: Auth;
+        notificationChannels: { mail: boolean; whatsapp: boolean };
+    }>().props;
+
+    const [hidden, setHidden] = useState(
+        () =>
+            localStorage.getItem(PERMANENT_KEY) === '1' ||
+            sessionStorage.getItem(SESSION_KEY) === '1',
+    );
+
+    // Only owners can reach the mail/WhatsApp settings, so only they see the nudge.
+    const visible =
+        auth.role === 'owner' &&
+        !notificationChannels?.mail &&
+        !notificationChannels?.whatsapp &&
+        !hidden;
+
+    function dismiss() {
+        sessionStorage.setItem(SESSION_KEY, '1');
+        setHidden(true);
+    }
+
+    function dontShowAgain() {
+        localStorage.setItem(PERMANENT_KEY, '1');
+        setHidden(true);
+    }
+
+    return { visible, dismiss, dontShowAgain };
+}

--- a/resources/js/layouts/app/app-sidebar-layout.tsx
+++ b/resources/js/layouts/app/app-sidebar-layout.tsx
@@ -4,19 +4,36 @@ import {
     AppSidebar,
     AppSidebarHeader,
 } from '@/components/features';
+import { NotificationSetupBanner } from '@/components/features/app/notification-setup-banner';
+import { useNotificationBanner } from '@/hooks/use-notification-banner';
 import type { AppLayoutProps } from '@/types';
 
 export default function AppSidebarLayout({
     children,
     breadcrumbs = [],
 }: AppLayoutProps) {
+    const banner = useNotificationBanner();
+
     return (
-        <AppShell variant="sidebar">
-            <AppSidebar />
-            <AppContent variant="sidebar" className="overflow-x-hidden">
-                <AppSidebarHeader breadcrumbs={breadcrumbs} />
-                {children}
-            </AppContent>
-        </AppShell>
+        <div
+            style={
+                banner.visible
+                    ? ({ '--app-banner-height': '2.75rem' } as React.CSSProperties)
+                    : undefined
+            }
+        >
+            <NotificationSetupBanner
+                visible={banner.visible}
+                dismiss={banner.dismiss}
+                dontShowAgain={banner.dontShowAgain}
+            />
+            <AppShell variant="sidebar">
+                <AppSidebar />
+                <AppContent variant="sidebar" className="overflow-x-hidden">
+                    <AppSidebarHeader breadcrumbs={breadcrumbs} />
+                    {children}
+                </AppContent>
+            </AppShell>
+        </div>
     );
 }

--- a/resources/js/lib/app-access.ts
+++ b/resources/js/lib/app-access.ts
@@ -1,0 +1,61 @@
+export type AppAccessStatus =
+    | 'active'
+    | 'invited'
+    | 'email_only'
+    | 'disabled'
+    | 'none';
+
+type AccessUser =
+    | {
+          is_active: boolean;
+          email_verified_at: string | null;
+          invited_at: string | null;
+      }
+    | null
+    | undefined;
+
+/**
+ * Derives a tenant's app-access state from its linked user.
+ * - none: no linked user
+ * - active: can sign in (activated + verified)
+ * - invited: invitation sent, not yet accepted
+ * - disabled: previously activated, access revoked (still receives notifications)
+ * - email_only: email saved for notifications, never invited
+ */
+export function appAccessStatus(user: AccessUser): AppAccessStatus {
+    if (!user) {
+        return 'none';
+    }
+
+    if (user.is_active && user.email_verified_at) {
+        return 'active';
+    }
+
+    if (user.invited_at) {
+        return 'invited';
+    }
+
+    if (user.email_verified_at) {
+        return 'disabled';
+    }
+
+    return 'email_only';
+}
+
+/**
+ * Label for the "send an activation link" action, matching the App Access section.
+ * Returns null for `none` (that state uses the "Invite to App" modal instead).
+ */
+export function inviteActionLabel(status: AppAccessStatus): string | null {
+    switch (status) {
+        case 'email_only':
+            return 'Send Invitation';
+        case 'invited':
+        case 'active':
+            return 'Resend Invitation';
+        case 'disabled':
+            return 'Re-invite';
+        default:
+            return null;
+    }
+}

--- a/resources/js/pages/tenants/index.tsx
+++ b/resources/js/pages/tenants/index.tsx
@@ -7,7 +7,9 @@ import {
     MailPlus,
     Pencil,
     RotateCcw,
+    Send,
     Trash2,
+    UserX,
 } from 'lucide-react';
 import { useState } from 'react';
 import { DataTable } from '@/components/data-table';
@@ -38,9 +40,11 @@ import {
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuItem,
+    DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { useTable } from '@/hooks/use-table';
+import { appAccessStatus, inviteActionLabel } from '@/lib/app-access';
 import tenants from '@/routes/tenants';
 import type {
     AvailableUnit,
@@ -94,6 +98,9 @@ export default function Index({
         useState<WorkspaceTenant | null>(null);
 
     const [archiveConfirm, setArchiveConfirm] =
+        useState<WorkspaceTenant | null>(null);
+
+    const [disableConfirm, setDisableConfirm] =
         useState<WorkspaceTenant | null>(null);
 
     const [inviteTenant, setInviteTenant] = useState<WorkspaceTenant | null>(
@@ -186,6 +193,19 @@ export default function Index({
         router.post(tenants.restore.url(tenant));
     }
 
+    function confirmDisable() {
+        if (!disableConfirm) {
+            return;
+        }
+
+        router.post(tenants.disableAccess(disableConfirm.id).url);
+        setDisableConfirm(null);
+    }
+
+    function resendInvitation(tenant: WorkspaceTenant) {
+        router.post(tenants.resendInvitation(tenant.id).url);
+    }
+
     const columns: TableColumn<WorkspaceTenant>[] = [
         {
             key: 'name',
@@ -224,6 +244,19 @@ export default function Index({
             },
         },
         {
+            key: '_app_access',
+            label: 'App Access',
+            render: (t) => {
+                const status = appAccessStatus(t.user);
+
+                return status === 'none' ? (
+                    <span className="text-muted-foreground">—</span>
+                ) : (
+                    <StatusBadge domain="app_access" value={status} />
+                );
+            },
+        },
+        {
             key: '_actions',
             label: '',
             render: (t) => (
@@ -246,14 +279,6 @@ export default function Index({
                             <ExternalLink className="size-4" />
                             Open Workspace
                         </DropdownMenuItem>
-                        {!t.deleted_at && !t.user_id && (
-                            <DropdownMenuItem
-                                onClick={() => setInviteTenant(t)}
-                            >
-                                <MailPlus className="size-4" />
-                                Invite to App
-                            </DropdownMenuItem>
-                        )}
                         <DropdownMenuItem onClick={() => openDetail(t)}>
                             <Eye className="size-4" />
                             View
@@ -275,6 +300,41 @@ export default function Index({
                                 Edit
                             </DropdownMenuItem>
                         )}
+
+                        {!t.deleted_at && <DropdownMenuSeparator />}
+
+                        {!t.deleted_at && !t.user_id && (
+                            <DropdownMenuItem
+                                onClick={() => setInviteTenant(t)}
+                            >
+                                <MailPlus className="size-4" />
+                                Invite to App
+                            </DropdownMenuItem>
+                        )}
+                        {!t.deleted_at &&
+                            inviteActionLabel(appAccessStatus(t.user)) && (
+                                <DropdownMenuItem
+                                    onClick={() => resendInvitation(t)}
+                                >
+                                    <Send className="size-4" />
+                                    {inviteActionLabel(appAccessStatus(t.user))}
+                                </DropdownMenuItem>
+                            )}
+                        {!t.deleted_at &&
+                            ['invited', 'active'].includes(
+                                appAccessStatus(t.user),
+                            ) && (
+                                <DropdownMenuItem
+                                    variant="destructive"
+                                    onClick={() => setDisableConfirm(t)}
+                                >
+                                    <UserX className="size-4" />
+                                    Disable Access
+                                </DropdownMenuItem>
+                            )}
+
+                        <DropdownMenuSeparator />
+
                         {t.deleted_at ? (
                             <DropdownMenuItem onClick={() => restore(t)}>
                                 <RotateCcw className="size-4" />
@@ -359,6 +419,19 @@ export default function Index({
                             setInviteTenant(viewingTenant);
                         }
                     }
+                }
+                onResend={
+                    viewingTenant
+                        ? () => resendInvitation(viewingTenant)
+                        : undefined
+                }
+                onDisableAccess={
+                    viewingTenant
+                        ? () => {
+                              setDetailOpen(false);
+                              setDisableConfirm(viewingTenant);
+                          }
+                        : undefined
                 }
             />
 
@@ -451,6 +524,37 @@ export default function Index({
                         </Button>
                         <Button variant="destructive" onClick={confirmArchive}>
                             Archive
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+
+            <Dialog
+                open={disableConfirm !== null}
+                onOpenChange={() => setDisableConfirm(null)}
+            >
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Disable app access</DialogTitle>
+                        <DialogDescription>
+                            This signs{' '}
+                            <span className="font-medium">
+                                {disableConfirm?.name}
+                            </span>{' '}
+                            out and revokes their portal access. They'll still
+                            receive notifications, and you can re-invite them
+                            later.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                        <Button
+                            variant="outline"
+                            onClick={() => setDisableConfirm(null)}
+                        >
+                            Cancel
+                        </Button>
+                        <Button variant="destructive" onClick={confirmDisable}>
+                            Disable Access
                         </Button>
                     </DialogFooter>
                 </DialogContent>

--- a/resources/js/pages/tenants/index.tsx
+++ b/resources/js/pages/tenants/index.tsx
@@ -1,4 +1,4 @@
-import { Head, router } from '@inertiajs/react';
+import { Head, router, usePage } from '@inertiajs/react';
 import {
     DoorOpen,
     EllipsisVertical,
@@ -47,6 +47,7 @@ import { useTable } from '@/hooks/use-table';
 import { appAccessStatus, inviteActionLabel } from '@/lib/app-access';
 import tenants from '@/routes/tenants';
 import type {
+    Auth,
     AvailableUnit,
     Lease,
     PaginatedData,
@@ -73,6 +74,8 @@ export default function Index({
     per_page: currentPerPage = 15,
     table: tableMeta,
 }: PageProps) {
+    const { auth } = usePage<{ auth: Auth }>().props;
+    const permissions = auth.permissions;
     const [dialogOpen, setDialogOpen] = useState(false);
     const [editingTenant, setEditingTenant] = useState<WorkspaceTenant | null>(
         null,
@@ -303,7 +306,7 @@ export default function Index({
 
                         {!t.deleted_at && <DropdownMenuSeparator />}
 
-                        {!t.deleted_at && !t.user_id && (
+                        {permissions.includes('tenants.invite') && !t.deleted_at && !t.user_id && (
                             <DropdownMenuItem
                                 onClick={() => setInviteTenant(t)}
                             >
@@ -311,7 +314,7 @@ export default function Index({
                                 Invite to App
                             </DropdownMenuItem>
                         )}
-                        {!t.deleted_at &&
+                        {permissions.includes('tenants.invite') && !t.deleted_at &&
                             inviteActionLabel(appAccessStatus(t.user)) && (
                                 <DropdownMenuItem
                                     onClick={() => resendInvitation(t)}
@@ -320,7 +323,7 @@ export default function Index({
                                     {inviteActionLabel(appAccessStatus(t.user))}
                                 </DropdownMenuItem>
                             )}
-                        {!t.deleted_at &&
+                        {permissions.includes('tenants.invite') && !t.deleted_at &&
                             ['invited', 'active'].includes(
                                 appAccessStatus(t.user),
                             ) && (
@@ -413,7 +416,7 @@ export default function Index({
                 onMoveOut={openMoveOut}
                 onDocuments={openDocuments}
                 onInvite={
-                    viewingTenant?.user_id ? undefined : () => {
+                    viewingTenant?.user_id || !permissions.includes('tenants.invite') ? undefined : () => {
                         if (viewingTenant) {
                             setDetailOpen(false);
                             setInviteTenant(viewingTenant);
@@ -421,12 +424,12 @@ export default function Index({
                     }
                 }
                 onResend={
-                    viewingTenant
+                    viewingTenant && permissions.includes('tenants.invite')
                         ? () => resendInvitation(viewingTenant)
                         : undefined
                 }
                 onDisableAccess={
-                    viewingTenant
+                    viewingTenant && permissions.includes('tenants.invite')
                         ? () => {
                               setDetailOpen(false);
                               setDisableConfirm(viewingTenant);

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -21,6 +21,7 @@ declare module '@inertiajs/core' {
                 currency: string;
                 timezone: string;
             };
+            notificationChannels: { mail: boolean; whatsapp: boolean };
             sidebarOpen: boolean;
             platform: Platform;
         };

--- a/tests/Feature/SharedPropsTest.php
+++ b/tests/Feature/SharedPropsTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use App\Models\Setting;
+use App\Models\User;
+use Database\Seeders\RoleAndPermissionSeeder;
+
+uses()->beforeEach(function () {
+    $this->seed(RoleAndPermissionSeeder::class);
+});
+
+it('does not leak mail or whatsapp secrets in shared props', function () {
+    Setting::set('mail_config', ['host' => 'smtp.example.com', 'password' => 'super-secret'], 'array');
+    Setting::set('whatsapp_config', ['baileys' => ['token' => 'wa-token-123']], 'array');
+
+    $props = $this->actingAs(User::factory()->owner()->create())
+        ->get(route('dashboard'))
+        ->viewData('page')['props'];
+
+    expect($props['setting'])->not->toHaveKey('mail_config');
+    expect($props['setting'])->not->toHaveKey('whatsapp_config');
+    expect(json_encode($props))->not->toContain('super-secret');
+    expect(json_encode($props))->not->toContain('wa-token-123');
+});
+
+it('exposes notification channel readiness as booleans only', function () {
+    $owner = User::factory()->owner()->create();
+
+    $props = $this->actingAs($owner)->get(route('dashboard'))->viewData('page')['props'];
+    expect($props['notificationChannels'])->toBe(['mail' => false, 'whatsapp' => false]);
+
+    Setting::set('mail_config', ['host' => 'smtp.example.com'], 'array');
+    Setting::set('whatsapp_driver', 'baileys', 'string');
+
+    $props = $this->actingAs($owner)->get(route('dashboard'))->viewData('page')['props'];
+    expect($props['notificationChannels'])->toBe(['mail' => true, 'whatsapp' => true]);
+});

--- a/tests/Feature/TenantInviteTest.php
+++ b/tests/Feature/TenantInviteTest.php
@@ -227,11 +227,11 @@ describe('invitation acceptance', function () {
         $token = Password::broker()->createToken($user);
 
         $this->post(route('tenants.invitations.complete'), [
-                'email' => 'tenant@example.com',
-                'token' => $token,
-                'password' => 'NewPassword123!',
-                'password_confirmation' => 'NewPassword123!',
-            ])
+            'email' => 'tenant@example.com',
+            'token' => $token,
+            'password' => 'NewPassword123!',
+            'password_confirmation' => 'NewPassword123!',
+        ])
             ->assertRedirect('/login')
             ->assertSessionHas('status');
 
@@ -323,5 +323,200 @@ describe('invitation acceptance', function () {
             ->assertSessionHasErrors(['email']);
 
         expect($user->fresh()->is_active)->toBeFalse();
+    });
+});
+
+describe('email via tenant form', function () {
+    it('links a user and sends invite from the create form', function () {
+        Notification::fake();
+        $owner = User::factory()->owner()->create();
+
+        $this->actingAs($owner)->post(route('tenants.store'), [
+            'name' => 'Budi',
+            'email' => 'budi@example.com',
+            'send_invite' => '1',
+        ])->assertSessionHasNoErrors();
+
+        $tenant = Tenant::where('name', 'Budi')->first();
+
+        expect($tenant->user)->not->toBeNull();
+        expect($tenant->user->email)->toBe('budi@example.com');
+        expect($tenant->user->invited_at)->not->toBeNull();
+        Notification::assertSentTo($tenant->user, TenantInvitation::class);
+    });
+
+    it('saves email without inviting from the create form', function () {
+        Notification::fake();
+        $owner = User::factory()->owner()->create();
+
+        $this->actingAs($owner)->post(route('tenants.store'), [
+            'name' => 'Budi',
+            'email' => 'budi@example.com',
+            'send_invite' => '0',
+        ])->assertSessionHasNoErrors();
+
+        $tenant = Tenant::where('name', 'Budi')->first();
+
+        expect($tenant->user->email)->toBe('budi@example.com');
+        expect($tenant->user->invited_at)->toBeNull();
+        Notification::assertNotSentTo($tenant->user, TenantInvitation::class);
+    });
+
+    it('creates no user when the create form omits email', function () {
+        $owner = User::factory()->owner()->create();
+
+        $this->actingAs($owner)->post(route('tenants.store'), [
+            'name' => 'Budi',
+        ])->assertSessionHasNoErrors();
+
+        expect(Tenant::where('name', 'Budi')->first()->user_id)->toBeNull();
+    });
+
+    it('rejects a create-form email already in use', function () {
+        $owner = User::factory()->owner()->create();
+        User::factory()->create(['email' => 'taken@example.com']);
+
+        $this->actingAs($owner)->post(route('tenants.store'), [
+            'name' => 'Budi',
+            'email' => 'taken@example.com',
+        ])->assertSessionHasErrors('email');
+    });
+
+    it('links a user when editing a tenant that has none', function () {
+        Notification::fake();
+        $owner = User::factory()->owner()->create();
+        $tenant = Tenant::factory()->create();
+
+        $this->actingAs($owner)->put(route('tenants.update', $tenant), [
+            'name' => $tenant->name,
+            'email' => 'new@example.com',
+            'send_invite' => '1',
+        ])->assertSessionHasNoErrors();
+
+        $tenant->refresh();
+
+        expect($tenant->user->email)->toBe('new@example.com');
+        Notification::assertSentTo($tenant->user, TenantInvitation::class);
+    });
+
+    it('updates the email of a non-active linked user', function () {
+        $owner = User::factory()->owner()->create();
+        $user = User::factory()->create([
+            'email' => 'old@example.com',
+            'is_active' => false,
+            'invited_at' => now(),
+        ]);
+        $tenant = Tenant::factory()->create(['user_id' => $user->id]);
+
+        $this->actingAs($owner)->put(route('tenants.update', $tenant), [
+            'name' => $tenant->name,
+            'email' => 'changed@example.com',
+        ])->assertSessionHasNoErrors();
+
+        expect($user->fresh()->email)->toBe('changed@example.com');
+    });
+
+    it('ignores an email change for an active linked user', function () {
+        $owner = User::factory()->owner()->create();
+        $user = User::factory()->create([
+            'email' => 'login@example.com',
+            'is_active' => true,
+            'email_verified_at' => now(),
+        ]);
+        $tenant = Tenant::factory()->create(['user_id' => $user->id]);
+
+        $this->actingAs($owner)->put(route('tenants.update', $tenant), [
+            'name' => $tenant->name,
+            'email' => 'hacker@example.com',
+        ])->assertSessionHasNoErrors();
+
+        expect($user->fresh()->email)->toBe('login@example.com');
+    });
+
+    it('lets a tenant edit keep its own linked email', function () {
+        $owner = User::factory()->owner()->create();
+        $user = User::factory()->create([
+            'email' => 'me@example.com',
+            'is_active' => false,
+            'invited_at' => now(),
+        ]);
+        $tenant = Tenant::factory()->create(['user_id' => $user->id]);
+
+        $this->actingAs($owner)->put(route('tenants.update', $tenant), [
+            'name' => 'Renamed',
+            'email' => 'me@example.com',
+        ])->assertSessionHasNoErrors();
+
+        expect($tenant->fresh()->name)->toBe('Renamed');
+    });
+});
+
+describe('app access filter', function () {
+    function tenantWithAccess(string $state): Tenant
+    {
+        $attrs = match ($state) {
+            'active' => ['is_active' => true, 'email_verified_at' => now(), 'invited_at' => null],
+            'invited' => ['is_active' => false, 'email_verified_at' => null, 'invited_at' => now()],
+            'disabled' => ['is_active' => false, 'email_verified_at' => now(), 'invited_at' => null],
+            'email_only' => ['is_active' => false, 'email_verified_at' => null, 'invited_at' => null],
+        };
+
+        return Tenant::factory()->create(['user_id' => User::factory()->create($attrs)->id]);
+    }
+
+    it('filters tenants by each app access bucket', function (string $filter, string $matching) {
+        $owner = User::factory()->owner()->create();
+
+        $expected = $filter === 'none'
+            ? Tenant::factory()->create()
+            : tenantWithAccess($matching);
+
+        // A tenant in a different bucket that must be excluded.
+        tenantWithAccess('active');
+        Tenant::factory()->create(); // a 'none' tenant
+
+        $ids = collect(
+            $this->actingAs($owner)
+                ->get(route('tenants.index', ['app_access' => $filter]))
+                ->viewData('page')['props']['tenants']['data']
+        )->pluck('id');
+
+        expect($ids)->toContain($expected->id);
+        expect($ids->count())->toBeGreaterThan(0);
+        // Every returned tenant is actually in the requested bucket.
+        Tenant::whereIn('id', $ids)->with('user')->get()->each(function (Tenant $t) use ($filter) {
+            $u = $t->user;
+            $bucket = match (true) {
+                ! $u => 'none',
+                $u->is_active && $u->email_verified_at => 'active',
+                (bool) $u->invited_at => 'invited',
+                (bool) $u->email_verified_at => 'disabled',
+                default => 'email_only',
+            };
+            expect($bucket)->toBe($filter);
+        });
+    })->with([
+        ['none', 'none'],
+        ['active', 'active'],
+        ['invited', 'invited'],
+        ['disabled', 'disabled'],
+        ['email_only', 'email_only'],
+    ]);
+
+    it('filters by multiple app access buckets at once', function () {
+        $owner = User::factory()->owner()->create();
+        $active = tenantWithAccess('active');
+        $none = Tenant::factory()->create();
+        $invited = tenantWithAccess('invited');
+
+        $ids = collect(
+            $this->actingAs($owner)
+                ->get(route('tenants.index', ['app_access' => 'active,none']))
+                ->viewData('page')['props']['tenants']['data']
+        )->pluck('id');
+
+        expect($ids)->toContain($active->id);
+        expect($ids)->toContain($none->id);
+        expect($ids)->not->toContain($invited->id);
     });
 });


### PR DESCRIPTION
## What's new since last merge

- **Email-only access** — tenants can have a linked user for notifications without an invite (`send_invite: false`). App Access section handles 5 states: active, invited, email-only, disabled, none
- **Shared `app-access.ts`** — status derivation (`appAccessStatus`) and action labels used across detail sheet, table dropdown, and workspace
- **Inline invite actions** — detail sheet and table dropdown show context-aware invite/resend/re-invite per access state, not just one generic "Invite" button
- **StatusBadge** — supports all 5 app-access states with appropriate colors
- **Notification setup banner** — prompts admins when push notifications aren't configured, dismissable via `useNotificationBanner` hook
- **Collapsible sidebar** — icon-only mode with toggle
- **32 invite tests** covering full lifecycle: email-only, invite, resend, disable, re-invite, password reset, disabled rejection, staff rejection

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add email-only app access state, inline invite actions, and notification setup banner for tenants
> - Introduces five app access states (`none`, `email_only`, `invited`, `active`, `disabled`) derived from user fields, surfaced as status badges in the tenants list and detail sheet via [`app-access.ts`](https://github.com/senatroxx/OpenKos/pull/80/files#diff-78bcb628d6dee1caf5b02a0ed57c635073bb2245e895b5b672999550733695ec).
> - Adds inline per-row actions (Invite to App, Resend Invitation, Disable Access) to the tenants index, gated by permissions, with a confirmation dialog before disabling.
> - Extends tenant create/edit to accept an optional `email` and `send_invite` flag; active verified users' emails are not editable.
> - Refactors invitation sending into `InviteTenant::sendInvitation()`, which stamps `invited_at` only for un-activated, not-yet-invited users and reuses this logic for resend flows.
> - Adds a dismissible `NotificationSetupBanner` shown at the top of the app layout when no notification channel is configured; sidebar and main content heights adjust via `--app-banner-height` CSS variable.
> - Behavioral Change: shared props no longer include raw `mail_config`/`whatsapp_config` objects; consumers now receive `notificationChannels` booleans instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 117f7b0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->