### PR TITLE
feat(notification): add pluggable MailChannel and driver architecture

### DIFF
--- a/app/Contracts/MailChannelNotification.php
+++ b/app/Contracts/MailChannelNotification.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Contracts;
+
+use App\Data\Mail\MailContent;
+
+interface MailChannelNotification
+{
+    public function toMailChannel(object $notifiable): MailContent;
+}

--- a/app/Contracts/MailDriver.php
+++ b/app/Contracts/MailDriver.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Contracts;
+
+use App\Data\Mail\DriverHealthResult;
+use App\Data\Mail\MailMessage;
+use App\Data\Mail\MailSendResult;
+
+interface MailDriver
+{
+    public function send(MailMessage $message): MailSendResult;
+
+    public function health(): DriverHealthResult;
+}

--- a/app/Data/Mail/DriverHealthResult.php
+++ b/app/Data/Mail/DriverHealthResult.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Data\Mail;
+
+final readonly class DriverHealthResult
+{
+    public function __construct(
+        public bool $healthy,
+        public ?string $message = null,
+    ) {}
+}

--- a/app/Data/Mail/MailAddress.php
+++ b/app/Data/Mail/MailAddress.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Data\Mail;
+
+use App\Exceptions\InvalidMailAddressException;
+
+final readonly class MailAddress
+{
+    public function __construct(
+        public string $address,
+        public ?string $name = null,
+    ) {
+        if (! filter_var($address, FILTER_VALIDATE_EMAIL)) {
+            throw InvalidMailAddressException::for($address);
+        }
+    }
+}

--- a/app/Data/Mail/MailContent.php
+++ b/app/Data/Mail/MailContent.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Data\Mail;
+
+final readonly class MailContent
+{
+    /**
+     * @param  list<MailAddress>  $cc
+     * @param  list<MailAddress>  $bcc
+     * @param  array<string, string>  $headers
+     */
+    public function __construct(
+        public string $subject,
+        public string $htmlBody,
+        public ?string $plainTextBody = null,
+        public ?MailAddress $from = null,
+        public ?MailAddress $replyTo = null,
+        public array $cc = [],
+        public array $bcc = [],
+        public array $headers = [],
+    ) {}
+}

--- a/app/Data/Mail/MailMessage.php
+++ b/app/Data/Mail/MailMessage.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Data\Mail;
+
+use InvalidArgumentException;
+
+final readonly class MailMessage
+{
+    /**
+     * @param  list<MailAddress>  $to
+     * @param  list<MailAddress>  $cc
+     * @param  list<MailAddress>  $bcc
+     * @param  array<string, string>  $headers
+     */
+    public function __construct(
+        public array $to,
+        public string $subject,
+        public string $htmlBody,
+        public ?string $plainTextBody = null,
+        public ?MailAddress $from = null,
+        public ?MailAddress $replyTo = null,
+        public array $cc = [],
+        public array $bcc = [],
+        public array $headers = [],
+    ) {
+        if ($to === []) {
+            throw new InvalidArgumentException('A mail message requires at least one recipient.');
+        }
+    }
+}

--- a/app/Data/Mail/MailSendResult.php
+++ b/app/Data/Mail/MailSendResult.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Data\Mail;
+
+final readonly class MailSendResult
+{
+    public function __construct(
+        public ?string $externalId = null,
+        public ?string $message = null,
+    ) {}
+}

--- a/app/Events/Mail/MailFailed.php
+++ b/app/Events/Mail/MailFailed.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Events\Mail;
+
+use App\Data\Mail\MailAddress;
+use App\Data\Mail\MailMessage;
+use App\Exceptions\MailDeliveryException;
+
+final readonly class MailFailed
+{
+    /** @var list<string> */
+    public array $recipients;
+
+    public function __construct(
+        public string $driver,
+        public string $subject,
+        MailMessage $message,
+        public MailDeliveryException $exception,
+    ) {
+        $this->recipients = array_map(fn (MailAddress $addr) => $addr->address, $message->to);
+    }
+}

--- a/app/Events/Mail/MailSent.php
+++ b/app/Events/Mail/MailSent.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Events\Mail;
+
+use App\Data\Mail\MailAddress;
+use App\Data\Mail\MailMessage;
+
+final readonly class MailSent
+{
+    /** @var list<string> */
+    public array $recipients;
+
+    public function __construct(
+        public string $driver,
+        public string $subject,
+        MailMessage $message,
+        public ?string $externalId = null,
+    ) {
+        $this->recipients = array_map(fn (MailAddress $addr) => $addr->address, $message->to);
+    }
+}

--- a/app/Exceptions/InvalidMailAddressException.php
+++ b/app/Exceptions/InvalidMailAddressException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Exceptions;
+
+use InvalidArgumentException;
+
+class InvalidMailAddressException extends InvalidArgumentException
+{
+    public static function for(string $address): self
+    {
+        return new self("Invalid email address [{$address}].");
+    }
+}

--- a/app/Exceptions/InvalidMailConfigurationException.php
+++ b/app/Exceptions/InvalidMailConfigurationException.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+class InvalidMailConfigurationException extends RuntimeException
+{
+    public static function missing(string $key): self
+    {
+        return new self("SMTP mail configuration is missing required field [{$key}].");
+    }
+
+    public static function invalid(string $key, string $reason): self
+    {
+        return new self("SMTP mail configuration field [{$key}] is invalid. {$reason}");
+    }
+}

--- a/app/Exceptions/InvalidMailDriverException.php
+++ b/app/Exceptions/InvalidMailDriverException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+class InvalidMailDriverException extends RuntimeException
+{
+    public static function for(string $name, string $class): self
+    {
+        return new self("Mail driver [{$name}] using class [{$class}] must implement App\\Contracts\\MailDriver.");
+    }
+}

--- a/app/Exceptions/MailDeliveryException.php
+++ b/app/Exceptions/MailDeliveryException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Exceptions;
+
+use RuntimeException;
+use Throwable;
+
+class MailDeliveryException extends RuntimeException
+{
+    public static function from(string $driver, Throwable $previous): self
+    {
+        return new self("Failed to send mail via driver [{$driver}]: {$previous->getMessage()}", 0, $previous);
+    }
+}

--- a/app/Exceptions/MailDriverNotFoundException.php
+++ b/app/Exceptions/MailDriverNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+class MailDriverNotFoundException extends RuntimeException
+{
+    public static function for(string $name): self
+    {
+        return new self("Mail driver [{$name}] is not registered in NotificationRegistry.");
+    }
+}

--- a/app/Http/Controllers/Settings/MailController.php
+++ b/app/Http/Controllers/Settings/MailController.php
@@ -19,13 +19,13 @@ class MailController extends Controller
 
     public function edit(): Response
     {
-        $settings = Setting::some(['mail_config']);
-        if (isset($settings['mail_config'])) {
-            unset($settings['mail_config']['password']);
-        }
+        $mailConfig = Setting::effectiveMailConfig();
+        unset($mailConfig['password']);
 
         return Inertia::render('settings/mail', [
-            'settings' => $settings,
+            'settings' => [
+                'mail_config' => $mailConfig,
+            ],
         ]);
     }
 
@@ -59,9 +59,9 @@ class MailController extends Controller
 
     public function test(): RedirectResponse
     {
-        $config = Setting::get('mail_config') ?? [];
+        $config = Setting::effectiveMailConfig();
 
-        if (! ($config['host'] ?? null)) {
+        if (! filled($config['host'] ?? null)) {
             Inertia::flash('toast', ['type' => 'error', 'message' => __('Configure SMTP host before testing.')]);
 
             return back();

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -45,7 +45,7 @@ class HandleInertiaRequests extends Middleware
                 ->except(['mail_config', 'whatsapp_config'])
                 ->all(),
             'notificationChannels' => fn () => [
-                'mail' => filled(data_get(Setting::get('mail_config'), 'host')),
+                'mail' => filled(data_get(Setting::effectiveMailConfig(), 'host')),
                 'whatsapp' => filled(Setting::get('whatsapp_driver')),
             ],
             'auth' => [

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -28,6 +28,11 @@ class Setting extends Model
         return app(SettingManager::class)->some($keys);
     }
 
+    public static function effectiveMailConfig(): array
+    {
+        return app(SettingManager::class)->getEffectiveMailConfig();
+    }
+
     public function resolveValue(): mixed
     {
         return app(SettingCaster::class)->deserialize($this->value, $this->type);

--- a/app/Notifications/Channels/MailChannel.php
+++ b/app/Notifications/Channels/MailChannel.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Notifications\Channels;
+
+use App\Contracts\MailChannelNotification;
+use App\Data\Mail\MailAddress;
+use App\Data\Mail\MailMessage;
+use App\Services\MailManager;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\Log;
+use InvalidArgumentException;
+
+class MailChannel
+{
+    public function __construct(private MailManager $mailManager) {}
+
+    public function send(object $notifiable, Notification $notification): void
+    {
+        if (! $notification instanceof MailChannelNotification) {
+            throw new InvalidArgumentException(sprintf(
+                'Notification [%s] must implement App\\Contracts\\MailChannelNotification.',
+                $notification::class,
+            ));
+        }
+
+        $route = method_exists($notifiable, 'routeNotificationFor')
+            ? $notifiable->routeNotificationFor('mail', $notification)
+            : (method_exists($notifiable, 'routeNotificationForMail')
+                ? $notifiable->routeNotificationForMail($notification)
+                : ($notifiable->email ?? null));
+
+        if (! $route) {
+            Log::warning('Mail notification skipped: no recipient route found.', [
+                'notifiable_type' => $notifiable::class,
+                'notifiable_id' => method_exists($notifiable, 'getKey') ? $notifiable->getKey() : null,
+                'notification' => $notification::class,
+            ]);
+
+            return;
+        }
+
+        $toRecipients = $this->normalizeRecipients($route);
+        $content = $notification->toMailChannel($notifiable);
+
+        $message = new MailMessage(
+            to: $toRecipients,
+            subject: $content->subject,
+            htmlBody: $content->htmlBody,
+            plainTextBody: $content->plainTextBody,
+            from: $content->from,
+            replyTo: $content->replyTo,
+            cc: $content->cc,
+            bcc: $content->bcc,
+            headers: $content->headers,
+        );
+
+        $this->mailManager->send($message);
+    }
+
+    /**
+     * @param  string|array<string, string|int>  $route
+     * @return list<MailAddress>
+     */
+    private function normalizeRecipients(string|array $route): array
+    {
+        if (is_string($route)) {
+            return [new MailAddress($route)];
+        }
+
+        $addresses = [];
+        foreach ($route as $key => $val) {
+            if (is_int($key)) {
+                $addresses[] = new MailAddress((string) $val);
+            } else {
+                $addresses[] = new MailAddress((string) $key, (string) $val);
+            }
+        }
+
+        return $addresses;
+    }
+}

--- a/app/Notifications/Drivers/LogMailDriver.php
+++ b/app/Notifications/Drivers/LogMailDriver.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Notifications\Drivers;
+
+use App\Contracts\MailDriver;
+use App\Data\Mail\DriverHealthResult;
+use App\Data\Mail\MailMessage;
+use App\Data\Mail\MailSendResult;
+use Illuminate\Support\Facades\Log;
+
+class LogMailDriver implements MailDriver
+{
+    public function __construct(private array $config = []) {}
+
+    public function send(MailMessage $message): MailSendResult
+    {
+        $recipients = array_map(fn ($addr) => $addr->address, $message->to);
+
+        $context = [
+            'to' => $recipients,
+            'subject' => $message->subject,
+            'has_html' => $message->htmlBody !== '',
+            'has_plain_text' => $message->plainTextBody !== null,
+        ];
+
+        if ($this->config['log_body'] ?? false) {
+            $context['plain_text'] = $message->plainTextBody;
+        }
+
+        Log::channel('mail')->info('Mail message dispatched to log driver.', $context);
+
+        return new MailSendResult(null, 'Logged to mail channel.');
+    }
+
+    public function health(): DriverHealthResult
+    {
+        return new DriverHealthResult(true, 'Log driver is active.');
+    }
+}

--- a/app/Notifications/Drivers/SmtpMailDriver.php
+++ b/app/Notifications/Drivers/SmtpMailDriver.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Notifications\Drivers;
+
+use App\Contracts\MailDriver;
+use App\Data\Mail\DriverHealthResult;
+use App\Data\Mail\MailMessage;
+use App\Data\Mail\MailSendResult;
+use App\Exceptions\InvalidMailConfigurationException;
+use Illuminate\Support\Facades\Mail;
+
+class SmtpMailDriver implements MailDriver
+{
+    public function __construct(private array $config = []) {}
+
+    public function send(MailMessage $message): MailSendResult
+    {
+        $this->validateConfig();
+
+        $mailerName = 'openkos-smtp';
+
+        config([
+            "mail.mailers.{$mailerName}" => [
+                'transport' => 'smtp',
+                'host' => $this->config['host'],
+                'port' => (int) $this->config['port'],
+                'username' => $this->config['username'] ?? '',
+                'password' => $this->config['password'] ?? '',
+                'encryption' => $this->config['encryption'] ?? null,
+            ],
+        ]);
+
+        Mail::purge($mailerName);
+
+        $fromAddress = $message->from?->address ?? data_get($this->config, 'from.address');
+        $fromName = $message->from?->name ?? data_get($this->config, 'from.name');
+
+        Mail::mailer($mailerName)->html($message->htmlBody, function ($mail) use ($message, $fromAddress, $fromName): void {
+            foreach ($message->to as $recipient) {
+                $mail->to($recipient->address, $recipient->name ?? '');
+            }
+
+            $mail->subject($message->subject);
+
+            if ($fromAddress) {
+                $mail->from($fromAddress, $fromName ?? '');
+            }
+
+            if ($message->replyTo) {
+                $mail->replyTo($message->replyTo->address, $message->replyTo->name ?? '');
+            }
+
+            foreach ($message->cc as $recipient) {
+                $mail->cc($recipient->address, $recipient->name ?? '');
+            }
+
+            foreach ($message->bcc as $recipient) {
+                $mail->bcc($recipient->address, $recipient->name ?? '');
+            }
+
+            if ($message->plainTextBody !== null) {
+                $mail->text($message->plainTextBody);
+            }
+
+            foreach ($message->headers as $name => $value) {
+                $mail->getHeaders()->addTextHeader($name, $value);
+            }
+        });
+
+        return new MailSendResult(null, 'Sent via SMTP.');
+    }
+
+    public function health(): DriverHealthResult
+    {
+        try {
+            $this->validateConfig();
+        } catch (InvalidMailConfigurationException $e) {
+            return new DriverHealthResult(false, $e->getMessage());
+        }
+
+        return new DriverHealthResult(true, 'SMTP configuration is complete.');
+    }
+
+    private function validateConfig(): void
+    {
+        $host = $this->config['host'] ?? null;
+        $port = $this->config['port'] ?? null;
+        $encryption = $this->config['encryption'] ?? null;
+
+        if (! is_string($host) || trim($host) === '') {
+            throw InvalidMailConfigurationException::missing('host');
+        }
+
+        if (filter_var($port, FILTER_VALIDATE_INT) === false || (int) $port < 1 || (int) $port > 65535) {
+            throw InvalidMailConfigurationException::invalid('port', 'Port must be an integer between 1 and 65535.');
+        }
+
+        if (! in_array($encryption, [null, 'tls', 'ssl'], true)) {
+            throw InvalidMailConfigurationException::invalid('encryption', 'Encryption must be tls, ssl, or null.');
+        }
+    }
+}

--- a/app/Notifications/RentReminder.php
+++ b/app/Notifications/RentReminder.php
@@ -2,18 +2,20 @@
 
 namespace App\Notifications;
 
+use App\Contracts\MailChannelNotification;
+use App\Data\Mail\MailContent;
 use App\Data\Reminder\ReminderEvent;
 use App\Enums\ReminderType;
 use App\Models\Setting;
 use App\Notifications\Channels\LogChannel;
+use App\Notifications\Channels\MailChannel;
 use App\Notifications\Channels\WhatsAppChannel;
 use Carbon\Carbon;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class RentReminder extends Notification implements ShouldQueue
+class RentReminder extends Notification implements MailChannelNotification, ShouldQueue
 {
     use Queueable;
 
@@ -24,7 +26,7 @@ class RentReminder extends Notification implements ShouldQueue
         $map = [
             'log' => LogChannel::class,
             'whatsapp' => WhatsAppChannel::class,
-            'mail' => 'mail',
+            'mail' => MailChannel::class,
         ];
 
         $channels = Setting::get('reminder_channels') ?? ['log'];
@@ -32,7 +34,7 @@ class RentReminder extends Notification implements ShouldQueue
         return array_values(array_intersect_key($map, array_flip($channels)));
     }
 
-    public function toMail(object $notifiable): MailMessage
+    public function toMailChannel(object $notifiable): MailContent
     {
         $subject = match ($this->event->type) {
             ReminderType::Upcoming => __('Rent Reminder'),
@@ -40,10 +42,13 @@ class RentReminder extends Notification implements ShouldQueue
             ReminderType::Overdue => __('Rent Overdue'),
         };
 
-        return (new MailMessage)
-            ->subject($subject)
-            ->greeting(__('Hi :name', ['name' => $notifiable->name]))
-            ->line($this->renderMessage($notifiable));
+        $messageText = $this->renderMessage($notifiable);
+
+        return new MailContent(
+            subject: $subject,
+            htmlBody: '<div>'.e($messageText).'</div>',
+            plainTextBody: $messageText,
+        );
     }
 
     public function toLog(object $notifiable): string

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -65,14 +65,12 @@ class AppServiceProvider extends ServiceProvider
     protected function configureMail(): void
     {
         try {
-            $config = Setting::get('mail_config');
+            $config = Setting::effectiveMailConfig();
         } catch (QueryException) {
             return;
         }
 
-        if (! ($config['host'] ?? null)) {
-            return;
-        }
+        config()->set('mail.default', $config['driver'] ?? 'log');
 
         config()->set('mail.mailers.smtp.host', $config['host'] ?? '');
         config()->set('mail.mailers.smtp.port', $config['port'] ?? 587);
@@ -88,8 +86,6 @@ class AppServiceProvider extends ServiceProvider
             config()->set('mail.from.address', $fromAddress);
             config()->set('mail.from.name', $config['from_name'] ?? '');
         }
-
-        config()->set('mail.default', 'smtp');
     }
 
     protected function configureDomainEvents(): void

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -23,6 +23,7 @@ class AppServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->singleton(SettingManager::class);
+        $this->app->singleton(MailManager::class);
         $this->app->singleton(WhatsAppManager::class);
 
         Connection::resolverFor('pgsql', fn ($pdo, $database, $prefix, $config) => new PostgresConnection($pdo, $database, $prefix, $config));

--- a/app/Services/MailManager.php
+++ b/app/Services/MailManager.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Services;
+
+use App\Contracts\MailDriver;
+use App\Data\Mail\DriverHealthResult;
+use App\Data\Mail\MailMessage;
+use App\Data\Mail\MailSendResult;
+use App\Events\Mail\MailFailed;
+use App\Events\Mail\MailSent;
+use App\Exceptions\InvalidMailDriverException;
+use App\Exceptions\MailDeliveryException;
+use App\Exceptions\MailDriverNotFoundException;
+use App\Models\Setting;
+use Illuminate\Contracts\Container\Container;
+use OpenKOS\Platform\Notification\NotificationRegistry;
+
+class MailManager
+{
+    public function __construct(
+        private NotificationRegistry $registry,
+        private Container $container,
+    ) {}
+
+    public function driver(?string $name = null): MailDriver
+    {
+        return $this->resolveDriver($name)[1];
+    }
+
+    public function send(MailMessage $message): MailSendResult
+    {
+        [$driverId, $driver] = $this->resolveDriver();
+
+        try {
+            $result = $driver->send($message);
+
+            event(new MailSent($driverId, $message->subject, $message, $result->externalId));
+
+            return $result;
+        } catch (\Throwable $exception) {
+            $deliveryException = MailDeliveryException::from($driverId, $exception);
+
+            event(new MailFailed($driverId, $message->subject, $message, $deliveryException));
+
+            throw $deliveryException;
+        }
+    }
+
+    public function health(): DriverHealthResult
+    {
+        return $this->driver()->health();
+    }
+
+    /**
+     * @return array{0: string, 1: MailDriver}
+     */
+    private function resolveDriver(?string $name = null): array
+    {
+        $effectiveConfig = Setting::effectiveMailConfig();
+        $name ??= $effectiveConfig['driver'] ?? 'openkos/log';
+
+        $normalizedId = $this->normalizeDriverId($name);
+
+        $registration = $this->registry->driver('mail', $normalizedId);
+
+        if (! $registration) {
+            throw MailDriverNotFoundException::for($normalizedId);
+        }
+
+        $driverConfig = $effectiveConfig['drivers'][$normalizedId] ?? [];
+
+        if (! isset($driverConfig['from']) && isset($effectiveConfig['from'])) {
+            $driverConfig['from'] = $effectiveConfig['from'];
+        }
+
+        $driver = $this->container->make($registration->driverClass, [
+            'config' => $driverConfig,
+        ]);
+
+        if (! $driver instanceof MailDriver) {
+            throw InvalidMailDriverException::for($normalizedId, $registration->driverClass);
+        }
+
+        return [$normalizedId, $driver];
+    }
+
+    private function normalizeDriverId(string $name): string
+    {
+        return match ($name) {
+            'smtp' => 'openkos/smtp',
+            'log' => 'openkos/log',
+            default => $name,
+        };
+    }
+}

--- a/app/Services/Settings/SettingManager.php
+++ b/app/Services/Settings/SettingManager.php
@@ -50,6 +50,39 @@ class SettingManager
         return $result;
     }
 
+    public function getEffectiveMailConfig(): array
+    {
+        try {
+            $stored = Setting::get('mail_config');
+        } catch (\Throwable) {
+            $stored = [];
+        }
+
+        if (! is_array($stored)) {
+            $stored = [];
+        }
+
+        $envDriver = config('mail.default') ?: env('MAIL_MAILER', 'log');
+        $envHost = config('mail.mailers.smtp.host') ?: env('MAIL_HOST');
+        $envPort = config('mail.mailers.smtp.port') ?: env('MAIL_PORT');
+        $envUsername = config('mail.mailers.smtp.username') ?: env('MAIL_USERNAME');
+        $envPassword = config('mail.mailers.smtp.password') ?: env('MAIL_PASSWORD');
+        $envEncryption = config('mail.mailers.smtp.encryption') ?: env('MAIL_ENCRYPTION');
+        $envFromAddress = config('mail.from.address') ?: env('MAIL_FROM_ADDRESS');
+        $envFromName = config('mail.from.name') ?: env('MAIL_FROM_NAME');
+
+        return [
+            'driver' => filled(data_get($stored, 'driver')) ? $stored['driver'] : ($envDriver ?: 'log'),
+            'host' => filled(data_get($stored, 'host')) ? (string) $stored['host'] : (string) ($envHost ?: ''),
+            'port' => filled(data_get($stored, 'port')) ? (int) $stored['port'] : ($envPort ? (int) $envPort : 587),
+            'username' => filled(data_get($stored, 'username')) ? (string) $stored['username'] : (string) ($envUsername ?: ''),
+            'password' => filled(data_get($stored, 'password')) ? (string) $stored['password'] : (string) ($envPassword ?: ''),
+            'encryption' => filled(data_get($stored, 'encryption')) ? (string) $stored['encryption'] : (string) ($envEncryption ?: 'null'),
+            'from_address' => filled(data_get($stored, 'from_address')) ? (string) $stored['from_address'] : (string) ($envFromAddress ?: ''),
+            'from_name' => filled(data_get($stored, 'from_name')) ? (string) $stored['from_name'] : (string) ($envFromName ?: ''),
+        ];
+    }
+
     private function allWithDefaults(): array
     {
         $defaults = [];

--- a/app/Services/Settings/SettingManager.php
+++ b/app/Services/Settings/SettingManager.php
@@ -53,7 +53,7 @@ class SettingManager
     public function getEffectiveMailConfig(): array
     {
         try {
-            $stored = Setting::get('mail_config');
+            $stored = Setting::get('mail_config') ?? [];
         } catch (\Throwable) {
             $stored = [];
         }
@@ -62,7 +62,14 @@ class SettingManager
             $stored = [];
         }
 
-        $envDriver = config('mail.default') ?: env('MAIL_MAILER', 'log');
+        $rawDriver = $stored['driver'] ?? config('mail.default') ?: env('MAIL_MAILER', 'log');
+
+        $driver = match ($rawDriver) {
+            'smtp' => 'openkos/smtp',
+            'log' => 'openkos/log',
+            default => $rawDriver,
+        };
+
         $envHost = config('mail.mailers.smtp.host') ?: env('MAIL_HOST');
         $envPort = config('mail.mailers.smtp.port') ?: env('MAIL_PORT');
         $envUsername = config('mail.mailers.smtp.username') ?: env('MAIL_USERNAME');
@@ -71,16 +78,68 @@ class SettingManager
         $envFromAddress = config('mail.from.address') ?: env('MAIL_FROM_ADDRESS');
         $envFromName = config('mail.from.name') ?: env('MAIL_FROM_NAME');
 
-        return [
-            'driver' => filled(data_get($stored, 'driver')) ? $stored['driver'] : ($envDriver ?: 'log'),
-            'host' => filled(data_get($stored, 'host')) ? (string) $stored['host'] : (string) ($envHost ?: ''),
-            'port' => filled(data_get($stored, 'port')) ? (int) $stored['port'] : ($envPort ? (int) $envPort : 587),
-            'username' => filled(data_get($stored, 'username')) ? (string) $stored['username'] : (string) ($envUsername ?: ''),
-            'password' => filled(data_get($stored, 'password')) ? (string) $stored['password'] : (string) ($envPassword ?: ''),
-            'encryption' => filled(data_get($stored, 'encryption')) ? (string) $stored['encryption'] : (string) ($envEncryption ?: 'null'),
-            'from_address' => filled(data_get($stored, 'from_address')) ? (string) $stored['from_address'] : (string) ($envFromAddress ?: ''),
-            'from_name' => filled(data_get($stored, 'from_name')) ? (string) $stored['from_name'] : (string) ($envFromName ?: ''),
-        ];
+        $fromAddress = filled(data_get($stored, 'from_address')) ? $stored['from_address'] : $envFromAddress;
+        $fromName = filled(data_get($stored, 'from_name')) ? $stored['from_name'] : $envFromName;
+
+        $host = filled(data_get($stored, 'host')) ? (string) $stored['host'] : ($envHost ?: null);
+        $port = filled(data_get($stored, 'port')) ? (int) $stored['port'] : ($envPort ? (int) $envPort : 587);
+        $username = filled(data_get($stored, 'username')) ? (string) $stored['username'] : ($envUsername ?: null);
+        $password = filled(data_get($stored, 'password')) ? (string) $stored['password'] : ($envPassword ?: null);
+        $encryption = filled(data_get($stored, 'encryption')) ? (string) $stored['encryption'] : ($envEncryption ?: null);
+
+        if (isset($stored['drivers']) && is_array($stored['drivers'])) {
+            $config = $stored;
+            $config['driver'] = $driver;
+            $config['host'] ??= $host;
+            $config['port'] ??= $port;
+            $config['username'] ??= $username;
+            $config['password'] ??= $password;
+            $config['encryption'] ??= $encryption;
+            $config['from_address'] ??= $fromAddress;
+            $config['from_name'] ??= $fromName;
+        } else {
+            $config = [
+                'driver' => $driver,
+                'from' => array_filter([
+                    'address' => $fromAddress ?: null,
+                    'name' => $fromName ?: null,
+                ], static fn ($value) => $value !== null),
+                'drivers' => [
+                    'openkos/smtp' => array_filter([
+                        'host' => $host,
+                        'port' => $port,
+                        'username' => $username,
+                        'password' => $password,
+                        'encryption' => $encryption,
+                    ], static fn ($value) => $value !== null),
+                    'openkos/log' => [
+                        'log_body' => false,
+                    ],
+                ],
+                'host' => $host,
+                'port' => $port,
+                'username' => $username,
+                'password' => $password,
+                'encryption' => $encryption,
+                'from_address' => $fromAddress,
+                'from_name' => $fromName,
+            ];
+        }
+
+        foreach ($config['drivers'] ?? [] as $key => $driverConfig) {
+            if (
+                isset($driverConfig['encryption']) &&
+                (($driverConfig['encryption'] === 'null') || ($driverConfig['encryption'] === ''))
+            ) {
+                $config['drivers'][$key]['encryption'] = null;
+            }
+        }
+
+        if (($config['encryption'] ?? null) === 'null' || ($config['encryption'] ?? null) === '') {
+            $config['encryption'] = null;
+        }
+
+        return $config;
     }
 
     private function allWithDefaults(): array

--- a/config/logging.php
+++ b/config/logging.php
@@ -130,6 +130,14 @@ return [
             'replace_placeholders' => true,
         ],
 
+        'mail' => [
+            'driver' => 'daily',
+            'path' => storage_path('logs/mail.log'),
+            'level' => env('LOG_LEVEL', 'debug'),
+            'days' => env('LOG_DAILY_DAYS', 14),
+            'replace_placeholders' => true,
+        ],
+
         'emergency' => [
             'path' => storage_path('logs/laravel.log'),
         ],

--- a/config/platform.php
+++ b/config/platform.php
@@ -1,5 +1,6 @@
 <?php
 
+use OpenKOS\Plugins\Mail\MailPlugin;
 use OpenKOS\Plugins\WhatsApp\WhatsAppPlugin;
 
 // Reference plugin, disabled by default (see below):
@@ -31,7 +32,8 @@ return [
     */
 
     'plugins' => [
-        // Core: registers the built-in WhatsApp drivers into NotificationRegistry.
+        // Core: registers the built-in Mail and WhatsApp drivers into NotificationRegistry.
+        MailPlugin::class,
         WhatsAppPlugin::class,
 
         // Reference plugin (src/Plugins/Example) — a live demo of every consumed

--- a/src/Platform/Notification/NotificationRegistry.php
+++ b/src/Platform/Notification/NotificationRegistry.php
@@ -7,18 +7,29 @@ use InvalidArgumentException;
 
 class NotificationRegistry implements Arrayable
 {
-    /** @var array<string, NotificationDriverRegistration> */
+    /** @var array<string, array<string, NotificationDriverRegistration>> */
     private array $drivers = [];
+
+    /** @var array<string, NotificationDriverRegistration> */
+    private array $flatDrivers = [];
 
     public function registerDriver(NotificationDriverRegistration $driver): static
     {
-        if (isset($this->drivers[$driver->name])) {
-            throw new InvalidArgumentException("Notification driver [{$driver->name}] is already registered.");
+        $existing = $this->drivers[$driver->channel][$driver->name] ?? null;
+
+        if ($existing && $existing->driverClass !== $driver->driverClass) {
+            throw new InvalidArgumentException("Conflicting notification driver [{$driver->name}] already registered for channel [{$driver->channel}].");
         }
 
-        $this->drivers[$driver->name] = $driver;
+        $this->drivers[$driver->channel][$driver->name] = $driver;
+        $this->flatDrivers[$driver->name] = $driver;
 
         return $this;
+    }
+
+    public function driver(string $channel, string $name): ?NotificationDriverRegistration
+    {
+        return $this->drivers[$channel][$name] ?? null;
     }
 
     /**
@@ -26,7 +37,7 @@ class NotificationRegistry implements Arrayable
      */
     public function drivers(): array
     {
-        return $this->drivers;
+        return $this->flatDrivers;
     }
 
     /**
@@ -34,27 +45,24 @@ class NotificationRegistry implements Arrayable
      */
     public function forChannel(string $channel): array
     {
-        return array_values(array_filter(
-            $this->drivers,
-            fn (NotificationDriverRegistration $d) => $d->channel === $channel,
-        ));
+        return array_values($this->drivers[$channel] ?? []);
     }
 
     public function get(string $name): ?NotificationDriverRegistration
     {
-        return $this->drivers[$name] ?? null;
+        return $this->flatDrivers[$name] ?? null;
     }
 
     public function has(string $name): bool
     {
-        return isset($this->drivers[$name]);
+        return isset($this->flatDrivers[$name]);
     }
 
     public function toArray(): array
     {
         return array_values(array_map(
             fn (NotificationDriverRegistration $d) => $d->toArray(),
-            $this->drivers,
+            $this->flatDrivers,
         ));
     }
 }

--- a/src/Plugins/Mail/MailPlugin.php
+++ b/src/Plugins/Mail/MailPlugin.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace OpenKOS\Plugins\Mail;
+
+use App\Notifications\Drivers\LogMailDriver;
+use App\Notifications\Drivers\SmtpMailDriver;
+use OpenKOS\Platform\Notification\NotificationDriverRegistration;
+use OpenKOS\Platform\OpenKOSManager;
+use OpenKOS\Platform\Plugin\Plugin;
+use OpenKOS\Platform\Plugin\PluginManifest;
+
+class MailPlugin extends Plugin
+{
+    public function manifest(): PluginManifest
+    {
+        return new PluginManifest(
+            id: 'openkos/mail',
+            name: 'Mail Notifications',
+            version: '1.0.0',
+            description: 'Registers built-in SMTP and Log mail drivers.',
+            coreVersion: '^0.1',
+        );
+    }
+
+    public function register(OpenKOSManager $platform): void
+    {
+        $platform->notifications()->registerDriver(new NotificationDriverRegistration(
+            name: 'openkos/log',
+            channel: 'mail',
+            driverClass: LogMailDriver::class,
+            label: 'Log (Local / Testing)',
+        ));
+
+        $platform->notifications()->registerDriver(new NotificationDriverRegistration(
+            name: 'openkos/smtp',
+            channel: 'mail',
+            driverClass: SmtpMailDriver::class,
+            label: 'SMTP Server',
+        ));
+    }
+}

--- a/tests/Feature/Notifications/MailMultipartTest.php
+++ b/tests/Feature/Notifications/MailMultipartTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use App\Data\Mail\MailAddress;
+use App\Data\Mail\MailMessage;
+use App\Notifications\Drivers\SmtpMailDriver;
+use Illuminate\Mail\Message;
+use Illuminate\Support\Facades\Mail;
+use Symfony\Component\Mime\Email;
+
+test('SmtpMailDriver composes both HTML and plain text alternative MIME parts', function () {
+    $driver = new SmtpMailDriver([
+        'host' => '127.0.0.1',
+        'port' => 1025,
+    ]);
+
+    $message = new MailMessage(
+        to: [new MailAddress('tenant@example.com', 'Tenant Name')],
+        subject: 'Rent Payment Reminder',
+        htmlBody: '<h1>Rent Due</h1><p>Please pay your rent.</p>',
+        plainTextBody: "Rent Due\n\nPlease pay your rent.",
+    );
+
+    $capturedSymfonyEmail = null;
+
+    Mail::shouldReceive('purge')->once()->with('openkos-smtp');
+    Mail::shouldReceive('mailer')->once()->with('openkos-smtp')->andReturnSelf();
+    Mail::shouldReceive('html')->once()->andReturnUsing(function ($html, $callback) use (&$capturedSymfonyEmail) {
+        $symfonyEmail = new Email;
+        $illuminateMessage = new Message($symfonyEmail);
+        $illuminateMessage->html($html);
+
+        $callback($illuminateMessage);
+
+        $capturedSymfonyEmail = $symfonyEmail;
+    });
+
+    $driver->send($message);
+
+    $this->assertNotNull($capturedSymfonyEmail);
+    $this->assertStringContainsString('<h1>Rent Due</h1>', (string) $capturedSymfonyEmail->getHtmlBody());
+    $this->assertStringContainsString("Rent Due\n\nPlease pay your rent.", (string) $capturedSymfonyEmail->getTextBody());
+});

--- a/tests/Feature/Settings/MailSettingsTest.php
+++ b/tests/Feature/Settings/MailSettingsTest.php
@@ -134,7 +134,7 @@ describe('Mail settings page', function () {
 
         Setting::set('mail_config', ['driver' => 'smtp']);
 
-        expect(Setting::effectiveMailConfig()['driver'])->toBe('smtp');
+        expect(Setting::effectiveMailConfig()['driver'])->toBe('openkos/smtp');
     });
 
     it('sends test email using effective config', function () {

--- a/tests/Feature/Settings/MailSettingsTest.php
+++ b/tests/Feature/Settings/MailSettingsTest.php
@@ -83,4 +83,71 @@ describe('Mail settings page', function () {
         $this->get(route('settings.mail.edit'))->assertRedirect(route('login'));
         $this->patch(route('settings.mail.update'))->assertRedirect(route('login'));
     });
+
+    it('pre-fills form with env-derived values when settings table has no mail_config', function () {
+        config([
+            'mail.mailers.smtp.host' => 'env-smtp.example.com',
+            'mail.mailers.smtp.port' => 1025,
+            'mail.from.address' => 'env-from@example.com',
+        ]);
+
+        $owner = User::factory()->owner()->create();
+
+        $this->actingAs($owner)
+            ->get(route('settings.mail.edit'))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('settings/mail')
+                ->where('settings.mail_config.host', 'env-smtp.example.com')
+                ->where('settings.mail_config.port', 1025)
+                ->where('settings.mail_config.from_address', 'env-from@example.com')
+                ->where('notificationChannels.mail', true)
+            );
+    });
+
+    it('overrides env values field-by-field and keeps env fallback for unset fields in partial settings row', function () {
+        config([
+            'mail.mailers.smtp.host' => 'env-host.com',
+            'mail.mailers.smtp.port' => 2525,
+            'mail.mailers.smtp.username' => 'env_user',
+            'mail.mailers.smtp.password' => 'env_pass',
+            'mail.from.address' => 'env@example.com',
+        ]);
+
+        Setting::set('mail_config', [
+            'host' => 'override-host.com',
+        ]);
+
+        $effective = Setting::effectiveMailConfig();
+
+        expect($effective['host'])->toBe('override-host.com');
+        expect($effective['port'])->toBe(2525);
+        expect($effective['username'])->toBe('env_user');
+        expect($effective['password'])->toBe('env_pass');
+        expect($effective['from_address'])->toBe('env@example.com');
+    });
+
+    it('resolves mail.default driver from settings driver to env mailer to log', function () {
+        config(['mail.default' => 'sendmail']);
+
+        expect(Setting::effectiveMailConfig()['driver'])->toBe('sendmail');
+
+        Setting::set('mail_config', ['driver' => 'smtp']);
+
+        expect(Setting::effectiveMailConfig()['driver'])->toBe('smtp');
+    });
+
+    it('sends test email using effective config', function () {
+        config([
+            'mail.mailers.smtp.host' => 'smtp.test.com',
+            'mail.from.address' => 'sender@test.com',
+        ]);
+
+        $owner = User::factory()->owner()->create();
+
+        $this->from(route('settings.mail.edit'))
+            ->actingAs($owner)
+            ->post(route('settings.mail.test'))
+            ->assertRedirect(route('settings.mail.edit'));
+    });
 });

--- a/tests/Feature/SharedPropsTest.php
+++ b/tests/Feature/SharedPropsTest.php
@@ -23,6 +23,11 @@ it('does not leak mail or whatsapp secrets in shared props', function () {
 });
 
 it('exposes notification channel readiness as booleans only', function () {
+    config(['mail.mailers.smtp.host' => null]);
+    putenv('MAIL_HOST=');
+    $_ENV['MAIL_HOST'] = '';
+    $_SERVER['MAIL_HOST'] = '';
+
     $owner = User::factory()->owner()->create();
 
     $props = $this->actingAs($owner)->get(route('dashboard'))->viewData('page')['props'];

--- a/tests/Unit/Notifications/MailChannelTest.php
+++ b/tests/Unit/Notifications/MailChannelTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use App\Contracts\MailChannelNotification;
+use App\Data\Mail\MailContent;
+use App\Data\Mail\MailSendResult;
+use App\Data\Reminder\ReminderEvent;
+use App\Enums\ReminderType;
+use App\Models\Lease;
+use App\Models\Setting;
+use App\Notifications\Channels\LogChannel;
+use App\Notifications\Channels\MailChannel;
+use App\Notifications\RentReminder;
+use App\Services\MailManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\Log;
+use Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+test('MailChannel rejects notifications without MailChannelNotification interface', function () {
+    $channel = app(MailChannel::class);
+    $notifiable = (object) ['email' => 'user@example.com'];
+    $invalidNotification = new class extends Notification {};
+
+    expect(fn () => $channel->send($notifiable, $invalidNotification))->toThrow(InvalidArgumentException::class);
+});
+
+test('MailChannel logs warning and skips sending when notifiable has no email route', function () {
+    Log::spy();
+
+    $channel = app(MailChannel::class);
+    $notifiable = (object) ['name' => 'No Email User'];
+
+    $notification = new class extends Notification implements MailChannelNotification
+    {
+        public function toMailChannel(object $notifiable): MailContent
+        {
+            return new MailContent('Subject', 'Body');
+        }
+    };
+
+    $channel->send($notifiable, $notification);
+
+    Log::shouldHaveReceived('warning')->once();
+});
+
+test('MailChannel normalizes string and array recipient routes', function () {
+    Setting::set('mail_config', ['driver' => 'log']);
+    $managerMock = Mockery::mock(MailManager::class);
+    $managerMock->shouldReceive('send')->once()->withArgs(function ($message) {
+        return count($message->to) === 2
+            && $message->to[0]->address === 'one@example.com'
+            && $message->to[1]->address === 'two@example.com'
+            && $message->to[1]->name === 'User Two';
+    })->andReturn(new MailSendResult('test-id', 'Sent'));
+
+    $channel = new MailChannel($managerMock);
+    $notifiable = new class
+    {
+        public function routeNotificationForMail(): array
+        {
+            return ['one@example.com', 'two@example.com' => 'User Two'];
+        }
+    };
+
+    $notification = new class extends Notification implements MailChannelNotification
+    {
+        public function toMailChannel(object $notifiable): MailContent
+        {
+            return new MailContent('Subject', 'Body');
+        }
+    };
+
+    $channel->send($notifiable, $notification);
+});
+
+test('RentReminder via returns only configured channels', function () {
+    Setting::set('reminder_channels', ['mail', 'log']);
+
+    $lease = new Lease;
+    $event = new ReminderEvent(
+        lease: $lease,
+        type: ReminderType::Upcoming,
+        periodStart: '2026-08-01',
+        periodEnd: '2026-08-31',
+        dueDate: '2026-08-01',
+        amount: 1500000,
+    );
+
+    $reminder = new RentReminder($event);
+    $via = $reminder->via((object) []);
+
+    expect($via)->toBe([LogChannel::class, MailChannel::class]);
+});

--- a/tests/Unit/Platform/NotificationRegistryTest.php
+++ b/tests/Unit/Platform/NotificationRegistryTest.php
@@ -1,53 +1,69 @@
 <?php
 
+use App\Notifications\Drivers\LogMailDriver;
+use App\Notifications\Drivers\SmtpMailDriver;
 use OpenKOS\Platform\Notification\NotificationDriverRegistration;
 use OpenKOS\Platform\Notification\NotificationRegistry;
 
-function reg(string $name, string $channel = 'whatsapp'): NotificationDriverRegistration
-{
-    return new NotificationDriverRegistration(
-        name: $name,
-        channel: $channel,
-        driverClass: 'App\\Notifications\\Drivers\\WhatsappLogDriver',
-        label: ucfirst($name),
-        config: ['token' => 'secret'],
+test('it registers drivers into channel-scoped storage', function () {
+    $registry = new NotificationRegistry;
+
+    $reg1 = new NotificationDriverRegistration(
+        name: 'openkos/smtp',
+        channel: 'mail',
+        driverClass: SmtpMailDriver::class,
+        label: 'SMTP',
     );
-}
 
-it('registers and looks up drivers', function () {
-    $registry = new NotificationRegistry;
-    $log = reg('log');
+    $reg2 = new NotificationDriverRegistration(
+        name: 'openkos/log',
+        channel: 'mail',
+        driverClass: LogMailDriver::class,
+        label: 'Log',
+    );
 
-    $registry->registerDriver($log);
+    $registry->registerDriver($reg1);
+    $registry->registerDriver($reg2);
 
-    expect($registry->get('log'))->toBe($log)
-        ->and($registry->has('log'))->toBeTrue()
-        ->and($registry->has('missing'))->toBeFalse()
-        ->and($registry->get('missing'))->toBeNull();
+    expect($registry->driver('mail', 'openkos/smtp'))->toBe($reg1);
+    expect($registry->driver('mail', 'openkos/log'))->toBe($reg2);
+    expect($registry->forChannel('mail'))->toHaveCount(2);
 });
 
-it('filters drivers by channel', function () {
+test('it allows identical re-registrations', function () {
     $registry = new NotificationRegistry;
-    $registry->registerDriver(reg('log', 'whatsapp'))
-        ->registerDriver(reg('smtp', 'email'));
 
-    expect($registry->forChannel('whatsapp'))->toHaveCount(1)
-        ->and($registry->forChannel('whatsapp')[0]->name)->toBe('log')
-        ->and($registry->forChannel('sms'))->toBe([]);
+    $reg = new NotificationDriverRegistration(
+        name: 'openkos/smtp',
+        channel: 'mail',
+        driverClass: SmtpMailDriver::class,
+        label: 'SMTP',
+    );
+
+    $registry->registerDriver($reg);
+    $registry->registerDriver($reg);
+
+    expect($registry->forChannel('mail'))->toHaveCount(1);
 });
 
-it('serializes without leaking credentials or class', function () {
+test('it rejects conflicting driver registrations for the same channel and name', function () {
     $registry = new NotificationRegistry;
-    $registry->registerDriver(reg('log'));
 
-    expect($registry->toArray())->toBe([
-        ['name' => 'log', 'channel' => 'whatsapp', 'label' => 'Log'],
-    ]);
+    $reg1 = new NotificationDriverRegistration(
+        name: 'openkos/smtp',
+        channel: 'mail',
+        driverClass: SmtpMailDriver::class,
+        label: 'SMTP',
+    );
+
+    $reg2 = new NotificationDriverRegistration(
+        name: 'openkos/smtp',
+        channel: 'mail',
+        driverClass: LogMailDriver::class,
+        label: 'Conflicting Driver',
+    );
+
+    $registry->registerDriver($reg1);
+
+    expect(fn () => $registry->registerDriver($reg2))->toThrow(InvalidArgumentException::class);
 });
-
-it('throws on duplicate driver names', function () {
-    $registry = new NotificationRegistry;
-    $registry->registerDriver(reg('log'));
-
-    $registry->registerDriver(reg('log'));
-})->throws(InvalidArgumentException::class, 'Notification driver [log] is already registered.');

--- a/tests/Unit/Services/MailManagerTest.php
+++ b/tests/Unit/Services/MailManagerTest.php
@@ -1,0 +1,79 @@
+<?php
+
+use App\Data\Mail\MailAddress;
+use App\Data\Mail\MailMessage;
+use App\Events\Mail\MailFailed;
+use App\Events\Mail\MailSent;
+use App\Exceptions\MailDeliveryException;
+use App\Exceptions\MailDriverNotFoundException;
+use App\Models\Setting;
+use App\Notifications\Drivers\SmtpMailDriver;
+use App\Services\MailManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+test('mail manager resolves driver using normalizeDriverId alias mapping', function () {
+    Setting::set('mail_config', ['driver' => 'smtp', 'host' => '127.0.0.1', 'port' => 1025]);
+
+    $manager = app(MailManager::class);
+    $driver = $manager->driver();
+
+    expect($driver)->toBeInstanceOf(SmtpMailDriver::class);
+});
+
+test('mail manager dispatches MailSent event on successful send', function () {
+    Event::fake();
+    Setting::set('mail_config', ['driver' => 'log']);
+
+    $manager = app(MailManager::class);
+    $message = new MailMessage(
+        to: [new MailAddress('user@example.com')],
+        subject: 'Test Subject',
+        htmlBody: '<p>Hello</p>',
+    );
+
+    $manager->send($message);
+
+    Event::assertDispatched(MailSent::class, function (MailSent $event) {
+        return $event->driver === 'openkos/log'
+            && $event->recipients === ['user@example.com']
+            && $event->subject === 'Test Subject';
+    });
+});
+
+test('mail manager dispatches MailFailed event and throws MailDeliveryException on failure', function () {
+    Event::fake();
+    Setting::set('mail_config', ['driver' => 'smtp', 'host' => '']);
+
+    $manager = app(MailManager::class);
+    $message = new MailMessage(
+        to: [new MailAddress('user@example.com')],
+        subject: 'Failing Subject',
+        htmlBody: '<p>Hello</p>',
+    );
+
+    expect(fn () => $manager->send($message))->toThrow(MailDeliveryException::class);
+
+    Event::assertDispatched(MailFailed::class, function (MailFailed $event) {
+        return $event->driver === 'openkos/smtp'
+            && $event->recipients === ['user@example.com']
+            && $event->subject === 'Failing Subject'
+            && $event->exception instanceof MailDeliveryException;
+    });
+});
+
+test('mail manager throws MailDriverNotFoundException when driver is unregistered', function () {
+    Setting::set('mail_config', ['driver' => 'nonexistent/driver']);
+
+    $manager = app(MailManager::class);
+    $message = new MailMessage(
+        to: [new MailAddress('user@example.com')],
+        subject: 'Test',
+        htmlBody: 'Body',
+    );
+
+    expect(fn () => $manager->send($message))->toThrow(MailDriverNotFoundException::class);
+});


### PR DESCRIPTION
## Summary of Changes

Introduces a pluggable, driver-backed `MailChannel` architecture for OpenKOS following the same channel-qualified transport model as WhatsApp:

1. **Platform Registry (`NotificationRegistry`)**: Upgraded to channel-scoped O(1) storage (`$drivers[$channel][$name]`) supporting idempotent duplicate registrations and channel isolation.
2. **Domain Contracts & DTOs**: Added `MailChannelNotification` interface (`toMailChannel()`), `MailDriver` interface, `MailAddress` (syntax validated), `MailContent`, `MailMessage` (recipient invariant enforced), `MailSendResult`, and `DriverHealthResult`.
3. **Domain Exceptions & Events**: Added `MailDeliveryException`, `MailDriverNotFoundException`, `InvalidMailDriverException`, `InvalidMailAddressException`, `InvalidMailConfigurationException`, `MailSent`, and `MailFailed`.
4. **Service & Resolution (`MailManager`)**: Container-based resolution (`app()->make()`), `normalizeDriverId()` legacy alias mapping (`'smtp'` -> `'openkos/smtp'`), and operational event dispatching.
5. **Built-in Drivers & Plugin (`MailPlugin`)**:
   - `openkos/log`: Redacted metadata logging to dedicated daily `mail.log` channel by default.
   - `openkos/smtp`: Runtime mailer configuration and strict port/encryption validation.
   - Registered `MailPlugin` in `config/platform.php`.
6. **Notification Routing**: `MailChannel` normalizes string and array recipient routing and dispatches via `MailManager`. `RentReminder` updated to implement `MailChannelNotification`.

## Verification

- **Pest Unit & Feature Test Suite**: All 21 mail tests + full test suite (642 tests) passing.
- **Release Gate**: `MailMultipartTest` verifies HTML and plain text alternative MIME parts.
- **Code Quality**: Formatted with Pint (`vendor/bin/pint --dirty`) and TypeScript type-checked (`npm run types:check`).
- **Knowledge Graph**: Updated via `graphify update .`.