### PR TITLE
feat(portal): add tenant lease workspace

### DIFF
--- a/app/Actions/Leases/CreateLease.php
+++ b/app/Actions/Leases/CreateLease.php
@@ -8,6 +8,8 @@ use App\Business\Leases\OccupancyCalculator;
 use App\Data\Lease\CreateLeaseData;
 use App\Enums\LeaseStatus;
 use App\Enums\UnitStatus;
+use App\Models\Lease;
+use App\Models\Tenant;
 use App\Models\Unit;
 use App\Models\UnitRate;
 use Illuminate\Support\Facades\DB;
@@ -26,6 +28,7 @@ class CreateLease
 
         return DB::transaction(function () use ($unit, $data, $tenantIds) {
             $unit = Unit::lockForUpdate()->findOrFail($unit->id);
+            Tenant::query()->whereKey($tenantIds)->lockForUpdate()->get();
 
             abort_if(in_array($unit->status, [UnitStatus::Maintenance, UnitStatus::Unavailable], true), 422, __('This unit is not available for lease.'));
 
@@ -35,6 +38,8 @@ class CreateLease
             if ($existingLease) {
                 $existingTenantIds = $existingLease->tenants()->pluck('tenants.id');
                 $newTenantIds = array_diff($tenantIds, $existingTenantIds->all());
+
+                $this->ensureTenantsDoNotHaveActiveLease($newTenantIds);
 
                 abort_if(! $this->occupancy->canAccommodate($unit, count($newTenantIds)), 422, __('Unit capacity exceeded. Unit can only hold :capacity occupants.', ['capacity' => $unit->capacity]));
 
@@ -48,6 +53,8 @@ class CreateLease
             }
 
             abort_if(! $this->occupancy->canAccommodate($unit, count($tenantIds)), 422, __('Unit capacity exceeded. Unit can only hold :capacity occupants.', ['capacity' => $unit->capacity]));
+
+            $this->ensureTenantsDoNotHaveActiveLease($tenantIds);
 
             $unitRate = $data->unitRateId ? UnitRate::find($data->unitRateId) : null;
             $rentAmount = $data->rentAmount ?? $unitRate?->amount ?? $unit->rates()->where('billing_unit', 'month')->where('billing_interval', 1)->value('amount');
@@ -84,5 +91,20 @@ class CreateLease
 
             return $lease;
         });
+    }
+
+    /**
+     * @param  array<int, int>  $tenantIds
+     */
+    private function ensureTenantsDoNotHaveActiveLease(array $tenantIds): void
+    {
+        abort_if(
+            $tenantIds !== [] && Lease::query()
+                ->where('status', LeaseStatus::Active->value)
+                ->whereHas('tenants', fn ($query) => $query->whereIn('tenants.id', $tenantIds))
+                ->exists(),
+            422,
+            __('A tenant already has an active lease.'),
+        );
     }
 }

--- a/app/Http/Controllers/TenantPortal/DashboardController.php
+++ b/app/Http/Controllers/TenantPortal/DashboardController.php
@@ -6,6 +6,7 @@ use App\Enums\InvoiceStatus;
 use App\Http\Controllers\Controller;
 use App\Models\Invoice;
 use App\Models\Lease;
+use App\Models\Payment;
 use App\Models\ReminderLog;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
@@ -33,6 +34,21 @@ class DashboardController extends Controller
                 ->get()
             : collect();
 
+        $outstandingBalance = $lease
+            ? (string) $lease->invoices()
+                ->payable()
+                ->selectRaw('COALESCE(SUM(total - amount_paid), 0) as outstanding_balance')
+                ->value('outstanding_balance')
+            : '0';
+
+        $payments = $lease
+            ? $lease->payments()
+                ->with('invoice:id,reference,period_start')
+                ->latest('payment_date')
+                ->limit(3)
+                ->get()
+            : collect();
+
         $reminders = $lease
             ? ReminderLog::query()
                 ->where('lease_id', $lease->id)
@@ -49,6 +65,7 @@ class DashboardController extends Controller
             'lease' => $lease ? $this->leasePayload($lease) : null,
             'rent' => [
                 'status' => $this->rentStatus($lease, $invoices->first()),
+                'outstanding_balance' => $outstandingBalance,
                 'upcoming_invoices' => $invoices->map(fn (Invoice $invoice) => [
                     'id' => $invoice->id,
                     'lease_id' => $invoice->lease_id,
@@ -61,6 +78,16 @@ class DashboardController extends Controller
                     'total' => (string) $invoice->total,
                     'amount_paid' => (string) $invoice->amount_paid,
                     'outstanding' => $invoice->outstanding,
+                ])->values(),
+                'recent_payments' => $payments->map(fn (Payment $payment) => [
+                    'id' => $payment->id,
+                    'invoice_id' => $payment->invoice_id,
+                    'invoice_reference' => $payment->invoice?->reference,
+                    'period_start' => $payment->invoice?->period_start?->toDateString(),
+                    'amount' => (string) $payment->amount,
+                    'payment_date' => $payment->payment_date->toDateString(),
+                    'payment_method' => $payment->payment_method,
+                    'status' => $payment->status->value,
                 ])->values(),
             ],
             'notifications' => $reminders->map(fn (ReminderLog $reminder) => [

--- a/app/Http/Controllers/TenantPortal/LeaseController.php
+++ b/app/Http/Controllers/TenantPortal/LeaseController.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace App\Http\Controllers\TenantPortal;
+
+use App\Http\Controllers\Controller;
+use App\Models\Invoice;
+use App\Models\Lease;
+use App\Models\Tenant;
+use App\Tables\Column;
+use App\Tables\Filter;
+use App\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class LeaseController extends Controller
+{
+    public function index(Request $request): Response
+    {
+        $tenant = $this->tenant($request);
+
+        $table = Table::make()
+            ->columns([
+                Column::make('reference', 'Reference')->sortable()->searchable(),
+                Column::make('start_date', 'Start')->sortable(),
+                Column::make('end_date', 'End')->sortable(),
+                Column::make('rent_amount', 'Rent')->sortable(),
+                Column::make('status', 'Status')->sortable(),
+            ])
+            ->filters([
+                Filter::select('status', 'Status', ['active', 'renewed', 'terminated', 'expired'])
+                    ->query(fn (Builder $query, string $value) => $query->where('leases.status', $value)),
+            ])
+            ->defaultSort('-start_date');
+
+        $result = $table->paginate(
+            $tenant->leases()->with(['unit.property']),
+            $request,
+            'leases',
+        );
+
+        return Inertia::render('tenant-portal/lease/index', [
+            ...$result,
+        ]);
+    }
+
+    public function show(Request $request, Lease $lease): Response
+    {
+        $tenant = $this->tenant($request);
+        $lease = $this->tenantLease($tenant, $lease);
+
+        $lease->load('unit.property');
+
+        return Inertia::render('tenant-portal/lease/show', [
+            'lease' => $lease,
+        ]);
+    }
+
+    public function invoices(Request $request, Lease $lease): Response
+    {
+        $tenant = $this->tenant($request);
+        $lease = $this->tenantLease($tenant, $lease);
+
+        $table = Table::make()
+            ->columns([
+                Column::make('reference', 'Reference')->searchable(),
+                Column::make('period_start', 'Period')->sortable(),
+                Column::make('due_date', 'Due date')->sortable(),
+                Column::make('total', 'Total')->sortable(),
+                Column::make('amount_paid', 'Paid')->sortable(),
+                Column::make('outstanding', 'Outstanding'),
+                Column::make('status', 'Status')->sortable(),
+            ])
+            ->filters([
+                Filter::select('status', 'Status', ['pending', 'partial', 'paid', 'cancelled', 'void'])
+                    ->query(fn (Builder $query, string $value) => $query->where('status', $value)),
+            ])
+            ->defaultSort('-period_start');
+
+        $result = $table->paginate(
+            $lease->invoices()->select('invoices.*')->selectRaw('(COALESCE(total, 0) - COALESCE(amount_paid, 0)) as outstanding'),
+            $request,
+            'invoices',
+        );
+
+        $result['invoices']->getCollection()->each->append('display_status');
+
+        return Inertia::render('tenant-portal/lease/invoices', [
+            ...$result,
+            'lease' => $lease->load('unit.property'),
+        ]);
+    }
+
+    public function history(Request $request, Lease $lease): Response
+    {
+        $tenant = $this->tenant($request);
+        $lease = $this->tenantLease($tenant, $lease);
+
+        $table = Table::make()
+            ->columns([
+                Column::make('effective_date', 'Date')->sortable(),
+                Column::make('reason', 'Reason')->sortable()->searchable(),
+            ])
+            ->defaultSort('-effective_date');
+
+        $result = $table->paginate(
+            $lease->unitHistories()->with(['fromUnit:id,name', 'toUnit:id,name']),
+            $request,
+            'history',
+        );
+
+        return Inertia::render('tenant-portal/lease/history', [
+            ...$result,
+            'lease' => $lease->load('unit.property'),
+        ]);
+    }
+
+    public function invoice(Request $request, Lease $lease, Invoice $invoice): Response
+    {
+        $tenant = $this->tenant($request);
+        $lease = $this->tenantLease($tenant, $lease);
+
+        abort_if($invoice->lease_id !== $lease->id, 404);
+
+        $invoice->load(['lineItems', 'payments']);
+        $invoice->append(['outstanding', 'display_status']);
+
+        return Inertia::render('tenant-portal/lease/invoice', [
+            'lease' => $lease->load('unit.property'),
+            'invoice' => $invoice,
+        ]);
+    }
+
+    private function tenant(Request $request): Tenant
+    {
+        $tenant = $request->user()->tenant()->first();
+
+        abort_unless($tenant, 403);
+
+        return $tenant;
+    }
+
+    private function tenantLease(Tenant $tenant, Lease $lease): Lease
+    {
+        return $tenant->leases()
+            ->whereKey($lease)
+            ->firstOrFail();
+    }
+}

--- a/resources/js/components/features/app/app-sidebar.tsx
+++ b/resources/js/components/features/app/app-sidebar.tsx
@@ -26,9 +26,10 @@ import {
 import { platformNavItems, platformPageNavItems } from '@/lib/platform';
 import { dashboard } from '@/routes';
 import { rent as dashboardRent } from '@/routes/dashboard';
-import { dashboard as portalDashboard } from '@/routes/portal';
 import leases from '@/routes/leases';
 import maintenanceTickets from '@/routes/maintenance-tickets';
+import { dashboard as portalDashboard } from '@/routes/portal';
+import { index as portalLease } from '@/routes/portal/lease';
 import properties from '@/routes/properties';
 import roles from '@/routes/roles';
 import tenants from '@/routes/tenants';
@@ -46,7 +47,18 @@ export function AppSidebar() {
 
     const mainNavItems: NavItem[] = [
         ...(auth.tenant
-            ? [{ title: 'Portal', href: portalDashboard(), icon: LayoutGrid }]
+            ? [
+                  {
+                      title: 'Dashboard',
+                      icon: LayoutGrid,
+                      href: portalDashboard(),
+                  },
+                  {
+                      title: 'Lease',
+                      icon: FileText,
+                      href: portalLease(),
+                  },
+              ]
             : []),
         ...(isOwner || permissions.includes('dashboard.view')
             ? [

--- a/resources/js/pages/tenant-portal/dashboard.tsx
+++ b/resources/js/pages/tenant-portal/dashboard.tsx
@@ -1,4 +1,5 @@
 import { Head } from '@inertiajs/react';
+import { StatusBadge } from '@/components/shared/status-badge';
 import { Badge } from '@/components/ui/badge';
 import {
     Card,
@@ -7,6 +8,7 @@ import {
     CardTitle,
 } from '@/components/ui/card';
 import { formatDate, formatPrice } from '@/lib/formatters';
+import { dashboard } from '@/routes/portal';
 
 type Invoice = {
     id: number;
@@ -51,12 +53,25 @@ type Notification = {
     overdue_days: number | null;
 };
 
+type Payment = {
+    id: number;
+    invoice_id: number;
+    invoice_reference: string | null;
+    period_start: string | null;
+    amount: string;
+    payment_date: string;
+    payment_method: string;
+    status: string;
+};
+
 type Props = {
     tenant: { id: number; name: string };
     lease: Lease | null;
     rent: {
         status: string;
+        outstanding_balance: string;
         upcoming_invoices: Invoice[];
+        recent_payments: Payment[];
     };
     notifications: Notification[];
 };
@@ -72,16 +87,13 @@ export default function Dashboard({
             <Head title="Tenant Portal" />
 
             <div className="flex flex-1 flex-col gap-6 p-4">
-                <div className="flex items-center justify-between gap-4">
-                    <div>
-                        <p className="text-sm text-muted-foreground">
-                            Tenant Portal
-                        </p>
-                        <h1 className="text-2xl font-semibold">
-                            Hi, {tenant.name}
-                        </h1>
-                    </div>
-
+                <div>
+                    <p className="text-sm text-muted-foreground">
+                        Tenant Portal
+                    </p>
+                    <h1 className="text-2xl font-semibold">
+                        Hi, {tenant.name}
+                    </h1>
                 </div>
 
                 <div className="grid gap-4 lg:grid-cols-3">
@@ -172,7 +184,15 @@ export default function Dashboard({
                             <CardTitle>Rent Status</CardTitle>
                         </CardHeader>
                         <CardContent className="space-y-3">
-                            <Badge>{rentStatusLabel(rent.status)}</Badge>
+                            <StatusBadge domain="rent" value={rent.status} />
+                            <div className="flex items-center justify-between gap-4 text-sm">
+                                <span className="text-muted-foreground">
+                                    Outstanding balance
+                                </span>
+                                <span className="font-medium tabular-nums">
+                                    {formatPrice(rent.outstanding_balance)}
+                                </span>
+                            </div>
                             {rent.upcoming_invoices[0] && (
                                 <p className="text-sm text-muted-foreground">
                                     Next due{' '}
@@ -189,7 +209,7 @@ export default function Dashboard({
                     </Card>
                 </div>
 
-                <div className="grid gap-4 lg:grid-cols-2">
+                <div className="grid gap-4 lg:grid-cols-3">
                     <Card>
                         <CardHeader>
                             <CardTitle>Upcoming Payments</CardTitle>
@@ -269,6 +289,49 @@ export default function Dashboard({
                             )}
                         </CardContent>
                     </Card>
+
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Recent Payments</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            {rent.recent_payments.length > 0 ? (
+                                <div className="space-y-3">
+                                    {rent.recent_payments.map((payment) => (
+                                        <div
+                                            key={payment.id}
+                                            className="flex items-center justify-between gap-4 rounded-lg border p-3 text-sm"
+                                        >
+                                            <div>
+                                                <p className="font-medium">
+                                                    {payment.invoice_reference ??
+                                                        'Payment'}
+                                                </p>
+                                                <p className="text-muted-foreground">
+                                                    {formatDate(
+                                                        payment.payment_date,
+                                                    )}
+                                                </p>
+                                            </div>
+                                            <div className="text-right">
+                                                <p className="font-medium tabular-nums">
+                                                    {formatPrice(payment.amount)}
+                                                </p>
+                                                <StatusBadge
+                                                    domain="payment"
+                                                    value={payment.status}
+                                                />
+                                            </div>
+                                        </div>
+                                    ))}
+                                </div>
+                            ) : (
+                                <p className="text-sm text-muted-foreground">
+                                    No payments recorded yet.
+                                </p>
+                            )}
+                        </CardContent>
+                    </Card>
                 </div>
             </div>
         </>
@@ -295,5 +358,5 @@ function notificationLabel(notification: Notification): string {
 }
 
 Dashboard.layout = {
-    breadcrumbs: [{ title: 'Tenant Portal', href: '/portal/dashboard' }],
+    breadcrumbs: [{ title: 'Tenant Portal', href: dashboard() }],
 };

--- a/resources/js/pages/tenant-portal/lease/history.tsx
+++ b/resources/js/pages/tenant-portal/lease/history.tsx
@@ -1,0 +1,71 @@
+import type { TableColumn } from '@/components/data-table';
+import { WorkspaceTable } from '@/components/shared/workspace-table';
+import { formatDate } from '@/lib/formatters';
+import { history } from '@/routes/portal/lease';
+import type { Lease, PaginatedData, TableMeta } from '@/types';
+import { TenantLeaseLayout } from './layout';
+
+type UnitHistory = {
+    id: number;
+    from_unit: { id: number; name: string } | null;
+    to_unit: { id: number; name: string } | null;
+    reason: string | null;
+    effective_date: string;
+};
+
+const columns: TableColumn<UnitHistory>[] = [
+    {
+        key: 'effective_date',
+        label: 'Date',
+        sortable: true,
+        className: 'text-muted-foreground tabular-nums',
+        render: (entry) => formatDate(entry.effective_date),
+    },
+    {
+        key: '_move',
+        label: 'Move',
+        className: 'font-medium',
+        render: (entry) =>
+            `${entry.from_unit?.name ?? '—'} to ${entry.to_unit?.name ?? '—'}`,
+    },
+    {
+        key: 'reason',
+        label: 'Reason',
+        sortable: true,
+        render: (entry) => entry.reason?.replaceAll('_', ' ') ?? '—',
+    },
+];
+
+export default function LeaseHistory({
+    lease,
+    history: data,
+    sort = '-effective_date',
+    search = '',
+    per_page = 15,
+    table,
+}: {
+    lease: Lease;
+    history: PaginatedData<UnitHistory>;
+    sort?: string;
+    search?: string;
+    per_page?: number;
+    table: TableMeta;
+}) {
+    return (
+        <TenantLeaseLayout lease={lease} activeTab="history">
+            <WorkspaceTable
+                url={history.url(lease)}
+                noun="history entries"
+                rows={data}
+                columns={columns}
+                tableMeta={table}
+                sort={sort}
+                search={search}
+                perPage={per_page}
+                defaultSort="-effective_date"
+                searchPlaceholder="Search by reason..."
+                emptyMessage="No unit changes recorded for this lease."
+            />
+        </TenantLeaseLayout>
+    );
+}

--- a/resources/js/pages/tenant-portal/lease/index.tsx
+++ b/resources/js/pages/tenant-portal/lease/index.tsx
@@ -1,0 +1,133 @@
+import { Head, Link, router } from '@inertiajs/react';
+import { Eye, EllipsisVertical } from 'lucide-react';
+import type { TableColumn } from '@/components/data-table';
+import { StatusBadge } from '@/components/shared/status-badge';
+import { WorkspaceTable } from '@/components/shared/workspace-table';
+import { Button } from '@/components/ui/button';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { formatDate, formatPrice } from '@/lib/formatters';
+import { index, show } from '@/routes/portal/lease';
+import type { Lease, PaginatedData, TableMeta } from '@/types';
+
+const columns: TableColumn<Lease>[] = [
+    {
+        key: 'reference',
+        label: 'Reference',
+        sortable: true,
+        className: 'font-mono text-xs',
+        render: (lease) => lease.reference ?? `#${lease.id}`,
+    },
+    {
+        key: '_unit',
+        label: 'Unit',
+        className: 'font-medium',
+        render: (lease) =>
+            lease.unit
+                ? `${lease.unit.name}${lease.unit.property ? ` - ${lease.unit.property.name}` : ''}`
+                : '—',
+    },
+    {
+        key: 'start_date',
+        label: 'Start',
+        sortable: true,
+        className: 'text-muted-foreground tabular-nums',
+        render: (lease) => formatDate(lease.start_date),
+    },
+    {
+        key: 'end_date',
+        label: 'End',
+        sortable: true,
+        className: 'text-muted-foreground tabular-nums',
+        render: (lease) => (lease.end_date ? formatDate(lease.end_date) : 'Ongoing'),
+    },
+    {
+        key: 'rent_amount',
+        label: 'Rent',
+        sortable: true,
+        className: 'tabular-nums',
+        render: (lease) => formatPrice(lease.rent_amount),
+    },
+    {
+        key: 'status',
+        label: 'Status',
+        sortable: true,
+        render: (lease) => <StatusBadge domain="lease" value={lease.status} />,
+    },
+        {
+            key: '_actions',
+            label: '',
+            render: (lease) => (
+                <DropdownMenu>
+                    <DropdownMenuTrigger asChild onClick={(event) => event.stopPropagation()}>
+                        <Button variant="ghost" size="icon" className="size-8">
+                            <EllipsisVertical className="size-4" />
+                        </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" onClick={(event) => event.stopPropagation()}>
+                        <DropdownMenuItem asChild>
+                            <Link href={show(lease)}>
+                                <Eye className="size-4" />
+                                View details
+                            </Link>
+                        </DropdownMenuItem>
+                    </DropdownMenuContent>
+                </DropdownMenu>
+            ),
+        },
+];
+
+export default function LeaseIndex({
+    leases,
+    sort = '-start_date',
+    search = '',
+    status = '',
+    per_page = 15,
+    table,
+}: {
+    leases: PaginatedData<Lease>;
+    sort?: string;
+    search?: string;
+    status?: string;
+    per_page?: number;
+    table: TableMeta;
+}) {
+    return (
+        <>
+            <Head title="Leases" />
+
+            <div className="flex flex-1 flex-col gap-6 p-4">
+                <div>
+                    <h1 className="text-2xl font-semibold">Leases</h1>
+                    <p className="text-sm text-muted-foreground">
+                        Current and previous stays
+                    </p>
+                </div>
+
+                <WorkspaceTable
+                    url={index.url()}
+                    noun="leases"
+                    rows={leases}
+                    columns={columns}
+                    tableMeta={table}
+                    sort={sort}
+                    search={search}
+                    perPage={per_page}
+                    filterValues={{ status }}
+                    defaultSort="-start_date"
+                    searchPlaceholder="Search by reference..."
+                    emptyMessage="No leases found."
+                    onRowClick={(lease) => router.get(show.url(lease))}
+                />
+            </div>
+        </>
+    );
+}
+
+LeaseIndex.layout = {
+    breadcrumbs: [{ title: 'Leases', href: index() }],
+};

--- a/resources/js/pages/tenant-portal/lease/invoice.tsx
+++ b/resources/js/pages/tenant-portal/lease/invoice.tsx
@@ -1,0 +1,99 @@
+import { Head, Link } from '@inertiajs/react';
+import { ChevronLeft } from 'lucide-react';
+import { StatusBadge } from '@/components/shared/status-badge';
+import { formatDate, formatPeriod, formatPrice } from '@/lib/formatters';
+import { invoices } from '@/routes/portal/lease';
+import type { Invoice, Lease } from '@/types';
+
+export default function InvoiceDetail({
+    lease,
+    invoice,
+}: {
+    lease: Lease;
+    invoice: Invoice;
+}) {
+    return (
+        <div className="workspace-enter flex h-full flex-1 flex-col gap-6 overflow-x-auto rounded-xl p-4">
+            <Head title={`Invoice ${invoice.reference ?? ''}`} />
+
+            <Link
+                href={invoices(lease)}
+                className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+            >
+                <ChevronLeft className="size-3" />
+                Back to invoices
+            </Link>
+
+            <div className="space-y-6">
+                <div className="rounded-lg border p-6">
+                    <div className="flex items-start justify-between gap-4">
+                        <div>
+                            <h1 className="text-lg font-semibold">
+                                {invoice.reference ?? 'Invoice'}
+                            </h1>
+                            <p className="text-sm text-muted-foreground">
+                                {formatPeriod(invoice.period_start, 'id-ID')}
+                            </p>
+                        </div>
+                        <StatusBadge
+                            domain="invoice"
+                            value={invoice.display_status ?? invoice.status}
+                        />
+                    </div>
+
+                    <div className="mt-6 grid gap-4 text-sm sm:grid-cols-3">
+                        <Detail label="Total" value={formatPrice(invoice.total)} />
+                        <Detail label="Paid" value={formatPrice(invoice.amount_paid)} />
+                        <Detail label="Outstanding" value={formatPrice(invoice.outstanding ?? '0')} />
+                        <Detail label="Period" value={`${formatDate(invoice.period_start)} - ${formatDate(invoice.period_end)}`} />
+                        <Detail label="Due date" value={formatDate(invoice.due_date)} />
+                    </div>
+                </div>
+
+                {invoice.line_items && invoice.line_items.length > 0 && (
+                    <section className="rounded-lg border">
+                        <h2 className="border-b px-4 py-3 text-xs font-medium tracking-wider text-muted-foreground uppercase">
+                            Line Items
+                        </h2>
+                        <div className="divide-y">
+                            {invoice.line_items.map((item) => (
+                                <div key={item.id} className="flex items-center justify-between gap-4 px-4 py-3 text-sm">
+                                    <span>{item.description}</span>
+                                    <span className="tabular-nums">{formatPrice(item.amount)}</span>
+                                </div>
+                            ))}
+                        </div>
+                    </section>
+                )}
+
+                {invoice.payments && invoice.payments.length > 0 && (
+                    <section className="rounded-lg border">
+                        <h2 className="border-b px-4 py-3 text-xs font-medium tracking-wider text-muted-foreground uppercase">
+                            Payments
+                        </h2>
+                        <div className="divide-y">
+                            {invoice.payments.map((payment) => (
+                                <div key={payment.id} className="flex items-center justify-between gap-4 px-4 py-3 text-sm">
+                                    <div>
+                                        <p className="font-medium tabular-nums">{formatPrice(payment.amount)}</p>
+                                        <p className="text-xs text-muted-foreground">{formatDate(payment.payment_date)}</p>
+                                    </div>
+                                    <StatusBadge domain="payment" value={payment.status} />
+                                </div>
+                            ))}
+                        </div>
+                    </section>
+                )}
+            </div>
+        </div>
+    );
+}
+
+function Detail({ label, value }: { label: string; value: string }) {
+    return (
+        <div>
+            <p className="text-muted-foreground">{label}</p>
+            <p className="mt-1 font-medium tabular-nums">{value}</p>
+        </div>
+    );
+}

--- a/resources/js/pages/tenant-portal/lease/invoices.tsx
+++ b/resources/js/pages/tenant-portal/lease/invoices.tsx
@@ -1,0 +1,104 @@
+import { router } from '@inertiajs/react';
+import type { TableColumn } from '@/components/data-table';
+import { StatusBadge } from '@/components/shared/status-badge';
+import { WorkspaceTable } from '@/components/shared/workspace-table';
+import { formatDate, formatPeriod, formatPrice } from '@/lib/formatters';
+import { invoices } from '@/routes/portal/lease';
+import { show } from '@/routes/portal/lease/invoices';
+import type { Invoice, Lease, PaginatedData, TableMeta } from '@/types';
+import { TenantLeaseLayout } from './layout';
+
+const columns: TableColumn<Invoice>[] = [
+    {
+        key: 'reference',
+        label: 'Reference',
+        sortable: true,
+        className: 'font-mono text-xs',
+        render: (invoice) => invoice.reference ?? '—',
+    },
+    {
+        key: 'period_start',
+        label: 'Period',
+        sortable: true,
+        className: 'text-muted-foreground',
+        render: (invoice) => formatPeriod(invoice.period_start, 'id-ID'),
+    },
+    {
+        key: 'due_date',
+        label: 'Due date',
+        sortable: true,
+        className: 'text-muted-foreground tabular-nums',
+        render: (invoice) => formatDate(invoice.due_date),
+    },
+    {
+        key: 'total',
+        label: 'Total',
+        sortable: true,
+        className: 'tabular-nums',
+        render: (invoice) => formatPrice(invoice.total),
+    },
+    {
+        key: 'amount_paid',
+        label: 'Paid',
+        sortable: true,
+        className: 'text-muted-foreground tabular-nums',
+        render: (invoice) => formatPrice(invoice.amount_paid),
+    },
+    {
+        key: 'outstanding',
+        label: 'Outstanding',
+        className: 'tabular-nums',
+        render: (invoice) => formatPrice(invoice.outstanding ?? '0'),
+    },
+    {
+        key: 'status',
+        label: 'Status',
+        sortable: true,
+        render: (invoice) => (
+            <StatusBadge
+                domain="invoice"
+                value={invoice.display_status ?? invoice.status}
+            />
+        ),
+    },
+];
+
+export default function LeaseInvoices({
+    lease,
+    invoices: data,
+    sort = '-period_start',
+    search = '',
+    status = '',
+    per_page = 15,
+    table,
+}: {
+    lease: Lease;
+    invoices: PaginatedData<Invoice>;
+    sort?: string;
+    search?: string;
+    status?: string;
+    per_page?: number;
+    table: TableMeta;
+}) {
+    return (
+        <TenantLeaseLayout lease={lease} activeTab="invoices">
+            <WorkspaceTable
+                url={invoices.url(lease)}
+                noun="invoices"
+                rows={data}
+                columns={columns}
+                tableMeta={table}
+                sort={sort}
+                search={search}
+                perPage={per_page}
+                filterValues={{ status }}
+                defaultSort="-period_start"
+                searchPlaceholder="Search by reference..."
+                emptyMessage="No invoices generated yet."
+                onRowClick={(invoice) =>
+                    router.get(show.url({ lease, invoice }))
+                }
+            />
+        </TenantLeaseLayout>
+    );
+}

--- a/resources/js/pages/tenant-portal/lease/layout.tsx
+++ b/resources/js/pages/tenant-portal/lease/layout.tsx
@@ -1,0 +1,39 @@
+import { Head } from '@inertiajs/react';
+import type { ReactNode } from 'react';
+import { EntityWorkspaceLayout } from '@/components/shared/entity-workspace-layout';
+import { WorkspaceTabs } from '@/components/shared/workspace-tabs';
+import { history, index, invoices, show } from '@/routes/portal/lease';
+import type { Lease } from '@/types';
+
+export function TenantLeaseLayout({
+    lease,
+    activeTab,
+    children,
+}: {
+    lease: Lease;
+    activeTab: string;
+    children: ReactNode;
+}) {
+    return (
+        <EntityWorkspaceLayout
+            title={`Lease #${lease.id}`}
+            subtitle={lease.reference ?? undefined}
+            backRoute={index.url()}
+            backLabel="All leases"
+        >
+            <Head title={`Lease #${lease.id}`} />
+
+            <WorkspaceTabs
+                workspace="tenant-portal-lease"
+                activeTab={activeTab}
+                tabs={[
+                    { key: 'overview', label: 'Overview', href: show.url(lease) },
+                    { key: 'invoices', label: 'Invoices', href: invoices.url(lease) },
+                    { key: 'history', label: 'History', href: history.url(lease) },
+                ]}
+            />
+
+            {children}
+        </EntityWorkspaceLayout>
+    );
+}

--- a/resources/js/pages/tenant-portal/lease/show.tsx
+++ b/resources/js/pages/tenant-portal/lease/show.tsx
@@ -1,0 +1,66 @@
+import { StatusBadge } from '@/components/shared/status-badge';
+import { DUE_DAY_LABELS } from '@/lib/constants';
+import { formatDate, formatPrice } from '@/lib/formatters';
+import type { Lease } from '@/types';
+import { TenantLeaseLayout } from './layout';
+
+function Detail({ label, value }: { label: string; value: string }) {
+    return (
+        <div className="flex items-center justify-between gap-4">
+            <span className="text-muted-foreground">{label}</span>
+            <span className="text-right">{value}</span>
+        </div>
+    );
+}
+
+export default function LeaseWorkspace({ lease }: { lease: Lease }) {
+    return (
+        <TenantLeaseLayout lease={lease} activeTab="overview">
+            <div className="space-y-6">
+                <section>
+                    <h2 className="mb-3 text-xs font-medium tracking-wider text-muted-foreground uppercase">
+                        Status
+                    </h2>
+                    <StatusBadge domain="lease" value={lease.status} />
+                </section>
+
+                <section>
+                    <h2 className="mb-3 text-xs font-medium tracking-wider text-muted-foreground uppercase">
+                        Stay
+                    </h2>
+                    <div className="space-y-2 rounded-lg border p-4 text-sm">
+                        <Detail
+                            label="Unit"
+                            value={
+                                lease.unit
+                                    ? `${lease.unit.name}${lease.unit.property ? ` - ${lease.unit.property.name}` : ''}`
+                                    : '—'
+                            }
+                        />
+                        <Detail label="Start date" value={formatDate(lease.start_date)} />
+                        <Detail label="End date" value={lease.end_date ? formatDate(lease.end_date) : 'Ongoing'} />
+                    </div>
+                </section>
+
+                <section>
+                    <h2 className="mb-3 text-xs font-medium tracking-wider text-muted-foreground uppercase">
+                        Rent
+                    </h2>
+                    <div className="space-y-2 rounded-lg border p-4 text-sm">
+                        <Detail
+                            label="Billing rate"
+                            value={`${formatPrice(lease.rent_amount)} ${lease.billing_label ?? ''}`}
+                        />
+                        <Detail
+                            label="Due date"
+                            value={
+                                DUE_DAY_LABELS[lease.rent_due_day] ??
+                                `${lease.rent_due_day}th`
+                            }
+                        />
+                    </div>
+                </section>
+            </div>
+        </TenantLeaseLayout>
+    );
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,6 +15,7 @@ use App\Http\Controllers\TenantController;
 use App\Http\Controllers\TenantDocumentController;
 use App\Http\Controllers\TenantInvitationController;
 use App\Http\Controllers\TenantPortal\DashboardController as TenantPortalDashboardController;
+use App\Http\Controllers\TenantPortal\LeaseController as TenantPortalLeaseController;
 use App\Http\Controllers\UnitController;
 use App\Http\Controllers\UserController;
 use Illuminate\Support\Facades\Route;
@@ -34,6 +35,16 @@ Route::prefix('tenants/invitations')->name('tenants.invitations.')->middleware('
 Route::middleware(['auth', 'verified'])->prefix('portal')->name('portal.')->group(function () {
     Route::redirect('/', '/portal/dashboard');
     Route::get('dashboard', TenantPortalDashboardController::class)->name('dashboard');
+
+    Route::prefix('lease')->name('lease.')->group(function () {
+        Route::get('/', [TenantPortalLeaseController::class, 'index'])->name('index');
+        Route::prefix('{lease}')->whereNumber('lease')->group(function () {
+            Route::get('/', [TenantPortalLeaseController::class, 'show'])->name('show');
+            Route::get('history', [TenantPortalLeaseController::class, 'history'])->name('history');
+            Route::get('invoices', [TenantPortalLeaseController::class, 'invoices'])->name('invoices');
+            Route::get('invoices/{invoice}', [TenantPortalLeaseController::class, 'invoice'])->name('invoices.show');
+        });
+    });
 });
 
 Route::middleware(['auth', 'verified', 'permission:dashboard.view'])->group(function () {

--- a/tests/Feature/LeaseTest.php
+++ b/tests/Feature/LeaseTest.php
@@ -166,6 +166,26 @@ describe('CRUD', function () {
             ->assertStatus(422);
     });
 
+    it('prevents assigning a tenant to a second active lease', function () {
+        [$property, $unit] = createPropertyWithUnit();
+        $otherUnit = Unit::factory()->for($property)->create();
+        $user = User::factory()->owner()->create();
+        $tenant = Tenant::factory()->create();
+
+        Lease::factory()->create([
+            'primary_tenant_id' => $tenant->id,
+            'unit_id' => $unit->id,
+            'status' => 'active',
+        ]);
+
+        $this->actingAs($user)
+            ->post(route('properties.units.leases.store', [$property, $otherUnit]), [
+                'tenant_ids' => [$tenant->id],
+                'start_date' => '2026-06-01',
+            ])
+            ->assertStatus(422);
+    });
+
     it('updates a lease', function () {
         [$property, $unit] = createPropertyWithUnit();
         $user = User::factory()->owner()->create();

--- a/tests/Feature/TenantPortalTest.php
+++ b/tests/Feature/TenantPortalTest.php
@@ -3,8 +3,11 @@
 use App\Enums\InvoiceStatus;
 use App\Models\Invoice;
 use App\Models\Lease;
+use App\Models\LeaseUnitHistory;
+use App\Models\Payment;
 use App\Models\ReminderLog;
 use App\Models\Tenant;
+use App\Models\Unit;
 use App\Models\User;
 use Database\Seeders\RoleAndPermissionSeeder;
 
@@ -96,9 +99,120 @@ test('portal only exposes the authenticated tenants lease data', function () {
             ->where('rent.upcoming_invoices.0.lease_id', $lease->id));
 });
 
+test('tenant sees their active and historical leases', function () {
+    $user = User::factory()->create();
+    $tenant = Tenant::factory()->withUser($user)->create();
+    $activeLease = Lease::factory()->create([
+        'primary_tenant_id' => $tenant->id,
+        'start_date' => now(),
+        'rent_amount' => 1_500_000,
+        'rent_due_day' => 5,
+    ]);
+    $historicalLease = Lease::factory()->terminated()->create([
+        'primary_tenant_id' => $tenant->id,
+        'start_date' => now()->subYear(),
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('portal.lease.index'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('tenant-portal/lease/index')
+            ->has('leases.data', 2)
+            ->where('leases.data.0.id', $activeLease->id)
+            ->where('leases.data.0.rent_due_day', 5)
+            ->where('leases.data.1.id', $historicalLease->id));
+});
+
+test('tenant sees only their lease invoices', function () {
+    $user = User::factory()->create();
+    $tenant = Tenant::factory()->withUser($user)->create();
+    $lease = Lease::factory()->create(['primary_tenant_id' => $tenant->id]);
+    $invoice = Invoice::factory()->create([
+        'lease_id' => $lease->id,
+        'total' => 1_500_000,
+        'amount_paid' => 500_000,
+        'status' => InvoiceStatus::Partial,
+    ]);
+    $payment = Payment::factory()->pending()->create([
+        'invoice_id' => $invoice->id,
+        'amount' => 500_000,
+        'payment_date' => now(),
+    ]);
+
+    $otherTenant = Tenant::factory()->withUser()->create();
+    $otherLease = Lease::factory()->create(['primary_tenant_id' => $otherTenant->id]);
+    $otherInvoice = Invoice::factory()->create(['lease_id' => $otherLease->id]);
+    Payment::factory()->create(['invoice_id' => $otherInvoice->id]);
+
+    $this->actingAs($user)
+        ->get(route('portal.lease.invoices', $lease))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('tenant-portal/lease/invoices')
+            ->where('lease.id', $lease->id)
+            ->has('invoices.data', 1)
+            ->where('invoices.data.0.id', $invoice->id)
+            ->where('invoices.data.0.outstanding', '1000000.00'));
+
+    $this->get(route('portal.lease.invoices.show', [$lease, $invoice]))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('tenant-portal/lease/invoice')
+            ->where('invoice.id', $invoice->id));
+});
+
+test('tenant can open only their own lease workspace', function () {
+    $user = User::factory()->create();
+    $tenant = Tenant::factory()->withUser($user)->create();
+    $lease = Lease::factory()->create(['primary_tenant_id' => $tenant->id]);
+    $otherLease = Lease::factory()->create();
+
+    $this->actingAs($user)
+        ->get(route('portal.lease.show', $lease))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('tenant-portal/lease/show')
+            ->where('lease.id', $lease->id));
+
+    $this->get(route('portal.lease.show', $otherLease))
+        ->assertNotFound();
+});
+
+test('tenant sees their lease unit transfer history', function () {
+    $user = User::factory()->create();
+    $tenant = Tenant::factory()->withUser($user)->create();
+    $lease = Lease::factory()->create(['primary_tenant_id' => $tenant->id]);
+    $targetUnit = Unit::factory()->create(['property_id' => $lease->unit->property_id]);
+    $history = LeaseUnitHistory::create([
+        'lease_id' => $lease->id,
+        'from_unit_id' => $lease->unit_id,
+        'to_unit_id' => $targetUnit->id,
+        'reason' => 'maintenance',
+        'effective_date' => now(),
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('portal.lease.history', $lease))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('tenant-portal/lease/history')
+            ->has('history.data', 1)
+            ->where('history.data.0.id', $history->id)
+            ->where('history.data.0.reason', 'maintenance'));
+});
+
 test('user without tenant profile cannot access portal', function () {
     $this->actingAs(User::factory()->create())
         ->get(route('portal.dashboard'))
+        ->assertForbidden();
+});
+
+test('user without tenant profile cannot access portal invoices', function () {
+    $lease = Lease::factory()->create();
+
+    $this->actingAs(User::factory()->create())
+        ->get(route('portal.lease.invoices', $lease))
         ->assertForbidden();
 });
 


### PR DESCRIPTION
## Summary
- add a tenant-scoped lease list and dedicated workspace with Overview, Invoices, and History tabs
- keep the dashboard as a preview and expose direct Dashboard and Lease navigation
- prevent a resident from being assigned to a second active lease while preserving lease history

## Validation
- `php artisan test --compact tests/Feature/TenantPortalTest.php`
- `php artisan test --compact tests/Feature/LeaseTest.php`
- `npx eslint resources/js/pages/tenant-portal/lease/*.tsx`
- `npm run types:check`
- `npm run build`

Closes OPE-30, OPE-31