### PR TITLE
feat(portal): add tenant dashboard

### DIFF
--- a/app/Http/Controllers/TenantPortal/DashboardController.php
+++ b/app/Http/Controllers/TenantPortal/DashboardController.php
@@ -48,7 +48,7 @@ class DashboardController extends Controller
             ],
             'lease' => $lease ? $this->leasePayload($lease) : null,
             'rent' => [
-                'status' => $this->rentStatus($invoices->first()),
+                'status' => $this->rentStatus($lease, $invoices->first()),
                 'upcoming_invoices' => $invoices->map(fn (Invoice $invoice) => [
                     'id' => $invoice->id,
                     'lease_id' => $invoice->lease_id,
@@ -99,8 +99,12 @@ class DashboardController extends Controller
         ];
     }
 
-    private function rentStatus(?Invoice $invoice): string
+    private function rentStatus(?Lease $lease, ?Invoice $invoice): string
     {
+        if (! $lease) {
+            return 'none';
+        }
+
         if (! $invoice) {
             return 'paid';
         }

--- a/app/Http/Controllers/TenantPortal/DashboardController.php
+++ b/app/Http/Controllers/TenantPortal/DashboardController.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Http\Controllers\TenantPortal;
+
+use App\Enums\InvoiceStatus;
+use App\Http\Controllers\Controller;
+use App\Models\Invoice;
+use App\Models\Lease;
+use App\Models\ReminderLog;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class DashboardController extends Controller
+{
+    public function __invoke(Request $request): Response
+    {
+        $tenant = $request->user()->tenant()->first();
+
+        abort_unless($tenant, 403);
+
+        $lease = $tenant->leases()
+            ->active()
+            ->with(['unit.property'])
+            ->latest('start_date')
+            ->first();
+
+        $invoices = $lease
+            ? $lease->invoices()
+                ->payable()
+                ->orderBy('due_date')
+                ->limit(5)
+                ->get()
+            : collect();
+
+        $reminders = $lease
+            ? ReminderLog::query()
+                ->where('lease_id', $lease->id)
+                ->latest('sent_at')
+                ->limit(5)
+                ->get()
+            : collect();
+
+        return Inertia::render('tenant-portal/dashboard', [
+            'tenant' => [
+                'id' => $tenant->id,
+                'name' => $tenant->name,
+            ],
+            'lease' => $lease ? $this->leasePayload($lease) : null,
+            'rent' => [
+                'status' => $this->rentStatus($invoices->first()),
+                'upcoming_invoices' => $invoices->map(fn (Invoice $invoice) => [
+                    'id' => $invoice->id,
+                    'lease_id' => $invoice->lease_id,
+                    'reference' => $invoice->reference,
+                    'period_start' => $invoice->period_start->toDateString(),
+                    'period_end' => $invoice->period_end->toDateString(),
+                    'due_date' => $invoice->due_date->toDateString(),
+                    'status' => $invoice->status->value,
+                    'total' => (string) $invoice->total,
+                    'amount_paid' => (string) $invoice->amount_paid,
+                    'outstanding' => $invoice->outstanding,
+                ])->values(),
+            ],
+            'notifications' => $reminders->map(fn (ReminderLog $reminder) => [
+                'id' => $reminder->id,
+                'type' => $reminder->reminder_type,
+                'channel' => $reminder->channel,
+                'scheduled_for' => $reminder->scheduled_for?->toDateString(),
+                'sent_at' => $reminder->sent_at?->toDateTimeString(),
+                'overdue_days' => $reminder->overdue_days,
+            ])->values(),
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function leasePayload(Lease $lease): array
+    {
+        return [
+            'id' => $lease->id,
+            'reference' => $lease->reference,
+            'start_date' => $lease->start_date->toDateString(),
+            'end_date' => $lease->end_date?->toDateString(),
+            'rent_amount' => (string) $lease->rent_amount,
+            'billing_label' => $lease->billing_label,
+            'status' => $lease->status->value,
+            'unit' => $lease->unit ? [
+                'id' => $lease->unit->id,
+                'name' => $lease->unit->name,
+                'status' => $lease->unit->status->value,
+                'property' => $lease->unit->property ? [
+                    'id' => $lease->unit->property->id,
+                    'name' => $lease->unit->property->name,
+                    'address' => $lease->unit->property->address,
+                ] : null,
+            ] : null,
+        ];
+    }
+
+    private function rentStatus(?Invoice $invoice): string
+    {
+        if (! $invoice) {
+            return 'paid';
+        }
+
+        if ($invoice->status === InvoiceStatus::Partial) {
+            return 'partial';
+        }
+
+        if ($invoice->due_date->isToday()) {
+            return 'due_today';
+        }
+
+        return $invoice->due_date->isPast() ? 'overdue' : 'upcoming';
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -45,6 +45,9 @@ class HandleInertiaRequests extends Middleware
             ],
             'auth' => [
                 'user' => $request->user(),
+                'tenant' => fn () => $request->user()?->tenant()
+                    ->select(['id', 'name'])
+                    ->first(),
                 'role' => $request->user()?->getRoleNames()->first(),
                 'roles' => $request->user()?->getRoleNames() ?? [],
                 'permissions' => $request->user()?->getAllPermissions()->pluck('name') ?? [],

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -13,8 +13,10 @@ use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rules\Password;
 use Inertia\Inertia;
+use Laravel\Fortify\Contracts\LoginResponse;
 use Laravel\Fortify\Features;
 use Laravel\Fortify\Fortify;
+use Symfony\Component\HttpFoundation\Response;
 
 class FortifyServiceProvider extends ServiceProvider
 {
@@ -23,7 +25,21 @@ class FortifyServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->app->singleton(LoginResponse::class, fn () => new class implements LoginResponse
+        {
+            public function toResponse($request): Response
+            {
+                if ($request->wantsJson()) {
+                    return response()->json(['two_factor' => false]);
+                }
+
+                if ($request->user()->hasTenantProfile()) {
+                    return redirect()->route('portal.dashboard');
+                }
+
+                return redirect()->intended(Fortify::redirects('login'));
+            }
+        });
     }
 
     /**

--- a/resources/js/components/features/app/app-sidebar.tsx
+++ b/resources/js/components/features/app/app-sidebar.tsx
@@ -26,6 +26,7 @@ import {
 import { platformNavItems, platformPageNavItems } from '@/lib/platform';
 import { dashboard } from '@/routes';
 import { rent as dashboardRent } from '@/routes/dashboard';
+import { dashboard as portalDashboard } from '@/routes/portal';
 import leases from '@/routes/leases';
 import maintenanceTickets from '@/routes/maintenance-tickets';
 import properties from '@/routes/properties';
@@ -41,8 +42,12 @@ export function AppSidebar() {
         .props;
     const permissions = auth.permissions;
     const isOwner = auth.role === 'owner';
+    const home = auth.tenant ? portalDashboard() : dashboard();
 
     const mainNavItems: NavItem[] = [
+        ...(auth.tenant
+            ? [{ title: 'Portal', href: portalDashboard(), icon: LayoutGrid }]
+            : []),
         ...(isOwner || permissions.includes('dashboard.view')
             ? [
                   {
@@ -123,7 +128,7 @@ export function AppSidebar() {
                 <SidebarMenu>
                     <SidebarMenuItem>
                         <SidebarMenuButton size="lg" asChild>
-                            <Link href={dashboard()} prefetch>
+                            <Link href={home} prefetch>
                                 <AppLogo />
                             </Link>
                         </SidebarMenuButton>

--- a/resources/js/pages/tenant-portal/dashboard.tsx
+++ b/resources/js/pages/tenant-portal/dashboard.tsx
@@ -1,0 +1,292 @@
+import { Head } from '@inertiajs/react';
+import { Badge } from '@/components/ui/badge';
+import {
+    Card,
+    CardContent,
+    CardHeader,
+    CardTitle,
+} from '@/components/ui/card';
+import { formatDate, formatPrice } from '@/lib/formatters';
+
+type Invoice = {
+    id: number;
+    lease_id: number;
+    reference: string | null;
+    period_start: string;
+    period_end: string;
+    due_date: string;
+    status: string;
+    total: string;
+    amount_paid: string;
+    outstanding: string;
+};
+
+type Lease = {
+    id: number;
+    reference: string | null;
+    start_date: string;
+    end_date: string | null;
+    rent_amount: string | null;
+    billing_label: string;
+    status: string;
+    unit: {
+        id: number;
+        name: string;
+        status: string;
+        property: {
+            id: number;
+            name: string;
+            address: string | null;
+        } | null;
+    } | null;
+};
+
+type Notification = {
+    id: number;
+    type: string;
+    channel: string;
+    scheduled_for: string | null;
+    sent_at: string | null;
+    overdue_days: number | null;
+};
+
+type Props = {
+    tenant: { id: number; name: string };
+    lease: Lease | null;
+    rent: {
+        status: string;
+        upcoming_invoices: Invoice[];
+    };
+    notifications: Notification[];
+};
+
+export default function Dashboard({
+    tenant,
+    lease,
+    rent,
+    notifications,
+}: Props) {
+    return (
+        <>
+            <Head title="Tenant Portal" />
+
+            <div className="flex flex-1 flex-col gap-6 p-4">
+                <div className="flex items-center justify-between gap-4">
+                    <div>
+                        <p className="text-sm text-muted-foreground">
+                            Tenant Portal
+                        </p>
+                        <h1 className="text-2xl font-semibold">
+                            Hi, {tenant.name}
+                        </h1>
+                    </div>
+
+                </div>
+
+                <div className="grid gap-4 lg:grid-cols-3">
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Lease</CardTitle>
+                        </CardHeader>
+                        <CardContent className="space-y-3 text-sm">
+                            {lease ? (
+                                <>
+                                    <div className="flex justify-between gap-4">
+                                        <span className="text-muted-foreground">
+                                            Reference
+                                        </span>
+                                        <span>{lease.reference ?? '—'}</span>
+                                    </div>
+                                    <div className="flex justify-between gap-4">
+                                        <span className="text-muted-foreground">
+                                            Period
+                                        </span>
+                                        <span>
+                                            {formatDate(lease.start_date)} –{' '}
+                                            {lease.end_date
+                                                ? formatDate(lease.end_date)
+                                                : 'ongoing'}
+                                        </span>
+                                    </div>
+                                    <div className="flex justify-between gap-4">
+                                        <span className="text-muted-foreground">
+                                            Rent
+                                        </span>
+                                        <span>
+                                            {lease.rent_amount
+                                                ? formatPrice(lease.rent_amount)
+                                                : '—'}{' '}
+                                            {lease.billing_label}
+                                        </span>
+                                    </div>
+                                    <Badge variant="outline">
+                                        {lease.status}
+                                    </Badge>
+                                </>
+                            ) : (
+                                <p className="text-muted-foreground">
+                                    No active lease found.
+                                </p>
+                            )}
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Room</CardTitle>
+                        </CardHeader>
+                        <CardContent className="space-y-3 text-sm">
+                            {lease?.unit ? (
+                                <>
+                                    <div className="flex justify-between gap-4">
+                                        <span className="text-muted-foreground">
+                                            Unit
+                                        </span>
+                                        <span>{lease.unit.name}</span>
+                                    </div>
+                                    <div className="flex justify-between gap-4">
+                                        <span className="text-muted-foreground">
+                                            Property
+                                        </span>
+                                        <span>
+                                            {lease.unit.property?.name ?? '—'}
+                                        </span>
+                                    </div>
+                                    {lease.unit.property?.address && (
+                                        <p className="text-muted-foreground">
+                                            {lease.unit.property.address}
+                                        </p>
+                                    )}
+                                </>
+                            ) : (
+                                <p className="text-muted-foreground">
+                                    No room assigned.
+                                </p>
+                            )}
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Rent Status</CardTitle>
+                        </CardHeader>
+                        <CardContent className="space-y-3">
+                            <Badge>{rentStatusLabel(rent.status)}</Badge>
+                            {rent.upcoming_invoices[0] && (
+                                <p className="text-sm text-muted-foreground">
+                                    Next due{' '}
+                                    {formatDate(
+                                        rent.upcoming_invoices[0].due_date,
+                                    )}
+                                    :{' '}
+                                    {formatPrice(
+                                        rent.upcoming_invoices[0].outstanding,
+                                    )}
+                                </p>
+                            )}
+                        </CardContent>
+                    </Card>
+                </div>
+
+                <div className="grid gap-4 lg:grid-cols-2">
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Upcoming Payments</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            {rent.upcoming_invoices.length > 0 ? (
+                                <div className="space-y-3">
+                                    {rent.upcoming_invoices.map((invoice) => (
+                                        <div
+                                            key={invoice.id}
+                                            className="flex items-center justify-between gap-4 rounded-lg border p-3 text-sm"
+                                        >
+                                            <div>
+                                                <p className="font-medium">
+                                                    {invoice.reference ?? '—'}
+                                                </p>
+                                                <p className="text-muted-foreground">
+                                                    Due{' '}
+                                                    {formatDate(
+                                                        invoice.due_date,
+                                                    )}
+                                                </p>
+                                            </div>
+                                            <div className="text-right">
+                                                <p className="font-medium">
+                                                    {formatPrice(
+                                                        invoice.outstanding,
+                                                    )}
+                                                </p>
+                                                <p className="text-muted-foreground">
+                                                    {invoice.status}
+                                                </p>
+                                            </div>
+                                        </div>
+                                    ))}
+                                </div>
+                            ) : (
+                                <p className="text-sm text-muted-foreground">
+                                    No payable invoices.
+                                </p>
+                            )}
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Notifications</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            {notifications.length > 0 ? (
+                                <div className="space-y-3">
+                                    {notifications.map((notification) => (
+                                        <div
+                                            key={notification.id}
+                                            className="rounded-lg border p-3 text-sm"
+                                        >
+                                            <p className="font-medium">
+                                                {notificationLabel(
+                                                    notification,
+                                                )}
+                                            </p>
+                                            <p className="text-muted-foreground">
+                                                {notification.channel}
+                                                {notification.sent_at
+                                                    ? ` · ${formatDate(notification.sent_at)}`
+                                                    : ''}
+                                            </p>
+                                        </div>
+                                    ))}
+                                </div>
+                            ) : (
+                                <p className="text-sm text-muted-foreground">
+                                    No notifications yet.
+                                </p>
+                            )}
+                        </CardContent>
+                    </Card>
+                </div>
+            </div>
+        </>
+    );
+}
+
+function rentStatusLabel(status: string): string {
+    return status
+        .split('_')
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(' ');
+}
+
+function notificationLabel(notification: Notification): string {
+    const label = rentStatusLabel(notification.type);
+
+    return notification.overdue_days
+        ? `${label} · ${notification.overdue_days} days overdue`
+        : label;
+}
+
+Dashboard.layout = {
+    breadcrumbs: [{ title: 'Tenant Portal', href: '/portal/dashboard' }],
+};

--- a/resources/js/pages/tenant-portal/dashboard.tsx
+++ b/resources/js/pages/tenant-portal/dashboard.tsx
@@ -273,6 +273,10 @@ export default function Dashboard({
 }
 
 function rentStatusLabel(status: string): string {
+    if (status === 'none') {
+        return 'No active lease';
+    }
+
     return status
         .split('_')
         .map((word) => word.charAt(0).toUpperCase() + word.slice(1))

--- a/resources/js/types/auth.ts
+++ b/resources/js/types/auth.ts
@@ -14,6 +14,7 @@ export type User = {
 
 export type Auth = {
     user: User;
+    tenant: { id: number; name: string } | null;
     role: string | null;
     roles: string[];
     permissions: string[];

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,6 +14,7 @@ use App\Http\Controllers\RoleController;
 use App\Http\Controllers\TenantController;
 use App\Http\Controllers\TenantDocumentController;
 use App\Http\Controllers\TenantInvitationController;
+use App\Http\Controllers\TenantPortal\DashboardController as TenantPortalDashboardController;
 use App\Http\Controllers\UnitController;
 use App\Http\Controllers\UserController;
 use Illuminate\Support\Facades\Route;
@@ -28,6 +29,11 @@ Route::prefix('invitations')->name('users.invitations.')->middleware('guest')->g
 Route::prefix('tenants/invitations')->name('tenants.invitations.')->middleware('guest')->group(function () {
     Route::get('{token}', [TenantInvitationController::class, 'acceptInvitation'])->name('accept');
     Route::post('accept', [TenantInvitationController::class, 'completeInvitation'])->name('complete');
+});
+
+Route::middleware(['auth', 'verified'])->prefix('portal')->name('portal.')->group(function () {
+    Route::redirect('/', '/portal/dashboard');
+    Route::get('dashboard', TenantPortalDashboardController::class)->name('dashboard');
 });
 
 Route::middleware(['auth', 'verified', 'permission:dashboard.view'])->group(function () {

--- a/tests/Feature/TenantPortalTest.php
+++ b/tests/Feature/TenantPortalTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use App\Enums\InvoiceStatus;
+use App\Models\Invoice;
+use App\Models\Lease;
+use App\Models\ReminderLog;
+use App\Models\Tenant;
+use App\Models\User;
+use Database\Seeders\RoleAndPermissionSeeder;
+
+uses()->beforeEach(function () {
+    $this->seed(RoleAndPermissionSeeder::class);
+});
+
+test('tenant sees their portal dashboard', function () {
+    $user = User::factory()->create(['email' => 'tenant@example.com']);
+    $tenant = Tenant::factory()->withUser($user)->create(['name' => 'Budi']);
+    $lease = Lease::factory()->create([
+        'primary_tenant_id' => $tenant->id,
+        'rent_amount' => 1_500_000,
+    ]);
+    Invoice::factory()->create([
+        'lease_id' => $lease->id,
+        'due_date' => now()->addDays(3),
+        'total' => 1_500_000,
+        'amount_paid' => 0,
+        'status' => InvoiceStatus::Pending,
+    ]);
+    ReminderLog::factory()->create(['lease_id' => $lease->id]);
+
+    $this->actingAs($user)
+        ->get(route('portal.dashboard'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('tenant-portal/dashboard')
+            ->where('tenant.name', 'Budi')
+            ->where('lease.id', $lease->id)
+            ->has('rent.upcoming_invoices', 1)
+            ->has('notifications', 1));
+});
+
+test('portal only exposes the authenticated tenants lease data', function () {
+    $user = User::factory()->create();
+    $tenant = Tenant::factory()->withUser($user)->create();
+    $lease = Lease::factory()->create(['primary_tenant_id' => $tenant->id]);
+    Invoice::factory()->create(['lease_id' => $lease->id]);
+
+    $otherTenant = Tenant::factory()->withUser()->create();
+    $otherLease = Lease::factory()->create(['primary_tenant_id' => $otherTenant->id]);
+    Invoice::factory()->create(['lease_id' => $otherLease->id]);
+
+    $this->actingAs($user)
+        ->get(route('portal.dashboard'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('lease.id', $lease->id)
+            ->has('rent.upcoming_invoices', 1)
+            ->where('rent.upcoming_invoices.0.lease_id', $lease->id));
+});
+
+test('user without tenant profile cannot access portal', function () {
+    $this->actingAs(User::factory()->create())
+        ->get(route('portal.dashboard'))
+        ->assertForbidden();
+});
+
+test('tenant without dashboard permission cannot access owner dashboard', function () {
+    $user = User::factory()->create();
+    Tenant::factory()->withUser($user)->create();
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertForbidden();
+});
+
+test('tenant login redirects to portal dashboard', function () {
+    $user = User::factory()->create(['email' => 'tenant@example.com']);
+    Tenant::factory()->withUser($user)->create();
+
+    $this->post(route('login.store'), [
+        'email' => 'tenant@example.com',
+        'password' => 'password',
+    ])->assertRedirect(route('portal.dashboard'));
+});

--- a/tests/Feature/TenantPortalTest.php
+++ b/tests/Feature/TenantPortalTest.php
@@ -64,6 +64,19 @@ test('user without tenant profile cannot access portal', function () {
         ->assertForbidden();
 });
 
+test('tenant without active lease does not show paid rent status', function () {
+    $user = User::factory()->create();
+    Tenant::factory()->withUser($user)->create();
+
+    $this->actingAs($user)
+        ->get(route('portal.dashboard'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('lease', null)
+            ->where('rent.status', 'none')
+            ->where('rent.upcoming_invoices', []));
+});
+
 test('tenant without dashboard permission cannot access owner dashboard', function () {
     $user = User::factory()->create();
     Tenant::factory()->withUser($user)->create();


### PR DESCRIPTION
## Summary

- add `/portal/dashboard` tenant portal route and dashboard controller
- redirect tenant-linked users to the portal after login
- show tenant lease, room, rent status, payable invoices, and reminder logs
- add focused portal feature tests

## Validation

- `php artisan test --compact tests/Feature/TenantPortalTest.php`
- `vendor/bin/pint --dirty --format agent`
- `npm run types:check`
- `npm run build`
- `graphify update .`
- `git diff --check`

Refs OPE-29

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tenant portal dashboard with lease, invoice, and notification summary
> - Adds a new `GET /portal/dashboard` route handled by [`TenantPortalDashboardController`](https://github.com/senatroxx/OpenKos/pull/84/files#diff-04160770afc0fd169283838c14c6a14ad0ff63853a11642b58dd8b5e4cbf6be7), returning an Inertia page with the tenant's active lease, up to 5 upcoming invoices, and up to 5 recent reminder notifications. Returns 403 for users without a tenant profile.
> - Computes a `rent.status` value (`none`, `paid`, `partial`, `due_today`, `overdue`, or `upcoming`) from the tenant's first payable invoice and active lease.
> - Redirects tenant users to `portal.dashboard` after login; non-tenant users continue to the owner dashboard.
> - Adds `auth.tenant` (id and name) to all Inertia shared props via [`HandleInertiaRequests`](https://github.com/senatroxx/OpenKos/pull/84/files#diff-83c0cdfc438586e614726fc44d098cd76e7605af4f067c21ceaaecae6e2051d1), and shows a 'Portal' nav entry in the sidebar for tenant users.
> - Behavioral Change: users with a tenant profile are now redirected to `/portal/dashboard` on login instead of the default Fortify redirect target.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f112f08.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->