### PR TITLE
docs: record tenant identity model and app-access flow

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -130,11 +130,12 @@ Property (has a type — see below)
 
 Tenant
   ├── Documents
-  └── Leases (pivot: lease_tenant)
+  ├── Leases (pivot: lease_tenant)
+  └── User (1:1 optional, via tenants.user_id — grants app access)
 
-User (staff / owner)
-  ├── Properties (pivot: property_user)
-  └── Roles / Permissions
+User (identity — backs owner, staff, and tenant accounts)
+  ├── Properties (pivot: property_user — owner/staff scope)
+  └── Roles / Permissions (owner / admin / staff; tenants are NOT a role — see [ADR-008](architecture/adr/008-tenant-identity.md))
 
 ActivityLog (records user-triggered activity across entities)
 AuditLog (records setting changes and sensitive operations)
@@ -161,6 +162,10 @@ Reminders are scheduled by `SendRentRemindersCommand` (daily at 08:00), which ca
 **Fortify** handles the auth backend (login, registration, password reset, 2FA, passkeys). The app is an Inertia SPA — Fortify actions are configured but the frontend renders React pages.
 
 **Authorization** uses Spatie Permission. A `Gate::before` in `AuthServiceProvider` fully bypasses all policy checks for users with the `owner` role. Non-owner users are checked against individual permissions and policies. Every model has a corresponding Policy class. Frontend permission checks reference a seeded `getAllPermissions()` list.
+
+### Tenant app access
+
+Tenants are domain records, not auth identities — but a tenant can be invited into the app to pay rent, file maintenance tickets, and view their lease. The Tenant↔User relationship is a 1:1 optional link via `tenants.user_id` (nullable, unique). `users.email` is the single source of truth for both authentication and notifications; the legacy `tenants.email` column was dropped (see [ADR-008](architecture/adr/008-tenant-identity.md)). The owner invites from the Tenant detail page; Fortify's password broker issues an activation token, delivered via `TenantInvitation` notification, and the tenant completes signup on a dedicated acceptance route. Tenant accounts are **not** a role — they are invisible on the Users page and managed entirely from the Tenant module.
 
 ### Permission Convention
 

--- a/docs/architecture/adr/008-tenant-identity.md
+++ b/docs/architecture/adr/008-tenant-identity.md
@@ -1,0 +1,41 @@
+# ADR-008: Tenant Identity
+
+**Status:** Accepted
+**Date:** 2026-07-20
+
+## Context
+
+Tenants are first-class domain records (`tenants` table) — the people who rent units. Previously they also carried an optional `email` column used purely as a contact field for reminders. The application now lets an owner invite a tenant into the app so the tenant can authenticate, pay rent, file maintenance tickets, view invoices, and see their lease.
+
+This created a modelling question: when a domain entity (Tenant) needs to become an authenticating user, how do the two concepts relate — and where does each piece of data live?
+
+The realistic alternatives:
+
+- **Tenant as a role.** Assign tenants a `tenant` role on the `users` table; treat them as a specialisation of User. Authentication is trivially solved, but the Tenant domain is now coupled to the auth/RBAC model: every change to role semantics ripples into tenant behaviour, and the Users page must either admit tenants or grow filters to exclude them.
+- **Duplicate identity columns.** Keep `tenants.email` as the contact field and add a separate `users.email` for auth. Two identities per tenant, no enforced link, no single source of truth for "where do we send mail."
+
+Both approaches were rejected during [OPE-17](https://linear.app/openkos/issue/OPE-17): they leak auth concerns into the Tenant domain or invite drift between two email columns with no way to reconcile them.
+
+## Decision
+
+We will model the Tenant↔User relationship as a **1:1 optional link** via `tenants.user_id` (nullable, unique, FK → `users.id`, `nullOnDelete`). A Tenant is a domain record; a User is an identity. Linking them is what grants the tenant app access.
+
+Concretely:
+
+- `users.email` is the **single source of truth** for authentication and for any notification delivered to that person. There is no `tenants.email`.
+- `tenants.user_id` is nullable: a tenant can exist without an account (the default — contact-only via phone, or no app access). Linking creates the account.
+- `tenants.user_id` is unique: one user backs at most one tenant (1:1).
+- Tenant is **not** a role. Tenants are not in the Spatie role/permission graph. Owner/staff remain the only entries on the Users page; tenant accounts are managed from the Tenant module.
+- A linked user is created inactive (`is_active = false`, random 64-char password). The owner invites via the Tenant detail page; activation happens through Fortify's password broker (`Password::broker()->createToken()`) with a `TenantInvitation` notification. The tenant sets their password and verifies email via a dedicated acceptance route.
+- Any code path that previously read `tenant->email` (rent reminders, contact resolution) now reads `tenant->user?->email`. An email contact exists only when a linked user exists.
+
+The `tenants.email` column was dropped irreversibly in migration `2026_07_18_000000_drop_email_from_tenants_table`. Existing rows with a contact email were backfilled into a linked (inactive) User; rows whose contact email already existed as a User with a *different* tenant linkage were left unlinked rather than hijacking an account, and a tripwire throws if a linked tenant's stored email disagrees with its user's login email.
+
+## Consequences
+
+- The Tenant domain stays free of auth concerns. `Tenant` is a renters record; `User` is an identity. The only coupling is one nullable FK.
+- The Users page stays Owner/Admin/Staff-only by construction — no filters, no special-case exclusion, because tenants are simply not in that table's domain.
+- Notifications and contact resolution require a null-check on `tenant->user` (was previously a null-check on `tenant->email`). Code that assumed `email` always exists on a Tenant now must traverse `user`.
+- A tenant cannot have a contact email distinct from their login email. This is deliberate: one identity per person. If a future case needs a separate billing-only email, that becomes a new column with a new purpose — not a revival of `tenants.email`.
+- Joining tenant data to auth data is a `tenants.user_id → users.id` join. Reporting/auth flows that need both pay one indexed FK lookup.
+- **Revisit trigger:** a tenant needs to back more than one user (shared login for a couple on a joint lease, or a tenant acting on behalf of another). The 1:1 constraint would then need to become 1:N with a notion of "primary" user, mirroring the lease_tenant pattern.

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -13,6 +13,7 @@ Architectural decisions with real trade-offs are recorded here as ADRs, so futur
 | [005](005-plugin-philosophy.md)           | Plugin Philosophy       | Accepted |
 | [006](006-api-strategy.md)                | API Strategy            | Accepted |
 | [007](007-invoice-aggregate.md)           | Invoice Aggregate       | Accepted |
+| [008](008-tenant-identity.md)             | Tenant Identity         | Accepted |
 
 Future ADR candidates: the Activity Log vs Audit Log split (`activity_logs` written by `RecordActivitySubscriber` from domain events; `audit_logs` written directly by actions like `UpdateSettings`) is a decision worth recording once it stabilizes.
 

--- a/docs/business-workflows.md
+++ b/docs/business-workflows.md
@@ -127,9 +127,12 @@ app/
 │   │   └── RenewLease.php
 │   ├── Payments/
 │   │   └── RecordPayment.php
-│   └── Reminders/
-│       ├── ForceSendReminder.php
-│       └── SendRentReminders.php
+│   ├── Reminders/
+│   │   ├── ForceSendReminder.php
+│   │   └── SendRentReminders.php
+│   └── Tenants/
+│       ├── DisableTenantAccess.php
+│       └── InviteTenant.php
 ├── Business/
 │   ├── Leases/
 │   │   ├── OccupancyCalculator.php
@@ -167,7 +170,9 @@ app/
 | Record Payment      | `PaymentController::store()`                            | `RecordPayment`     | `RecordPaymentData` | `RecordPaymentResult` | —                                                    |
 | Generate Invoices   | Console Command (`invoices:generate`, daily 01:00)      | `GenerateInvoices`  | —                   | —                     | —                                                    |
 | Force Reminder      | `LeaseController::sendReminder()`                       | `ForceSendReminder` | —                   | —                     | —                                                    |
-| Scheduled Reminders | Console Command                                         | `SendRentReminders` | —                   | —                     | `PaymentReminderScheduler`                           |
+| Scheduled Reminders | Console Command                                      | `SendRentReminders` | —                   | —                     | `PaymentReminderScheduler`                           |
+| Invite Tenant       | `TenantController::invite()`                            | `InviteTenant`      | —                   | —                     | —                                                    |
+| Disable Tenant Access | `TenantController::disableAccess()`                   | `DisableTenantAccess` | —                 | —                     | —                                                    |
 
 ## Invoice-Centric Billing (ADR-007)
 

--- a/docs/rent-reminders.md
+++ b/docs/rent-reminders.md
@@ -94,6 +94,8 @@ Reminders are sent to the lease's primary tenant only (not all tenants on the le
 
 **Rationale:** Kos convention — one tenant is responsible for payment. Simplifies implementation for MVP. Easily extended to all tenants later if needed.
 
+> **Contact path note (post [ADR-008](architecture/adr/008-tenant-identity.md)):** mail contact now resolves via `tenant->user?->email`, not a `tenants.email` column (which was dropped). A tenant has an email contact only when a linked user exists; `ForceSendReminder` and `SendRentReminders` null-check `tenant->user` before adding `mail` to the dispatchable channels.
+
 ## Architecture
 
 ```
@@ -157,5 +159,4 @@ app/
 - Email and in-app notification channels
 - SMTP config UI + channel selector on settings page
 - Baileys driver for real WhatsApp integration
-- Optional tenant email field
 - Send to all tenants on lease (not just primary)


### PR DESCRIPTION
## What's new

Follow-up docs for the tenant app-access feature shipped in #78 / #79 / #80. The branch makes a real architectural decision (Tenant↔User as 1:1 optional link, `tenants.email` dropped, `users.email` as single source of truth, tenant is not a role) — recording it so the next reader doesn't have to re-excavate the PRs.

- **`docs/architecture/adr/008-tenant-identity.md`** (new) — ADR for the identity model. Captures the decision, the rejected alternatives (Tenant-as-role, duplicate email column), the irreversible `tenants.email` drop with its backfill + tripwire migration, and a revisit trigger (1:N user case, e.g. joint-lease couples).
- **`docs/architecture/adr/README.md`** — adds ADR-008 to the index.
- **`docs/architecture.md`** — Domain Model: `User (staff / owner)` → `User (identity — backs owner, staff, and tenant accounts)`; `Tenant` now shows the `User` link. New "Tenant app access" subsection under Auth & Authorization covering the 1:1 link, the dropped column, and the Fortify-broker activation flow.
- **`docs/business-workflows.md`** — Directory Layout adds `Actions/Tenants/{InviteTenant, DisableTenantAccess}`. Current Workflows table gets two rows for invite + disable-access.
- **`docs/rent-reminders.md`** — Note under Decision #12 that mail contact now resolves via `tenant->user?->email` (the `tenants.email` column it used to read no longer exists). Dropped the stale "Optional tenant email field" bullet from Future Work.

Refs: [OPE-17](https://linear.app/openkos/issue/OPE-17)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document tenant identity model and app-access flow in architecture docs
> - Adds [ADR-008](https://github.com/senatroxx/OpenKos/pull/81/files#diff-f2738137e3a132e09fe8ff03ac3e67ddc1e2424228324581e1109d69ec6f783b) recording the decision to model Tenant↔User as a 1:1 optional link via `tenants.user_id`, dropping `tenants.email` in favor of `users.email` as the single source of truth.
> - Updates [architecture.md](https://github.com/senatroxx/OpenKos/pull/81/files#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782) to reflect that tenants are not a role/permission concept and documents the invite/activation flow using Fortify's password broker.
> - Adds `InviteTenant` and `DisableTenantAccess` action entries to [business-workflows.md](https://github.com/senatroxx/OpenKos/pull/81/files#diff-a7a3ea2c263253d93431aa141ba79c2905a51dfc28a2c0ee38647d07a431d6fc).
> - Updates [rent-reminders.md](https://github.com/senatroxx/OpenKos/pull/81/files#diff-2a3daf4c47691944d51f8ba9a81d1130ed64e70d2d2bd5ee3a0d268a69f00f60) to note that mail contact resolves via `tenant->user?->email` and removes the now-resolved 'Optional tenant email field' future work item.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 1eb9680. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->