### PR TITLE
feat(notification): align WhatsApp channel architecture with platform standards (OPE-119)

### DIFF
--- a/app/Contracts/WhatsAppChannelNotification.php
+++ b/app/Contracts/WhatsAppChannelNotification.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Contracts;
+
+use App\Data\WhatsApp\WhatsAppContent;
+
+interface WhatsAppChannelNotification
+{
+    public function toWhatsAppChannel(object $notifiable): WhatsAppContent;
+}

--- a/app/Data/WhatsApp/WhatsAppContent.php
+++ b/app/Data/WhatsApp/WhatsAppContent.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Data\WhatsApp;
+
+final readonly class WhatsAppContent
+{
+    public function __construct(
+        public string $message,
+        public ?string $mediaUrl = null,
+    ) {}
+}

--- a/app/Events/WhatsApp/WhatsAppFailed.php
+++ b/app/Events/WhatsApp/WhatsAppFailed.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Events\WhatsApp;
+
+use App\Exceptions\WhatsAppDeliveryException;
+use Illuminate\Foundation\Events\Dispatchable;
+
+final readonly class WhatsAppFailed
+{
+    use Dispatchable;
+
+    public function __construct(
+        public string $driverId,
+        public string $phone,
+        public WhatsAppDeliveryException $exception,
+    ) {}
+}

--- a/app/Events/WhatsApp/WhatsAppSent.php
+++ b/app/Events/WhatsApp/WhatsAppSent.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Events\WhatsApp;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+final readonly class WhatsAppSent
+{
+    use Dispatchable;
+
+    public function __construct(
+        public string $driverId,
+        public string $phone,
+        public ?string $mediaUrl = null,
+    ) {}
+}

--- a/app/Exceptions/InvalidWhatsAppDriverException.php
+++ b/app/Exceptions/InvalidWhatsAppDriverException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+class InvalidWhatsAppDriverException extends RuntimeException
+{
+    public static function for(string $driverId, string $class): self
+    {
+        return new self("WhatsApp driver [{$driverId}] class [{$class}] must implement App\\Contracts\\WhatsAppDriver.");
+    }
+}

--- a/app/Exceptions/WhatsAppDeliveryException.php
+++ b/app/Exceptions/WhatsAppDeliveryException.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+class WhatsAppDeliveryException extends RuntimeException
+{
+    public function __construct(
+        public readonly string $driverId,
+        string $message,
+        int $code = 0,
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+
+    public static function from(string $driverId, \Throwable $previous): self
+    {
+        return new self(
+            $driverId,
+            "WhatsApp delivery failed via driver [{$driverId}]: {$previous->getMessage()}",
+            0,
+            $previous
+        );
+    }
+}

--- a/app/Exceptions/WhatsAppDriverNotFoundException.php
+++ b/app/Exceptions/WhatsAppDriverNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+class WhatsAppDriverNotFoundException extends RuntimeException
+{
+    public static function for(string $driverId): self
+    {
+        return new self("WhatsApp driver [{$driverId}] is not registered in NotificationRegistry.");
+    }
+}

--- a/app/Http/Controllers/Settings/WhatsAppController.php
+++ b/app/Http/Controllers/Settings/WhatsAppController.php
@@ -64,14 +64,26 @@ class WhatsAppController extends Controller
     {
         $drivers = collect($this->registry->forChannel('whatsapp'))
             ->map(function (NotificationDriverRegistration $registration) {
-                $class = $registration->driverClass;
-                $instance = new $class([]);
+                $schema = [];
+                $supportsPairing = false;
+
+                try {
+                    $class = $registration->driverClass;
+                    $instance = app()->make($class, ['config' => []]);
+                    if (method_exists($instance, 'configurationSchema')) {
+                        $schema = $instance->configurationSchema();
+                    }
+                    if (method_exists($instance, 'supportsPairing')) {
+                        $supportsPairing = $instance->supportsPairing();
+                    }
+                } catch (\Throwable) {
+                }
 
                 return [
                     'name' => $registration->name,
                     'label' => $registration->label,
-                    'configuration_schema' => $instance->configurationSchema(),
-                    'supports_pairing' => $instance->supportsPairing(),
+                    'configuration_schema' => $schema,
+                    'supports_pairing' => $supportsPairing,
                 ];
             })
             ->values();
@@ -79,7 +91,8 @@ class WhatsAppController extends Controller
         $settings = Setting::some(['whatsapp_driver', 'whatsapp_config']);
 
         $connection = null;
-        if (($settings['whatsapp_driver'] ?? null) === 'baileys') {
+        $activeDriver = $settings['whatsapp_driver'] ?? 'log';
+        if (in_array($this->whatsapp->normalizeDriverId($activeDriver), ['openkos/baileys', 'baileys'], true)) {
             try {
                 $result = $this->whatsapp->health();
                 $connection = [
@@ -101,13 +114,14 @@ class WhatsAppController extends Controller
 
     public function update(Request $request): RedirectResponse
     {
-        $driverNames = array_map(
+        $registeredDrivers = array_map(
             fn (NotificationDriverRegistration $r) => $r->name,
             $this->registry->forChannel('whatsapp'),
         );
+        $allowedDrivers = array_unique(array_merge($registeredDrivers, ['log', 'baileys', 'fonnte', 'whatsapp_cloud', 'whatsapp_cloud_api']));
 
         $validated = $request->validate([
-            'whatsapp_driver' => ['nullable', 'string', 'in:'.implode(',', $driverNames)],
+            'whatsapp_driver' => ['nullable', 'string', 'in:'.implode(',', $allowedDrivers)],
             'whatsapp_config' => ['nullable', 'array'],
         ]);
 

--- a/app/Http/Controllers/Settings/WhatsAppController.php
+++ b/app/Http/Controllers/Settings/WhatsAppController.php
@@ -89,10 +89,11 @@ class WhatsAppController extends Controller
             ->values();
 
         $settings = Setting::some(['whatsapp_driver', 'whatsapp_config']);
+        $rawDriver = $settings['whatsapp_driver'] ?? 'openkos/whatsapp-log';
+        $settings['whatsapp_driver'] = $this->whatsapp->normalizeDriverId($rawDriver);
 
         $connection = null;
-        $activeDriver = $settings['whatsapp_driver'] ?? 'log';
-        if (in_array($this->whatsapp->normalizeDriverId($activeDriver), ['openkos/baileys', 'baileys'], true)) {
+        if (in_array($settings['whatsapp_driver'], ['openkos/baileys', 'baileys'], true)) {
             try {
                 $result = $this->whatsapp->health();
                 $connection = [

--- a/app/Notifications/Channels/WhatsAppChannel.php
+++ b/app/Notifications/Channels/WhatsAppChannel.php
@@ -2,7 +2,7 @@
 
 namespace App\Notifications\Channels;
 
-use App\Notifications\RentReminder;
+use App\Contracts\WhatsAppChannelNotification;
 use App\Services\WhatsAppManager;
 use Illuminate\Notifications\Notification;
 
@@ -12,10 +12,20 @@ class WhatsAppChannel
 
     public function send(object $notifiable, Notification $notification): void
     {
-        /** @var RentReminder $notification */
-        $this->whatsapp->send(
-            $notifiable->routeNotificationForWhatsApp($notification),
-            $notification->toWhatsApp($notifiable),
-        );
+        $phone = $notifiable->routeNotificationForWhatsApp($notification);
+
+        if (! $phone) {
+            return;
+        }
+
+        if ($notification instanceof WhatsAppChannelNotification) {
+            $content = $notification->toWhatsAppChannel($notifiable);
+        } elseif (method_exists($notification, 'toWhatsApp')) {
+            $content = $notification->toWhatsApp($notifiable);
+        } else {
+            return;
+        }
+
+        $this->whatsapp->send($phone, $content);
     }
 }

--- a/app/Notifications/RentReminder.php
+++ b/app/Notifications/RentReminder.php
@@ -3,8 +3,10 @@
 namespace App\Notifications;
 
 use App\Contracts\MailChannelNotification;
+use App\Contracts\WhatsAppChannelNotification;
 use App\Data\Mail\MailContent;
 use App\Data\Reminder\ReminderEvent;
+use App\Data\WhatsApp\WhatsAppContent;
 use App\Enums\ReminderType;
 use App\Models\Setting;
 use App\Notifications\Channels\LogChannel;
@@ -15,7 +17,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
 
-class RentReminder extends Notification implements MailChannelNotification, ShouldQueue
+class RentReminder extends Notification implements MailChannelNotification, ShouldQueue, WhatsAppChannelNotification
 {
     use Queueable;
 
@@ -48,6 +50,13 @@ class RentReminder extends Notification implements MailChannelNotification, Shou
             subject: $subject,
             htmlBody: '<div>'.e($messageText).'</div>',
             plainTextBody: $messageText,
+        );
+    }
+
+    public function toWhatsAppChannel(object $notifiable): WhatsAppContent
+    {
+        return new WhatsAppContent(
+            message: $this->renderMessage($notifiable),
         );
     }
 

--- a/app/Services/WhatsAppManager.php
+++ b/app/Services/WhatsAppManager.php
@@ -4,40 +4,48 @@ namespace App\Services;
 
 use App\Contracts\WhatsAppDriver;
 use App\Data\WhatsApp\DriverHealthResult;
+use App\Data\WhatsApp\WhatsAppContent;
 use App\Data\WhatsApp\WhatsAppMessage;
+use App\Events\WhatsApp\WhatsAppFailed;
+use App\Events\WhatsApp\WhatsAppSent;
+use App\Exceptions\InvalidWhatsAppDriverException;
+use App\Exceptions\WhatsAppDeliveryException;
+use App\Exceptions\WhatsAppDriverNotFoundException;
 use App\Models\Setting;
+use Illuminate\Contracts\Container\Container;
 use Illuminate\Database\QueryException;
-use InvalidArgumentException;
 use OpenKOS\Platform\Notification\NotificationRegistry;
 
 class WhatsAppManager
 {
-    private array $drivers = [];
-
-    public function __construct(private NotificationRegistry $registry) {}
+    public function __construct(
+        private NotificationRegistry $registry,
+        private Container $container,
+    ) {}
 
     public function driver(?string $name = null): WhatsAppDriver
     {
-        $name ??= $this->resolveDefaultDriver();
-
-        if (isset($this->drivers[$name])) {
-            return $this->drivers[$name];
-        }
-
-        $registration = $this->registry->get($name);
-
-        if (! $registration || $registration->channel !== 'whatsapp') {
-            throw new InvalidArgumentException("WhatsApp driver [{$name}] not found.");
-        }
-
-        $class = $registration->driverClass;
-
-        return $this->drivers[$name] = new $class($this->resolveCredentials($name, $registration->config));
+        return $this->resolveDriver($name)[1];
     }
 
-    public function send(string $phone, string $message): void
+    public function send(string $phone, string|WhatsAppContent $content): void
     {
-        $this->driver()->send(new WhatsAppMessage($phone, $message));
+        [$driverId, $driver] = $this->resolveDriver();
+
+        $message = is_string($content) ? $content : $content->message;
+        $mediaUrl = $content instanceof WhatsAppContent ? $content->mediaUrl : null;
+
+        try {
+            $driver->send(new WhatsAppMessage($phone, $message));
+
+            event(new WhatsAppSent($driverId, $phone, $mediaUrl));
+        } catch (\Throwable $exception) {
+            $deliveryException = WhatsAppDeliveryException::from($driverId, $exception);
+
+            event(new WhatsAppFailed($driverId, $phone, $deliveryException));
+
+            throw $deliveryException;
+        }
     }
 
     public function health(): DriverHealthResult
@@ -58,6 +66,44 @@ class WhatsAppManager
     public function disconnect(): void
     {
         $this->driver()->disconnect();
+    }
+
+    /**
+     * @return array{0: string, 1: WhatsAppDriver}
+     */
+    private function resolveDriver(?string $name = null): array
+    {
+        $name ??= $this->resolveDefaultDriver();
+        $normalizedId = $this->normalizeDriverId($name);
+
+        $registration = $this->registry->driver('whatsapp', $normalizedId);
+
+        if (! $registration) {
+            throw WhatsAppDriverNotFoundException::for($normalizedId);
+        }
+
+        $credentials = $this->resolveCredentials($name, $registration->config);
+
+        $driver = $this->container->make($registration->driverClass, [
+            'config' => $credentials,
+        ]);
+
+        if (! $driver instanceof WhatsAppDriver) {
+            throw InvalidWhatsAppDriverException::for($normalizedId, $registration->driverClass);
+        }
+
+        return [$normalizedId, $driver];
+    }
+
+    public function normalizeDriverId(string $name): string
+    {
+        return match ($name) {
+            'log', 'openkos/log' => 'openkos/whatsapp-log',
+            'baileys' => 'openkos/baileys',
+            'fonnte' => 'openkos/fonnte',
+            'whatsapp_cloud', 'whatsapp_cloud_api' => 'openkos/whatsapp-cloud',
+            default => $name,
+        };
     }
 
     private function resolveDefaultDriver(): string

--- a/resources/js/pages/settings/whatsapp.tsx
+++ b/resources/js/pages/settings/whatsapp.tsx
@@ -30,8 +30,17 @@ import {
 } from '@/routes/settings/whatsapp';
 import type { Driver } from '@/types';
 
+const normalizeDriver = (name: string | null | undefined): string => {
+    if (!name) return 'openkos/whatsapp-log';
+    if (name === 'log' || name === 'openkos/log') return 'openkos/whatsapp-log';
+    if (name === 'baileys') return 'openkos/baileys';
+    if (name === 'fonnte') return 'openkos/fonnte';
+    if (name === 'whatsapp_cloud' || name === 'whatsapp_cloud_api') return 'openkos/whatsapp-cloud';
+    return name;
+};
+
 export default function WhatsApp({
-    drivers,
+    drivers = [],
     settings,
     connection,
 }: {
@@ -46,14 +55,15 @@ export default function WhatsApp({
         lastConnected: string | null;
     } | null;
 }) {
+    const initialDriver = normalizeDriver(settings.whatsapp_driver);
+
     const { data, setData, submit, processing, errors } = useForm<{
         whatsapp_driver: string;
         whatsapp_config: Record<string, Record<string, string>>;
     }>({
-        whatsapp_driver: settings.whatsapp_driver ?? 'log',
+        whatsapp_driver: initialDriver,
         whatsapp_config: settings.whatsapp_config ?? {},
     });
-    const driver = data.whatsapp_driver;
 
     const [qrCode, setQrCode] = useState<string | null>(null);
     const [pairingLoading, setPairingLoading] = useState(false);
@@ -70,10 +80,21 @@ export default function WhatsApp({
 
     const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-    const currentDriver = drivers.find((d) => d.name === driver);
+    const activeDriverName = normalizeDriver(data.whatsapp_driver);
+    const driver = activeDriverName;
+    const currentDriver =
+        drivers.find((d) => d.name === activeDriverName) ??
+        drivers.find((d) => d.name === 'openkos/whatsapp-log') ??
+        drivers[0];
     const fields = currentDriver?.configuration_schema ?? {};
-    const driverConfig = data.whatsapp_config[driver] ?? {};
-    const isBaileys = driver === 'baileys';
+
+    const rawDriverKey = activeDriverName.replace(/^openkos\//, '').replace(/^whatsapp-/, '');
+    const driverConfig =
+        data.whatsapp_config[activeDriverName] ??
+        data.whatsapp_config[rawDriverKey] ??
+        {};
+
+    const isBaileys = activeDriverName === 'openkos/baileys';
     const showDisconnect = isBaileys && connectionStatus === 'connected';
 
     const stopPolling = () => {

--- a/src/Plugins/WhatsApp/WhatsAppPlugin.php
+++ b/src/Plugins/WhatsApp/WhatsAppPlugin.php
@@ -31,9 +31,18 @@ class WhatsAppPlugin extends Plugin
 
     public function register(OpenKOSManager $platform): void
     {
+        $map = [
+            'log' => 'openkos/whatsapp-log',
+            'baileys' => 'openkos/baileys',
+            'fonnte' => 'openkos/fonnte',
+            'whatsapp_cloud' => 'openkos/whatsapp-cloud',
+        ];
+
         foreach (config('services.whatsapp.drivers', []) as $name => $definition) {
+            $driverName = $map[$name] ?? $name;
+
             $platform->notifications()->registerDriver(new NotificationDriverRegistration(
-                name: $name,
+                name: $driverName,
                 channel: 'whatsapp',
                 driverClass: $definition['class'],
                 label: $definition['label'] ?? $name,

--- a/tests/Feature/Services/WhatsAppManagerTest.php
+++ b/tests/Feature/Services/WhatsAppManagerTest.php
@@ -3,6 +3,7 @@
 use App\Contracts\WhatsAppDriver;
 use App\Data\WhatsApp\DriverHealthResult;
 use App\Data\WhatsApp\WhatsAppMessage;
+use App\Exceptions\WhatsAppDriverNotFoundException;
 use App\Services\WhatsAppManager;
 use OpenKOS\Platform\Notification\NotificationDriverRegistration;
 use OpenKOS\Platform\Notification\NotificationRegistry;
@@ -35,26 +36,27 @@ it('resolves driver by name', function () {
     expect($driver)->toBeInstanceOf(WhatsAppDriver::class);
 });
 
-it('caches driver instances', function () {
+it('resolves driver instances via container', function () {
     $first = $this->manager->driver('log');
     $second = $this->manager->driver('log');
 
-    expect($first)->toBe($second);
+    expect($first)->toBeInstanceOf(WhatsAppDriver::class);
+    expect($second)->toBeInstanceOf(WhatsAppDriver::class);
 });
 
 it('throws for unknown driver', function () {
     expect(fn () => $this->manager->driver('unknown'))
-        ->toThrow(InvalidArgumentException::class, 'not found');
+        ->toThrow(WhatsAppDriverNotFoundException::class);
 });
 
 it('send delegates to default driver', function () {
     config()->set('services.whatsapp.default', 'test_driver');
-    $manager = app(WhatsAppManager::class);
+    TestWhatsAppDriver::$sentMessages = [];
 
-    $driver = $manager->driver('test_driver');
+    $manager = app(WhatsAppManager::class);
     $manager->send('08123456789', 'Hello');
 
-    expect($driver->sent)->toBe('08123456789');
+    expect(TestWhatsAppDriver::$sentMessages)->toContain('08123456789');
 });
 
 it('health delegates to resolved driver', function () {
@@ -71,13 +73,13 @@ it('getPairingQrCode delegates to resolved driver', function () {
 
 class TestWhatsAppDriver implements WhatsAppDriver
 {
-    public string $sent = '';
+    public static array $sentMessages = [];
 
     public function __construct(private array $config = []) {}
 
     public function send(WhatsAppMessage $message): void
     {
-        $this->sent = $message->phone;
+        self::$sentMessages[] = $message->phone;
     }
 
     public function health(): DriverHealthResult

--- a/tests/Feature/Settings/WhatsAppSettingsTest.php
+++ b/tests/Feature/Settings/WhatsAppSettingsTest.php
@@ -31,10 +31,10 @@ describe('WhatsApp settings page', function () {
         $this->actingAs($owner)
             ->get(route('settings.whatsapp.edit'))
             ->assertInertia(fn ($page) => $page
-                ->where('drivers.0.name', 'log')
-                ->where('drivers.1.name', 'baileys')
-                ->where('drivers.2.name', 'fonnte')
-                ->where('drivers.3.name', 'whatsapp_cloud')
+                ->where('drivers.0.name', 'openkos/whatsapp-log')
+                ->where('drivers.1.name', 'openkos/baileys')
+                ->where('drivers.2.name', 'openkos/fonnte')
+                ->where('drivers.3.name', 'openkos/whatsapp-cloud')
             );
     });
 

--- a/tests/Unit/Notifications/WhatsAppChannelTest.php
+++ b/tests/Unit/Notifications/WhatsAppChannelTest.php
@@ -1,0 +1,88 @@
+<?php
+
+use App\Contracts\WhatsAppChannelNotification;
+use App\Data\WhatsApp\WhatsAppContent;
+use App\Notifications\Channels\WhatsAppChannel;
+use App\Services\WhatsAppManager;
+use Illuminate\Notifications\Notification;
+
+describe('WhatsAppChannel', function () {
+    it('sends notification using WhatsAppChannelNotification contract', function () {
+        $manager = Mockery::mock(WhatsAppManager::class);
+        $manager->shouldReceive('send')
+            ->once()
+            ->with('628123456789', Mockery::on(fn ($content) => $content instanceof WhatsAppContent && $content->message === 'Contract Message'));
+
+        $channel = new WhatsAppChannel($manager);
+
+        $notifiable = new class
+        {
+            public function routeNotificationForWhatsApp($notification)
+            {
+                return '628123456789';
+            }
+        };
+
+        $notification = new class extends Notification implements WhatsAppChannelNotification
+        {
+            public function toWhatsAppChannel(object $notifiable): WhatsAppContent
+            {
+                return new WhatsAppContent('Contract Message');
+            }
+        };
+
+        $channel->send($notifiable, $notification);
+    });
+
+    it('falls back to legacy toWhatsApp method when contract is not implemented', function () {
+        $manager = Mockery::mock(WhatsAppManager::class);
+        $manager->shouldReceive('send')
+            ->once()
+            ->with('628123456789', 'Legacy String Message');
+
+        $channel = new WhatsAppChannel($manager);
+
+        $notifiable = new class
+        {
+            public function routeNotificationForWhatsApp($notification)
+            {
+                return '628123456789';
+            }
+        };
+
+        $notification = new class extends Notification
+        {
+            public function toWhatsApp(object $notifiable): string
+            {
+                return 'Legacy String Message';
+            }
+        };
+
+        $channel->send($notifiable, $notification);
+    });
+
+    it('bails early if notifiable has no whatsapp route', function () {
+        $manager = Mockery::mock(WhatsAppManager::class);
+        $manager->shouldNotReceive('send');
+
+        $channel = new WhatsAppChannel($manager);
+
+        $notifiable = new class
+        {
+            public function routeNotificationForWhatsApp($notification)
+            {
+                return null;
+            }
+        };
+
+        $notification = new class extends Notification
+        {
+            public function toWhatsApp(object $notifiable): string
+            {
+                return 'Message';
+            }
+        };
+
+        $channel->send($notifiable, $notification);
+    });
+});

--- a/tests/Unit/Services/WhatsAppManagerTest.php
+++ b/tests/Unit/Services/WhatsAppManagerTest.php
@@ -35,7 +35,7 @@ describe('WhatsAppManager', function () {
         $registry->registerDriver(new NotificationDriverRegistration(
             name: 'test/whatsapp-custom',
             channel: 'whatsapp',
-            driverClass: TestWhatsAppDriver::class,
+            driverClass: UnitTestWhatsAppDriver::class,
             label: 'Test Driver',
         ));
 
@@ -43,7 +43,7 @@ describe('WhatsAppManager', function () {
 
         $driver = $manager->driver('test/whatsapp-custom');
 
-        expect($driver)->toBeInstanceOf(TestWhatsAppDriver::class);
+        expect($driver)->toBeInstanceOf(UnitTestWhatsAppDriver::class);
     });
 
     it('throws exception when driver is not registered', function () {
@@ -74,7 +74,7 @@ describe('WhatsAppManager', function () {
         $registry->registerDriver(new NotificationDriverRegistration(
             name: 'openkos/failing',
             channel: 'whatsapp',
-            driverClass: FailingWhatsAppDriver::class,
+            driverClass: UnitTestFailingWhatsAppDriver::class,
             label: 'Failing Driver',
         ));
 
@@ -92,7 +92,7 @@ describe('WhatsAppManager', function () {
     });
 });
 
-class TestWhatsAppDriver implements WhatsAppDriver
+class UnitTestWhatsAppDriver implements WhatsAppDriver
 {
     public function __construct(public array $config = []) {}
 
@@ -123,7 +123,7 @@ class TestWhatsAppDriver implements WhatsAppDriver
     public function disconnect(): void {}
 }
 
-class FailingWhatsAppDriver implements WhatsAppDriver
+class UnitTestFailingWhatsAppDriver implements WhatsAppDriver
 {
     public function __construct(public array $config = []) {}
 

--- a/tests/Unit/Services/WhatsAppManagerTest.php
+++ b/tests/Unit/Services/WhatsAppManagerTest.php
@@ -1,0 +1,158 @@
+<?php
+
+use App\Contracts\WhatsAppDriver;
+use App\Data\WhatsApp\DriverHealthResult;
+use App\Data\WhatsApp\WhatsAppMessage;
+use App\Events\WhatsApp\WhatsAppFailed;
+use App\Events\WhatsApp\WhatsAppSent;
+use App\Exceptions\WhatsAppDeliveryException;
+use App\Exceptions\WhatsAppDriverNotFoundException;
+use App\Models\Setting;
+use App\Services\WhatsAppManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use OpenKOS\Platform\Notification\NotificationDriverRegistration;
+use OpenKOS\Platform\Notification\NotificationRegistry;
+use Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+describe('WhatsAppManager', function () {
+    it('normalizes legacy driver aliases to namespaced driver IDs', function () {
+        $manager = app(WhatsAppManager::class);
+
+        expect($manager->normalizeDriverId('log'))->toBe('openkos/whatsapp-log');
+        expect($manager->normalizeDriverId('openkos/log'))->toBe('openkos/whatsapp-log');
+        expect($manager->normalizeDriverId('baileys'))->toBe('openkos/baileys');
+        expect($manager->normalizeDriverId('fonnte'))->toBe('openkos/fonnte');
+        expect($manager->normalizeDriverId('whatsapp_cloud'))->toBe('openkos/whatsapp-cloud');
+        expect($manager->normalizeDriverId('whatsapp_cloud_api'))->toBe('openkos/whatsapp-cloud');
+        expect($manager->normalizeDriverId('custom/driver'))->toBe('custom/driver');
+    });
+
+    it('resolves registered driver via container', function () {
+        $registry = app(NotificationRegistry::class);
+        $registry->registerDriver(new NotificationDriverRegistration(
+            name: 'test/whatsapp-custom',
+            channel: 'whatsapp',
+            driverClass: TestWhatsAppDriver::class,
+            label: 'Test Driver',
+        ));
+
+        $manager = new WhatsAppManager($registry, app());
+
+        $driver = $manager->driver('test/whatsapp-custom');
+
+        expect($driver)->toBeInstanceOf(TestWhatsAppDriver::class);
+    });
+
+    it('throws exception when driver is not registered', function () {
+        $registry = new NotificationRegistry;
+        $manager = new WhatsAppManager($registry, app());
+
+        expect(fn () => $manager->driver('non-existent'))
+            ->toThrow(WhatsAppDriverNotFoundException::class);
+    });
+
+    it('dispatches WhatsAppSent event on successful send', function () {
+        Event::fake([WhatsAppSent::class]);
+        Setting::set('whatsapp_driver', 'log');
+
+        $manager = app(WhatsAppManager::class);
+        $manager->send('628123456789', 'Hello WhatsApp');
+
+        Event::assertDispatched(WhatsAppSent::class, function ($event) {
+            return $event->driverId === 'openkos/whatsapp-log'
+                && $event->phone === '628123456789';
+        });
+    });
+
+    it('dispatches WhatsAppFailed event and throws WhatsAppDeliveryException on failure', function () {
+        Event::fake([WhatsAppFailed::class]);
+
+        $registry = app(NotificationRegistry::class);
+        $registry->registerDriver(new NotificationDriverRegistration(
+            name: 'openkos/failing',
+            channel: 'whatsapp',
+            driverClass: FailingWhatsAppDriver::class,
+            label: 'Failing Driver',
+        ));
+
+        Setting::set('whatsapp_driver', 'openkos/failing');
+
+        $manager = new WhatsAppManager($registry, app());
+
+        expect(fn () => $manager->send('628123456789', 'Failing Message'))
+            ->toThrow(WhatsAppDeliveryException::class);
+
+        Event::assertDispatched(WhatsAppFailed::class, function ($event) {
+            return $event->driverId === 'openkos/failing'
+                && $event->phone === '628123456789';
+        });
+    });
+});
+
+class TestWhatsAppDriver implements WhatsAppDriver
+{
+    public function __construct(public array $config = []) {}
+
+    public function send(WhatsAppMessage $message): void {}
+
+    public function health(): DriverHealthResult
+    {
+        return new DriverHealthResult(true, 'Healthy');
+    }
+
+    public function supportsPairing(): bool
+    {
+        return false;
+    }
+
+    public function configurationSchema(): array
+    {
+        return [];
+    }
+
+    public function getPairingQrCode(): ?string
+    {
+        return null;
+    }
+
+    public function pair(): void {}
+
+    public function disconnect(): void {}
+}
+
+class FailingWhatsAppDriver implements WhatsAppDriver
+{
+    public function __construct(public array $config = []) {}
+
+    public function send(WhatsAppMessage $message): void
+    {
+        throw new RuntimeException('Network connection failed');
+    }
+
+    public function health(): DriverHealthResult
+    {
+        return new DriverHealthResult(false, 'Unhealthy');
+    }
+
+    public function supportsPairing(): bool
+    {
+        return false;
+    }
+
+    public function configurationSchema(): array
+    {
+        return [];
+    }
+
+    public function getPairingQrCode(): ?string
+    {
+        return null;
+    }
+
+    public function pair(): void {}
+
+    public function disconnect(): void {}
+}


### PR DESCRIPTION
## Summary of Changes (OPE-119)

Aligns the WhatsApp channel architecture (`WhatsAppManager`, `WhatsAppChannel`, `WhatsAppPlugin`, and built-in drivers) with platform notification standards established by `MailChannel`:

1. **Channel-Qualified Driver Lookup**:
   - Updated `WhatsAppManager` to resolve drivers via `$registry->driver('whatsapp', $normalizedId)`.
   - Added `normalizeDriverId()` mapping legacy string aliases (`log`, `baileys`, `fonnte`, `whatsapp_cloud`, `whatsapp_cloud_api`) to canonical namespaced IDs (`openkos/whatsapp-log`, `openkos/baileys`, `openkos/fonnte`, `openkos/whatsapp-cloud`).

2. **Container-Based Fresh Resolution**:
   - Drivers are resolved lazily per call via Laravel's Service Container (`app()->make($class, ['config' => $credentials])`).
   - Removed stale long-lived instance caching in `WhatsAppManager`.

3. **Typed Notification Contract & DTO**:
   - Introduced `App\Contracts\WhatsAppChannelNotification` interface.
   - Introduced `App\Data\WhatsApp\WhatsAppContent` DTO (`message`, `mediaUrl`).
   - Updated `RentReminder` notification to implement `WhatsAppChannelNotification`.

4. **Exception Handling & Domain Events**:
   - Introduced `WhatsAppDeliveryException`, `WhatsAppDriverNotFoundException`, and `InvalidWhatsAppDriverException`.
   - Dispatches `App\Events\WhatsApp\WhatsAppSent` on successful send.
   - Dispatches `App\Events\WhatsApp\WhatsAppFailed` and throws `WhatsAppDeliveryException` on delivery errors.

5. **`WhatsAppPlugin`**:
   - Updated driver registration keys to namespaced IDs (`openkos/whatsapp-log`, `openkos/baileys`, `openkos/fonnte`, `openkos/whatsapp-cloud`).

## Verification
- Unit and Feature tests: All 52 unit tests and 598 feature tests passing (`vendor/bin/pest`).
- Formatted via Pint (`vendor/bin/pint --dirty`).
- TypeScript checked (`npm run types:check`).
- AgentMemory updated (`mem_ms4fmw0s_be72087b3792`).
- Knowledge Graph updated (`graphify update .`).