### PR TITLE
feat(reminders): link reminders to invoices

### DIFF
--- a/app/Actions/Reminders/ForceSendReminder.php
+++ b/app/Actions/Reminders/ForceSendReminder.php
@@ -25,9 +25,8 @@ class ForceSendReminder
         $tenant = $lease->primaryTenant;
 
         $channels = Setting::get('reminder_channels') ?? ['log'];
-        $hasContact = $tenant?->phone || ($tenant?->user?->email && in_array('mail', $channels));
 
-        if (! $hasContact) {
+        if (! $tenant?->hasReminderRoute($channels)) {
             return 'no_contact';
         }
 

--- a/app/Actions/Reminders/ForceSendReminder.php
+++ b/app/Actions/Reminders/ForceSendReminder.php
@@ -75,6 +75,7 @@ class ForceSendReminder
             dueDate: $invoice->due_date->toDateString(),
             amount: (int) round((float) $invoice->outstanding * 100),
             overdueDays: $overdueDays,
+            invoice: $invoice,
         );
 
         $log = $this->repository->recordIfAbsent($event, $channels);

--- a/app/Actions/Reminders/SendRentReminders.php
+++ b/app/Actions/Reminders/SendRentReminders.php
@@ -41,8 +41,7 @@ class SendRentReminders
 
         foreach ($leases as $lease) {
             $tenant = $lease->primaryTenant;
-            $hasContact = $tenant?->phone || ($tenant?->user?->email && in_array('mail', $channels));
-            if (! $hasContact) {
+            if (! $tenant?->hasReminderRoute($channels)) {
                 continue;
             }
 

--- a/app/Business/Reminders/PaymentReminderScheduler.php
+++ b/app/Business/Reminders/PaymentReminderScheduler.php
@@ -5,6 +5,7 @@ namespace App\Business\Reminders;
 use App\Data\Reminder\ReminderEvent;
 use App\Data\Reminder\ReminderSettings;
 use App\Enums\ReminderType;
+use App\Models\Invoice;
 use App\Models\Lease;
 use Carbon\Carbon;
 use Carbon\CarbonInterface;
@@ -30,9 +31,9 @@ class PaymentReminderScheduler
                 : ($dueDate->greaterThan($today) ? 'upcoming' : 'due');
 
             match ($status) {
-                'upcoming' => $this->collectUpcoming($events, $lease, $periodStart, $periodEnd, $dueDateStr, $amount, $dueDate, $today, $settings),
-                'due' => $this->collectDueToday($events, $lease, $periodStart, $periodEnd, $dueDateStr, $amount, $dueDate, $today),
-                'overdue' => $this->collectOverdue($events, $lease, $periodStart, $periodEnd, $dueDateStr, $amount, $dueDate, $today, $settings),
+                'upcoming' => $this->collectUpcoming($events, $lease, $invoice, $periodStart, $periodEnd, $dueDateStr, $amount, $dueDate, $today, $settings),
+                'due' => $this->collectDueToday($events, $lease, $invoice, $periodStart, $periodEnd, $dueDateStr, $amount, $dueDate, $today),
+                'overdue' => $this->collectOverdue($events, $lease, $invoice, $periodStart, $periodEnd, $dueDateStr, $amount, $dueDate, $today, $settings),
             };
         }
 
@@ -42,6 +43,7 @@ class PaymentReminderScheduler
     private function collectUpcoming(
         array &$events,
         Lease $lease,
+        Invoice $invoice,
         string $periodStart,
         string $periodEnd,
         string $dueDateStr,
@@ -60,6 +62,7 @@ class PaymentReminderScheduler
                 periodEnd: $periodEnd,
                 dueDate: $dueDateStr,
                 amount: $amount,
+                invoice: $invoice,
             );
         }
     }
@@ -67,6 +70,7 @@ class PaymentReminderScheduler
     private function collectDueToday(
         array &$events,
         Lease $lease,
+        Invoice $invoice,
         string $periodStart,
         string $periodEnd,
         string $dueDateStr,
@@ -82,6 +86,7 @@ class PaymentReminderScheduler
                 periodEnd: $periodEnd,
                 dueDate: $dueDateStr,
                 amount: $amount,
+                invoice: $invoice,
             );
         }
     }
@@ -89,6 +94,7 @@ class PaymentReminderScheduler
     private function collectOverdue(
         array &$events,
         Lease $lease,
+        Invoice $invoice,
         string $periodStart,
         string $periodEnd,
         string $dueDateStr,
@@ -109,6 +115,7 @@ class PaymentReminderScheduler
                     dueDate: $dueDateStr,
                     amount: $amount,
                     overdueDays: $interval,
+                    invoice: $invoice,
                 );
             }
         }

--- a/app/Business/Reminders/PaymentReminderScheduler.php
+++ b/app/Business/Reminders/PaymentReminderScheduler.php
@@ -21,7 +21,7 @@ class PaymentReminderScheduler
 
         foreach ($invoices as $invoice) {
             $dueDate = Carbon::parse($invoice->due_date)->startOfDay();
-            $amount = (int) ((float) $invoice->outstanding * 100);
+            $amount = (int) str_replace('.', '', $invoice->outstanding);
             $periodStart = $invoice->period_start->toDateString();
             $periodEnd = $invoice->period_end->toDateString();
             $dueDateStr = $dueDate->toDateString();

--- a/app/Data/Reminder/ReminderEvent.php
+++ b/app/Data/Reminder/ReminderEvent.php
@@ -3,6 +3,7 @@
 namespace App\Data\Reminder;
 
 use App\Enums\ReminderType;
+use App\Models\Invoice;
 use App\Models\Lease;
 
 class ReminderEvent
@@ -15,5 +16,6 @@ class ReminderEvent
         public readonly string $dueDate,
         public readonly int $amount,
         public readonly ?int $overdueDays = null,
+        public readonly ?Invoice $invoice = null,
     ) {}
 }

--- a/app/Models/Tenant.php
+++ b/app/Models/Tenant.php
@@ -48,6 +48,15 @@ class Tenant extends Model
         return $email ? [$email => $this->name] : [];
     }
 
+    public function hasReminderRoute(array $channels): bool
+    {
+        $hasPhoneRoute = $this->phone
+            && (in_array('whatsapp', $channels, true) || in_array('log', $channels, true));
+        $hasMailRoute = $this->user?->email && in_array('mail', $channels, true);
+
+        return (bool) ($hasPhoneRoute || $hasMailRoute);
+    }
+
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);

--- a/app/Notifications/RentReminder.php
+++ b/app/Notifications/RentReminder.php
@@ -38,6 +38,17 @@ class RentReminder extends Notification implements MailChannelNotification, Shou
         return array_values(array_intersect_key($map, array_flip($channels)));
     }
 
+    public function shouldSend(object $notifiable, string $channel): bool
+    {
+        $invoice = $this->invoice();
+
+        if (! $invoice?->getKey()) {
+            return true;
+        }
+
+        return Invoice::query()->payable()->whereKey($invoice->getKey())->exists();
+    }
+
     public function toMailChannel(object $notifiable): MailContent
     {
         $subject = match ($this->event->type) {

--- a/app/Notifications/RentReminder.php
+++ b/app/Notifications/RentReminder.php
@@ -8,7 +8,9 @@ use App\Data\Mail\MailContent;
 use App\Data\Reminder\ReminderEvent;
 use App\Data\WhatsApp\WhatsAppContent;
 use App\Enums\ReminderType;
+use App\Models\Invoice;
 use App\Models\Setting;
+use App\Models\Tenant;
 use App\Notifications\Channels\LogChannel;
 use App\Notifications\Channels\MailChannel;
 use App\Notifications\Channels\WhatsAppChannel;
@@ -45,11 +47,23 @@ class RentReminder extends Notification implements MailChannelNotification, Shou
         };
 
         $messageText = $this->renderMessage($notifiable);
+        $invoice = $this->invoice();
+        $invoiceUrl = $invoice && $notifiable instanceof Tenant && $notifiable->user_id
+            ? route('portal.billing.invoices.show', $invoice)
+            : null;
+        $htmlBody = '<div>'.nl2br(e($messageText)).'</div>';
+        $plainTextBody = $messageText;
+
+        if ($invoiceUrl) {
+            $label = __('notifications.rent.view_invoice');
+            $htmlBody .= '<p><a href="'.e($invoiceUrl).'">'.e($label).'</a></p>';
+            $plainTextBody .= "\n\n{$label}: {$invoiceUrl}";
+        }
 
         return new MailContent(
             subject: $subject,
-            htmlBody: '<div>'.e($messageText).'</div>',
-            plainTextBody: $messageText,
+            htmlBody: $htmlBody,
+            plainTextBody: $plainTextBody,
         );
     }
 
@@ -80,20 +94,37 @@ class RentReminder extends Notification implements MailChannelNotification, Shou
 
         $template = Setting::get('reminder_message_template');
 
-        if ($template) {
-            return str_replace(
+        $message = $template
+            ? str_replace(
                 [':name', ':unit:', ':days', ':amount', ':date'],
                 [$notifiable->name, $this->event->lease->unit?->name ?? '—', $this->event->lease->unit?->name ?? '—', $days, $amount, $date],
                 $template,
-            );
+            )
+            : __("notifications.rent.{$this->event->type->value}", [
+                'name' => $notifiable->name,
+                'unit' => $this->event->lease->unit?->name ?? '—',
+                'days' => $days,
+                'amount' => $amount,
+                'date' => $date,
+            ]);
+
+        $invoice = $this->invoice();
+
+        if (! $invoice) {
+            return $message;
         }
 
-        return __("notifications.rent.{$this->event->type->value}", [
-            'name' => $notifiable->name,
-            'unit' => $this->event->lease->unit?->name ?? '—',
-            'days' => $days,
-            'amount' => $amount,
+        return $message."\n\n".__('notifications.rent.invoice_context', [
+            'reference' => $invoice->reference,
+            'period' => Carbon::parse($this->event->periodStart)->format('d M Y')
+                .' – '.Carbon::parse($this->event->periodEnd)->format('d M Y'),
             'date' => $date,
+            'amount' => $amount,
         ]);
+    }
+
+    private function invoice(): ?Invoice
+    {
+        return isset($this->event->invoice) ? $this->event->invoice : null;
     }
 }

--- a/app/Notifications/RentReminder.php
+++ b/app/Notifications/RentReminder.php
@@ -96,8 +96,8 @@ class RentReminder extends Notification implements MailChannelNotification, Shou
 
         $message = $template
             ? str_replace(
-                [':name', ':unit:', ':days', ':amount', ':date'],
-                [$notifiable->name, $this->event->lease->unit?->name ?? '—', $this->event->lease->unit?->name ?? '—', $days, $amount, $date],
+                [':name', ':unit', ':days', ':amount', ':date'],
+                [$notifiable->name, $this->event->lease->unit?->name ?? '—', $days, $amount, $date],
                 $template,
             )
             : __("notifications.rent.{$this->event->type->value}", [

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -97,9 +97,8 @@ class AppServiceProvider extends ServiceProvider
             $tenant = $lease->primaryTenant;
 
             $channels = Setting::get('reminder_channels') ?? ['log'];
-            $hasContact = $tenant?->phone || ($tenant?->user?->email && in_array('mail', $channels));
 
-            if (! $hasContact) {
+            if (! $tenant?->hasReminderRoute($channels)) {
                 return;
             }
 

--- a/lang/en/notifications.php
+++ b/lang/en/notifications.php
@@ -5,6 +5,8 @@ return [
         'upcoming' => "Hi :name,\n\nRent for :unit is due in :days days.\n\nAmount: :amount\nDue date: :date",
         'due_today' => "Hi :name,\n\nRent for :unit is due today.\n\nAmount: :amount",
         'overdue' => "Hi :name,\n\nRent for :unit is overdue by :days day(s).\n\nAmount: :amount",
+        'invoice_context' => "Invoice: :reference\nPeriod: :period\nDue date: :date\nOutstanding: :amount",
+        'view_invoice' => 'View invoice',
     ],
     'tenant_invitation' => [
         'subject' => 'You have been invited to OpenKos',

--- a/lang/id/notifications.php
+++ b/lang/id/notifications.php
@@ -5,6 +5,8 @@ return [
         'upcoming' => "Halo :name,\n\nSewa kamar :unit akan jatuh tempo dalam :days hari.\n\nJumlah: :amount\nTanggal jatuh tempo: :date",
         'due_today' => "Halo :name,\n\nSewa kamar :unit jatuh tempo hari ini.\n\nJumlah: :amount",
         'overdue' => "Halo :name,\n\nPembayaran sewa kamar :unit terlambat :days hari.\n\nJumlah: :amount",
+        'invoice_context' => "Invoice: :reference\nPeriode: :period\nTanggal jatuh tempo: :date\nSisa tagihan: :amount",
+        'view_invoice' => 'Lihat invoice',
     ],
     'tenant_invitation' => [
         'subject' => 'Anda diundang ke OpenKos',

--- a/tests/Feature/SendRentRemindersTest.php
+++ b/tests/Feature/SendRentRemindersTest.php
@@ -207,6 +207,23 @@ describe('SendRentRemindersAction', function () {
         Carbon::setTestNow();
     });
 
+    it('does not treat a phone as a mail contact', function () {
+        Carbon::setTestNow(Carbon::parse('2026-07-01'));
+        Setting::set('reminder_channels', ['mail'], 'array');
+        Notification::fake();
+
+        $lease = createLeaseWithTenant(['rent_due_day' => 1, 'start_date' => '2026-07-01']);
+        $lease->load(['primaryTenant.user']);
+
+        $sent = app(SendRentReminders::class)->execute($lease);
+
+        expect($sent)->toBeEmpty();
+        expect(ReminderLog::count())->toBe(0);
+        Notification::assertNothingSent();
+
+        Carbon::setTestNow();
+    });
+
     it('emails an invited but unverified tenant', function () {
         Carbon::setTestNow(Carbon::parse('2026-07-01'));
         Setting::set('reminder_channels', ['mail'], 'array');

--- a/tests/Feature/SendRentRemindersTest.php
+++ b/tests/Feature/SendRentRemindersTest.php
@@ -72,6 +72,23 @@ describe('PaymentReminderScheduler', function () {
         Carbon::setTestNow();
     });
 
+    it('converts fractional outstanding amounts to cents without truncation', function () {
+        Carbon::setTestNow(Carbon::parse('2026-07-01'));
+        $lease = createLeaseWithTenant(['rent_due_day' => 1, 'start_date' => '2026-06-01']);
+        $lease->invoices()->whereDate('due_date', '2026-07-01')->firstOrFail()->update([
+            'total' => '0.29',
+            'amount_paid' => '0.00',
+        ]);
+        $settings = new ReminderSettings(true, 3, []);
+
+        $events = (new PaymentReminderScheduler)->pendingFor($lease, $settings);
+
+        expect($events)->toHaveCount(1);
+        expect($events[0]->amount)->toBe(29);
+
+        Carbon::setTestNow();
+    });
+
     it('returns overdue event at configured interval', function () {
         Carbon::setTestNow(Carbon::parse('2026-07-02'));
         $lease = createLeaseWithTenant(['rent_due_day' => 1, 'start_date' => '2026-07-01']);

--- a/tests/Feature/SendRentRemindersTest.php
+++ b/tests/Feature/SendRentRemindersTest.php
@@ -53,6 +53,8 @@ describe('PaymentReminderScheduler', function () {
         expect($events)->toHaveCount(1);
         expect($events[0]->type->value)->toBe('upcoming');
         expect($events[0]->dueDate)->toBe('2026-07-01');
+        expect($events[0]->invoice)->not->toBeNull();
+        expect($events[0]->invoice?->due_date->toDateString())->toBe('2026-07-01');
 
         Carbon::setTestNow();
     });
@@ -240,6 +242,78 @@ describe('SendRentRemindersAction', function () {
 
         Carbon::setTestNow();
     });
+
+    it('includes invoice context and portal link in scheduled mail reminders', function () {
+        Carbon::setTestNow(Carbon::parse('2026-07-01'));
+        Setting::set('reminder_channels', ['mail'], 'array');
+        Notification::fake();
+
+        $user = User::factory()->create(['email' => 'tenant@example.com']);
+        $lease = createLeaseWithTenant(['rent_due_day' => 1, 'start_date' => '2026-07-01']);
+        $lease->primaryTenant->update([
+            'phone' => null,
+            'user_id' => $user->id,
+        ]);
+        $lease->load(['primaryTenant.user']);
+        $tenant = $lease->primaryTenant;
+        $invoice = $lease->invoices()->payable()->orderBy('period_start')->firstOrFail();
+
+        app(SendRentReminders::class)->execute($lease);
+
+        Notification::assertSentTo(
+            $tenant,
+            RentReminder::class,
+            function (RentReminder $notification) use ($invoice, $tenant): bool {
+                $content = $notification->toMailChannel($tenant);
+                $invoiceUrl = route('portal.billing.invoices.show', $invoice);
+
+                expect($content->plainTextBody)
+                    ->toContain($invoice->reference)
+                    ->toContain($invoice->period_start->format('d M Y'))
+                    ->toContain($invoice->period_end->format('d M Y'))
+                    ->toContain($invoice->due_date->format('d M Y'))
+                    ->toContain(number_format((float) $invoice->outstanding, 0))
+                    ->toContain($invoiceUrl);
+                expect($content->htmlBody)->toContain($invoiceUrl);
+
+                return true;
+            },
+        );
+
+        Carbon::setTestNow();
+    });
+
+    it('includes invoice context without a portal link for whatsapp-only tenants', function () {
+        Carbon::setTestNow(Carbon::parse('2026-07-01'));
+        Notification::fake();
+
+        $lease = createLeaseWithTenant(['rent_due_day' => 1, 'start_date' => '2026-07-01']);
+        $lease->load(['primaryTenant']);
+        $tenant = $lease->primaryTenant;
+        $invoice = $lease->invoices()->payable()->orderBy('period_start')->firstOrFail();
+
+        app(SendRentReminders::class)->execute($lease);
+
+        Notification::assertSentTo(
+            $tenant,
+            RentReminder::class,
+            function (RentReminder $notification) use ($invoice, $tenant): bool {
+                $message = $notification->toWhatsAppChannel($tenant)->message;
+
+                expect($message)
+                    ->toContain($invoice->reference)
+                    ->toContain($invoice->period_start->format('d M Y'))
+                    ->toContain($invoice->period_end->format('d M Y'))
+                    ->toContain($invoice->due_date->format('d M Y'))
+                    ->toContain(number_format((float) $invoice->outstanding, 0))
+                    ->not->toContain(route('portal.billing.invoices.show', $invoice));
+
+                return true;
+            },
+        );
+
+        Carbon::setTestNow();
+    });
 });
 
 describe('Command', function () {
@@ -294,6 +368,45 @@ describe('Manual Send via Controller', function () {
             ->assertRedirect();
 
         expect(ReminderLog::count())->toBe(1);
+
+        Carbon::setTestNow();
+    });
+
+    it('includes the selected invoice and portal link in a manual fallback reminder', function () {
+        Carbon::setTestNow(Carbon::parse('2026-06-20'));
+        Setting::set('reminder_channels', ['mail'], 'array');
+        Notification::fake();
+
+        $owner = User::factory()->owner()->create();
+        $tenantUser = User::factory()->create(['email' => 'tenant@example.com']);
+        $lease = createLeaseWithTenant(['rent_due_day' => 1, 'start_date' => '2026-07-01']);
+        $lease->primaryTenant->update([
+            'phone' => null,
+            'user_id' => $tenantUser->id,
+        ]);
+        $lease->unit->property->users()->attach($owner);
+        $lease->load(['primaryTenant.user']);
+        $tenant = $lease->primaryTenant;
+        $invoice = $lease->invoices()->payable()->orderBy('period_start')->firstOrFail();
+
+        $this->actingAs($owner)
+            ->post(route('leases.send-reminder', $lease))
+            ->assertRedirect();
+
+        expect(ReminderLog::count())->toBe(1);
+        Notification::assertSentTo(
+            $tenant,
+            RentReminder::class,
+            function (RentReminder $notification) use ($invoice, $tenant): bool {
+                $content = $notification->toMailChannel($tenant);
+
+                expect($content->plainTextBody)
+                    ->toContain($invoice->reference)
+                    ->toContain(route('portal.billing.invoices.show', $invoice));
+
+                return true;
+            },
+        );
 
         Carbon::setTestNow();
     });

--- a/tests/Feature/SendRentRemindersTest.php
+++ b/tests/Feature/SendRentRemindersTest.php
@@ -117,6 +117,22 @@ describe('PaymentReminderScheduler', function () {
 
         Carbon::setTestNow();
     });
+
+    it('suppresses a queued reminder when its invoice is no longer payable', function () {
+        Carbon::setTestNow(Carbon::parse('2026-07-01'));
+        $lease = createLeaseWithTenant(['rent_due_day' => 1, 'start_date' => '2026-06-01']);
+        $settings = new ReminderSettings(true, 3, []);
+        $event = (new PaymentReminderScheduler)->pendingFor($lease, $settings)[0];
+        $queuedReminder = unserialize(serialize(new RentReminder($event)));
+
+        expect($queuedReminder->shouldSend($lease->primaryTenant, 'mail'))->toBeTrue();
+
+        $event->invoice?->update(['status' => InvoiceStatus::Paid]);
+
+        expect($queuedReminder->shouldSend($lease->primaryTenant, 'mail'))->toBeFalse();
+
+        Carbon::setTestNow();
+    });
 });
 
 describe('SendRentRemindersAction', function () {

--- a/tests/Unit/Notifications/MailChannelTest.php
+++ b/tests/Unit/Notifications/MailChannelTest.php
@@ -93,3 +93,22 @@ test('RentReminder via returns only configured channels', function () {
 
     expect($via)->toBe([LogChannel::class, MailChannel::class]);
 });
+
+test('RentReminder still renders events without invoice context', function () {
+    $lease = new Lease;
+    $lease->setRelation('unit', null);
+    $event = new ReminderEvent(
+        lease: $lease,
+        type: ReminderType::Upcoming,
+        periodStart: '2026-08-01',
+        periodEnd: '2026-08-31',
+        dueDate: '2026-08-01',
+        amount: 150000000,
+    );
+
+    $content = (new RentReminder($event))->toMailChannel((object) ['name' => 'Tenant']);
+
+    expect($content->plainTextBody)
+        ->toContain('Tenant')
+        ->not->toContain('/portal/billing/invoices/');
+});

--- a/tests/Unit/Notifications/MailChannelTest.php
+++ b/tests/Unit/Notifications/MailChannelTest.php
@@ -107,11 +107,13 @@ test('RentReminder still renders events without invoice context', function () {
         amount: 150000000,
     );
 
-    $content = (new RentReminder($event))->toMailChannel((object) ['name' => 'Tenant']);
+    $reminder = new RentReminder($event);
+    $content = $reminder->toMailChannel((object) ['name' => 'Tenant']);
 
     expect($content->plainTextBody)
         ->toContain('Tenant')
         ->not->toContain('/portal/billing/invoices/');
+    expect($reminder->shouldSend((object) [], 'mail'))->toBeTrue();
 });
 
 test('RentReminder replaces every documented custom template placeholder', function () {

--- a/tests/Unit/Notifications/MailChannelTest.php
+++ b/tests/Unit/Notifications/MailChannelTest.php
@@ -7,6 +7,7 @@ use App\Data\Reminder\ReminderEvent;
 use App\Enums\ReminderType;
 use App\Models\Lease;
 use App\Models\Setting;
+use App\Models\Unit;
 use App\Notifications\Channels\LogChannel;
 use App\Notifications\Channels\MailChannel;
 use App\Notifications\RentReminder;
@@ -111,4 +112,24 @@ test('RentReminder still renders events without invoice context', function () {
     expect($content->plainTextBody)
         ->toContain('Tenant')
         ->not->toContain('/portal/billing/invoices/');
+});
+
+test('RentReminder replaces every documented custom template placeholder', function () {
+    Setting::set('reminder_message_template', ':name|:unit|:days|:amount|:date');
+
+    $lease = new Lease;
+    $lease->setRelation('unit', new Unit(['name' => 'A-01']));
+    $event = new ReminderEvent(
+        lease: $lease,
+        type: ReminderType::Overdue,
+        periodStart: '2026-08-01',
+        periodEnd: '2026-08-31',
+        dueDate: '2026-08-01',
+        amount: 150000000,
+        overdueDays: 3,
+    );
+
+    $content = (new RentReminder($event))->toMailChannel((object) ['name' => 'Ayu']);
+
+    expect($content->plainTextBody)->toBe('Ayu|A-01|3|1,500,000|01 Aug 2026');
 });


### PR DESCRIPTION
## Summary

- associate scheduled and manual rent reminders with the selected payable invoice
- include localized invoice reference, billing period, due date, and outstanding balance
- add secure portal links to email reminders for linked tenant users while keeping WhatsApp link-free
- harden custom templates, channel eligibility, queued settlement checks, and fractional-cent conversion

## Verification

- `php artisan test --compact tests/Feature/SendRentRemindersTest.php tests/Unit/Notifications/MailChannelTest.php` — 26 passed, 98 assertions
- focused tenant portal ownership tests — 2 passed, 54 assertions
- `vendor/bin/pint --dirty --format agent`
- `git diff --check`
- `graphify update .`

Linear: [OPE-113](https://linear.app/openkos/issue/OPE-113)