### PR TITLE
fix(billing): tighten payment review flow

### DIFF
--- a/app/Actions/Invoices/AllocatePayment.php
+++ b/app/Actions/Invoices/AllocatePayment.php
@@ -23,8 +23,7 @@ class AllocatePayment
             // Lock payment row so concurrent execute() calls serialize
             $payment = Payment::lockForUpdate()->findOrFail($payment->id);
 
-            $previousIds = $payment->allocations()->pluck('invoice_id');
-            $affectedIds = $previousIds
+            $affectedIds = $payment->allocations()->pluck('invoice_id')
                 ->push($payment->invoice_id)
                 ->unique()
                 ->values();

--- a/app/Actions/Invoices/AllocatePayment.php
+++ b/app/Actions/Invoices/AllocatePayment.php
@@ -3,7 +3,6 @@
 namespace App\Actions\Invoices;
 
 use App\Enums\InvoiceStatus;
-use App\Enums\PaymentStatus;
 use App\Events\Invoice\InvoiceFullyPaid;
 use App\Models\Invoice;
 use App\Models\Payment;
@@ -24,82 +23,35 @@ class AllocatePayment
             // Lock payment row so concurrent execute() calls serialize
             $payment = Payment::lockForUpdate()->findOrFail($payment->id);
 
-            // Track invoices previously affected so we can reset their
-            // amount_paid before re-computing from new allocations.
             $previousIds = $payment->allocations()->pluck('invoice_id');
-            $priorStatuses = Invoice::whereIn('id', $previousIds)
+            $affectedIds = $previousIds
+                ->push($payment->invoice_id)
+                ->unique()
+                ->values();
+            $priorStatuses = Invoice::whereIn('id', $affectedIds)
                 ->pluck('status', 'id');
-            Invoice::whereIn('id', $previousIds)->update([
-                'amount_paid' => 0,
-                'status' => InvoiceStatus::Pending,
-            ]);
 
             $payment->allocations()->delete();
+            PaymentAllocation::create([
+                'payment_id' => $payment->id,
+                'invoice_id' => $payment->invoice_id,
+                'amount' => $payment->amount,
+            ]);
 
-            $remaining = (float) $payment->amount;
-            $affected = collect();
-
-            // ponytail: orderBy('id') ensures consistent lock ordering and
-            // reduces deadlock risk with concurrent payments on the same
-            // lease. The caller (RecordPayment) already holds a lock on the
-            // primary invoice, which creates an implicit lock outside this
-            // ordered set — a true fix would move all locking into this query.
-            $invoices = Invoice::where('lease_id', $payment->invoice->lease_id)
-                ->payable()
-                ->orderBy('due_date')
+            // A payment settles the invoice it was recorded against. Keep
+            // allocations aligned with invoice_id, then recompute any invoice
+            // this payment used to affect.
+            $invoices = Invoice::whereIn('id', $affectedIds)
                 ->orderBy('id')
                 ->lockForUpdate()
                 ->get();
 
             foreach ($invoices as $invoice) {
-                if ($remaining <= 0) {
-                    break;
-                }
+                $invoice->recalculateStatus();
 
-                $outstanding = (float) $invoice->total - (float) $invoice->amount_paid;
-                $allocated = min($remaining, $outstanding);
-
-                if ($allocated <= 0) {
-                    continue;
-                }
-
-                PaymentAllocation::create([
-                    'payment_id' => $payment->id,
-                    'invoice_id' => $invoice->id,
-                    'amount' => $allocated,
-                ]);
-
-                $remaining -= $allocated;
-                $affected->push($invoice);
-            }
-
-            // ponytail: if $remaining > 0 after allocating all payable
-            // invoices, the excess is unallocated overpayment. Credit
-            // balance/refund handling is a future enhancement.
-
-            // Update invoice balances from allocations (not from payments
-            // by invoice_id, which would miss cross-invoice allocations).
-            foreach ($affected as $invoice) {
-                $paid = (float) $invoice->allocations()
-                    ->whereHas('payment', fn ($q) => $q->where('status', PaymentStatus::Confirmed->value))
-                    ->sum('amount');
-
-                $status = match (true) {
-                    $paid >= (float) $invoice->total => InvoiceStatus::Paid,
-                    $paid > 0 => InvoiceStatus::Partial,
-                    default => InvoiceStatus::Pending,
-                };
-
-                $invoice->update([
-                    'amount_paid' => $paid,
-                    'status' => $status,
-                ]);
-
-                if ($status === InvoiceStatus::Paid
-                    && ($priorStatuses[$invoice->id] ?? null) !== InvoiceStatus::Paid
+                if ($invoice->status === InvoiceStatus::Paid
+                    && ($priorStatuses[$invoice->id] ?? null) !== InvoiceStatus::Paid->value
                 ) {
-                    // ponytail: dispatched via afterCommit so listeners
-                    // never see uncommitted data.
                     DB::afterCommit(fn () => InvoiceFullyPaid::dispatch($invoice));
                 }
             }

--- a/app/Actions/Payments/RecordPayment.php
+++ b/app/Actions/Payments/RecordPayment.php
@@ -48,8 +48,8 @@ class RecordPayment
                 'status' => $forcePending || ($hasProof && ! $canAutoVerify) ? PaymentStatus::Pending : PaymentStatus::Confirmed,
                 'confirmed_by' => ! $forcePending && ($canAutoVerify || ! $hasProof) ? $user->id : null,
                 'recorded_by' => $user->id,
-                'verified_by' => $canAutoVerify ? $user->id : null,
-                'verified_at' => $canAutoVerify ? now() : null,
+                'verified_by' => ! $forcePending && ($canAutoVerify || ! $hasProof) ? $user->id : null,
+                'verified_at' => ! $forcePending && ($canAutoVerify || ! $hasProof) ? now() : null,
             ]);
 
             if ($hasProof) {

--- a/app/Http/Controllers/Dashboard/OverviewController.php
+++ b/app/Http/Controllers/Dashboard/OverviewController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Dashboard;
 use App\Business\Dashboard\OverviewStatsCalculator;
 use App\Enums\LeaseStatus;
 use App\Enums\MaintenanceStatus;
+use App\Enums\PaymentStatus;
 use App\Enums\UnitStatus;
 use App\Http\Controllers\Controller;
 use App\Models\AuditLog;
@@ -12,6 +13,7 @@ use App\Models\Invoice;
 use App\Models\Lease;
 use App\Models\LeaseUnitHistory;
 use App\Models\MaintenanceTicket;
+use App\Models\Payment;
 use App\Models\Property;
 use App\Models\PropertyType;
 use App\Models\Region;
@@ -88,6 +90,11 @@ class OverviewController extends Controller
             ->whereDate('end_date', '>', Carbon::today())
             ->count();
 
+        $pendingPaymentVerification = Payment::query()
+            ->where('status', PaymentStatus::Pending->value)
+            ->whereHas('invoice.lease.unit.property', fn (Builder $q) => $q->whereIn('id', $accessibleProperties))
+            ->count();
+
         $attention = [
             'overdue_invoices' => [
                 'count' => (int) ($overdueInvoices->count ?? 0),
@@ -96,6 +103,7 @@ class OverviewController extends Controller
             'due_today' => $dueTodayInvoices,
             'open_maintenance' => $openMaintenance,
             'leases_ending_soon' => $leasesEndingSoon,
+            'pending_payment_verification' => $pendingPaymentVerification,
         ];
 
         $recentActivity = AuditLog::query()

--- a/app/Http/Controllers/Dashboard/RentController.php
+++ b/app/Http/Controllers/Dashboard/RentController.php
@@ -254,9 +254,9 @@ class RentController extends Controller
             ->whereHas('lease.unit', fn (Builder $q) => $q->whereIn('property_id', $propertyIds));
 
         match ($operator) {
-            '<' => $query->where('due_date', '<', $now->toDateString()),
+            '<' => $query->whereDate('due_date', '<', $now->toDateString()),
             '=' => $query->whereDate('due_date', '=', $now->toDateString()),
-            '>' => $query->where('due_date', '>', $now->toDateString()),
+            '>' => $query->whereDate('due_date', '>', $now->toDateString()),
             default => null,
         };
 

--- a/app/Http/Controllers/Dashboard/RentController.php
+++ b/app/Http/Controllers/Dashboard/RentController.php
@@ -7,6 +7,7 @@ use App\Enums\PaymentStatus;
 use App\Http\Controllers\Controller;
 use App\Models\Invoice;
 use App\Models\Payment;
+use App\Models\PaymentProof;
 use App\Models\Property;
 use App\Models\ReminderLog;
 use App\Tables\Column;
@@ -51,11 +52,17 @@ class RentController extends Controller
                 ->whereHas('lease', fn (Builder $q) => $q->where('status', 'active'))
                 ->whereHas('lease.unit', fn (Builder $q) => $q->whereIn('property_id', $accessiblePropertyIds))
                 ->count(),
+            'pending_review' => Invoice::query()
+                ->whereHas('payments', fn (Builder $q) => $q->where('status', PaymentStatus::Pending->value))
+                ->whereHas('lease', fn (Builder $q) => $q->where('status', 'active'))
+                ->whereHas('lease.unit', fn (Builder $q) => $q->whereIn('property_id', $accessiblePropertyIds))
+                ->count(),
         ];
 
         // --- Outstanding card ---
 
         $outstandingCount = $tabCounts['overdue'] + $tabCounts['due_today'] + $tabCounts['upcoming'];
+        $tabCounts['all'] = $outstandingCount;
 
         $outstandingAmount = (int) Invoice::query()
             ->payable()
@@ -84,13 +91,25 @@ class RentController extends Controller
 
         $isPaidTab = $urgency === 'paid';
         $isPartialTab = $urgency === 'partial';
+        $isPendingReviewTab = $urgency === 'pending_review';
 
         $queueQuery = Invoice::query()
-            ->with(['lease.primaryTenant', 'lease.tenants', 'lease.unit.property'])
+            ->with([
+                'lease.primaryTenant',
+                'lease.tenants',
+                'lease.unit.property',
+                'lineItems',
+                'payments' => fn ($q) => $q
+                    ->with(['confirmedBy:id,name', 'proofs'])
+                    ->latest('payment_date')
+                    ->latest('id'),
+            ])
             ->whereHas('lease', fn (Builder $q) => $q->where('status', 'active'))
             ->whereHas('lease.unit', fn (Builder $q) => $q->whereIn('property_id', $accessiblePropertyIds));
 
-        if (! $isPaidTab && ! $isPartialTab) {
+        if ($isPendingReviewTab) {
+            $queueQuery->whereHas('payments', fn (Builder $q) => $q->where('status', PaymentStatus::Pending->value));
+        } elseif (! $isPaidTab && ! $isPartialTab) {
             $queueQuery->payable();
         } elseif ($isPartialTab) {
             $queueQuery->where('status', InvoiceStatus::Partial->value);
@@ -120,11 +139,12 @@ class RentController extends Controller
                     ['value' => 'overdue', 'label' => 'Overdue'],
                     ['value' => 'due_today', 'label' => 'Due Today'],
                     ['value' => 'upcoming', 'label' => 'Upcoming'],
+                    ['value' => 'pending_review', 'label' => 'Pending Review'],
                     ['value' => 'partial', 'label' => 'Partial'],
                     ['value' => 'paid', 'label' => 'Paid'],
                 ])
-                    ->query(function (Builder $q, string $value) use ($now, $isPaidTab, $isPartialTab): void {
-                        if ($isPaidTab || $isPartialTab) {
+                    ->query(function (Builder $q, string $value) use ($now, $isPaidTab, $isPartialTab, $isPendingReviewTab): void {
+                        if ($isPaidTab || $isPartialTab || $isPendingReviewTab) {
                             return;
                         }
 
@@ -280,6 +300,44 @@ class RentController extends Controller
             'days_overdue' => $daysOverdue,
             'urgency' => $urgency,
             'status' => $invoice->status->value,
+            'pending_payment_review_count' => $invoice->payments
+                ->filter(fn (Payment $payment) => $payment->status === PaymentStatus::Pending)
+                ->count(),
+            'line_items' => $invoice->lineItems->map(fn ($item) => [
+                'id' => $item->id,
+                'invoice_id' => $item->invoice_id,
+                'type' => $item->type,
+                'description' => $item->description,
+                'amount' => (string) $item->amount,
+            ])->values()->all(),
+            'payments' => $invoice->payments->map(fn (Payment $payment) => [
+                'id' => $payment->id,
+                'invoice_id' => $payment->invoice_id,
+                'amount' => (string) $payment->amount,
+                'payment_date' => $payment->payment_date->toDateString(),
+                'payment_method' => $payment->payment_method,
+                'reference' => $payment->reference_number,
+                'notes' => $payment->notes,
+                'status' => $payment->status->value,
+                'confirmed_by' => $payment->confirmed_by,
+                'confirmed_by_user' => $payment->confirmedBy ? [
+                    'id' => $payment->confirmedBy->id,
+                    'name' => $payment->confirmedBy->name,
+                ] : null,
+                'recorded_by' => $payment->recorded_by,
+                'recorded_by_user' => null,
+                'verified_by' => $payment->verified_by,
+                'verified_by_user' => null,
+                'verified_at' => $payment->verified_at?->toDateTimeString(),
+                'proofs' => $payment->proofs->map(fn (PaymentProof $proof) => [
+                    'id' => $proof->id,
+                    'payment_id' => $proof->payment_id,
+                    'path' => $proof->path,
+                    'original_name' => $proof->original_name,
+                    'mime_type' => $proof->mime_type,
+                    'created_at' => $proof->created_at->toDateTimeString(),
+                ])->values()->all(),
+            ])->values()->all(),
         ];
     }
 }

--- a/app/Http/Controllers/LeaseController.php
+++ b/app/Http/Controllers/LeaseController.php
@@ -228,6 +228,10 @@ class LeaseController extends Controller
                 ->whereIn('status', [InvoiceStatus::Pending->value, InvoiceStatus::Partial->value])
                 ->whereDate('due_date', '<', now()),
             ])
+            ->withCount([
+                'payments as pending_payment_review_count' => fn (Builder $q) => $q
+                    ->where('payments.status', PaymentStatus::Pending->value),
+            ])
             ->when(! $request->user()->isOwner(), fn (Builder $q) => $q->whereHas(
                 'unit.property.users',
                 fn (Builder $q) => $q->whereKey($request->user()->id),
@@ -274,6 +278,13 @@ class LeaseController extends Controller
             ->whereHas('lease', fn (Builder $q) => $q->where('status', LeaseStatus::Active->value)->when($accessibleQuery))
             ->sum(DB::raw('total - amount_paid'));
 
+        $pendingPaymentVerification = Payment::query()
+            ->where('status', PaymentStatus::Pending->value)
+            ->whereHas('invoice.lease.unit.property', fn (Builder $q) => $request->user()->isOwner()
+                ? $q
+                : $q->whereHas('users', fn (Builder $q) => $q->whereKey($request->user()->id)))
+            ->count();
+
         return Inertia::render('leases/index', [
             ...$result,
             'availableUnits' => $availableUnits,
@@ -281,6 +292,7 @@ class LeaseController extends Controller
                 'active_leases' => $activeLeases,
                 'collected_this_month' => $collectedThisMonth,
                 'overdue_amount' => $overdueAmount,
+                'pending_payment_verification' => $pendingPaymentVerification,
             ],
         ]);
     }

--- a/app/Http/Controllers/LeaseInvoiceController.php
+++ b/app/Http/Controllers/LeaseInvoiceController.php
@@ -54,7 +54,7 @@ class LeaseInvoiceController extends Controller
 
         $this->authorize('view', $lease);
 
-        $invoice->load(['lineItems', 'payments']);
+        $invoice->load(['lineItems', 'payments.confirmedBy:id,name', 'payments.proofs']);
         $invoice->append(['outstanding', 'display_status']);
 
         return Inertia::render('leases/invoice-detail', [

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -126,16 +126,26 @@ class PaymentController extends Controller
 
                 $this->allocatePayment->execute($lockedPayment);
             } else {
-                $invoice = Invoice::lockForUpdate()->findOrFail($payment->invoice_id);
+                $affectedInvoiceIds = $lockedPayment->allocations()
+                    ->pluck('invoice_id')
+                    ->push($lockedPayment->invoice_id)
+                    ->unique()
+                    ->values();
+
+                $lockedPayment->allocations()->delete();
 
                 $lockedPayment->update([
                     'status' => $newStatus,
-                    'confirmed_by' => $request->user()->id,
+                    'confirmed_by' => null,
                     'verified_by' => $request->user()->id,
                     'verified_at' => now(),
                 ]);
 
-                $invoice->recalculateStatus();
+                Invoice::whereIn('id', $affectedInvoiceIds)
+                    ->lockForUpdate()
+                    ->get()
+                    ->each
+                    ->recalculateStatus();
             }
         });
 

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -21,6 +21,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
     'confirmed_by',
     'recorded_by',
     'verified_by',
+    'verified_at',
 ])]
 class Payment extends Model
 {

--- a/resources/js/components/features/payments/index.ts
+++ b/resources/js/components/features/payments/index.ts
@@ -1,1 +1,3 @@
 export { default as RecordPaymentSheet } from './record-payment-sheet';
+export { default as PaymentDetailSheet } from './payment-detail-sheet';
+export { default as InvoiceDetailSheet } from './invoice-detail-sheet';

--- a/resources/js/components/features/payments/invoice-detail-sheet.tsx
+++ b/resources/js/components/features/payments/invoice-detail-sheet.tsx
@@ -1,0 +1,330 @@
+import { Link, router, usePage } from '@inertiajs/react';
+import { ArrowUpRight, Banknote } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { DocumentPreview } from '@/components/shared';
+import { StatusBadge } from '@/components/shared/status-badge';
+import { Button } from '@/components/ui/button';
+import {
+    Sheet,
+    SheetContent,
+    SheetHeader,
+    SheetTitle,
+} from '@/components/ui/sheet';
+import { formatDate, formatPeriod, formatPrice } from '@/lib/formatters';
+import leases from '@/routes/leases';
+import leaseInvoices from '@/routes/leases/workspace/invoices';
+import paymentRoutes from '@/routes/payments';
+import type {
+    NeedsAttentionInvoice,
+    Payment,
+    PaymentProof,
+} from '@/types';
+import PaymentDetailSheet from './payment-detail-sheet';
+
+export default function InvoiceDetailSheet({
+    invoice,
+    open,
+    onOpenChange,
+    onRecordPayment,
+}: {
+    invoice: NeedsAttentionInvoice | null;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    onRecordPayment: (invoice: NeedsAttentionInvoice) => void;
+}) {
+    const { auth } = usePage<{ auth: { permissions: string[] } }>().props;
+    const [verifyingId, setVerifyingId] = useState<number | null>(null);
+    const [selectedPaymentId, setSelectedPaymentId] = useState<number | null>(
+        null,
+    );
+    const [paymentDetailOpen, setPaymentDetailOpen] = useState(false);
+    const [previewProof, setPreviewProof] = useState<{
+        src: string;
+        mimeType: string;
+        name: string;
+    } | null>(null);
+    const canVerify = auth.permissions.includes('payments.verify');
+    const selectedPayment = (
+        invoice?.payments?.find((payment) => payment.id === selectedPaymentId)
+            ? {
+                  ...invoice.payments.find(
+                      (payment) => payment.id === selectedPaymentId,
+                  )!,
+                  invoice: {
+                      id: invoice.id,
+                      reference: invoice.reference,
+                      period_start: invoice.period_start,
+                      period_end: invoice.period_end,
+                      status: invoice.status,
+                  },
+              }
+            : null
+    ) as Payment | null;
+
+    useEffect(() => {
+        if (
+            paymentDetailOpen &&
+            selectedPaymentId !== null &&
+            selectedPayment === null
+        ) {
+            setPaymentDetailOpen(false);
+            setSelectedPaymentId(null);
+        }
+    }, [paymentDetailOpen, selectedPayment, selectedPaymentId]);
+
+    function handlePreview(payment: Payment, proof: PaymentProof) {
+        setPreviewProof({
+            src: paymentRoutes.proof.url([payment, proof]),
+            mimeType: proof.mime_type,
+            name: proof.original_name,
+        });
+    }
+
+    function handleVerify(payment: Payment, action: 'confirm' | 'reject') {
+        setVerifyingId(payment.id);
+        router.post(
+            paymentRoutes.verify.url(payment),
+            { action },
+            {
+                preserveState: true,
+                preserveScroll: true,
+                onFinish: () => setVerifyingId(null),
+            },
+        );
+    }
+
+    return (
+        <>
+            <Sheet open={open && !paymentDetailOpen} onOpenChange={onOpenChange}>
+                <SheetContent className="sm:max-w-lg">
+                    <SheetHeader>
+                        <SheetTitle>
+                            {invoice?.reference ?? 'Invoice'}
+                        </SheetTitle>
+                    </SheetHeader>
+
+                    {invoice && (
+                        <div className="flex flex-1 flex-col justify-between gap-6 overflow-y-auto px-4 pt-4 pb-6">
+                            <div className="space-y-6">
+                                <section className="rounded-lg border p-4">
+                                    <div className="flex items-start justify-between gap-4">
+                                        <div>
+                                            <p className="font-medium">
+                                                {formatPeriod(
+                                                    invoice.period_start,
+                                                    'id-ID',
+                                                )}
+                                            </p>
+                                            <p className="text-sm text-muted-foreground">
+                                                {invoice.tenant_name}
+                                                {' · '}
+                                                {invoice.unit_name}
+                                                {' · '}
+                                                {invoice.property_name}
+                                            </p>
+                                        </div>
+                                        <StatusBadge
+                                            domain="invoice"
+                                            value={invoice.status}
+                                        />
+                                    </div>
+
+                                    <div className="mt-4 grid grid-cols-2 gap-4 text-sm sm:grid-cols-3">
+                                        <DetailRow
+                                            label="Total"
+                                            value={formatPrice(invoice.total)}
+                                        />
+                                        <DetailRow
+                                            label="Paid"
+                                            value={formatPrice(
+                                                invoice.amount_paid,
+                                            )}
+                                        />
+                                        <DetailRow
+                                            label="Outstanding"
+                                            value={formatPrice(
+                                                invoice.outstanding,
+                                            )}
+                                        />
+                                        <DetailRow
+                                            label="Due date"
+                                            value={formatDate(
+                                                invoice.due_date,
+                                            )}
+                                        />
+                                        <DetailRow
+                                            label="Lease"
+                                            value={
+                                                invoice.lease_reference ??
+                                                `#${invoice.lease_id}`
+                                            }
+                                        />
+                                    </div>
+                                </section>
+
+                                {invoice.line_items &&
+                                    invoice.line_items.length > 0 && (
+                                        <section className="rounded-lg border">
+                                            <div className="border-b px-4 py-3">
+                                                <h3 className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
+                                                    Line Items
+                                                </h3>
+                                            </div>
+                                            <div className="divide-y">
+                                                {invoice.line_items.map(
+                                                    (item) => (
+                                                        <div
+                                                            key={item.id}
+                                                            className="flex items-center justify-between px-4 py-3 text-sm"
+                                                        >
+                                                            <div>
+                                                                <p className="font-medium">
+                                                                    {
+                                                                        item.description
+                                                                    }
+                                                                </p>
+                                                                <p className="text-xs text-muted-foreground">
+                                                                    {item.type}
+                                                                </p>
+                                                            </div>
+                                                            <p className="tabular-nums">
+                                                                {formatPrice(
+                                                                    item.amount,
+                                                                )}
+                                                            </p>
+                                                        </div>
+                                                    ),
+                                                )}
+                                            </div>
+                                        </section>
+                                    )}
+
+                                <section className="rounded-lg border">
+                                    <div className="border-b px-4 py-3">
+                                        <h3 className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
+                                            Payments
+                                        </h3>
+                                    </div>
+                                    {invoice.payments &&
+                                    invoice.payments.length > 0 ? (
+                                        <div className="divide-y">
+                                            {invoice.payments.map((payment) => (
+                                                <div
+                                                    key={payment.id}
+                                                    className="flex cursor-pointer items-center justify-between px-4 py-3 text-sm hover:bg-muted/30"
+                                                    onClick={() => {
+                                                        setSelectedPaymentId(
+                                                            payment.id,
+                                                        );
+                                                        setPaymentDetailOpen(
+                                                            true,
+                                                        );
+                                                    }}
+                                                >
+                                                    <div>
+                                                        <p className="font-medium tabular-nums">
+                                                            {formatPrice(
+                                                                payment.amount,
+                                                            )}
+                                                        </p>
+                                                        <p className="text-xs text-muted-foreground">
+                                                            {formatDate(
+                                                                payment.payment_date,
+                                                            )}
+                                                        </p>
+                                                    </div>
+                                                    <StatusBadge
+                                                        domain="payment"
+                                                        value={payment.status}
+                                                    />
+                                                </div>
+                                            ))}
+                                        </div>
+                                    ) : (
+                                        <div className="px-4 py-6 text-sm text-muted-foreground">
+                                            No payments recorded yet.
+                                        </div>
+                                    )}
+                                </section>
+                            </div>
+
+                            <div className="flex flex-wrap items-center justify-end gap-4">
+                                {invoice.status !== 'paid' && (
+                                    <Button
+                                        type="button"
+                                        onClick={() => onRecordPayment(invoice)}
+                                    >
+                                        <Banknote className="size-4" />
+                                        Record Payment
+                                    </Button>
+                                )}
+                                <Button variant="outline" asChild>
+                                    <Link
+                                        href={leaseInvoices.show.url([
+                                            { id: invoice.lease_id },
+                                            { id: invoice.id },
+                                        ])}
+                                    >
+                                        <ArrowUpRight className="size-4" />
+                                        View Invoice
+                                    </Link>
+                                </Button>
+                                <Button variant="outline" asChild>
+                                    <Link
+                                        href={leases.show.url({
+                                            id: invoice.lease_id,
+                                        })}
+                                    >
+                                        <ArrowUpRight className="size-4" />
+                                        View Lease
+                                    </Link>
+                                </Button>
+                                <Button
+                                    type="button"
+                                    variant="outline"
+                                    onClick={() => onOpenChange(false)}
+                                >
+                                    Close
+                                </Button>
+                            </div>
+                        </div>
+                    )}
+                </SheetContent>
+            </Sheet>
+
+            <PaymentDetailSheet
+                payment={selectedPayment}
+                open={paymentDetailOpen}
+                onOpenChange={(next) => {
+                    setPaymentDetailOpen(next);
+                    if (!next) {
+                        setSelectedPaymentId(null);
+                    }
+                }}
+                verifyingId={verifyingId}
+                canVerify={canVerify}
+                onPreview={handlePreview}
+                onVerify={handleVerify}
+            />
+
+            {previewProof && (
+                <DocumentPreview
+                    src={previewProof.src}
+                    mimeType={previewProof.mimeType}
+                    title={previewProof.name}
+                    subtitle="Payment Proof"
+                    onClose={() => setPreviewProof(null)}
+                />
+            )}
+        </>
+    );
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+    return (
+        <div>
+            <p className="text-muted-foreground">{label}</p>
+            <p className="mt-1 font-medium tabular-nums">{value}</p>
+        </div>
+    );
+}

--- a/resources/js/components/features/payments/invoice-detail-sheet.tsx
+++ b/resources/js/components/features/payments/invoice-detail-sheet.tsx
@@ -43,22 +43,19 @@ export default function InvoiceDetailSheet({
         name: string;
     } | null>(null);
     const canVerify = auth.permissions.includes('payments.verify');
-    const selectedPayment = (
-        invoice?.payments?.find((payment) => payment.id === selectedPaymentId)
-            ? {
-                  ...invoice.payments.find(
-                      (payment) => payment.id === selectedPaymentId,
-                  )!,
-                  invoice: {
-                      id: invoice.id,
-                      reference: invoice.reference,
-                      period_start: invoice.period_start,
-                      period_end: invoice.period_end,
-                      status: invoice.status,
-                  },
-              }
-            : null
-    ) as Payment | null;
+    const selectedPaymentData = invoice?.payments?.find((payment) => payment.id === selectedPaymentId);
+    const selectedPayment = (selectedPaymentData && invoice
+        ? {
+              ...selectedPaymentData,
+              invoice: {
+                  id: invoice.id,
+                  reference: invoice.reference,
+                  period_start: invoice.period_start,
+                  period_end: invoice.period_end,
+                  status: invoice.status,
+              },
+          }
+        : null) as Payment | null;
     const paymentDetailOpen =
         selectedPaymentId !== null && selectedPayment !== null;
 

--- a/resources/js/components/features/payments/invoice-detail-sheet.tsx
+++ b/resources/js/components/features/payments/invoice-detail-sheet.tsx
@@ -1,6 +1,6 @@
 import { Link, router, usePage } from '@inertiajs/react';
 import { ArrowUpRight, Banknote } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { DocumentPreview } from '@/components/shared';
 import { StatusBadge } from '@/components/shared/status-badge';
 import { Button } from '@/components/ui/button';
@@ -37,7 +37,6 @@ export default function InvoiceDetailSheet({
     const [selectedPaymentId, setSelectedPaymentId] = useState<number | null>(
         null,
     );
-    const [paymentDetailOpen, setPaymentDetailOpen] = useState(false);
     const [previewProof, setPreviewProof] = useState<{
         src: string;
         mimeType: string;
@@ -60,17 +59,8 @@ export default function InvoiceDetailSheet({
               }
             : null
     ) as Payment | null;
-
-    useEffect(() => {
-        if (
-            paymentDetailOpen &&
-            selectedPaymentId !== null &&
-            selectedPayment === null
-        ) {
-            setPaymentDetailOpen(false);
-            setSelectedPaymentId(null);
-        }
-    }, [paymentDetailOpen, selectedPayment, selectedPaymentId]);
+    const paymentDetailOpen =
+        selectedPaymentId !== null && selectedPayment !== null;
 
     function handlePreview(payment: Payment, proof: PaymentProof) {
         setPreviewProof({
@@ -95,7 +85,10 @@ export default function InvoiceDetailSheet({
 
     return (
         <>
-            <Sheet open={open && !paymentDetailOpen} onOpenChange={onOpenChange}>
+            <Sheet
+                open={open && !paymentDetailOpen}
+                onOpenChange={onOpenChange}
+            >
                 <SheetContent className="sm:max-w-lg">
                     <SheetHeader>
                         <SheetTitle>
@@ -216,9 +209,6 @@ export default function InvoiceDetailSheet({
                                                         setSelectedPaymentId(
                                                             payment.id,
                                                         );
-                                                        setPaymentDetailOpen(
-                                                            true,
-                                                        );
                                                     }}
                                                 >
                                                     <div>
@@ -296,7 +286,6 @@ export default function InvoiceDetailSheet({
                 payment={selectedPayment}
                 open={paymentDetailOpen}
                 onOpenChange={(next) => {
-                    setPaymentDetailOpen(next);
                     if (!next) {
                         setSelectedPaymentId(null);
                     }

--- a/resources/js/components/features/payments/payment-detail-sheet.tsx
+++ b/resources/js/components/features/payments/payment-detail-sheet.tsx
@@ -28,19 +28,8 @@ export default function PaymentDetailSheet({
     onPreview: (payment: Payment, proof: PaymentProof) => void;
     onVerify: (payment: Payment, action: 'confirm' | 'reject') => void;
 }) {
-    const paymentUsers = payment as (Payment & {
-        confirmed_by?: { id: number; name: string } | null;
-        confirmedBy?: { id: number; name: string } | null;
-    }) | null;
-    const verifiedDate =
-        payment?.status === 'confirmed'
-            ? (payment.verified_at ?? payment.payment_date)
-            : payment?.verified_at ?? null;
-    const confirmedByName =
-        payment?.confirmed_by_user?.name ??
-        paymentUsers?.confirmed_by?.name ??
-        paymentUsers?.confirmedBy?.name ??
-        '—';
+    const verifiedDate = payment?.verified_at ?? null;
+    const confirmedByName = payment?.confirmed_by_user?.name ?? '—';
 
     return (
         <Sheet open={open} onOpenChange={onOpenChange}>

--- a/resources/js/components/features/payments/payment-detail-sheet.tsx
+++ b/resources/js/components/features/payments/payment-detail-sheet.tsx
@@ -1,0 +1,202 @@
+import { Check, FileText, X } from 'lucide-react';
+import { StatusBadge } from '@/components/shared/status-badge';
+import { Button } from '@/components/ui/button';
+import {
+    Sheet,
+    SheetContent,
+    SheetHeader,
+    SheetTitle,
+} from '@/components/ui/sheet';
+import { PAYMENT_METHOD_LABELS } from '@/lib/constants/billing';
+import { formatDate, formatPeriod, formatPrice } from '@/lib/formatters';
+import type { Payment, PaymentProof } from '@/types';
+
+export default function PaymentDetailSheet({
+    payment,
+    open,
+    onOpenChange,
+    verifyingId,
+    canVerify,
+    onPreview,
+    onVerify,
+}: {
+    payment: Payment | null;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    verifyingId: number | null;
+    canVerify: boolean;
+    onPreview: (payment: Payment, proof: PaymentProof) => void;
+    onVerify: (payment: Payment, action: 'confirm' | 'reject') => void;
+}) {
+    const paymentUsers = payment as (Payment & {
+        confirmed_by?: { id: number; name: string } | null;
+        confirmedBy?: { id: number; name: string } | null;
+    }) | null;
+    const verifiedDate =
+        payment?.status === 'confirmed'
+            ? (payment.verified_at ?? payment.payment_date)
+            : payment?.verified_at ?? null;
+    const confirmedByName =
+        payment?.confirmed_by_user?.name ??
+        paymentUsers?.confirmed_by?.name ??
+        paymentUsers?.confirmedBy?.name ??
+        '—';
+
+    return (
+        <Sheet open={open} onOpenChange={onOpenChange}>
+            <SheetContent className="sm:max-w-lg">
+                <SheetHeader>
+                    <SheetTitle>
+                        {payment?.invoice
+                            ? formatPeriod(payment.invoice.period_start, 'id-ID')
+                            : 'Payment'}
+                    </SheetTitle>
+                </SheetHeader>
+
+                {payment && (
+                    <div className="flex flex-1 flex-col justify-between gap-6 overflow-y-auto px-4 pt-4 pb-6">
+                        <div className="space-y-6">
+                            <section>
+                                <h3 className="mb-3 text-xs font-medium tracking-wider text-muted-foreground uppercase">
+                                    Status
+                                </h3>
+                                <StatusBadge
+                                    domain="payment"
+                                    value={
+                                        verifiedDate &&
+                                        payment.status === 'confirmed'
+                                            ? 'verified'
+                                            : payment.status
+                                    }
+                                />
+                            </section>
+
+                            <section>
+                                <h3 className="mb-3 text-xs font-medium tracking-wider text-muted-foreground uppercase">
+                                    Details
+                                </h3>
+                                <div className="space-y-3 rounded-lg border bg-muted/30 p-4">
+                                    <DetailRow
+                                        label="Amount"
+                                        value={formatPrice(payment.amount)}
+                                    />
+                                    <DetailRow
+                                        label="Paid on"
+                                        value={formatDate(payment.payment_date)}
+                                    />
+                                    <DetailRow
+                                        label="Method"
+                                        value={
+                                            PAYMENT_METHOD_LABELS[
+                                                payment.payment_method
+                                            ] ?? payment.payment_method
+                                        }
+                                    />
+                                    <DetailRow
+                                        label="Reference"
+                                        value={payment.invoice?.reference ?? '—'}
+                                    />
+                                    <DetailRow
+                                        label="Confirmed by"
+                                        value={confirmedByName}
+                                    />
+                                    <DetailRow
+                                        label="Verified"
+                                        value={formatDate(verifiedDate)}
+                                    />
+                                </div>
+                            </section>
+
+                            {payment.notes && (
+                                <section>
+                                    <h3 className="mb-3 text-xs font-medium tracking-wider text-muted-foreground uppercase">
+                                        Notes
+                                    </h3>
+                                    <div className="rounded-lg border p-4 text-sm whitespace-pre-wrap">
+                                        {payment.notes}
+                                    </div>
+                                </section>
+                            )}
+
+                            <section>
+                                <h3 className="mb-3 text-xs font-medium tracking-wider text-muted-foreground uppercase">
+                                    Proofs
+                                </h3>
+                                <div className="rounded-lg border p-4">
+                                    {payment.proofs.length > 0 ? (
+                                        <div className="flex flex-wrap gap-2">
+                                            {payment.proofs.map((proof) => (
+                                                <Button
+                                                    key={proof.id}
+                                                    type="button"
+                                                    variant="outline"
+                                                    size="xs"
+                                                    onClick={() =>
+                                                        onPreview(payment, proof)
+                                                    }
+                                                >
+                                                    <FileText className="size-3" />
+                                                    {proof.original_name}
+                                                </Button>
+                                            ))}
+                                        </div>
+                                    ) : (
+                                        <p className="text-sm text-muted-foreground">
+                                            No proofs uploaded.
+                                        </p>
+                                    )}
+                                </div>
+                            </section>
+                        </div>
+
+                        <div className="flex flex-wrap items-center justify-end gap-4">
+                            {payment.status === 'pending' && canVerify && (
+                                <>
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        disabled={verifyingId === payment.id}
+                                        onClick={() =>
+                                            onVerify(payment, 'confirm')
+                                        }
+                                    >
+                                        <Check className="size-4" />
+                                        Confirm
+                                    </Button>
+                                    <Button
+                                        type="button"
+                                        variant="destructive"
+                                        disabled={verifyingId === payment.id}
+                                        onClick={() =>
+                                            onVerify(payment, 'reject')
+                                        }
+                                    >
+                                        <X className="size-4" />
+                                        Reject
+                                    </Button>
+                                </>
+                            )}
+
+                            <Button
+                                type="button"
+                                variant="outline"
+                                onClick={() => onOpenChange(false)}
+                            >
+                                Close
+                            </Button>
+                        </div>
+                    </div>
+                )}
+            </SheetContent>
+        </Sheet>
+    );
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+    return (
+        <div className="flex items-center justify-between gap-4">
+            <span className="text-sm text-muted-foreground">{label}</span>
+            <span className="text-right text-sm">{value}</span>
+        </div>
+    );
+}

--- a/resources/js/components/shared/status-badge.tsx
+++ b/resources/js/components/shared/status-badge.tsx
@@ -45,7 +45,7 @@ const STATUS_CONFIGS: Record<string, Record<string, StatusConfig>> = {
     payment: {
         confirmed: { label: 'Confirmed', className: 'bg-green-600 text-white' },
         pending: { label: 'Pending', className: 'bg-amber-500 text-white' },
-        cancelled: { label: 'Cancelled', className: 'bg-gray-400 text-white' },
+        cancelled: { label: 'Rejected', className: 'bg-gray-400 text-white' },
         verified: { label: 'Verified', className: 'bg-green-600 text-white' },
     },
     tenant_payment: {
@@ -54,7 +54,7 @@ const STATUS_CONFIGS: Record<string, Record<string, StatusConfig>> = {
             label: 'Awaiting verification',
             className: 'bg-amber-500 text-white',
         },
-        cancelled: { label: 'Cancelled', className: 'bg-gray-400 text-white' },
+        cancelled: { label: 'Rejected', className: 'bg-gray-400 text-white' },
         verified: { label: 'Verified', className: 'bg-green-600 text-white' },
     },
     maintenance: {

--- a/resources/js/pages/dashboard/overview.tsx
+++ b/resources/js/pages/dashboard/overview.tsx
@@ -10,6 +10,7 @@ interface Attention {
     due_today: number;
     open_maintenance: number;
     leases_ending_soon: number;
+    pending_payment_verification: number;
 }
 
 type MaintenanceProperty = { id: number; name: string };
@@ -52,7 +53,7 @@ export default function Overview({
                     <h2 className="mb-4 text-sm font-medium tracking-wider text-muted-foreground uppercase">
                         Today&apos;s Attention
                     </h2>
-                    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
                         <AttentionCard
                             label="Overdue Invoices"
                             count={attention.overdue_invoices.count}
@@ -77,6 +78,12 @@ export default function Overview({
                             count={attention.leases_ending_soon}
                             bgColor="bg-sky-50 dark:bg-sky-950/20"
                             textColor="text-sky-600 dark:text-sky-400"
+                        />
+                        <AttentionCard
+                            label="Pending Payment Review"
+                            count={attention.pending_payment_verification}
+                            bgColor="bg-violet-50 dark:bg-violet-950/20"
+                            textColor="text-violet-600 dark:text-violet-400"
                         />
                     </div>
                 </section>

--- a/resources/js/pages/dashboard/rent.tsx
+++ b/resources/js/pages/dashboard/rent.tsx
@@ -13,7 +13,7 @@ import {
     Square,
     TrendingUp,
 } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { DataTable } from '@/components/data-table';
 import type { TableColumn } from '@/components/data-table';
 import { SearchInput } from '@/components/data-table/search-input';
@@ -216,8 +216,6 @@ export default function CollectionQueue({
         useState<NeedsAttentionInvoice | null>(null);
     const [detailInvoice, setDetailInvoice] =
         useState<NeedsAttentionInvoice | null>(null);
-    const [queuedPaymentInvoice, setQueuedPaymentInvoice] =
-        useState<NeedsAttentionInvoice | null>(null);
 
     const openPaymentSheet = (entry: NeedsAttentionInvoice) => {
         setPaymentSheetInvoice(entry);
@@ -228,16 +226,9 @@ export default function CollectionQueue({
     };
 
     const handleRecordPaymentFromDetail = (entry: NeedsAttentionInvoice) => {
-        setQueuedPaymentInvoice(entry);
         setDetailInvoice(null);
+        setPaymentSheetInvoice(entry);
     };
-
-    useEffect(() => {
-        if (detailInvoice === null && queuedPaymentInvoice !== null) {
-            setPaymentSheetInvoice(queuedPaymentInvoice);
-            setQueuedPaymentInvoice(null);
-        }
-    }, [detailInvoice, queuedPaymentInvoice]);
 
     const applyTab = (tab: string) => {
         router.get(

--- a/resources/js/pages/dashboard/rent.tsx
+++ b/resources/js/pages/dashboard/rent.tsx
@@ -13,10 +13,11 @@ import {
     Square,
     TrendingUp,
 } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { DataTable } from '@/components/data-table';
 import type { TableColumn } from '@/components/data-table';
 import { SearchInput } from '@/components/data-table/search-input';
+import InvoiceDetailSheet from '@/components/features/payments/invoice-detail-sheet';
 import QueuePaymentSheet from '@/components/features/payments/queue-payment-sheet';
 import { Button } from '@/components/ui/button';
 import {
@@ -42,9 +43,11 @@ import type {
 } from '@/types';
 
 type TabCounts = {
+    all: number;
     overdue: number;
     due_today: number;
     upcoming: number;
+    pending_review: number;
     partial: number;
     paid: number;
 };
@@ -81,6 +84,7 @@ const TABS = [
     { key: 'overdue', label: 'Overdue' },
     { key: 'due_today', label: 'Due Today' },
     { key: 'upcoming', label: 'Upcoming' },
+    { key: 'pending_review', label: 'Pending Review' },
     { key: 'partial', label: 'Partial' },
     { key: 'paid', label: 'Paid' },
 ] as const;
@@ -120,6 +124,14 @@ return { text: 'Due tomorrow', color: 'text-amber-500' };
 }
 
     return { text: 'Upcoming', color: 'text-muted-foreground' };
+}
+
+function pendingReviewLabel(count: number | undefined): string {
+    if (!count || count < 1) {
+        return 'Pending review';
+    }
+
+    return `Pending review · ${count}`;
 }
 
 function timeAgo(dateStr: string | null): string | null {
@@ -202,10 +214,30 @@ export default function CollectionQueue({
 
     const [paymentSheetInvoice, setPaymentSheetInvoice] =
         useState<NeedsAttentionInvoice | null>(null);
+    const [detailInvoice, setDetailInvoice] =
+        useState<NeedsAttentionInvoice | null>(null);
+    const [queuedPaymentInvoice, setQueuedPaymentInvoice] =
+        useState<NeedsAttentionInvoice | null>(null);
 
     const openPaymentSheet = (entry: NeedsAttentionInvoice) => {
         setPaymentSheetInvoice(entry);
     };
+
+    const openInvoiceDetail = (entry: NeedsAttentionInvoice) => {
+        setDetailInvoice(entry);
+    };
+
+    const handleRecordPaymentFromDetail = (entry: NeedsAttentionInvoice) => {
+        setQueuedPaymentInvoice(entry);
+        setDetailInvoice(null);
+    };
+
+    useEffect(() => {
+        if (detailInvoice === null && queuedPaymentInvoice !== null) {
+            setPaymentSheetInvoice(queuedPaymentInvoice);
+            setQueuedPaymentInvoice(null);
+        }
+    }, [detailInvoice, queuedPaymentInvoice]);
 
     const applyTab = (tab: string) => {
         router.get(
@@ -290,6 +322,14 @@ export default function CollectionQueue({
             key: 'urgency',
             label: 'Status',
             render: (entry) => {
+                if (currentUrgency === 'pending_review') {
+                    return (
+                        <span className="text-sm text-violet-600">
+                            {pendingReviewLabel(entry.pending_payment_review_count)}
+                        </span>
+                    );
+                }
+
                 const { text, color } = urgencyLabel(
                     entry.urgency,
                     entry.days_overdue,
@@ -366,9 +406,7 @@ export default function CollectionQueue({
     ];
 
     const onRowClick = (entry: NeedsAttentionInvoice) => {
-        if (entry.status !== 'paid') {
-            openPaymentSheet(entry);
-        }
+        openInvoiceDetail(entry);
     };
 
     const progressPercent =
@@ -384,7 +422,7 @@ export default function CollectionQueue({
             <div className="flex h-full flex-1 flex-col gap-4 overflow-x-auto p-4">
                 {/* Header cards */}
                 <h1 className="text-lg font-semibold">Collection Queue</h1>
-                <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-4">
                     <div className="flex items-center gap-3 rounded-lg border px-4 py-3">
                         <AlertTriangle className="size-8 shrink-0 text-red-500" />
                         <div className="min-w-0">
@@ -409,6 +447,15 @@ export default function CollectionQueue({
                             <p className="text-xs text-muted-foreground">Upcoming</p>
                             <p className="text-xl font-bold tabular-nums">
                                 {tabCounts.upcoming}
+                            </p>
+                        </div>
+                    </div>
+                    <div className="flex items-center gap-3 rounded-lg border px-4 py-3">
+                        <Bell className="size-8 shrink-0 text-violet-600" />
+                        <div className="min-w-0">
+                            <p className="text-xs text-muted-foreground">Pending Review</p>
+                            <p className="text-xl font-bold tabular-nums">
+                                {tabCounts.pending_review}
                             </p>
                         </div>
                     </div>
@@ -510,7 +557,7 @@ export default function CollectionQueue({
                     {TABS.map((tab) => {
                         const count =
                             tab.key === ''
-                                ? data.total
+                                ? tabCounts.all
                                 : tabCounts[tab.key as keyof TabCounts] ?? 0;
                         const active =
                             currentUrgency === tab.key ||
@@ -655,6 +702,17 @@ export default function CollectionQueue({
                 </Collapsible>
                 )}
             </div>
+
+            <InvoiceDetailSheet
+                invoice={detailInvoice}
+                open={detailInvoice !== null}
+                onOpenChange={(open) => {
+                    if (!open) {
+                        setDetailInvoice(null);
+                    }
+                }}
+                onRecordPayment={handleRecordPaymentFromDetail}
+            />
 
             <QueuePaymentSheet
                 key={paymentSheetInvoice?.id}

--- a/resources/js/pages/leases/index.tsx
+++ b/resources/js/pages/leases/index.tsx
@@ -8,6 +8,7 @@ import {
     Building2,
     Banknote,
     AlertTriangle,
+    Clock3,
 } from 'lucide-react';
 import { useState } from 'react';
 import { DataTable } from '@/components/data-table';
@@ -52,6 +53,7 @@ type PageProps = {
         active_leases: number;
         collected_this_month: number;
         overdue_amount: number;
+        pending_payment_verification: number;
     };
 };
 
@@ -104,7 +106,20 @@ export default function Index({
             key: 'reference',
             label: 'Reference',
             className: 'font-mono text-xs',
-            render: (lease) => lease.reference ?? '\u2014',
+            render: (lease) => (
+                <div className="flex items-center gap-2">
+                    <span>{lease.reference ?? '\u2014'}</span>
+                    {lease.pending_payment_review_count ? (
+                        <span
+                            className="relative inline-flex size-2"
+                            title={`${lease.pending_payment_review_count} payment review pending`}
+                        >
+                            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-violet-600 opacity-75" />
+                            <span className="relative inline-flex size-2 rounded-full bg-violet-600" />
+                        </span>
+                    ) : null}
+                </div>
+            ),
         },
         {
             key: '_tenant',
@@ -278,7 +293,7 @@ export default function Index({
                 </div>
 
                 {stats && (
-                    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 lg:gap-4">
+                    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4 lg:gap-4">
                         <Card>
                             <CardContent className="flex items-center gap-4 px-6">
                                 <Building2 className="size-10 shrink-0 text-blue-600" />
@@ -320,6 +335,20 @@ export default function Index({
                                         {formatPrice(
                                             String(stats.overdue_amount),
                                         )}
+                                    </p>
+                                </div>
+                            </CardContent>
+                        </Card>
+
+                        <Card>
+                            <CardContent className="flex items-center gap-4 px-6">
+                                <Clock3 className="size-10 shrink-0 text-violet-600" />
+                                <div className="min-w-0">
+                                    <p className="text-sm text-muted-foreground">
+                                        Pending Review
+                                    </p>
+                                    <p className="truncate text-2xl font-bold tabular-nums">
+                                        {stats.pending_payment_verification}
                                     </p>
                                 </div>
                             </CardContent>

--- a/resources/js/pages/leases/invoice-detail.tsx
+++ b/resources/js/pages/leases/invoice-detail.tsx
@@ -1,6 +1,6 @@
 import { Head, Link, router, usePage } from '@inertiajs/react';
 import { ChevronLeft } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { PaymentDetailSheet } from '@/components/features';
 import { DocumentPreview } from '@/components/shared';
 import { StatusBadge } from '@/components/shared/status-badge';
@@ -20,7 +20,6 @@ export default function InvoiceDetail({
     const [selectedPaymentId, setSelectedPaymentId] = useState<number | null>(
         null,
     );
-    const [detailOpen, setDetailOpen] = useState(false);
     const [previewProof, setPreviewProof] = useState<{
         src: string;
         mimeType: string;
@@ -43,13 +42,7 @@ export default function InvoiceDetail({
               }
             : null
     ) as Payment | null;
-
-    useEffect(() => {
-        if (detailOpen && selectedPaymentId !== null && selectedPayment === null) {
-            setDetailOpen(false);
-            setSelectedPaymentId(null);
-        }
-    }, [detailOpen, selectedPayment, selectedPaymentId]);
+    const detailOpen = selectedPaymentId !== null && selectedPayment !== null;
 
     function handlePreview(payment: Payment, proof: PaymentProof) {
         setPreviewProof({
@@ -185,7 +178,6 @@ export default function InvoiceDetail({
                                     className="flex cursor-pointer items-center justify-between px-4 py-3 text-sm hover:bg-muted/30"
                                     onClick={() => {
                                         setSelectedPaymentId(payment.id);
-                                        setDetailOpen(true);
                                     }}
                                 >
                                     <div>
@@ -216,7 +208,6 @@ export default function InvoiceDetail({
                 payment={selectedPayment}
                 open={detailOpen}
                 onOpenChange={(open) => {
-                    setDetailOpen(open);
                     if (!open) {
                         setSelectedPaymentId(null);
                     }

--- a/resources/js/pages/leases/invoice-detail.tsx
+++ b/resources/js/pages/leases/invoice-detail.tsx
@@ -1,8 +1,12 @@
-import { Head, Link } from '@inertiajs/react';
+import { Head, Link, router, usePage } from '@inertiajs/react';
 import { ChevronLeft } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { PaymentDetailSheet } from '@/components/features';
+import { DocumentPreview } from '@/components/shared';
 import { StatusBadge } from '@/components/shared/status-badge';
 import { formatDate, formatPeriod, formatPrice } from '@/lib/formatters';
-import type { Invoice, WorkspaceLease } from '@/types';
+import paymentRoutes from '@/routes/payments';
+import type { Invoice, Payment, PaymentProof, WorkspaceLease } from '@/types';
 
 export default function InvoiceDetail({
     lease,
@@ -11,6 +15,63 @@ export default function InvoiceDetail({
     lease: WorkspaceLease;
     invoice: Invoice;
 }) {
+    const { auth } = usePage<{ auth: { permissions: string[] } }>().props;
+    const [verifyingId, setVerifyingId] = useState<number | null>(null);
+    const [selectedPaymentId, setSelectedPaymentId] = useState<number | null>(
+        null,
+    );
+    const [detailOpen, setDetailOpen] = useState(false);
+    const [previewProof, setPreviewProof] = useState<{
+        src: string;
+        mimeType: string;
+        name: string;
+    } | null>(null);
+    const canVerify = auth.permissions.includes('payments.verify');
+    const selectedPayment = (
+        invoice.payments?.find((payment) => payment.id === selectedPaymentId)
+            ? {
+                  ...invoice.payments.find(
+                      (payment) => payment.id === selectedPaymentId,
+                  )!,
+                  invoice: {
+                      id: invoice.id,
+                      reference: invoice.reference,
+                      period_start: invoice.period_start,
+                      period_end: invoice.period_end,
+                      status: invoice.status,
+                  },
+              }
+            : null
+    ) as Payment | null;
+
+    useEffect(() => {
+        if (detailOpen && selectedPaymentId !== null && selectedPayment === null) {
+            setDetailOpen(false);
+            setSelectedPaymentId(null);
+        }
+    }, [detailOpen, selectedPayment, selectedPaymentId]);
+
+    function handlePreview(payment: Payment, proof: PaymentProof) {
+        setPreviewProof({
+            src: paymentRoutes.proof.url([payment, proof]),
+            mimeType: proof.mime_type,
+            name: proof.original_name,
+        });
+    }
+
+    function handleVerify(payment: Payment, action: 'confirm' | 'reject') {
+        setVerifyingId(payment.id);
+        router.post(
+            paymentRoutes.verify.url(payment),
+            { action },
+            {
+                preserveState: true,
+                preserveScroll: true,
+                onFinish: () => setVerifyingId(null),
+            },
+        );
+    }
+
     return (
         <div className="workspace-enter flex h-full flex-1 flex-col gap-6 overflow-x-auto rounded-xl p-4">
             <Head title={`Invoice ${invoice.reference} — Lease #${lease.id}`} />
@@ -121,7 +182,11 @@ export default function InvoiceDetail({
                             {invoice.payments.map((payment) => (
                                 <div
                                     key={payment.id}
-                                    className="flex items-center justify-between px-4 py-3 text-sm"
+                                    className="flex cursor-pointer items-center justify-between px-4 py-3 text-sm hover:bg-muted/30"
+                                    onClick={() => {
+                                        setSelectedPaymentId(payment.id);
+                                        setDetailOpen(true);
+                                    }}
                                 >
                                     <div>
                                         <p className="font-medium tabular-nums">
@@ -146,6 +211,31 @@ export default function InvoiceDetail({
                     Activity timeline, reminders, and PDF download coming soon.
                 </div>
             </div>
+
+            <PaymentDetailSheet
+                payment={selectedPayment}
+                open={detailOpen}
+                onOpenChange={(open) => {
+                    setDetailOpen(open);
+                    if (!open) {
+                        setSelectedPaymentId(null);
+                    }
+                }}
+                verifyingId={verifyingId}
+                canVerify={canVerify}
+                onPreview={handlePreview}
+                onVerify={handleVerify}
+            />
+
+            {previewProof && (
+                <DocumentPreview
+                    src={previewProof.src}
+                    mimeType={previewProof.mimeType}
+                    title={previewProof.name}
+                    subtitle="Payment Proof"
+                    onClose={() => setPreviewProof(null)}
+                />
+            )}
         </div>
     );
 }

--- a/resources/js/pages/leases/payments.tsx
+++ b/resources/js/pages/leases/payments.tsx
@@ -1,6 +1,6 @@
 import { Link, router, usePage } from '@inertiajs/react';
 import { Check, X } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import type { TableColumn } from '@/components/data-table';
 import { PaymentDetailSheet } from '@/components/features';
 import { DocumentPreview } from '@/components/shared';
@@ -45,7 +45,6 @@ export default function LeasePayments({
     const [selectedPaymentId, setSelectedPaymentId] = useState<number | null>(
         null,
     );
-    const [detailOpen, setDetailOpen] = useState(false);
     const [previewProof, setPreviewProof] = useState<{
         src: string;
         mimeType: string;
@@ -55,13 +54,7 @@ export default function LeasePayments({
     const selectedPayment =
         payments.data.find((payment) => payment.id === selectedPaymentId) ??
         null;
-
-    useEffect(() => {
-        if (detailOpen && selectedPaymentId !== null && selectedPayment === null) {
-            setDetailOpen(false);
-            setSelectedPaymentId(null);
-        }
-    }, [detailOpen, selectedPayment, selectedPaymentId]);
+    const detailOpen = selectedPaymentId !== null && selectedPayment !== null;
 
     function handlePreview(payment: Payment, proof: PaymentProof) {
         setPreviewProof({
@@ -86,7 +79,6 @@ export default function LeasePayments({
 
     function openDetail(payment: Payment) {
         setSelectedPaymentId(payment.id);
-        setDetailOpen(true);
     }
 
     const columns: TableColumn<Payment>[] = [
@@ -219,7 +211,6 @@ export default function LeasePayments({
                 payment={selectedPayment}
                 open={detailOpen}
                 onOpenChange={(open) => {
-                    setDetailOpen(open);
                     if (!open) {
                         setSelectedPaymentId(null);
                     }

--- a/resources/js/pages/leases/payments.tsx
+++ b/resources/js/pages/leases/payments.tsx
@@ -1,84 +1,25 @@
-import { FileText } from 'lucide-react';
+import { Link, router, usePage } from '@inertiajs/react';
+import { Check, X } from 'lucide-react';
+import { useEffect, useState } from 'react';
 import type { TableColumn } from '@/components/data-table';
+import { PaymentDetailSheet } from '@/components/features';
+import { DocumentPreview } from '@/components/shared';
 import { PluginRegion } from '@/components/shared/plugin-region';
 import { StatusBadge } from '@/components/shared/status-badge';
 import { WorkspaceTable } from '@/components/shared/workspace-table';
+import { Button } from '@/components/ui/button';
 import { PAYMENT_METHOD_LABELS } from '@/lib/constants/billing';
 import { formatDate, formatPeriod, formatPrice } from '@/lib/formatters';
+import leaseInvoices from '@/routes/leases/workspace/invoices';
+import paymentRoutes from '@/routes/payments';
 import type {
     PaginatedData,
     Payment,
+    PaymentProof,
     TableMeta,
     WorkspaceLease,
 } from '@/types';
 import { LeaseLayout } from './layout';
-
-const columns: TableColumn<Payment>[] = [
-    {
-        key: 'period_start',
-        label: 'Period',
-        className: 'font-medium',
-        render: (p) =>
-            p.invoice ? formatPeriod(p.invoice.period_start, 'id-ID') : '—',
-    },
-    {
-        key: 'payment_date',
-        label: 'Paid on',
-        sortable: true,
-        className: 'text-muted-foreground tabular-nums',
-        render: (p) => (p.payment_date ? formatDate(p.payment_date) : '—'),
-    },
-    {
-        key: 'amount',
-        label: 'Amount',
-        sortable: true,
-        className: 'tabular-nums',
-        render: (p) => formatPrice(p.amount),
-    },
-    {
-        key: 'payment_method',
-        label: 'Method',
-        sortable: true,
-        className: 'text-muted-foreground',
-        render: (p) =>
-            PAYMENT_METHOD_LABELS[p.payment_method] ?? p.payment_method,
-    },
-    {
-        key: 'reference',
-        label: 'Reference',
-        sortable: true,
-        className: 'font-mono text-xs text-muted-foreground',
-        render: (p) => p.reference ?? '—',
-    },
-    {
-        key: 'status',
-        label: 'Status',
-        sortable: true,
-        render: (p) => (
-            <StatusBadge
-                domain="payment"
-                value={
-                    p.verified_at && p.status === 'confirmed'
-                        ? 'verified'
-                        : p.status
-                }
-            />
-        ),
-    },
-    {
-        key: '_proofs',
-        label: 'Proofs',
-        render: (p) =>
-            p.proofs && p.proofs.length > 0 ? (
-                <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
-                    <FileText className="size-3" />
-                    {p.proofs.length}
-                </span>
-            ) : (
-                '—'
-            ),
-    },
-];
 
 export default function LeasePayments({
     lease,
@@ -99,6 +40,161 @@ export default function LeasePayments({
     per_page?: number;
     table: TableMeta;
 }) {
+    const { auth } = usePage<{ auth: { permissions: string[] } }>().props;
+    const [verifyingId, setVerifyingId] = useState<number | null>(null);
+    const [selectedPaymentId, setSelectedPaymentId] = useState<number | null>(
+        null,
+    );
+    const [detailOpen, setDetailOpen] = useState(false);
+    const [previewProof, setPreviewProof] = useState<{
+        src: string;
+        mimeType: string;
+        name: string;
+    } | null>(null);
+    const canVerify = auth.permissions.includes('payments.verify');
+    const selectedPayment =
+        payments.data.find((payment) => payment.id === selectedPaymentId) ??
+        null;
+
+    useEffect(() => {
+        if (detailOpen && selectedPaymentId !== null && selectedPayment === null) {
+            setDetailOpen(false);
+            setSelectedPaymentId(null);
+        }
+    }, [detailOpen, selectedPayment, selectedPaymentId]);
+
+    function handlePreview(payment: Payment, proof: PaymentProof) {
+        setPreviewProof({
+            src: paymentRoutes.proof.url([payment, proof]),
+            mimeType: proof.mime_type,
+            name: proof.original_name,
+        });
+    }
+
+    function handleVerify(payment: Payment, action: 'confirm' | 'reject') {
+        setVerifyingId(payment.id);
+        router.post(
+            paymentRoutes.verify.url(payment),
+            { action },
+            {
+                preserveState: true,
+                preserveScroll: true,
+                onFinish: () => setVerifyingId(null),
+            },
+        );
+    }
+
+    function openDetail(payment: Payment) {
+        setSelectedPaymentId(payment.id);
+        setDetailOpen(true);
+    }
+
+    const columns: TableColumn<Payment>[] = [
+        {
+            key: 'period_start',
+            label: 'Period',
+            className: 'font-medium',
+            render: (payment) =>
+                payment.invoice
+                    ? formatPeriod(payment.invoice.period_start, 'id-ID')
+                    : '—',
+        },
+        {
+            key: 'payment_date',
+            label: 'Paid on',
+            sortable: true,
+            className: 'text-muted-foreground tabular-nums',
+            render: (payment) =>
+                payment.payment_date ? formatDate(payment.payment_date) : '—',
+        },
+        {
+            key: 'amount',
+            label: 'Amount',
+            sortable: true,
+            className: 'tabular-nums',
+            render: (payment) => formatPrice(payment.amount),
+        },
+        {
+            key: 'payment_method',
+            label: 'Method',
+            sortable: true,
+            className: 'text-muted-foreground',
+            render: (payment) =>
+                PAYMENT_METHOD_LABELS[payment.payment_method] ??
+                payment.payment_method,
+        },
+        {
+            key: 'reference',
+            label: 'Reference',
+            sortable: true,
+            className: 'font-mono text-xs text-muted-foreground',
+            render: (payment) =>
+                payment.invoice ? (
+                    <Link
+                        href={leaseInvoices.show.url([lease, payment.invoice])}
+                        onClick={(event) => event.stopPropagation()}
+                        className="text-blue-600 hover:underline"
+                    >
+                        {payment.invoice.reference ?? '—'}
+                    </Link>
+                ) : (
+                    '—'
+                ),
+        },
+        {
+            key: 'status',
+            label: 'Status',
+            sortable: true,
+            render: (payment) => (
+                <StatusBadge
+                    domain="payment"
+                    value={
+                        payment.verified_at && payment.status === 'confirmed'
+                            ? 'verified'
+                            : payment.status
+                    }
+                />
+            ),
+        },
+        {
+            key: '_actions',
+            label: 'Actions',
+            render: (payment) =>
+                payment.status === 'pending' && canVerify ? (
+                    <div className="flex items-center gap-2">
+                        <Button
+                            type="button"
+                            size="xs"
+                            variant="outline"
+                            disabled={verifyingId === payment.id}
+                            onClick={(event) => {
+                                event.stopPropagation();
+                                handleVerify(payment, 'confirm');
+                            }}
+                        >
+                            <Check className="size-3" />
+                            Confirm
+                        </Button>
+                        <Button
+                            type="button"
+                            size="xs"
+                            variant="destructive"
+                            disabled={verifyingId === payment.id}
+                            onClick={(event) => {
+                                event.stopPropagation();
+                                handleVerify(payment, 'reject');
+                            }}
+                        >
+                            <X className="size-3" />
+                            Reject
+                        </Button>
+                    </div>
+                ) : (
+                    <span className="text-muted-foreground">—</span>
+                ),
+        },
+    ];
+
     return (
         <LeaseLayout lease={lease} activeTab="payments">
             <PluginRegion name="workspace-tab-payments">
@@ -113,10 +209,36 @@ export default function LeasePayments({
                     perPage={per_page}
                     filterValues={{ status, payment_method }}
                     defaultSort="-payment_date"
-                    searchPlaceholder="Search by reference..."
+                    searchPlaceholder="Search by invoice reference..."
                     emptyMessage="No payments recorded yet."
+                    onRowClick={openDetail}
                 />
             </PluginRegion>
+
+            <PaymentDetailSheet
+                payment={selectedPayment}
+                open={detailOpen}
+                onOpenChange={(open) => {
+                    setDetailOpen(open);
+                    if (!open) {
+                        setSelectedPaymentId(null);
+                    }
+                }}
+                verifyingId={verifyingId}
+                canVerify={canVerify}
+                onPreview={handlePreview}
+                onVerify={handleVerify}
+            />
+
+            {previewProof && (
+                <DocumentPreview
+                    src={previewProof.src}
+                    mimeType={previewProof.mimeType}
+                    title={previewProof.name}
+                    subtitle="Payment Proof"
+                    onClose={() => setPreviewProof(null)}
+                />
+            )}
         </LeaseLayout>
     );
 }

--- a/resources/js/pages/tenant-portal/payments/index.tsx
+++ b/resources/js/pages/tenant-portal/payments/index.tsx
@@ -377,7 +377,7 @@ function SummaryItem({
 
 function PaymentRow({
     payment,
-    showDetails = true,
+    showDetails = false,
 }: {
     payment: PortalPayment;
     showDetails?: boolean;

--- a/resources/js/pages/tenant-portal/payments/index.tsx
+++ b/resources/js/pages/tenant-portal/payments/index.tsx
@@ -8,6 +8,7 @@ import TenantLeaseContext from '@/components/features/tenant-portal/lease-contex
 import { StatusBadge } from '@/components/shared/status-badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
+import { PAYMENT_METHOD_LABELS } from '@/lib/constants/billing';
 import { formatDate, formatPeriod, formatPrice } from '@/lib/formatters';
 import { index as billingIndex } from '@/routes/portal/billing';
 import {
@@ -376,32 +377,36 @@ function SummaryItem({
 
 function PaymentRow({
     payment,
-    showDetails = false,
+    showDetails = true,
 }: {
     payment: PortalPayment;
     showDetails?: boolean;
 }) {
+    const paymentMethodLabel =
+        PAYMENT_METHOD_LABELS[payment.payment_method] ?? payment.payment_method;
+
     return (
         <BillingQueueItem
-            title={`${formatPeriod(payment.invoice.period_start)} Rent`}
+            title={`${paymentMethodLabel} payment`}
             statusDomain="tenant_payment"
             status={payment.status}
             amount={formatPrice(payment.amount)}
             description={
                 <>
-                    Due {formatDate(payment.invoice.due_date)}
+                    Paid on {formatDate(payment.payment_date)} for{' '}
+                    {formatPeriod(payment.invoice.period_start)} rent
                     {payment.invoice.reference && (
                         <span className="hidden sm:inline">
-                            {' '}
-                            · Invoice {payment.invoice.reference}
+                            {' · '}
+                            Invoice {payment.invoice.reference}
                         </span>
                     )}
                 </>
             }
             mobileDescription={
                 payment.invoice.reference
-                    ? `Invoice ${payment.invoice.reference}`
-                    : undefined
+                    ? `${formatPeriod(payment.invoice.period_start)} rent · Invoice ${payment.invoice.reference}`
+                    : `${formatPeriod(payment.invoice.period_start)} rent`
             }
             actions={
                 showDetails ? (
@@ -411,7 +416,7 @@ function PaymentRow({
                         asChild
                     >
                         <Link href={showInvoice(payment.invoice)}>
-                            View details <ChevronRight className="sm:hidden" />
+                            View invoice <ChevronRight className="sm:hidden" />
                         </Link>
                     </Button>
                 ) : undefined

--- a/resources/js/pages/tenant-portal/payments/payment-history.tsx
+++ b/resources/js/pages/tenant-portal/payments/payment-history.tsx
@@ -1,11 +1,14 @@
 import { Head, Link } from '@inertiajs/react';
-import { ChevronLeft } from 'lucide-react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 import PortalHistoryPagination from '@/components/features/payments/portal-history-pagination';
 import TenantLeaseContext from '@/components/features/tenant-portal/lease-context';
 import { StatusBadge } from '@/components/shared/status-badge';
+import { Button } from '@/components/ui/button';
+import { PAYMENT_METHOD_LABELS } from '@/lib/constants/billing';
 import { formatDate, formatPeriod, formatPrice } from '@/lib/formatters';
 import { index as billingIndex } from '@/routes/portal/billing';
 import { payments as paymentHistory } from '@/routes/portal/billing/history';
+import { show as showInvoice } from '@/routes/portal/billing/invoices';
 import type {
     Invoice,
     PaginatedData,
@@ -45,7 +48,7 @@ export default function PaymentHistory({
             <div>
                 <h1 className="text-2xl font-semibold">Payment history</h1>
                 <p className="text-sm text-muted-foreground">
-                    Confirmed and cancelled payment submissions.
+                    Confirmed and cancelled payment records.
                 </p>
             </div>
 
@@ -58,7 +61,7 @@ export default function PaymentHistory({
 
             {payments.data.length === 0 ? (
                 <p className="rounded-lg border p-4 text-sm text-muted-foreground">
-                    No finalized payments yet.
+                    No payment records yet.
                 </p>
             ) : (
                 <div className="divide-y rounded-lg border">
@@ -69,14 +72,20 @@ export default function PaymentHistory({
                         >
                             <div className="min-w-0">
                                 <p className="truncate font-medium">
-                                    {payment.invoice.reference ??
-                                        formatPeriod(
-                                            payment.invoice.period_start,
-                                        )}
+                                    {(PAYMENT_METHOD_LABELS[
+                                        payment.payment_method
+                                    ] ?? payment.payment_method) + ' payment'}
                                 </p>
                                 <p className="text-muted-foreground">
-                                    {formatDate(payment.payment_date)} ·{' '}
-                                    {payment.payment_method}
+                                    Paid on {formatDate(payment.payment_date)}{' '}
+                                    · {formatPeriod(payment.invoice.period_start)}{' '}
+                                    rent
+                                    {payment.invoice.reference && (
+                                        <>
+                                            {' · '}
+                                            Invoice {payment.invoice.reference}
+                                        </>
+                                    )}
                                 </p>
                             </div>
                             <div className="flex items-center gap-3">
@@ -87,6 +96,12 @@ export default function PaymentHistory({
                                     domain="tenant_payment"
                                     value={payment.status}
                                 />
+                                <Button variant="link" className="h-8 px-2" asChild>
+                                    <Link href={showInvoice(payment.invoice)}>
+                                        View invoice
+                                        <ChevronRight className="size-4 sm:hidden" />
+                                    </Link>
+                                </Button>
                             </div>
                         </div>
                     ))}

--- a/resources/js/types/dashboard.ts
+++ b/resources/js/types/dashboard.ts
@@ -1,3 +1,5 @@
+import type { InvoiceLineItem, Payment } from './models';
+
 export type PropertyStats = {
     id: number;
     name: string;
@@ -64,6 +66,9 @@ export type NeedsAttentionInvoice = {
     days_overdue: number | null;
     urgency: 'overdue' | 'due_today' | 'due_tomorrow' | 'due_soon' | 'upcoming';
     status: string;
+    pending_payment_review_count?: number;
+    line_items?: InvoiceLineItem[];
+    payments?: Payment[];
 };
 
 export type RecentPaymentEntry = {

--- a/resources/js/types/models.ts
+++ b/resources/js/types/models.ts
@@ -158,6 +158,7 @@ export type Lease = {
     id: number;
     reference: string | null;
     payment_status?: string | null;
+    pending_payment_review_count?: number;
     start_date: string;
     end_date: string | null;
     rent_amount: string | null;

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -2,9 +2,11 @@
 
 use App\Enums\InvoiceStatus;
 use App\Enums\LeaseStatus;
+use App\Enums\PaymentStatus;
 use App\Models\Invoice;
 use App\Models\Lease;
 use App\Models\MaintenanceTicket;
+use App\Models\Payment;
 use App\Models\Property;
 use App\Models\Unit;
 use App\Models\User;
@@ -301,6 +303,52 @@ test('dashboard shows leases ending soon count in attention', function () {
     Carbon::setTestNow();
 });
 
+test('dashboard shows pending payment verification count in attention', function () {
+    $user = User::factory()->owner()->create();
+
+    $lease = Lease::factory()->create();
+    $invoice = Invoice::factory()->create(['lease_id' => $lease->id]);
+    Payment::factory()->pending()->create(['invoice_id' => $invoice->id]);
+    Payment::factory()->create([
+        'invoice_id' => $invoice->id,
+        'status' => PaymentStatus::Confirmed,
+    ]);
+
+    $otherLease = Lease::factory()->create();
+    $otherInvoice = Invoice::factory()->create(['lease_id' => $otherLease->id]);
+    Payment::factory()->pending()->create(['invoice_id' => $otherInvoice->id]);
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('attention.pending_payment_verification', 2)
+        );
+});
+
+test('dashboard scopes pending payment verification count to accessible properties', function () {
+    $user = User::factory()->admin()->create();
+
+    $accessibleProperty = Property::factory()->create();
+    $user->properties()->sync([$accessibleProperty->id]);
+    $accessibleLease = Lease::factory()->create([
+        'unit_id' => Unit::factory()->for($accessibleProperty)->create()->id,
+    ]);
+    $accessibleInvoice = Invoice::factory()->create(['lease_id' => $accessibleLease->id]);
+    Payment::factory()->pending()->create(['invoice_id' => $accessibleInvoice->id]);
+
+    $hiddenLease = Lease::factory()->create();
+    $hiddenInvoice = Invoice::factory()->create(['lease_id' => $hiddenLease->id]);
+    Payment::factory()->pending()->create(['invoice_id' => $hiddenInvoice->id]);
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('attention.pending_payment_verification', 1)
+        );
+});
+
 test('dashboard includes recent activity from audit log', function () {
     Carbon::setTestNow(Carbon::parse('2026-07-10'));
 
@@ -328,6 +376,7 @@ test('dashboard attention shows zeros when no actionable items exist', function 
             ->where('attention.due_today', 0)
             ->where('attention.open_maintenance', 0)
             ->where('attention.leases_ending_soon', 0)
+            ->where('attention.pending_payment_verification', 0)
         );
 });
 

--- a/tests/Feature/InvoiceWorkspaceTest.php
+++ b/tests/Feature/InvoiceWorkspaceTest.php
@@ -4,6 +4,8 @@ use App\Enums\InvoiceStatus;
 use App\Models\Invoice;
 use App\Models\InvoiceLineItem;
 use App\Models\Lease;
+use App\Models\Payment;
+use App\Models\PaymentProof;
 use App\Models\User;
 use Database\Seeders\RegionAndCitySeeder;
 use Database\Seeders\RoleAndPermissionSeeder;
@@ -79,6 +81,11 @@ describe('invoice workspace show', function () {
             'description' => 'Monthly rent',
             'amount' => $invoice->total,
         ]);
+        $payment = Payment::factory()->create([
+            'invoice_id' => $invoice->id,
+            'confirmed_by' => $this->owner->id,
+        ]);
+        PaymentProof::factory()->create(['payment_id' => $payment->id]);
 
         $this->actingAs($this->owner)
             ->get(route('leases.workspace.invoices.show', [$lease, $invoice]))
@@ -87,7 +94,10 @@ describe('invoice workspace show', function () {
                 ->component('leases/invoice-detail')
                 ->where('lease.id', $lease->id)
                 ->where('invoice.id', $invoice->id)
-                ->has('invoice.line_items', 1));
+                ->has('invoice.line_items', 1)
+                ->has('invoice.payments', 1)
+                ->where('invoice.payments.0.confirmed_by.name', $this->owner->name)
+                ->has('invoice.payments.0.proofs', 1));
     });
 
     it('derives overdue display status on invoice detail', function () {

--- a/tests/Feature/LeaseIndexTest.php
+++ b/tests/Feature/LeaseIndexTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use App\Models\Invoice;
+use App\Models\Lease;
+use App\Models\Payment;
+use App\Models\Property;
+use App\Models\Unit;
+use App\Models\User;
+use Database\Seeders\RegionAndCitySeeder;
+use Database\Seeders\RoleAndPermissionSeeder;
+
+uses()->beforeEach(function () {
+    $this->seed(RoleAndPermissionSeeder::class);
+    $this->seed(RegionAndCitySeeder::class);
+});
+
+test('lease index shows pending payment verification count in stats', function () {
+    $user = User::factory()->owner()->create();
+
+    $lease = Lease::factory()->create();
+    $invoice = Invoice::factory()->create(['lease_id' => $lease->id]);
+    Payment::factory()->pending()->create(['invoice_id' => $invoice->id]);
+    Payment::factory()->pending()->create(['invoice_id' => $invoice->id]);
+
+    $this->actingAs($user)
+        ->get(route('leases.index'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('leases/index')
+            ->where('stats.pending_payment_verification', 2)
+            ->where('leases.data.0.pending_payment_review_count', 2)
+        );
+});
+
+test('lease index scopes pending payment verification count to accessible properties', function () {
+    $user = User::factory()->admin()->create();
+
+    $accessibleProperty = Property::factory()->create();
+    $user->properties()->sync([$accessibleProperty->id]);
+    $accessibleLease = Lease::factory()->create([
+        'unit_id' => Unit::factory()->for($accessibleProperty)->create()->id,
+    ]);
+    $accessibleInvoice = Invoice::factory()->create(['lease_id' => $accessibleLease->id]);
+    Payment::factory()->pending()->create(['invoice_id' => $accessibleInvoice->id]);
+
+    $hiddenLease = Lease::factory()->create();
+    $hiddenInvoice = Invoice::factory()->create(['lease_id' => $hiddenLease->id]);
+    Payment::factory()->pending()->create(['invoice_id' => $hiddenInvoice->id]);
+
+    $this->actingAs($user)
+        ->get(route('leases.index'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('leases/index')
+            ->where('stats.pending_payment_verification', 1)
+        );
+});

--- a/tests/Feature/PaymentAllocationTest.php
+++ b/tests/Feature/PaymentAllocationTest.php
@@ -77,3 +77,39 @@ it('marks invoice as paid after full payment', function () {
 
     expect($invoice->status)->toBe(InvoiceStatus::Paid);
 });
+
+it('keeps a payment on its recorded invoice instead of settling an older one', function () {
+    $lease = Lease::factory()->create();
+    $olderInvoice = Invoice::factory()->create([
+        'lease_id' => $lease->id,
+        'period_start' => now()->startOfMonth(),
+        'period_end' => now()->endOfMonth(),
+        'due_date' => now()->startOfMonth()->addDays(4),
+        'total' => 1_000_000,
+        'amount_paid' => 0,
+        'status' => InvoiceStatus::Pending,
+    ]);
+    $targetInvoice = Invoice::factory()->create([
+        'lease_id' => $lease->id,
+        'period_start' => now()->addMonth()->startOfMonth(),
+        'period_end' => now()->addMonth()->endOfMonth(),
+        'due_date' => now()->addMonth()->startOfMonth()->addDays(4),
+        'total' => 1_000_000,
+        'amount_paid' => 0,
+        'status' => InvoiceStatus::Pending,
+    ]);
+    $payment = Payment::factory()->create([
+        'invoice_id' => $targetInvoice->id,
+        'amount' => 1_000_000,
+        'status' => PaymentStatus::Confirmed,
+    ]);
+
+    app(AllocatePayment::class)->execute($payment);
+
+    expect($payment->allocations()->count())->toBe(1)
+        ->and((int) $payment->allocations()->first()->invoice_id)->toBe($targetInvoice->id)
+        ->and($olderInvoice->fresh()->status)->toBe(InvoiceStatus::Pending)
+        ->and((float) $olderInvoice->fresh()->amount_paid)->toBe(0.0)
+        ->and($targetInvoice->fresh()->status)->toBe(InvoiceStatus::Paid)
+        ->and((float) $targetInvoice->fresh()->amount_paid)->toBe(1000000.0);
+});

--- a/tests/Feature/PaymentTest.php
+++ b/tests/Feature/PaymentTest.php
@@ -6,6 +6,7 @@ use App\Enums\Permission;
 use App\Models\Invoice;
 use App\Models\Lease;
 use App\Models\Payment;
+use App\Models\PaymentAllocation;
 use App\Models\PaymentProof;
 use App\Models\Property;
 use App\Models\Tenant;
@@ -244,6 +245,8 @@ describe('payment recording', function () {
 
         expect((int) $payment->recorded_by)->toBe((int) $user->id);
         expect((int) $payment->confirmed_by)->toBe((int) $user->id);
+        expect((int) $payment->verified_by)->toBe((int) $user->id);
+        expect($payment->verified_at)->not->toBeNull();
         expect($payment->status)->toBe(PaymentStatus::Confirmed);
     });
 });
@@ -319,6 +322,44 @@ describe('invoice settlement', function () {
 
         expect($payment2->fresh()->status)->toBe(PaymentStatus::Cancelled)
             ->and($payment2->invoice->fresh()->status)->toBe(InvoiceStatus::Pending);
+    });
+
+    it('clears stale allocations and confirmed_by when rejecting a pending payment', function () {
+        $user = User::factory()->owner()->create();
+        $lease = createLeaseForProperty();
+        $olderInvoice = createInvoiceFor($lease);
+        $invoice = createInvoiceFor($lease, [
+            'period_start' => now()->addMonth()->startOfMonth(),
+            'period_end' => now()->addMonth()->endOfMonth(),
+            'due_date' => now()->addMonth()->startOfMonth()->addDays(4),
+        ]);
+
+        $payment = Payment::factory()->pending()->create([
+            'invoice_id' => $invoice->id,
+            'amount' => 500_000,
+            'confirmed_by' => $user->id,
+        ]);
+
+        PaymentAllocation::create([
+            'payment_id' => $payment->id,
+            'invoice_id' => $olderInvoice->id,
+            'amount' => 500_000,
+        ]);
+
+        $olderInvoice->update([
+            'status' => InvoiceStatus::Partial,
+            'amount_paid' => 500_000,
+        ]);
+
+        $this->actingAs($user)
+            ->post(route('payments.verify', $payment), ['action' => 'reject']);
+
+        expect($payment->fresh()->status)->toBe(PaymentStatus::Cancelled)
+            ->and($payment->fresh()->confirmed_by)->toBeNull()
+            ->and((int) $payment->allocations()->count())->toBe(0)
+            ->and($olderInvoice->fresh()->status)->toBe(InvoiceStatus::Pending)
+            ->and((float) $olderInvoice->fresh()->amount_paid)->toBe(0.0)
+            ->and($invoice->fresh()->status)->toBe(InvoiceStatus::Pending);
     });
 });
 

--- a/tests/Feature/RentDashboardTest.php
+++ b/tests/Feature/RentDashboardTest.php
@@ -3,8 +3,10 @@
 use App\Enums\InvoiceStatus;
 use App\Enums\PaymentStatus;
 use App\Models\Invoice;
+use App\Models\InvoiceLineItem;
 use App\Models\Lease;
 use App\Models\Payment;
+use App\Models\PaymentProof;
 use App\Models\Property;
 use App\Models\ReminderLog;
 use App\Models\Tenant;
@@ -40,6 +42,62 @@ test('collection queue loads with data for owner', function () {
             ->has('tab_counts')
             ->has('recent_payments')
             ->has('recent_reminders')
+        );
+
+    Carbon::setTestNow();
+});
+
+test('collection queue includes invoice detail payload', function () {
+    Carbon::setTestNow(Carbon::parse('2026-07-10'));
+
+    $user = User::factory()->owner()->create();
+
+    $tenant = Tenant::factory()->create(['name' => 'Rina Putri']);
+    $lease = Lease::factory()->create([
+        'primary_tenant_id' => $tenant->id,
+        'start_date' => now()->subMonths(2),
+        'status' => 'active',
+    ]);
+    $lease->tenants()->sync([$tenant->id => ['is_primary' => true]]);
+
+    $invoice = Invoice::factory()->create([
+        'lease_id' => $lease->id,
+        'reference' => 'INV-QUEUE-001',
+        'period_start' => '2026-07-01',
+        'period_end' => '2026-07-31',
+        'due_date' => '2026-07-05',
+        'total' => 500000,
+        'amount_paid' => 250000,
+        'status' => InvoiceStatus::Partial,
+    ]);
+
+    InvoiceLineItem::factory()->create([
+        'invoice_id' => $invoice->id,
+        'description' => 'Monthly Rent',
+        'amount' => 500000,
+    ]);
+
+    $payment = Payment::factory()->create([
+        'invoice_id' => $invoice->id,
+        'amount' => 250000,
+        'payment_date' => '2026-07-08',
+        'payment_method' => 'transfer',
+        'status' => PaymentStatus::Pending,
+    ]);
+
+    PaymentProof::factory()->create([
+        'payment_id' => $payment->id,
+        'original_name' => 'receipt.png',
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('dashboard.rent'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('entries.data.0.reference', 'INV-QUEUE-001')
+            ->where('entries.data.0.line_items.0.description', 'Monthly Rent')
+            ->where('entries.data.0.payments.0.amount', '250000.00')
+            ->where('entries.data.0.payments.0.proofs.0.original_name', 'receipt.png')
         );
 
     Carbon::setTestNow();
@@ -119,11 +177,21 @@ test('collection queue tab counts are correct', function () {
         'status' => InvoiceStatus::Paid,
     ]);
 
+    Payment::factory()->create([
+        'invoice_id' => $lease1->invoices()->first()->id,
+        'amount' => 100000,
+        'payment_date' => '2026-07-09',
+        'payment_method' => 'transfer',
+        'status' => PaymentStatus::Pending,
+    ]);
+
     $this->actingAs($user)
         ->get(route('dashboard.rent'))
         ->assertInertia(fn ($page) => $page
+            ->where('tab_counts.all', 4)
             ->where('tab_counts.overdue', 1)
             ->where('tab_counts.due_today', 1)
+            ->where('tab_counts.pending_review', 1)
             ->where('tab_counts.paid', 1)
         );
 
@@ -158,6 +226,52 @@ test('collection queue overdue tab is selected', function () {
         ->assertOk()
         ->assertInertia(fn ($page) => $page
             ->has('entries.data', 1)
+            ->where('entries.total', 1)
+            ->where('tab_counts.all', 3)
+        );
+
+    Carbon::setTestNow();
+});
+
+test('collection queue pending review tab lists invoices with pending payments', function () {
+    Carbon::setTestNow(Carbon::parse('2026-07-10'));
+
+    $user = User::factory()->owner()->create();
+
+    $reviewLease = Lease::factory()->create(['status' => 'active', 'start_date' => now()->subMonths(2)]);
+    $reviewInvoice = Invoice::factory()->create([
+        'lease_id' => $reviewLease->id,
+        'due_date' => '2026-07-12',
+        'total' => 200000,
+        'amount_paid' => 0,
+        'status' => InvoiceStatus::Pending,
+    ]);
+    Payment::factory()->create([
+        'invoice_id' => $reviewInvoice->id,
+        'amount' => 200000,
+        'payment_date' => '2026-07-09',
+        'payment_method' => 'transfer',
+        'status' => PaymentStatus::Pending,
+    ]);
+
+    $otherLease = Lease::factory()->create(['status' => 'active', 'start_date' => now()->subMonths(2)]);
+    Invoice::factory()->create([
+        'lease_id' => $otherLease->id,
+        'due_date' => '2026-07-05',
+        'total' => 100000,
+        'amount_paid' => 0,
+        'status' => InvoiceStatus::Pending,
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('dashboard.rent', ['urgency' => 'pending_review']))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->has('entries.data', 1)
+            ->where('entries.data.0.id', $reviewInvoice->id)
+            ->where('entries.data.0.pending_payment_review_count', 1)
+            ->where('tab_counts.pending_review', 1)
+            ->where('tab_counts.all', 2)
         );
 
     Carbon::setTestNow();

--- a/tests/Feature/RentDashboardTest.php
+++ b/tests/Feature/RentDashboardTest.php
@@ -188,7 +188,7 @@ test('collection queue tab counts are correct', function () {
     $this->actingAs($user)
         ->get(route('dashboard.rent'))
         ->assertInertia(fn ($page) => $page
-            ->where('tab_counts.all', 4)
+            ->where('tab_counts.all', 3)
             ->where('tab_counts.overdue', 1)
             ->where('tab_counts.due_today', 1)
             ->where('tab_counts.pending_review', 1)
@@ -227,7 +227,7 @@ test('collection queue overdue tab is selected', function () {
         ->assertInertia(fn ($page) => $page
             ->has('entries.data', 1)
             ->where('entries.total', 1)
-            ->where('tab_counts.all', 3)
+            ->where('tab_counts.all', 2)
         );
 
     Carbon::setTestNow();


### PR DESCRIPTION
## Summary
- fix payment allocation and payment review state handling so confirmed money only affects the intended invoice
- add invoice-first payment review surfaces across leases and the collection queue, including pending-review indicators and tabs
- make tenant portal payment history read like payment records and link back to the invoice

## Verification
- php artisan test --compact tests/Feature/RentDashboardTest.php
- vendor/bin/pint --dirty --format agent
- npm run types:check
- npm run build