### PR TITLE
fix(portal): label overdue invoices

### DIFF
--- a/app/Http/Controllers/LeaseInvoiceController.php
+++ b/app/Http/Controllers/LeaseInvoiceController.php
@@ -40,6 +40,8 @@ class LeaseInvoiceController extends Controller
             'invoices',
         );
 
+        $result['invoices']->getCollection()->each->append('display_status');
+
         return Inertia::render('leases/invoices', [
             ...$result,
             'lease' => $lease->only('id', 'reference', 'status'),
@@ -53,7 +55,7 @@ class LeaseInvoiceController extends Controller
         $this->authorize('view', $lease);
 
         $invoice->load(['lineItems', 'payments']);
-        $invoice->append('outstanding');
+        $invoice->append(['outstanding', 'display_status']);
 
         return Inertia::render('leases/invoice-detail', [
             'lease' => $lease->only('id', 'reference', 'status'),

--- a/app/Http/Controllers/TenantPortal/DashboardController.php
+++ b/app/Http/Controllers/TenantPortal/DashboardController.php
@@ -110,14 +110,14 @@ class DashboardController extends Controller
             return 'paid';
         }
 
-        if ($invoice->status === InvoiceStatus::Partial) {
-            return 'partial';
+        if ($invoice->isOverdue()) {
+            return 'overdue';
         }
 
         if ($invoice->due_date->isToday()) {
             return 'due_today';
         }
 
-        return $invoice->due_date->isPast() ? 'overdue' : 'upcoming';
+        return $invoice->status === InvoiceStatus::Partial ? 'partial' : 'upcoming';
     }
 }

--- a/app/Http/Controllers/TenantPortal/DashboardController.php
+++ b/app/Http/Controllers/TenantPortal/DashboardController.php
@@ -57,7 +57,7 @@ class DashboardController extends Controller
                     'period_end' => $invoice->period_end->toDateString(),
                     'due_date' => $invoice->due_date->toDateString(),
                     'status' => $invoice->status->value,
-                    'display_status' => $this->invoiceDisplayStatus($invoice),
+                    'display_status' => $invoice->display_status,
                     'total' => (string) $invoice->total,
                     'amount_paid' => (string) $invoice->amount_paid,
                     'outstanding' => $invoice->outstanding,
@@ -119,18 +119,5 @@ class DashboardController extends Controller
         }
 
         return $invoice->due_date->isPast() ? 'overdue' : 'upcoming';
-    }
-
-    private function invoiceDisplayStatus(Invoice $invoice): string
-    {
-        if ($invoice->due_date->isPast()) {
-            return 'overdue';
-        }
-
-        if ($invoice->due_date->isToday()) {
-            return 'due_today';
-        }
-
-        return $invoice->status->value;
     }
 }

--- a/app/Http/Controllers/TenantPortal/DashboardController.php
+++ b/app/Http/Controllers/TenantPortal/DashboardController.php
@@ -57,6 +57,7 @@ class DashboardController extends Controller
                     'period_end' => $invoice->period_end->toDateString(),
                     'due_date' => $invoice->due_date->toDateString(),
                     'status' => $invoice->status->value,
+                    'display_status' => $this->invoiceDisplayStatus($invoice),
                     'total' => (string) $invoice->total,
                     'amount_paid' => (string) $invoice->amount_paid,
                     'outstanding' => $invoice->outstanding,
@@ -118,5 +119,18 @@ class DashboardController extends Controller
         }
 
         return $invoice->due_date->isPast() ? 'overdue' : 'upcoming';
+    }
+
+    private function invoiceDisplayStatus(Invoice $invoice): string
+    {
+        if ($invoice->due_date->isPast()) {
+            return 'overdue';
+        }
+
+        if ($invoice->due_date->isToday()) {
+            return 'due_today';
+        }
+
+        return $invoice->status->value;
     }
 }

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -89,6 +89,11 @@ class Invoice extends Model
         return number_format((float) $this->total - (float) $this->amount_paid, 2, '.', '');
     }
 
+    public function getDisplayStatusAttribute(): string
+    {
+        return $this->isOverdue() ? 'overdue' : $this->status->value;
+    }
+
     public function isOverdue(): bool
     {
         return in_array($this->status, [InvoiceStatus::Pending, InvoiceStatus::Partial], true)

--- a/resources/js/components/shared/status-badge.tsx
+++ b/resources/js/components/shared/status-badge.tsx
@@ -94,6 +94,7 @@ const STATUS_CONFIGS: Record<string, Record<string, StatusConfig>> = {
     invoice: {
         pending: { label: 'Pending', className: 'bg-yellow-500 text-white' },
         partial: { label: 'Partial', className: 'bg-blue-600 text-white' },
+        overdue: { label: 'Overdue', className: 'bg-red-600 text-white' },
         paid: { label: 'Paid', className: 'bg-green-600 text-white' },
         cancelled: { label: 'Cancelled', className: 'bg-gray-400 text-white' },
         void: { label: 'Void', className: 'bg-gray-300 text-gray-700' },

--- a/resources/js/pages/leases/invoice-detail.tsx
+++ b/resources/js/pages/leases/invoice-detail.tsx
@@ -35,7 +35,10 @@ export default function InvoiceDetail({
                                 {formatPeriod(invoice.period_start, 'id-ID')}
                             </p>
                         </div>
-                        <StatusBadge domain="invoice" value={invoice.status} />
+                        <StatusBadge
+                            domain="invoice"
+                            value={invoice.display_status ?? invoice.status}
+                        />
                     </div>
 
                     <div className="mt-6 grid grid-cols-3 gap-4 text-sm">

--- a/resources/js/pages/leases/invoices.tsx
+++ b/resources/js/pages/leases/invoices.tsx
@@ -58,7 +58,12 @@ const columns: TableColumn<Invoice>[] = [
         key: 'status',
         label: 'Status',
         sortable: true,
-        render: (inv) => <StatusBadge domain="invoice" value={inv.status} />,
+        render: (inv) => (
+            <StatusBadge
+                domain="invoice"
+                value={inv.display_status ?? inv.status}
+            />
+        ),
     },
 ];
 

--- a/resources/js/pages/tenant-portal/dashboard.tsx
+++ b/resources/js/pages/tenant-portal/dashboard.tsx
@@ -16,6 +16,7 @@ type Invoice = {
     period_end: string;
     due_date: string;
     status: string;
+    display_status: string;
     total: string;
     amount_paid: string;
     outstanding: string;
@@ -219,7 +220,9 @@ export default function Dashboard({
                                                     )}
                                                 </p>
                                                 <p className="text-muted-foreground">
-                                                    {invoice.status}
+                                                    {rentStatusLabel(
+                                                        invoice.display_status,
+                                                    )}
                                                 </p>
                                             </div>
                                         </div>

--- a/resources/js/types/models.ts
+++ b/resources/js/types/models.ts
@@ -233,6 +233,7 @@ export type Invoice = {
     period_end: string;
     due_date: string;
     status: string;
+    display_status?: string;
     total: string;
     amount_paid: string;
     outstanding?: string;

--- a/tests/Feature/InvoiceWorkspaceTest.php
+++ b/tests/Feature/InvoiceWorkspaceTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\InvoiceStatus;
 use App\Models\Invoice;
 use App\Models\InvoiceLineItem;
 use App\Models\Lease;
@@ -31,6 +32,22 @@ describe('invoice workspace index', function () {
                 ->component('leases/invoices')
                 ->where('lease.id', $lease->id)
                 ->has('invoices.data', 3));
+    });
+
+    it('derives overdue display status without changing stored status', function () {
+        $lease = Lease::factory()->create();
+        Invoice::factory()->create([
+            'lease_id' => $lease->id,
+            'due_date' => now()->subDay(),
+            'status' => InvoiceStatus::Pending,
+        ]);
+
+        $this->actingAs($this->owner)
+            ->get(route('leases.workspace.invoices', $lease))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->where('invoices.data.0.status', 'pending')
+                ->where('invoices.data.0.display_status', 'overdue'));
     });
 
     it('returns empty state when lease has no invoices', function () {
@@ -71,6 +88,22 @@ describe('invoice workspace show', function () {
                 ->where('lease.id', $lease->id)
                 ->where('invoice.id', $invoice->id)
                 ->has('invoice.line_items', 1));
+    });
+
+    it('derives overdue display status on invoice detail', function () {
+        $lease = Lease::factory()->create();
+        $invoice = Invoice::factory()->create([
+            'lease_id' => $lease->id,
+            'due_date' => now()->subDay(),
+            'status' => InvoiceStatus::Pending,
+        ]);
+
+        $this->actingAs($this->owner)
+            ->get(route('leases.workspace.invoices.show', [$lease, $invoice]))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->where('invoice.status', 'pending')
+                ->where('invoice.display_status', 'overdue'));
     });
 
     it('denies access to invoice from another lease', function () {

--- a/tests/Feature/TenantPortalTest.php
+++ b/tests/Feature/TenantPortalTest.php
@@ -39,6 +39,25 @@ test('tenant sees their portal dashboard', function () {
             ->has('notifications', 1));
 });
 
+test('portal displays overdue for past payable invoices', function () {
+    $user = User::factory()->create();
+    $tenant = Tenant::factory()->withUser($user)->create();
+    $lease = Lease::factory()->create(['primary_tenant_id' => $tenant->id]);
+    Invoice::factory()->create([
+        'lease_id' => $lease->id,
+        'due_date' => now()->subDay(),
+        'status' => InvoiceStatus::Pending,
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('portal.dashboard'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('rent.status', 'overdue')
+            ->where('rent.upcoming_invoices.0.status', 'pending')
+            ->where('rent.upcoming_invoices.0.display_status', 'overdue'));
+});
+
 test('portal only exposes the authenticated tenants lease data', function () {
     $user = User::factory()->create();
     $tenant = Tenant::factory()->withUser($user)->create();

--- a/tests/Feature/TenantPortalTest.php
+++ b/tests/Feature/TenantPortalTest.php
@@ -58,6 +58,25 @@ test('portal displays overdue for past payable invoices', function () {
             ->where('rent.upcoming_invoices.0.display_status', 'overdue'));
 });
 
+test('portal displays overdue for past partial invoices', function () {
+    $user = User::factory()->create();
+    $tenant = Tenant::factory()->withUser($user)->create();
+    $lease = Lease::factory()->create(['primary_tenant_id' => $tenant->id]);
+    Invoice::factory()->create([
+        'lease_id' => $lease->id,
+        'due_date' => now()->subDay(),
+        'status' => InvoiceStatus::Partial,
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('portal.dashboard'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('rent.status', 'overdue')
+            ->where('rent.upcoming_invoices.0.status', 'partial')
+            ->where('rent.upcoming_invoices.0.display_status', 'overdue'));
+});
+
 test('portal only exposes the authenticated tenants lease data', function () {
     $user = User::factory()->create();
     $tenant = Tenant::factory()->withUser($user)->create();


### PR DESCRIPTION
## Summary

- derive tenant portal invoice display status from due date
- show past payable invoices as `Overdue` instead of stored `pending`
- keep stored invoice status unchanged for the billing aggregate
- add regression coverage for past payable invoices

## Validation

- `php artisan test --compact tests/Feature/TenantPortalTest.php`
- `vendor/bin/pint --dirty --format agent`
- `npm run types:check`
- `git diff --check`
- `graphify update .`

Follow-up to OPE-29 / PR #84.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `display_status` to label overdue invoices without mutating stored status
> - Adds a `getDisplayStatusAttribute` accessor on [`Invoice`](https://github.com/senatroxx/OpenKos/pull/85/files#diff-2cbcfc25f25e33074bab704ac90e03242b19017dcaa304d64066913f6443bf03) that returns `'overdue'` when the invoice is past due, otherwise returning the stored status value.
> - Exposes `display_status` in the lease invoices index, invoice detail, and tenant portal dashboard API responses.
> - Updates the invoice list and detail pages to prefer `display_status` over `status` when rendering the `StatusBadge`, which now supports a red `'Overdue'` variant.
> - Fixes `rentStatus` resolution in the tenant portal dashboard so partial-but-overdue invoices show `'overdue'` instead of `'partial'`.
> - Behavioral Change: overdue partial invoices previously showed `'Partial'` status in the tenant portal dashboard; they now show `'Overdue'`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ac58913.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->