### PR TITLE
feat(settings): unify mail config resolution with env fallbacks (OPE-104)

### DIFF
--- a/app/Http/Controllers/Settings/MailController.php
+++ b/app/Http/Controllers/Settings/MailController.php
@@ -19,13 +19,13 @@ class MailController extends Controller
 
     public function edit(): Response
     {
-        $settings = Setting::some(['mail_config']);
-        if (isset($settings['mail_config'])) {
-            unset($settings['mail_config']['password']);
-        }
+        $mailConfig = Setting::effectiveMailConfig();
+        unset($mailConfig['password']);
 
         return Inertia::render('settings/mail', [
-            'settings' => $settings,
+            'settings' => [
+                'mail_config' => $mailConfig,
+            ],
         ]);
     }
 
@@ -59,9 +59,9 @@ class MailController extends Controller
 
     public function test(): RedirectResponse
     {
-        $config = Setting::get('mail_config') ?? [];
+        $config = Setting::effectiveMailConfig();
 
-        if (! ($config['host'] ?? null)) {
+        if (! filled($config['host'] ?? null)) {
             Inertia::flash('toast', ['type' => 'error', 'message' => __('Configure SMTP host before testing.')]);
 
             return back();

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -45,7 +45,7 @@ class HandleInertiaRequests extends Middleware
                 ->except(['mail_config', 'whatsapp_config'])
                 ->all(),
             'notificationChannels' => fn () => [
-                'mail' => filled(data_get(Setting::get('mail_config'), 'host')),
+                'mail' => filled(data_get(Setting::effectiveMailConfig(), 'host')),
                 'whatsapp' => filled(Setting::get('whatsapp_driver')),
             ],
             'auth' => [

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -28,6 +28,11 @@ class Setting extends Model
         return app(SettingManager::class)->some($keys);
     }
 
+    public static function effectiveMailConfig(): array
+    {
+        return app(SettingManager::class)->getEffectiveMailConfig();
+    }
+
     public function resolveValue(): mixed
     {
         return app(SettingCaster::class)->deserialize($this->value, $this->type);

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -65,14 +65,12 @@ class AppServiceProvider extends ServiceProvider
     protected function configureMail(): void
     {
         try {
-            $config = Setting::get('mail_config');
+            $config = Setting::effectiveMailConfig();
         } catch (QueryException) {
             return;
         }
 
-        if (! ($config['host'] ?? null)) {
-            return;
-        }
+        config()->set('mail.default', $config['driver'] ?? 'log');
 
         config()->set('mail.mailers.smtp.host', $config['host'] ?? '');
         config()->set('mail.mailers.smtp.port', $config['port'] ?? 587);
@@ -88,8 +86,6 @@ class AppServiceProvider extends ServiceProvider
             config()->set('mail.from.address', $fromAddress);
             config()->set('mail.from.name', $config['from_name'] ?? '');
         }
-
-        config()->set('mail.default', 'smtp');
     }
 
     protected function configureDomainEvents(): void

--- a/app/Services/Settings/SettingManager.php
+++ b/app/Services/Settings/SettingManager.php
@@ -50,6 +50,39 @@ class SettingManager
         return $result;
     }
 
+    public function getEffectiveMailConfig(): array
+    {
+        try {
+            $stored = Setting::get('mail_config');
+        } catch (\Throwable) {
+            $stored = [];
+        }
+
+        if (! is_array($stored)) {
+            $stored = [];
+        }
+
+        $envDriver = config('mail.default') ?: env('MAIL_MAILER', 'log');
+        $envHost = config('mail.mailers.smtp.host') ?: env('MAIL_HOST');
+        $envPort = config('mail.mailers.smtp.port') ?: env('MAIL_PORT');
+        $envUsername = config('mail.mailers.smtp.username') ?: env('MAIL_USERNAME');
+        $envPassword = config('mail.mailers.smtp.password') ?: env('MAIL_PASSWORD');
+        $envEncryption = config('mail.mailers.smtp.encryption') ?: env('MAIL_ENCRYPTION');
+        $envFromAddress = config('mail.from.address') ?: env('MAIL_FROM_ADDRESS');
+        $envFromName = config('mail.from.name') ?: env('MAIL_FROM_NAME');
+
+        return [
+            'driver' => filled(data_get($stored, 'driver')) ? $stored['driver'] : ($envDriver ?: 'log'),
+            'host' => filled(data_get($stored, 'host')) ? (string) $stored['host'] : (string) ($envHost ?: ''),
+            'port' => filled(data_get($stored, 'port')) ? (int) $stored['port'] : ($envPort ? (int) $envPort : 587),
+            'username' => filled(data_get($stored, 'username')) ? (string) $stored['username'] : (string) ($envUsername ?: ''),
+            'password' => filled(data_get($stored, 'password')) ? (string) $stored['password'] : (string) ($envPassword ?: ''),
+            'encryption' => filled(data_get($stored, 'encryption')) ? (string) $stored['encryption'] : (string) ($envEncryption ?: 'null'),
+            'from_address' => filled(data_get($stored, 'from_address')) ? (string) $stored['from_address'] : (string) ($envFromAddress ?: ''),
+            'from_name' => filled(data_get($stored, 'from_name')) ? (string) $stored['from_name'] : (string) ($envFromName ?: ''),
+        ];
+    }
+
     private function allWithDefaults(): array
     {
         $defaults = [];

--- a/tests/Feature/Settings/MailSettingsTest.php
+++ b/tests/Feature/Settings/MailSettingsTest.php
@@ -83,4 +83,71 @@ describe('Mail settings page', function () {
         $this->get(route('settings.mail.edit'))->assertRedirect(route('login'));
         $this->patch(route('settings.mail.update'))->assertRedirect(route('login'));
     });
+
+    it('pre-fills form with env-derived values when settings table has no mail_config', function () {
+        config([
+            'mail.mailers.smtp.host' => 'env-smtp.example.com',
+            'mail.mailers.smtp.port' => 1025,
+            'mail.from.address' => 'env-from@example.com',
+        ]);
+
+        $owner = User::factory()->owner()->create();
+
+        $this->actingAs($owner)
+            ->get(route('settings.mail.edit'))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('settings/mail')
+                ->where('settings.mail_config.host', 'env-smtp.example.com')
+                ->where('settings.mail_config.port', 1025)
+                ->where('settings.mail_config.from_address', 'env-from@example.com')
+                ->where('notificationChannels.mail', true)
+            );
+    });
+
+    it('overrides env values field-by-field and keeps env fallback for unset fields in partial settings row', function () {
+        config([
+            'mail.mailers.smtp.host' => 'env-host.com',
+            'mail.mailers.smtp.port' => 2525,
+            'mail.mailers.smtp.username' => 'env_user',
+            'mail.mailers.smtp.password' => 'env_pass',
+            'mail.from.address' => 'env@example.com',
+        ]);
+
+        Setting::set('mail_config', [
+            'host' => 'override-host.com',
+        ]);
+
+        $effective = Setting::effectiveMailConfig();
+
+        expect($effective['host'])->toBe('override-host.com');
+        expect($effective['port'])->toBe(2525);
+        expect($effective['username'])->toBe('env_user');
+        expect($effective['password'])->toBe('env_pass');
+        expect($effective['from_address'])->toBe('env@example.com');
+    });
+
+    it('resolves mail.default driver from settings driver to env mailer to log', function () {
+        config(['mail.default' => 'sendmail']);
+
+        expect(Setting::effectiveMailConfig()['driver'])->toBe('sendmail');
+
+        Setting::set('mail_config', ['driver' => 'smtp']);
+
+        expect(Setting::effectiveMailConfig()['driver'])->toBe('smtp');
+    });
+
+    it('sends test email using effective config', function () {
+        config([
+            'mail.mailers.smtp.host' => 'smtp.test.com',
+            'mail.from.address' => 'sender@test.com',
+        ]);
+
+        $owner = User::factory()->owner()->create();
+
+        $this->from(route('settings.mail.edit'))
+            ->actingAs($owner)
+            ->post(route('settings.mail.test'))
+            ->assertRedirect(route('settings.mail.edit'));
+    });
 });

--- a/tests/Feature/SharedPropsTest.php
+++ b/tests/Feature/SharedPropsTest.php
@@ -23,6 +23,11 @@ it('does not leak mail or whatsapp secrets in shared props', function () {
 });
 
 it('exposes notification channel readiness as booleans only', function () {
+    config(['mail.mailers.smtp.host' => null]);
+    putenv('MAIL_HOST=');
+    $_ENV['MAIL_HOST'] = '';
+    $_SERVER['MAIL_HOST'] = '';
+
     $owner = User::factory()->owner()->create();
 
     $props = $this->actingAs($owner)->get(route('dashboard'))->viewData('page')['props'];


### PR DESCRIPTION
## Summary of Changes (OPE-104)

Unifies mail configuration resolution across OpenKOS by establishing a single source of truth (`Setting::effectiveMailConfig()`) with defined precedence:

> **The settings table is the source of truth; non-empty settings fields override env values field-by-field, while unset fields fall back to `env` values (`MAIL_HOST`, `MAIL_PORT`, `MAIL_USERNAME`, `MAIL_PASSWORD`, `MAIL_ENCRYPTION`, `MAIL_FROM_ADDRESS`, `MAIL_FROM_NAME`).**

### Key Improvements:
1. **`SettingManager::getEffectiveMailConfig()` & `Setting::effectiveMailConfig()`**: Single resolution point merging database settings with env defaults.
2. **AppServiceProvider (`configureMail()`)**: Configures runtime mailer using effective config instead of hardcoding `smtp` or requiring a non-empty settings host.
3. **`MailController`**: `edit()` pre-fills settings form with effective config (password masked); `test()` dispatches test emails using effective config.
4. **`HandleInertiaRequests`**: `notificationChannels.mail` shared prop correctly evaluates `true` whenever effective config has a valid host.
5. **Testing**: Feature tests in `MailSettingsTest` cover env-fallback, settings override, partial settings row, and default driver resolution.

## Verification
- `tests/Feature/Settings/MailSettingsTest.php` passing (9/9 tests).
- Formatted via Pint.