### PR TITLE
feat(portal): add tenant billing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ testing_test_*
 /graphify-out
 /boost.json
 /data/
+DESIGN.md
+PRODUCT.md
+/.impeccable/

--- a/app/Actions/Payments/RecordPayment.php
+++ b/app/Actions/Payments/RecordPayment.php
@@ -18,12 +18,12 @@ class RecordPayment
         private AllocatePayment $allocatePayment,
     ) {}
 
-    public function execute(Invoice $invoice, RecordPaymentData $data, User $user): RecordPaymentResult
+    public function execute(Invoice $invoice, RecordPaymentData $data, User $user, bool $forcePending = false): RecordPaymentResult
     {
         $hasProof = $data->proof !== null;
-        $canAutoVerify = $hasProof && $user->can('payments.verify');
+        $canAutoVerify = ! $forcePending && $hasProof && $user->can('payments.verify');
 
-        $payment = DB::transaction(function () use ($invoice, $data, $user, $hasProof, $canAutoVerify) {
+        $payment = DB::transaction(function () use ($invoice, $data, $user, $hasProof, $canAutoVerify, $forcePending) {
             // Ponytail: lock the invoice so concurrent payments see the
             // correct outstanding balance and cannot overpay.
             $locked = Invoice::lockForUpdate()->findOrFail($invoice->id);
@@ -37,8 +37,8 @@ class RecordPayment
                 'payment_date' => $data->paymentDate,
                 'payment_method' => $data->paymentMethod,
                 'notes' => $data->notes,
-                'status' => $hasProof && ! $canAutoVerify ? PaymentStatus::Pending : PaymentStatus::Confirmed,
-                'confirmed_by' => $canAutoVerify || ! $hasProof ? $user->id : null,
+                'status' => $forcePending || ($hasProof && ! $canAutoVerify) ? PaymentStatus::Pending : PaymentStatus::Confirmed,
+                'confirmed_by' => ! $forcePending && ($canAutoVerify || ! $hasProof) ? $user->id : null,
                 'recorded_by' => $user->id,
                 'verified_by' => $canAutoVerify ? $user->id : null,
                 'verified_at' => $canAutoVerify ? now() : null,

--- a/app/Http/Controllers/TenantPortal/PaymentController.php
+++ b/app/Http/Controllers/TenantPortal/PaymentController.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App\Http\Controllers\TenantPortal;
+
+use App\Actions\Payments\RecordPayment;
+use App\Data\Payment\RecordPaymentData;
+use App\Enums\PaymentStatus;
+use App\Events\Payment\PaymentRecorded;
+use App\Exceptions\PaymentOverflowException;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Payment\StoreTenantPortalPaymentRequest;
+use App\Models\Invoice;
+use App\Models\Lease;
+use App\Models\Payment;
+use App\Models\Tenant;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class PaymentController extends Controller
+{
+    public function index(Request $request): Response
+    {
+        $tenant = $this->tenant($request);
+
+        $leases = $tenant->leases()
+            ->active()
+            ->with([
+                'invoices' => fn ($query) => $query->payable()->orderBy('due_date'),
+                'unit.property',
+            ])
+            ->latest('start_date')
+            ->get();
+
+        $leases->each(fn (Lease $lease) => $lease->invoices->each->append('outstanding'));
+
+        $leaseIds = $tenant->leases()->select((new Lease)->qualifyColumn('id'));
+
+        $paymentQuery = Payment::query()
+            ->whereHas('invoice', fn (Builder $query) => $query->whereIn(
+                'lease_id',
+                $leaseIds,
+            ))
+            ->with('invoice.lease.unit.property');
+
+        return Inertia::render('tenant-portal/payments/index', [
+            'leases' => $leases,
+            'pendingPayments' => (clone $paymentQuery)
+                ->where('status', PaymentStatus::Pending)
+                ->latest('payment_date')
+                ->latest('id')
+                ->get(),
+            'paymentHistory' => (clone $paymentQuery)
+                ->whereIn('status', [PaymentStatus::Confirmed, PaymentStatus::Cancelled])
+                ->latest('payment_date')
+                ->latest('id')
+                ->limit(10)
+                ->get(),
+        ]);
+    }
+
+    public function store(StoreTenantPortalPaymentRequest $request, RecordPayment $action): RedirectResponse
+    {
+        $tenant = $this->tenant($request);
+        $invoice = Invoice::with('lease')->findOrFail($request->integer('invoice_id'));
+        $lease = $tenant->leases()->whereKey($invoice->lease_id)->firstOrFail();
+
+        $request->ensureLeaseIsActive($lease);
+        $request->ensureInvoiceIsPayable($invoice);
+
+        $data = new RecordPaymentData(
+            amount: (int) $request->amount,
+            paymentDate: $request->paid_at,
+            paymentMethod: $request->payment_method,
+            notes: $request->notes,
+            proof: $request->file('proof'),
+        );
+
+        try {
+            $result = $action->execute($invoice, $data, $request->user(), forcePending: true);
+        } catch (PaymentOverflowException) {
+            abort(422, __('Payment exceeds the invoice outstanding balance.'));
+        }
+
+        if ($result->failed()) {
+            abort(422, $result->error);
+        }
+
+        $payment = $result->payment;
+
+        PaymentRecorded::dispatch($payment, actorId: $request->user()->id);
+
+        Inertia::flash('toast', [
+            'type' => 'success',
+            'message' => __('Payment submitted for verification.'),
+        ]);
+
+        return back();
+    }
+
+    private function tenant(Request $request): Tenant
+    {
+        $tenant = $request->user()->tenant()->first();
+
+        abort_unless($tenant, 403);
+
+        return $tenant;
+    }
+}

--- a/app/Http/Requests/Payment/StorePaymentRequest.php
+++ b/app/Http/Requests/Payment/StorePaymentRequest.php
@@ -27,6 +27,16 @@ class StorePaymentRequest extends FormRequest
                 'integer',
                 Rule::exists('invoices', 'id')->where('lease_id', $lease instanceof Lease ? $lease->id : null),
             ],
+            ...$this->paymentRules(),
+        ];
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    protected function paymentRules(): array
+    {
+        return [
             'amount' => ['required', 'numeric', 'min:1'],
             'payment_method' => ['required', 'string', Rule::in(PaymentMethod::values())],
             'paid_at' => ['required', 'date'],
@@ -35,9 +45,9 @@ class StorePaymentRequest extends FormRequest
         ];
     }
 
-    public function ensureLeaseIsActive(): void
+    public function ensureLeaseIsActive(?Lease $lease = null): void
     {
-        $lease = $this->route('lease');
+        $lease ??= $this->route('lease');
 
         if (! $lease instanceof Lease || $lease->status !== LeaseStatus::Active) {
             throw ValidationException::withMessages([

--- a/app/Http/Requests/Payment/StoreTenantPortalPaymentRequest.php
+++ b/app/Http/Requests/Payment/StoreTenantPortalPaymentRequest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Requests\Payment;
+
+use Illuminate\Validation\Rule;
+
+class StoreTenantPortalPaymentRequest extends StorePaymentRequest
+{
+    public function rules(): array
+    {
+        return [
+            'invoice_id' => ['required', 'integer', Rule::exists('invoices', 'id')],
+            ...$this->paymentRules(),
+        ];
+    }
+}

--- a/resources/js/components/features/app/app-sidebar.tsx
+++ b/resources/js/components/features/app/app-sidebar.tsx
@@ -30,6 +30,7 @@ import leases from '@/routes/leases';
 import maintenanceTickets from '@/routes/maintenance-tickets';
 import { dashboard as portalDashboard } from '@/routes/portal';
 import { index as portalLease } from '@/routes/portal/lease';
+import { index as portalPayments } from '@/routes/portal/payments';
 import properties from '@/routes/properties';
 import roles from '@/routes/roles';
 import tenants from '@/routes/tenants';
@@ -57,6 +58,11 @@ export function AppSidebar() {
                       title: 'Lease',
                       icon: FileText,
                       href: portalLease(),
+                  },
+                  {
+                      title: 'Billing',
+                      icon: Receipt,
+                      href: portalPayments(),
                   },
               ]
             : []),

--- a/resources/js/components/features/payments/submit-portal-payment-form.tsx
+++ b/resources/js/components/features/payments/submit-portal-payment-form.tsx
@@ -1,0 +1,200 @@
+import { router } from '@inertiajs/react';
+import { useRef, useState } from 'react';
+import type { FormEvent } from 'react';
+import { InputError } from '@/components/shared';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+    Select,
+    SelectContent,
+    SelectGroup,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import { PAYMENT_METHODS } from '@/lib/constants/billing';
+import { formatDate, formatPrice, todayISO } from '@/lib/formatters';
+import { store } from '@/routes/portal/payments';
+import type { Invoice } from '@/types';
+
+export default function SubmitPortalPaymentForm({
+    invoice,
+    onSuccess,
+    onCancel,
+}: {
+    invoice: Invoice;
+    onSuccess?: () => void;
+    onCancel?: () => void;
+}) {
+    const [processing, setProcessing] = useState(false);
+    const [errors, setErrors] = useState<Record<string, string>>({});
+    const [fileName, setFileName] = useState<string | null>(null);
+    const formRef = useRef<HTMLFormElement>(null);
+
+    function handleSubmit(event: FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+
+        const formData = new FormData(event.currentTarget);
+        formData.append('invoice_id', String(invoice.id));
+
+        setProcessing(true);
+        setErrors({});
+
+        router.post(store.url(), formData, {
+            preserveState: true,
+            replace: true,
+            onSuccess: () => {
+                formRef.current?.reset();
+                setFileName(null);
+                onSuccess?.();
+            },
+            onError: setErrors,
+            onFinish: () => setProcessing(false),
+        });
+    }
+
+    return (
+        <form
+            ref={formRef}
+            onSubmit={handleSubmit}
+            className="flex flex-1 flex-col justify-between gap-6 overflow-y-auto px-4 pt-4 pb-6"
+        >
+            <div className="grid gap-4">
+                <div
+                    className="grid gap-1 border-y py-4 text-sm"
+                    aria-live="polite"
+                >
+                    <p className="font-medium">
+                        Outstanding balance:{' '}
+                        <span className="tabular-nums">
+                            {formatPrice(invoice.outstanding ?? '0')}
+                        </span>
+                    </p>
+                    <p className="text-muted-foreground">
+                        Due {formatDate(invoice.due_date)}. Your payment will be
+                        submitted for verification.
+                    </p>
+                </div>
+
+                <InputError message={errors.invoice_id} />
+
+                <div className="grid gap-2">
+                    <Label htmlFor="amount">Amount (IDR)</Label>
+                    <Input
+                        id="amount"
+                        name="amount"
+                        type="number"
+                        min={1}
+                        max={invoice.outstanding ?? undefined}
+                        step="1"
+                        inputMode="numeric"
+                        defaultValue={invoice.outstanding ?? ''}
+                        aria-describedby="amount-help"
+                        required
+                    />
+                    <p
+                        id="amount-help"
+                        className="text-sm text-muted-foreground"
+                    >
+                        Enter up to {formatPrice(invoice.outstanding ?? '0')}.
+                    </p>
+                    <InputError message={errors.amount} />
+                </div>
+
+                <div className="grid gap-4 sm:grid-cols-2">
+                    <div className="grid gap-2">
+                        <Label htmlFor="payment_method">Payment Method</Label>
+                        <Select name="payment_method" defaultValue="transfer">
+                            <SelectTrigger
+                                id="payment_method"
+                                className="w-full"
+                            >
+                                <SelectValue placeholder="Select method" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectGroup>
+                                    {PAYMENT_METHODS.map((method) => (
+                                        <SelectItem
+                                            key={method.value}
+                                            value={method.value}
+                                        >
+                                            {method.label}
+                                        </SelectItem>
+                                    ))}
+                                </SelectGroup>
+                            </SelectContent>
+                        </Select>
+                        <InputError message={errors.payment_method} />
+                    </div>
+
+                    <div className="grid gap-2">
+                        <Label htmlFor="paid_at">Paid At</Label>
+                        <Input
+                            id="paid_at"
+                            name="paid_at"
+                            type="date"
+                            defaultValue={todayISO()}
+                            required
+                        />
+                        <InputError message={errors.paid_at} />
+                    </div>
+                </div>
+
+                <div className="grid gap-2">
+                    <Label htmlFor="notes">Notes</Label>
+                    <Textarea
+                        id="notes"
+                        name="notes"
+                        placeholder="Optional notes"
+                    />
+                    <InputError message={errors.notes} />
+                </div>
+
+                <div className="grid gap-2">
+                    <Label htmlFor="proof">Payment Proof (optional)</Label>
+                    <Input
+                        id="proof"
+                        name="proof"
+                        type="file"
+                        accept=".jpg,.jpeg,.png,.pdf"
+                        aria-describedby="proof-help"
+                        className="file:mr-3 file:rounded file:border-0 file:bg-primary file:px-3 file:py-1.5 file:text-xs file:font-medium file:text-primary-foreground hover:file:bg-primary/90"
+                        onChange={(event) =>
+                            setFileName(event.target.files?.[0]?.name ?? null)
+                        }
+                    />
+                    <p
+                        id="proof-help"
+                        className="text-sm text-muted-foreground"
+                    >
+                        JPG, PNG, or PDF up to 10 MB.
+                    </p>
+                    {fileName && (
+                        <p className="truncate text-xs text-muted-foreground">
+                            Selected: {fileName}
+                        </p>
+                    )}
+                    <InputError message={errors.proof} />
+                </div>
+            </div>
+
+            <div className="flex flex-wrap items-center justify-end gap-4">
+                {onCancel && (
+                    <Button
+                        variant="outline"
+                        type="button"
+                        onClick={onCancel}
+                        disabled={processing}
+                    >
+                        Cancel
+                    </Button>
+                )}
+                <Button disabled={processing}>
+                    {processing ? 'Submitting...' : 'Submit Payment'}
+                </Button>
+            </div>
+        </form>
+    );
+}

--- a/resources/js/components/features/payments/submit-portal-payment-sheet.tsx
+++ b/resources/js/components/features/payments/submit-portal-payment-sheet.tsx
@@ -1,0 +1,39 @@
+import {
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetHeader,
+    SheetTitle,
+} from '@/components/ui/sheet';
+import type { Invoice } from '@/types';
+import SubmitPortalPaymentForm from './submit-portal-payment-form';
+
+export default function SubmitPortalPaymentSheet({
+    invoice,
+    open,
+    onOpenChange,
+}: {
+    invoice: Invoice;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}) {
+    return (
+        <Sheet open={open} onOpenChange={onOpenChange}>
+            <SheetContent className="sm:max-w-lg">
+                <SheetHeader>
+                    <SheetTitle>Submit Payment</SheetTitle>
+                    <SheetDescription>
+                        Your payment will be reviewed before it is applied to this invoice.
+                    </SheetDescription>
+                </SheetHeader>
+
+                <SubmitPortalPaymentForm
+                    key={invoice.id}
+                    invoice={invoice}
+                    onSuccess={() => onOpenChange(false)}
+                    onCancel={() => onOpenChange(false)}
+                />
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/resources/js/pages/tenant-portal/lease/invoice.tsx
+++ b/resources/js/pages/tenant-portal/lease/invoice.tsx
@@ -1,6 +1,9 @@
 import { Head, Link } from '@inertiajs/react';
 import { ChevronLeft } from 'lucide-react';
+import { useState } from 'react';
+import SubmitPortalPaymentSheet from '@/components/features/payments/submit-portal-payment-sheet';
 import { StatusBadge } from '@/components/shared/status-badge';
+import { Button } from '@/components/ui/button';
 import { formatDate, formatPeriod, formatPrice } from '@/lib/formatters';
 import { invoices } from '@/routes/portal/lease';
 import type { Invoice, Lease } from '@/types';
@@ -12,6 +15,9 @@ export default function InvoiceDetail({
     lease: Lease;
     invoice: Invoice;
 }) {
+    const [paymentOpen, setPaymentOpen] = useState(false);
+    const isPayable = ['pending', 'partial'].includes(invoice.status);
+
     return (
         <div className="workspace-enter flex h-full flex-1 flex-col gap-6 overflow-x-auto rounded-xl p-4">
             <Head title={`Invoice ${invoice.reference ?? ''}`} />
@@ -35,10 +41,10 @@ export default function InvoiceDetail({
                                 {formatPeriod(invoice.period_start, 'id-ID')}
                             </p>
                         </div>
-                        <StatusBadge
-                            domain="invoice"
-                            value={invoice.display_status ?? invoice.status}
-                        />
+                        <div className="flex items-center gap-2">
+                            <StatusBadge domain="invoice" value={invoice.display_status ?? invoice.status} />
+                            {isPayable && <Button size="sm" onClick={() => setPaymentOpen(true)}>Add payment</Button>}
+                        </div>
                     </div>
 
                     <div className="mt-6 grid gap-4 text-sm sm:grid-cols-3">
@@ -85,6 +91,12 @@ export default function InvoiceDetail({
                     </section>
                 )}
             </div>
+
+            <SubmitPortalPaymentSheet
+                invoice={invoice}
+                open={paymentOpen}
+                onOpenChange={setPaymentOpen}
+            />
         </div>
     );
 }

--- a/resources/js/pages/tenant-portal/payments/index.tsx
+++ b/resources/js/pages/tenant-portal/payments/index.tsx
@@ -1,0 +1,168 @@
+import { Head } from '@inertiajs/react';
+import { useState } from 'react';
+import SubmitPortalPaymentSheet from '@/components/features/payments/submit-portal-payment-sheet';
+import { StatusBadge } from '@/components/shared/status-badge';
+import { Button } from '@/components/ui/button';
+import { formatDate, formatPeriod, formatPrice } from '@/lib/formatters';
+import type { Invoice } from '@/types';
+
+type PaymentLease = {
+    invoices: Invoice[];
+};
+
+type PortalPayment = {
+    id: number;
+    amount: string;
+    payment_date: string;
+    payment_method: string;
+    status: string;
+    invoice: Invoice & { reference: string | null };
+};
+
+export default function Payments({
+    leases,
+    pendingPayments,
+    paymentHistory,
+}: {
+    leases: PaymentLease[];
+    pendingPayments: PortalPayment[];
+    paymentHistory: PortalPayment[];
+}) {
+    const [invoiceToPay, setInvoiceToPay] = useState<Invoice | null>(null);
+    const outstandingInvoices = leases.flatMap((item) => item.invoices);
+
+    return (
+        <div className="flex flex-1 flex-col gap-6 p-4">
+            <Head title="Billing" />
+
+            <div>
+                <p className="text-sm text-muted-foreground">Tenant Portal</p>
+                <h1 className="text-2xl font-semibold">Billing</h1>
+            </div>
+
+            <section className="space-y-3">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                        <h2 className="font-semibold">Outstanding Invoices</h2>
+                        <p className="text-sm text-muted-foreground">
+                            Pay an invoice and we will verify your submission.
+                        </p>
+                    </div>
+                </div>
+
+                {outstandingInvoices.length === 0 ? (
+                    <p className="rounded-lg border p-4 text-sm text-muted-foreground">
+                        You have no outstanding invoices.
+                    </p>
+                ) : (
+                    <div className="divide-y rounded-lg border">
+                        {outstandingInvoices.map((item) => (
+                            <div
+                                key={item.id}
+                                className="flex flex-wrap items-center justify-between gap-3 p-4"
+                            >
+                                <div className="min-w-0">
+                                    <p className="truncate font-medium">
+                                        {item.reference ??
+                                            formatPeriod(item.period_start)}
+                                    </p>
+                                    <p className="text-sm text-muted-foreground">
+                                        Due {formatDate(item.due_date)} ·{' '}
+                                        <span className="tabular-nums">
+                                            {formatPrice(
+                                                item.outstanding ?? '0',
+                                            )}
+                                        </span>
+                                    </p>
+                                </div>
+                                <Button
+                                    size="sm"
+                                    onClick={() => setInvoiceToPay(item)}
+                                >
+                                    Pay Invoice
+                                </Button>
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </section>
+
+            <section className="space-y-3">
+                <div>
+                    <h2 className="font-semibold">Pending Payments</h2>
+                    <p className="text-sm text-muted-foreground">
+                        Payments waiting for verification.
+                    </p>
+                </div>
+
+                {pendingPayments.length === 0 ? (
+                    <p className="rounded-lg border p-4 text-sm text-muted-foreground">
+                        No payments are waiting for verification.
+                    </p>
+                ) : (
+                    <div className="divide-y rounded-lg border">
+                        {pendingPayments.map((payment) => (
+                            <PaymentRow key={payment.id} payment={payment} />
+                        ))}
+                    </div>
+                )}
+            </section>
+
+            <section className="space-y-3">
+                <div>
+                    <h2 className="font-semibold">Payment History</h2>
+                    <p className="text-sm text-muted-foreground">
+                        Your 10 most recent verified or cancelled payments.
+                    </p>
+                </div>
+
+                {paymentHistory.length === 0 ? (
+                    <p className="rounded-lg border p-4 text-sm text-muted-foreground">
+                        No payment history yet.
+                    </p>
+                ) : (
+                    <div className="divide-y rounded-lg border">
+                        {paymentHistory.map((payment) => (
+                            <PaymentRow key={payment.id} payment={payment} />
+                        ))}
+                    </div>
+                )}
+            </section>
+
+            {invoiceToPay && (
+                <SubmitPortalPaymentSheet
+                    invoice={invoiceToPay}
+                    open
+                    onOpenChange={(open) => {
+                        if (!open) {
+                            setInvoiceToPay(null);
+                        }
+                    }}
+                />
+            )}
+        </div>
+    );
+}
+
+function PaymentRow({ payment }: { payment: PortalPayment }) {
+    return (
+        <div className="flex flex-wrap items-center justify-between gap-3 p-4 text-sm">
+            <div className="min-w-0">
+                <p className="truncate font-medium">
+                    {payment.invoice.reference ??
+                        formatPeriod(payment.invoice.period_start)}
+                </p>
+                <p className="text-muted-foreground">
+                    {formatDate(payment.payment_date)} ·{' '}
+                    {payment.payment_method}
+                </p>
+            </div>
+            <div className="flex items-center gap-3">
+                <span className="font-medium tabular-nums">
+                    {formatPrice(payment.amount)}
+                </span>
+                <StatusBadge domain="payment" value={payment.status} />
+            </div>
+        </div>
+    );
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,6 +16,7 @@ use App\Http\Controllers\TenantDocumentController;
 use App\Http\Controllers\TenantInvitationController;
 use App\Http\Controllers\TenantPortal\DashboardController as TenantPortalDashboardController;
 use App\Http\Controllers\TenantPortal\LeaseController as TenantPortalLeaseController;
+use App\Http\Controllers\TenantPortal\PaymentController as TenantPortalPaymentController;
 use App\Http\Controllers\UnitController;
 use App\Http\Controllers\UserController;
 use Illuminate\Support\Facades\Route;
@@ -35,6 +36,8 @@ Route::prefix('tenants/invitations')->name('tenants.invitations.')->middleware('
 Route::middleware(['auth', 'verified'])->prefix('portal')->name('portal.')->group(function () {
     Route::redirect('/', '/portal/dashboard');
     Route::get('dashboard', TenantPortalDashboardController::class)->name('dashboard');
+    Route::get('payments', [TenantPortalPaymentController::class, 'index'])->name('payments.index');
+    Route::post('payments', [TenantPortalPaymentController::class, 'store'])->name('payments.store');
 
     Route::prefix('lease')->name('lease.')->group(function () {
         Route::get('/', [TenantPortalLeaseController::class, 'index'])->name('index');

--- a/tests/Feature/TenantPortalTest.php
+++ b/tests/Feature/TenantPortalTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Enums\InvoiceStatus;
+use App\Enums\PaymentStatus;
 use App\Models\Invoice;
 use App\Models\Lease;
 use App\Models\LeaseUnitHistory;
@@ -10,6 +11,8 @@ use App\Models\Tenant;
 use App\Models\Unit;
 use App\Models\User;
 use Database\Seeders\RoleAndPermissionSeeder;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
 
 uses()->beforeEach(function () {
     $this->seed(RoleAndPermissionSeeder::class);
@@ -162,6 +165,40 @@ test('tenant sees only their lease invoices', function () {
             ->where('invoice.id', $invoice->id));
 });
 
+test('tenant sees only their payable invoices on the payments page', function () {
+    $user = User::factory()->create();
+    $tenant = Tenant::factory()->withUser($user)->create();
+    $lease = Lease::factory()->create(['primary_tenant_id' => $tenant->id]);
+    $invoice = Invoice::factory()->create([
+        'lease_id' => $lease->id,
+        'status' => InvoiceStatus::Pending,
+    ]);
+
+    $otherLease = Lease::factory()->create();
+    Invoice::factory()->create(['lease_id' => $otherLease->id]);
+
+    $pendingPayment = Payment::factory()->pending()->create([
+        'invoice_id' => $invoice->id,
+    ]);
+    $historyPayment = Payment::factory()->create([
+        'invoice_id' => $invoice->id,
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('portal.payments.index'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('tenant-portal/payments/index')
+            ->has('leases', 1)
+            ->where('leases.0.id', $lease->id)
+            ->where('leases.0.unit.name', $lease->unit->name)
+            ->where('leases.0.invoices.0.id', $invoice->id)
+            ->has('pendingPayments', 1)
+            ->where('pendingPayments.0.id', $pendingPayment->id)
+            ->has('paymentHistory', 1)
+            ->where('paymentHistory.0.id', $historyPayment->id));
+});
+
 test('tenant can open only their own lease workspace', function () {
     $user = User::factory()->create();
     $tenant = Tenant::factory()->withUser($user)->create();
@@ -177,6 +214,112 @@ test('tenant can open only their own lease workspace', function () {
 
     $this->get(route('portal.lease.show', $otherLease))
         ->assertNotFound();
+});
+
+test('tenant submits a pending invoice payment for verification', function () {
+    Storage::fake('local');
+
+    $tenantUser = User::factory()->create();
+    $tenant = Tenant::factory()->withUser($tenantUser)->create();
+    $lease = Lease::factory()->create(['primary_tenant_id' => $tenant->id]);
+    $invoice = Invoice::factory()->create([
+        'lease_id' => $lease->id,
+        'total' => 1_500_000,
+        'amount_paid' => 0,
+        'status' => InvoiceStatus::Pending,
+    ]);
+
+    $this->actingAs($tenantUser)
+        ->post(route('portal.payments.store'), [
+            'invoice_id' => $invoice->id,
+            'amount' => 1_500_000,
+            'payment_method' => 'transfer',
+            'paid_at' => now()->toDateString(),
+            'notes' => 'Paid by bank transfer.',
+            'proof' => UploadedFile::fake()->image('proof.jpg'),
+        ]);
+
+    $payment = $invoice->payments()->sole();
+
+    expect($payment->status)->toBe(PaymentStatus::Pending)
+        ->and($payment->recorded_by)->toBe($tenantUser->id)
+        ->and($payment->confirmed_by)->toBeNull()
+        ->and($payment->proofs)->toHaveCount(1)
+        ->and($invoice->fresh()->amount_paid)->toBe('0.00')
+        ->and($invoice->fresh()->status)->toBe(InvoiceStatus::Pending);
+
+    Storage::disk('local')->assertExists($payment->proofs->sole()->path);
+
+    $this->actingAs($tenantUser)
+        ->post(route('portal.payments.store'), [
+            'invoice_id' => $invoice->id,
+            'amount' => 1,
+            'payment_method' => 'transfer',
+            'paid_at' => now()->toDateString(),
+        ]);
+
+    $paymentWithoutProof = $invoice->payments()->latest('id')->first();
+
+    expect($paymentWithoutProof->status)->toBe(PaymentStatus::Pending)
+        ->and($paymentWithoutProof->confirmed_by)->toBeNull();
+
+    $owner = User::factory()->owner()->create();
+
+    $this->actingAs($owner)
+        ->post(route('payments.verify', $payment), ['action' => 'confirm']);
+
+    expect($payment->fresh()->status)->toBe(PaymentStatus::Confirmed)
+        ->and($invoice->fresh()->amount_paid)->toBe('1500000.00')
+        ->and($invoice->fresh()->status)->toBe(InvoiceStatus::Paid);
+});
+
+test('tenant cannot submit a payment for another tenants invoice', function () {
+    $tenantUser = User::factory()->create();
+    Tenant::factory()->withUser($tenantUser)->create();
+    $lease = Lease::factory()->create();
+    $invoice = Invoice::factory()->create(['lease_id' => $lease->id]);
+
+    $this->actingAs($tenantUser)
+        ->post(route('portal.payments.store'), [
+            'invoice_id' => $invoice->id,
+            'amount' => 1_500_000,
+            'payment_method' => 'transfer',
+            'paid_at' => now()->toDateString(),
+        ])
+        ->assertNotFound();
+});
+
+test('tenant cannot overpay or submit to a non-payable invoice', function () {
+    $tenantUser = User::factory()->create();
+    $tenant = Tenant::factory()->withUser($tenantUser)->create();
+    $lease = Lease::factory()->create(['primary_tenant_id' => $tenant->id]);
+    $invoice = Invoice::factory()->create([
+        'lease_id' => $lease->id,
+        'total' => 1_500_000,
+        'amount_paid' => 0,
+        'status' => InvoiceStatus::Pending,
+    ]);
+
+    $this->actingAs($tenantUser)
+        ->post(route('portal.payments.store'), [
+            'invoice_id' => $invoice->id,
+            'amount' => 1_500_001,
+            'payment_method' => 'transfer',
+            'paid_at' => now()->toDateString(),
+        ])
+        ->assertSessionHasErrors('amount');
+
+    $invoice->update([
+        'amount_paid' => 1_500_000,
+        'status' => InvoiceStatus::Paid,
+    ]);
+
+    $this->post(route('portal.payments.store'), [
+        'invoice_id' => $invoice->id,
+        'amount' => 1,
+        'payment_method' => 'transfer',
+        'paid_at' => now()->toDateString(),
+    ])->assertSessionHasErrors('invoice_id');
 });
 
 test('tenant sees their lease unit transfer history', function () {


### PR DESCRIPTION
## Summary

- Turn the tenant Payments page into a Billing hub for outstanding invoices, pending payments, and payment history.
- Keep payment submission in a focused side-sheet workflow.
- Include the related payment validation, routing, and focused portal coverage.

## Validation

- `php artisan test --compact tests/Feature/TenantPortalTest.php`
- `npm run types:check`
- `vendor/bin/pint --dirty --format agent`
- `npm run build`
- `git diff --check`