### PR TITLE
Restrict tenant access to installation settings

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -30,6 +30,11 @@ class HandleInertiaRequests extends Middleware
 
     public function share(Request $request): array
     {
+        $settingsPages = array_values(array_filter(
+            OpenKOS::settings()->toArray(),
+            fn (array $page) => $this->canSeeSettingsPage($request, $page),
+        ));
+
         return [
             ...parent::share($request),
             'name' => config('app.name'),
@@ -56,9 +61,29 @@ class HandleInertiaRequests extends Middleware
             'platform' => fn () => [
                 'navigation' => OpenKOS::navigation()->toArray(),
                 'workspaces' => OpenKOS::workspaces()->toArray(),
-                'settings' => OpenKOS::settings()->toArray(),
+                'settings' => $settingsPages,
                 'dashboard' => OpenKOS::dashboard()->toArray(),
             ],
         ];
+    }
+
+    /**
+     * @param  array{permission?: string|null, ownerOnly?: bool}  $page
+     */
+    private function canSeeSettingsPage(Request $request, array $page): bool
+    {
+        $user = $request->user();
+
+        if (! $user) {
+            return false;
+        }
+
+        if (($page['ownerOnly'] ?? true) && ! $user->isOwner()) {
+            return false;
+        }
+
+        $permission = $page['permission'] ?? null;
+
+        return $permission === null || $user->isOwner() || $user->can($permission);
     }
 }

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -38,11 +38,21 @@ const appName = resolveAppName();
 
 createInertiaApp({
     title: (title) => (title ? `${title} - ${appName}` : appName),
-    layout: (name) => {
+    layout: (name, page) => {
+        const auth = page.props as {
+            auth?: {
+                tenant?: unknown;
+            };
+        };
+
         switch (true) {
             case name.startsWith('auth/'):
                 return AuthLayout;
             case name.startsWith('settings/'):
+                if (auth.auth?.tenant) {
+                    return [TenantPortalLayout, SettingsLayout];
+                }
+
                 return [AppLayout, SettingsLayout];
             case name.startsWith('tenant-portal/'):
                 return TenantPortalLayout;

--- a/resources/js/lib/platform.ts
+++ b/resources/js/lib/platform.ts
@@ -23,6 +23,14 @@ export function canSee(permission: string | null, auth: Auth): boolean {
     );
 }
 
+export function canSeePlatformPage(page: PlatformPage, auth: Auth): boolean {
+    if (page.ownerOnly && auth.role !== 'owner') {
+        return false;
+    }
+
+    return canSee(page.permission, auth);
+}
+
 export function platformNavItems(
     items: PlatformNavigationItem[] | undefined,
     auth: Auth,
@@ -52,7 +60,7 @@ export function platformPageNavItems(
     pages: PlatformPage[],
     auth: Auth,
 ): NavItem[] {
-    const visible = pages.filter((page) => canSee(page.permission, auth));
+    const visible = pages.filter((page) => canSeePlatformPage(page, auth));
     const groups: Record<string, NavItem[]> = Object.create(null);
     const ungrouped: NavItem[] = [];
 

--- a/resources/js/types/platform.ts
+++ b/resources/js/types/platform.ts
@@ -21,6 +21,7 @@ export type PlatformPage = {
     title: string;
     href: string;
     permission: string | null;
+    ownerOnly: boolean;
     group?: string | null;
 };
 

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -29,13 +29,13 @@ Route::middleware(['auth', 'verified'])->group(function () {
         ->middleware('throttle:6,1')
         ->name('user-password.update');
 
-    Route::get('settings/general', [GeneralController::class, 'edit'])->name('settings.general.edit');
-    Route::patch('settings/general', [GeneralController::class, 'update'])->name('settings.general.update');
-
-    Route::get('settings/reminders', [ReminderController::class, 'edit'])->name('settings.reminders.edit');
-    Route::patch('settings/reminders', [ReminderController::class, 'update'])->name('settings.reminders.update');
-
     Route::middleware('role:owner')->group(function () {
+        Route::get('settings/general', [GeneralController::class, 'edit'])->name('settings.general.edit');
+        Route::patch('settings/general', [GeneralController::class, 'update'])->name('settings.general.update');
+
+        Route::get('settings/reminders', [ReminderController::class, 'edit'])->name('settings.reminders.edit');
+        Route::patch('settings/reminders', [ReminderController::class, 'update'])->name('settings.reminders.update');
+
         Route::post('settings/values', [SettingValuesController::class, 'upsert'])->name('settings.values.upsert');
         Route::get('settings/mail', [MailController::class, 'edit'])->name('settings.mail.edit');
         Route::patch('settings/mail', [MailController::class, 'update'])->name('settings.mail.update');
@@ -53,8 +53,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::post('settings/property-types', [PropertyTypeController::class, 'store'])->name('settings.property-types.store');
         Route::patch('settings/property-types/{propertyType}', [PropertyTypeController::class, 'update'])->name('settings.property-types.update');
         Route::delete('settings/property-types/{propertyType}', [PropertyTypeController::class, 'destroy'])->name('settings.property-types.destroy');
-    });
 
-    // Catch-all for plugin-defined settings pages — must be last so explicit routes match first.
-    Route::get('settings/{page}', [SettingValuesController::class, 'edit'])->name('settings.dynamic.edit');
+        // Catch-all for plugin-defined settings pages — must be last so explicit routes match first.
+        Route::get('settings/{page}', [SettingValuesController::class, 'edit'])->name('settings.dynamic.edit');
+    });
 });

--- a/src/Platform/PlatformServiceProvider.php
+++ b/src/Platform/PlatformServiceProvider.php
@@ -74,8 +74,8 @@ class PlatformServiceProvider extends ServiceProvider
     private function registerCoreSettingsPages(OpenKOSManager $manager): void
     {
         $manager->settings()
-            ->registerPage(new SettingsPage('profile', 'Profile', '/settings/profile', group: 'Account', order: 100, routeName: 'profile.edit'))
-            ->registerPage(new SettingsPage('security', 'Security', '/settings/security', group: 'Account', order: 200, routeName: 'security.edit'))
+            ->registerPage(new SettingsPage('profile', 'Profile', '/settings/profile', ownerOnly: false, group: 'Account', order: 100, routeName: 'profile.edit'))
+            ->registerPage(new SettingsPage('security', 'Security', '/settings/security', ownerOnly: false, group: 'Account', order: 200, routeName: 'security.edit'))
             ->registerPage(new SettingsPage('general', 'General', '/settings/general', group: 'Preferences', order: 100, routeName: 'settings.general.edit'))
             ->registerPage(new SettingsPage('reminders', 'Reminders', '/settings/reminders', group: 'Preferences', order: 300, routeName: 'settings.reminders.edit'))
             ->registerPage(new SettingsPage('property-types', 'Property Types', '/settings/property-types', group: 'Property', order: 100, routeName: 'settings.property-types.index'))

--- a/src/Platform/Settings/SettingsPage.php
+++ b/src/Platform/Settings/SettingsPage.php
@@ -11,6 +11,7 @@ final readonly class SettingsPage implements Arrayable
         public string $title,
         public string $href,
         public ?string $permission = null,
+        public bool $ownerOnly = true,
         public ?string $group = null,
         public ?string $routeName = null,
         public int $order = 500,
@@ -23,6 +24,7 @@ final readonly class SettingsPage implements Arrayable
             'title' => $this->title,
             'href' => $this->routeName ? route($this->routeName) : $this->href,
             'permission' => $this->permission,
+            'ownerOnly' => $this->ownerOnly,
             'group' => $this->group,
         ];
     }

--- a/tests/Feature/Settings/DynamicSettingsAccessTest.php
+++ b/tests/Feature/Settings/DynamicSettingsAccessTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use App\Models\Setting;
+use App\Models\Tenant;
+use App\Models\User;
+use Database\Seeders\RoleAndPermissionSeeder;
+use Inertia\Testing\AssertableInertia as Assert;
+use OpenKOS\Platform\Facades\OpenKOS;
+use OpenKOS\Platform\Settings\SettingDefinition;
+use OpenKOS\Platform\Settings\SettingsPage;
+
+uses()->beforeEach(function () {
+    $this->seed(RoleAndPermissionSeeder::class);
+
+    OpenKOS::settings()
+        ->registerPage(new SettingsPage(
+            key: 'plugin-demo',
+            title: 'Plugin Demo',
+            href: '/settings/plugin-demo',
+            group: 'Integrations',
+        ))
+        ->registerSetting(new SettingDefinition(
+            key: 'plugin_demo.api_key',
+            label: 'API Key',
+            page: 'plugin-demo',
+        ));
+});
+
+test('tenant-linked users cannot view registered dynamic settings pages', function () {
+    $tenantUser = User::factory()->create();
+    Tenant::factory()->withUser($tenantUser)->create();
+
+    $this->actingAs($tenantUser)
+        ->get(route('settings.dynamic.edit', 'plugin-demo'))
+        ->assertForbidden();
+});
+
+test('tenant-linked users cannot update registered dynamic settings', function () {
+    $tenantUser = User::factory()->create();
+    Tenant::factory()->withUser($tenantUser)->create();
+
+    $this->actingAs($tenantUser)
+        ->post(route('settings.values.upsert'), [
+            'key' => 'plugin_demo.api_key',
+            'value' => 'tenant-secret',
+        ])
+        ->assertForbidden();
+});
+
+test('owners can view and update registered dynamic settings', function () {
+    $owner = User::factory()->owner()->create();
+
+    $this->from(route('settings.dynamic.edit', 'plugin-demo'))->actingAs($owner)
+        ->get(route('settings.dynamic.edit', 'plugin-demo'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('settings/dynamic')
+            ->where('page', 'plugin-demo')
+            ->has('definitions', 1)
+            ->where('definitions.0.key', 'plugin_demo.api_key'));
+
+    $this->from(route('settings.dynamic.edit', 'plugin-demo'))->actingAs($owner)
+        ->post(route('settings.values.upsert'), [
+            'key' => 'plugin_demo.api_key',
+            'value' => 'owner-secret',
+        ])
+        ->assertRedirect(route('settings.dynamic.edit', 'plugin-demo'));
+
+    expect(Setting::get('plugin_demo.api_key'))->toBe('owner-secret');
+});

--- a/tests/Feature/Settings/GeneralSettingsTest.php
+++ b/tests/Feature/Settings/GeneralSettingsTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\Setting;
+use App\Models\Tenant;
 use App\Models\User;
 
 uses()->beforeEach(function () {
@@ -9,6 +10,32 @@ uses()->beforeEach(function () {
 });
 
 describe('General settings page', function () {
+    it('forbids tenant-linked users from viewing the page', function () {
+        $tenantUser = User::factory()->create();
+        Tenant::factory()->withUser($tenantUser)->create();
+
+        $this->actingAs($tenantUser)
+            ->get(route('settings.general.edit'))
+            ->assertForbidden();
+    });
+
+    it('forbids tenant-linked users from updating settings', function () {
+        $tenantUser = User::factory()->create();
+        Tenant::factory()->withUser($tenantUser)->create();
+
+        $this->actingAs($tenantUser)
+            ->patch(route('settings.general.update'), [
+                'site_name' => 'Tenant Attempt',
+                'country_code' => 'ID',
+                'locale' => 'id',
+                'currency' => 'IDR',
+                'timezone' => 'Asia/Jakarta',
+                'lease_id_prefix' => 'TEN',
+                'invoice_id_prefix' => 'INV',
+            ])
+            ->assertForbidden();
+    });
+
     it('renders the form with all settings', function () {
         $owner = User::factory()->owner()->create();
 

--- a/tests/Feature/Settings/ProfileUpdateTest.php
+++ b/tests/Feature/Settings/ProfileUpdateTest.php
@@ -1,6 +1,8 @@
 <?php
 
+use App\Models\Tenant;
 use App\Models\User;
+use Inertia\Testing\AssertableInertia as Assert;
 
 test('profile page is displayed', function () {
     $user = User::factory()->create();
@@ -10,6 +12,24 @@ test('profile page is displayed', function () {
         ->get(route('profile.edit'));
 
     $response->assertOk();
+});
+
+test('tenant profile page only shares account settings pages', function () {
+    $user = User::factory()->create();
+    $tenant = Tenant::factory()->withUser($user)->create();
+
+    $this->actingAs($user)
+        ->get(route('profile.edit'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('auth.tenant.id', $tenant->id)
+            ->where('auth.tenant.name', $tenant->name)
+            ->has('platform.settings', 2)
+            ->where('platform.settings.0.key', 'profile')
+            ->where('platform.settings.0.ownerOnly', false)
+            ->where('platform.settings.1.key', 'security')
+            ->where('platform.settings.1.ownerOnly', false)
+            ->missing('platform.settings.2'));
 });
 
 test('profile information can be updated', function () {

--- a/tests/Feature/Settings/ReminderSettingsTest.php
+++ b/tests/Feature/Settings/ReminderSettingsTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\Setting;
+use App\Models\Tenant;
 use App\Models\User;
 
 uses()->beforeEach(function () {
@@ -8,6 +9,29 @@ uses()->beforeEach(function () {
 });
 
 describe('Reminder settings page', function () {
+    it('forbids tenant-linked users from viewing the page', function () {
+        $tenantUser = User::factory()->create();
+        Tenant::factory()->withUser($tenantUser)->create();
+
+        $this->actingAs($tenantUser)
+            ->get(route('settings.reminders.edit'))
+            ->assertForbidden();
+    });
+
+    it('forbids tenant-linked users from updating settings', function () {
+        $tenantUser = User::factory()->create();
+        Tenant::factory()->withUser($tenantUser)->create();
+
+        $this->actingAs($tenantUser)
+            ->patch(route('settings.reminders.update'), [
+                'reminder_enabled' => true,
+                'reminder_days_before' => 3,
+                'reminder_overdue_intervals' => '1, 3, 7',
+                'reminder_channels' => ['log'],
+            ])
+            ->assertForbidden();
+    });
+
     it('renders the form', function () {
         $owner = User::factory()->owner()->create();
 

--- a/tests/Unit/Platform/SettingsRegistryTest.php
+++ b/tests/Unit/Platform/SettingsRegistryTest.php
@@ -15,6 +15,7 @@ it('registers pages keyed by page key', function () {
             'title' => 'Billing',
             'href' => '/settings/billing',
             'permission' => null,
+            'ownerOnly' => true,
             'group' => null,
         ]]);
 });


### PR DESCRIPTION
## Summary
- restrict installation-wide settings routes and dynamic settings access to owners
- hide installation-wide settings from tenant-linked users in shared platform settings navigation
- keep tenant account settings inside the tenant portal shell while retaining the settings sidebar

## Testing
- php artisan test --compact tests/Feature/Settings/ProfileUpdateTest.php tests/Feature/Settings/GeneralSettingsTest.php tests/Feature/Settings/ReminderSettingsTest.php tests/Feature/Settings/DynamicSettingsAccessTest.php
- vendor/bin/pint --dirty --format agent
- npm run types:check
- npm run build