### PR TITLE
fix(adr): Users page exclusion is explicit whereDoesntHave filter, not by-construction

### DIFF
--- a/docs/architecture/adr/008-tenant-identity.md
+++ b/docs/architecture/adr/008-tenant-identity.md
@@ -34,7 +34,7 @@ The `tenants.email` column was dropped irreversibly in migration `2026_07_18_000
 ## Consequences
 
 - The Tenant domain stays free of auth concerns. `Tenant` is a renters record; `User` is an identity. The only coupling is one nullable FK.
-- The Users page stays Owner/Admin/Staff-only by construction — no filters, no special-case exclusion, because tenants are simply not in that table's domain.
+- The Users page stays Owner/Admin/Staff-only via an **explicit `whereDoesntHave('tenant')` filter** in `UserController::index()`. Tenant-linked accounts are rows in `users` like any other, so this filter is load-bearing — removing it would surface tenant accounts on the staff Users page. The filter must not be dropped without replacing it with an equivalent exclusion.
 - Notifications and contact resolution require a null-check on `tenant->user` (was previously a null-check on `tenant->email`). Code that assumed `email` always exists on a Tenant now must traverse `user`.
 - A tenant cannot have a contact email distinct from their login email. This is deliberate: one identity per person. If a future case needs a separate billing-only email, that becomes a new column with a new purpose — not a revival of `tenants.email`.
 - Joining tenant data to auth data is a `tenants.user_id → users.id` join. Reporting/auth flows that need both pay one indexed FK lookup.


### PR DESCRIPTION
Fixes a factual error in ADR-008's Consequences section. The original text stated the Users page stays tenant-free "by construction — no filters, no special-case exclusion, because tenants are simply not in that table's domain." This is wrong: tenant-linked accounts **are** rows in `users`, and `UserController::index()` excludes them with an explicit `whereDoesntHave('tenant')` filter.

The corrected text:
> The Users page stays Owner/Admin/Staff-only via an **explicit `whereDoesntHave('tenant')` filter** in `UserController::index()`. Tenant-linked accounts are rows in `users` like any other, so this filter is load-bearing — removing it would surface tenant accounts on the staff Users page. The filter must not be dropped without replacing it with an equivalent exclusion.

One file changed, one line.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Correct ADR-008 to document explicit `whereDoesntHave('tenant')` filter on Users page
> Updates [008-tenant-identity.md](https://github.com/senatroxx/OpenKos/pull/83/files#diff-f2738137e3a132e09fe8ff03ac3e67ddc1e2424228324581e1109d69ec6f783b) to accurately describe how the Users page is restricted. The previous wording claimed the restriction was "by construction"; it is actually enforced by an explicit `whereDoesntHave('tenant')` filter in `UserController::index()`. The doc now notes this filter is load-bearing and must not be removed without an equivalent exclusion in place.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 860c18e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->