### PR TITLE
fix(portal): remove redundant lease context

### DIFF
--- a/app/Http/Controllers/TenantPortal/DashboardController.php
+++ b/app/Http/Controllers/TenantPortal/DashboardController.php
@@ -16,8 +16,11 @@ class DashboardController extends TenantPortalController
     public function __invoke(Request $request): Response
     {
         $tenant = $this->tenant($request);
-        $leaseContext = $this->leaseContext($request, $tenant);
-        $lease = $leaseContext['selectedLease'];
+        $lease = $tenant->leases()
+            ->active()
+            ->with('unit.property')
+            ->latest('start_date')
+            ->first();
 
         $invoices = $lease
             ? $lease->invoices()
@@ -56,7 +59,6 @@ class DashboardController extends TenantPortalController
                 'name' => $tenant->name,
             ],
             'lease' => $lease ? $this->dashboardLeasePayload($lease) : null,
-            'leaseContext' => $this->leaseContextPayload($lease, $leaseContext['leases']),
             'rent' => [
                 'status' => $this->rentStatus($lease, $invoices->first()),
                 'outstanding_balance' => $outstandingBalance,

--- a/app/Http/Controllers/TenantPortal/LeaseController.php
+++ b/app/Http/Controllers/TenantPortal/LeaseController.php
@@ -14,7 +14,6 @@ class LeaseController extends TenantPortalController
     public function index(Request $request): Response
     {
         $tenant = $this->tenant($request);
-        $leaseContext = $this->leaseContext($request, $tenant);
 
         return Inertia::render('tenant-portal/lease/index', [
             'currentLeases' => $tenant->leases()
@@ -27,17 +26,12 @@ class LeaseController extends TenantPortalController
                 ->with('unit.property')
                 ->latest('start_date')
                 ->get(),
-            'leaseContext' => $this->leaseContextPayload(
-                $leaseContext['selectedLease'],
-                $leaseContext['leases'],
-            ),
         ]);
     }
 
     public function show(Request $request, Lease $lease): Response
     {
         $tenant = $this->tenant($request);
-        $leaseContext = $this->leaseContext($request, $tenant);
         $lease = $this->tenantLease($tenant, $lease);
 
         $lease->load([
@@ -48,7 +42,6 @@ class LeaseController extends TenantPortalController
 
         return Inertia::render('tenant-portal/lease/show', [
             'lease' => $lease,
-            'leaseContext' => $this->leaseContextPayload($lease, $leaseContext['leases']),
         ]);
     }
 

--- a/app/Http/Controllers/TenantPortal/PaymentController.php
+++ b/app/Http/Controllers/TenantPortal/PaymentController.php
@@ -149,18 +149,13 @@ class PaymentController extends TenantPortalController
     public function invoice(Request $request, Invoice $invoice): Response
     {
         $tenant = $this->tenant($request);
-        $leaseContext = $this->leaseContext($request, $tenant);
-        $lease = $tenant->leases()
-            ->with('unit.property')
-            ->whereKey($invoice->lease_id)
-            ->firstOrFail();
+        abort_unless($tenant->leases()->whereKey($invoice->lease_id)->exists(), 404);
 
         $invoice->load(['lineItems', 'payments']);
         $invoice->append(['outstanding', 'display_status']);
 
         return Inertia::render('tenant-portal/payments/invoice', [
             'invoice' => $invoice,
-            'leaseContext' => $this->leaseContextPayload($lease, $leaseContext['leases']),
         ]);
     }
 

--- a/resources/js/pages/tenant-portal/dashboard.tsx
+++ b/resources/js/pages/tenant-portal/dashboard.tsx
@@ -1,11 +1,9 @@
 import { Head } from '@inertiajs/react';
-import TenantLeaseContext from '@/components/features/tenant-portal/lease-context';
 import { StatusBadge } from '@/components/shared/status-badge';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { formatDate, formatPrice } from '@/lib/formatters';
 import { dashboard } from '@/routes/portal';
-import type { TenantLeaseContext as LeaseContext } from '@/types';
 
 type Invoice = {
     id: number;
@@ -71,7 +69,6 @@ type Props = {
         recent_payments: Payment[];
     };
     notifications: Notification[];
-    leaseContext: LeaseContext;
 };
 
 export default function Dashboard({
@@ -79,7 +76,6 @@ export default function Dashboard({
     lease,
     rent,
     notifications,
-    leaseContext,
 }: Props) {
     return (
         <>
@@ -94,13 +90,6 @@ export default function Dashboard({
                         Hi, {tenant.name}
                     </h1>
                 </div>
-
-                <TenantLeaseContext
-                    leaseContext={leaseContext}
-                    hrefForLease={(leaseId) =>
-                        dashboard({ query: { lease: leaseId } }).url
-                    }
-                />
 
                 <div className="grid gap-4 lg:grid-cols-3">
                     <Card>

--- a/resources/js/pages/tenant-portal/lease/index.tsx
+++ b/resources/js/pages/tenant-portal/lease/index.tsx
@@ -1,19 +1,15 @@
 import { Head, Link } from '@inertiajs/react';
-import TenantLeaseContext from '@/components/features/tenant-portal/lease-context';
 import { StatusBadge } from '@/components/shared/status-badge';
 import { formatDate, formatPrice } from '@/lib/formatters';
 import { show } from '@/routes/portal/lease';
-import { index } from '@/routes/portal/lease';
-import type { Lease, TenantLeaseContext as LeaseContext } from '@/types';
+import type { Lease } from '@/types';
 
 export default function LeaseIndex({
     currentLeases,
     previousLeases,
-    leaseContext,
 }: {
     currentLeases: Lease[];
     previousLeases: Lease[];
-    leaseContext: LeaseContext;
 }) {
     return (
         <>
@@ -26,13 +22,6 @@ export default function LeaseIndex({
                         Current and previous stays
                     </p>
                 </div>
-
-                <TenantLeaseContext
-                    leaseContext={leaseContext}
-                    hrefForLease={(leaseId) =>
-                        index({ query: { lease: leaseId } }).url
-                    }
-                />
 
                 <LeaseSection
                     title="Current stay"

--- a/resources/js/pages/tenant-portal/lease/show.tsx
+++ b/resources/js/pages/tenant-portal/lease/show.tsx
@@ -1,11 +1,10 @@
 import { Head, Link } from '@inertiajs/react';
 import { ChevronLeft } from 'lucide-react';
-import TenantLeaseContext from '@/components/features/tenant-portal/lease-context';
 import { StatusBadge } from '@/components/shared/status-badge';
 import { DUE_DAY_LABELS } from '@/lib/constants';
 import { formatDate, formatPrice } from '@/lib/formatters';
-import { index, show } from '@/routes/portal/lease';
-import type { Lease, TenantLeaseContext as LeaseContext } from '@/types';
+import { index } from '@/routes/portal/lease';
+import type { Lease } from '@/types';
 
 function Detail({ label, value }: { label: string; value: string }) {
     return (
@@ -16,13 +15,7 @@ function Detail({ label, value }: { label: string; value: string }) {
     );
 }
 
-export default function LeaseWorkspace({
-    lease,
-    leaseContext,
-}: {
-    lease: Lease;
-    leaseContext: LeaseContext;
-}) {
+export default function LeaseWorkspace({ lease }: { lease: Lease }) {
     return (
         <div className="flex flex-1 flex-col gap-6 p-4">
             <Head title="Lease" />
@@ -33,10 +26,6 @@ export default function LeaseWorkspace({
                 <ChevronLeft className="size-3" />
                 Back to stays
             </Link>
-            <TenantLeaseContext
-                leaseContext={leaseContext}
-                hrefForLease={(leaseId) => show(leaseId).url}
-            />
             <div className="space-y-6">
                 <section>
                     <h2 className="mb-3 text-xs font-medium tracking-wider text-muted-foreground uppercase">

--- a/resources/js/pages/tenant-portal/payments/index.tsx
+++ b/resources/js/pages/tenant-portal/payments/index.tsx
@@ -165,7 +165,6 @@ export default function Payments({
                                             key={item.id}
                                             invoice={item}
                                             onPay={() => setInvoiceToPay(item)}
-                                            leaseId={leaseContext.selected?.id}
                                         />
                                     ))}
                                 </div>
@@ -203,7 +202,6 @@ export default function Payments({
                                         key={payment.id}
                                         payment={payment}
                                         showDetails
-                                        leaseId={leaseContext.selected?.id}
                                     />
                                 ))}
                             </div>
@@ -345,11 +343,9 @@ export default function Payments({
 function InvoiceActionItem({
     invoice,
     onPay,
-    leaseId,
 }: {
     invoice: Invoice;
     onPay: () => void;
-    leaseId?: number;
 }) {
     const status = invoice.display_status ?? invoice.status;
     const amount = formatPrice(
@@ -386,11 +382,7 @@ function InvoiceActionItem({
                         className="h-10 w-fit px-0 sm:h-8 sm:px-2"
                         asChild
                     >
-                        <Link
-                            href={showInvoice(invoice, {
-                                query: { lease: leaseId },
-                            })}
-                        >
+                        <Link href={showInvoice(invoice)}>
                             View details <ChevronRight className="sm:hidden" />
                         </Link>
                     </Button>
@@ -465,11 +457,9 @@ function SummaryItem({
 function PaymentRow({
     payment,
     showDetails = false,
-    leaseId,
 }: {
     payment: PortalPayment;
     showDetails?: boolean;
-    leaseId?: number;
 }) {
     return (
         <BillingQueueItem
@@ -500,11 +490,7 @@ function PaymentRow({
                         className="h-10 w-fit px-0 sm:h-8 sm:px-2"
                         asChild
                     >
-                        <Link
-                            href={showInvoice(payment.invoice, {
-                                query: { lease: leaseId },
-                            })}
-                        >
+                        <Link href={showInvoice(payment.invoice)}>
                             View details <ChevronRight className="sm:hidden" />
                         </Link>
                     </Button>

--- a/resources/js/pages/tenant-portal/payments/invoice-history.tsx
+++ b/resources/js/pages/tenant-portal/payments/invoice-history.tsx
@@ -57,9 +57,7 @@ export default function InvoiceHistory({
                     {invoices.data.map((invoice) => (
                         <Link
                             key={invoice.id}
-                            href={showInvoice(invoice, {
-                                query: { lease: leaseContext.selected?.id },
-                            })}
+                            href={showInvoice(invoice)}
                             className="flex flex-wrap items-center justify-between gap-3 p-4 text-sm"
                         >
                             <div>

--- a/resources/js/pages/tenant-portal/payments/invoice.tsx
+++ b/resources/js/pages/tenant-portal/payments/invoice.tsx
@@ -2,20 +2,13 @@ import { Head, Link } from '@inertiajs/react';
 import { ChevronLeft } from 'lucide-react';
 import { useState } from 'react';
 import SubmitPortalPaymentSheet from '@/components/features/payments/submit-portal-payment-sheet';
-import TenantLeaseContext from '@/components/features/tenant-portal/lease-context';
 import { StatusBadge } from '@/components/shared/status-badge';
 import { Button } from '@/components/ui/button';
 import { formatDate, formatPeriod, formatPrice } from '@/lib/formatters';
 import { index } from '@/routes/portal/billing';
-import type { Invoice, TenantLeaseContext as LeaseContext } from '@/types';
+import type { Invoice } from '@/types';
 
-export default function InvoiceDetail({
-    invoice,
-    leaseContext,
-}: {
-    invoice: Invoice;
-    leaseContext: LeaseContext;
-}) {
+export default function InvoiceDetail({ invoice }: { invoice: Invoice }) {
     const [paymentOpen, setPaymentOpen] = useState(false);
     const isPayable = ['pending', 'partial'].includes(invoice.status);
 
@@ -24,19 +17,12 @@ export default function InvoiceDetail({
             <Head title={`Invoice ${invoice.reference ?? ''}`} />
 
             <Link
-                href={index({ query: { lease: leaseContext.selected?.id } })}
+                href={index()}
                 className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
             >
                 <ChevronLeft className="size-3" />
                 Back to billing
             </Link>
-
-            <TenantLeaseContext
-                leaseContext={leaseContext}
-                hrefForLease={(leaseId) =>
-                    index({ query: { lease: leaseId } }).url
-                }
-            />
 
             <div className="space-y-6">
                 <div className="rounded-lg border p-6">

--- a/tests/Feature/TenantPortalTest.php
+++ b/tests/Feature/TenantPortalTest.php
@@ -41,6 +41,7 @@ test('tenant sees their portal dashboard', function () {
             ->component('tenant-portal/dashboard')
             ->where('tenant.name', 'Budi')
             ->where('lease.id', $lease->id)
+            ->missing('leaseContext')
             ->has('rent.upcoming_invoices', 1)
             ->has('notifications', 1));
 });
@@ -125,7 +126,8 @@ test('tenant sees their current and previous stays', function () {
             ->where('currentLeases.0.id', $activeLease->id)
             ->where('currentLeases.0.rent_due_day', 5)
             ->has('previousLeases', 1)
-            ->where('previousLeases.0.id', $historicalLease->id));
+            ->where('previousLeases.0.id', $historicalLease->id)
+            ->missing('leaseContext'));
 });
 
 test('tenant sees only their invoices in billing', function () {
@@ -170,7 +172,8 @@ test('tenant sees only their invoices in billing', function () {
         ->assertOk()
         ->assertInertia(fn ($page) => $page
             ->component('tenant-portal/payments/invoice')
-            ->where('invoice.id', $invoice->id));
+            ->where('invoice.id', $invoice->id)
+            ->missing('leaseContext'));
 
     $this->get(route('portal.billing.invoices.show', $otherInvoice))
         ->assertNotFound();
@@ -343,7 +346,8 @@ test('tenant can open only their own lease workspace', function () {
         ->assertOk()
         ->assertInertia(fn ($page) => $page
             ->component('tenant-portal/lease/show')
-            ->where('lease.id', $lease->id));
+            ->where('lease.id', $lease->id)
+            ->missing('leaseContext'));
 
     $this->get(route('portal.lease.show', $otherLease))
         ->assertNotFound();


### PR DESCRIPTION
## Summary

- remove lease context switching from tenant dashboard, lease, and invoice-detail pages
- keep billing scoped by lease while removing the redundant `lease` parameter from invoice-detail links
- retain authorization through the invoice's lease relationship

## Validation

- `php artisan test --compact tests/Feature/TenantPortalTest.php`
- `npm run types:check`
- `npm run build`
- ESLint and Prettier checks for the changed billing pages