### PR TITLE
feat(reminders): attach invoice PDFs to mail

### DIFF
--- a/app/Actions/Invoices/GenerateInvoicePdf.php
+++ b/app/Actions/Invoices/GenerateInvoicePdf.php
@@ -11,6 +11,17 @@ final class GenerateInvoicePdf
 {
     public function execute(Invoice $invoice): string
     {
+        $invoice->loadMissing([
+            'lease.primaryTenant.user',
+            'lease.unit.property',
+            'lineItems',
+            'payments' => fn ($query) => $query
+                ->where('status', 'confirmed')
+                ->orderBy('payment_date')
+                ->orderBy('id'),
+        ]);
+        $invoice->append(['outstanding', 'display_status']);
+
         $settings = Setting::some(['site_name', 'locale', 'currency']);
         $options = new Options;
         $options->setDefaultFont('DejaVu Sans');

--- a/app/Data/Mail/MailAttachment.php
+++ b/app/Data/Mail/MailAttachment.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Data\Mail;
+
+final readonly class MailAttachment
+{
+    public function __construct(
+        public string $content,
+        public string $filename,
+        public string $mimeType,
+    ) {}
+}

--- a/app/Data/Mail/MailContent.php
+++ b/app/Data/Mail/MailContent.php
@@ -8,6 +8,7 @@ final readonly class MailContent
      * @param  list<MailAddress>  $cc
      * @param  list<MailAddress>  $bcc
      * @param  array<string, string>  $headers
+     * @param  list<MailAttachment>  $attachments
      */
     public function __construct(
         public string $subject,
@@ -18,5 +19,6 @@ final readonly class MailContent
         public array $cc = [],
         public array $bcc = [],
         public array $headers = [],
+        public array $attachments = [],
     ) {}
 }

--- a/app/Data/Mail/MailMessage.php
+++ b/app/Data/Mail/MailMessage.php
@@ -11,6 +11,7 @@ final readonly class MailMessage
      * @param  list<MailAddress>  $cc
      * @param  list<MailAddress>  $bcc
      * @param  array<string, string>  $headers
+     * @param  list<MailAttachment>  $attachments
      */
     public function __construct(
         public array $to,
@@ -22,6 +23,7 @@ final readonly class MailMessage
         public array $cc = [],
         public array $bcc = [],
         public array $headers = [],
+        public array $attachments = [],
     ) {
         if ($to === []) {
             throw new InvalidArgumentException('A mail message requires at least one recipient.');

--- a/app/Notifications/Channels/MailChannel.php
+++ b/app/Notifications/Channels/MailChannel.php
@@ -52,6 +52,7 @@ class MailChannel
             cc: $content->cc,
             bcc: $content->bcc,
             headers: $content->headers,
+            attachments: $content->attachments,
         );
 
         $this->mailManager->send($message);

--- a/app/Notifications/Drivers/LogMailDriver.php
+++ b/app/Notifications/Drivers/LogMailDriver.php
@@ -26,6 +26,7 @@ class LogMailDriver implements MailDriver
             'subject' => $message->subject,
             'has_html' => $message->htmlBody !== '',
             'has_plain_text' => $message->plainTextBody !== null,
+            'attachment_count' => count($message->attachments),
         ];
 
         if ($this->config['log_body'] ?? false) {

--- a/app/Notifications/Drivers/SmtpMailDriver.php
+++ b/app/Notifications/Drivers/SmtpMailDriver.php
@@ -80,6 +80,12 @@ class SmtpMailDriver implements MailDriver
             foreach ($message->headers as $name => $value) {
                 $mail->getHeaders()->addTextHeader($name, $value);
             }
+
+            foreach ($message->attachments as $attachment) {
+                $mail->attachData($attachment->content, $attachment->filename, [
+                    'mime' => $attachment->mimeType,
+                ]);
+            }
         });
 
         return new MailSendResult(null, 'Sent via SMTP.');

--- a/app/Notifications/RentReminder.php
+++ b/app/Notifications/RentReminder.php
@@ -2,8 +2,10 @@
 
 namespace App\Notifications;
 
+use App\Actions\Invoices\GenerateInvoicePdf;
 use App\Contracts\MailChannelNotification;
 use App\Contracts\WhatsAppChannelNotification;
+use App\Data\Mail\MailAttachment;
 use App\Data\Mail\MailContent;
 use App\Data\Reminder\ReminderEvent;
 use App\Data\WhatsApp\WhatsAppContent;
@@ -71,10 +73,26 @@ class RentReminder extends Notification implements MailChannelNotification, Shou
             $plainTextBody .= "\n\n{$label}: {$invoiceUrl}";
         }
 
+        $attachments = [];
+        if ($invoice && $notifiable instanceof Tenant && $notifiable->user?->email) {
+            $reference = preg_replace(
+                '/[^A-Za-z0-9_-]/',
+                '-',
+                $invoice->reference ?? (string) $invoice->getKey(),
+            );
+
+            $attachments[] = new MailAttachment(
+                content: app(GenerateInvoicePdf::class)->execute($invoice),
+                filename: 'invoice-'.($reference ?: $invoice->getKey()).'.pdf',
+                mimeType: 'application/pdf',
+            );
+        }
+
         return new MailContent(
             subject: $subject,
             htmlBody: $htmlBody,
             plainTextBody: $plainTextBody,
+            attachments: $attachments,
         );
     }
 

--- a/tests/Feature/Notifications/MailMultipartTest.php
+++ b/tests/Feature/Notifications/MailMultipartTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Data\Mail\MailAddress;
+use App\Data\Mail\MailAttachment;
 use App\Data\Mail\MailMessage;
 use App\Notifications\Drivers\SmtpMailDriver;
 use Illuminate\Mail\Message;
@@ -18,6 +19,7 @@ test('SmtpMailDriver composes both HTML and plain text alternative MIME parts', 
         subject: 'Rent Payment Reminder',
         htmlBody: '<h1>Rent Due</h1><p>Please pay your rent.</p>',
         plainTextBody: "Rent Due\n\nPlease pay your rent.",
+        attachments: [new MailAttachment('%PDF-test', 'invoice-2026.pdf', 'application/pdf')],
     );
 
     $capturedSymfonyEmail = null;
@@ -39,4 +41,8 @@ test('SmtpMailDriver composes both HTML and plain text alternative MIME parts', 
     $this->assertNotNull($capturedSymfonyEmail);
     $this->assertStringContainsString('<h1>Rent Due</h1>', (string) $capturedSymfonyEmail->getHtmlBody());
     $this->assertStringContainsString("Rent Due\n\nPlease pay your rent.", (string) $capturedSymfonyEmail->getTextBody());
+    expect($capturedSymfonyEmail->getAttachments())->toHaveCount(1);
+    expect($capturedSymfonyEmail->getAttachments()[0]->getFilename())->toBe('invoice-2026.pdf');
+    expect($capturedSymfonyEmail->getAttachments()[0]->getMediaType())->toBe('application');
+    expect($capturedSymfonyEmail->getAttachments()[0]->getMediaSubtype())->toBe('pdf');
 });

--- a/tests/Feature/SendRentRemindersTest.php
+++ b/tests/Feature/SendRentRemindersTest.php
@@ -325,6 +325,10 @@ describe('SendRentRemindersAction', function () {
                     ->toContain(number_format((float) $invoice->outstanding, 0))
                     ->toContain($invoiceUrl);
                 expect($content->htmlBody)->toContain($invoiceUrl);
+                expect($content->attachments)->toHaveCount(1);
+                expect($content->attachments[0]->filename)->toBe("invoice-{$invoice->reference}.pdf");
+                expect($content->attachments[0]->mimeType)->toBe('application/pdf');
+                expect($content->attachments[0]->content)->toStartWith('%PDF-');
 
                 return true;
             },
@@ -453,6 +457,9 @@ describe('Manual Send via Controller', function () {
                 expect($content->plainTextBody)
                     ->toContain($invoice->reference)
                     ->toContain(route('portal.billing.invoices.show', $invoice));
+                expect($content->attachments)->toHaveCount(1);
+                expect($content->attachments[0]->filename)->toBe("invoice-{$invoice->reference}.pdf");
+                expect($content->attachments[0]->content)->toStartWith('%PDF-');
 
                 return true;
             },

--- a/tests/Unit/Notifications/MailChannelTest.php
+++ b/tests/Unit/Notifications/MailChannelTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Contracts\MailChannelNotification;
+use App\Data\Mail\MailAttachment;
 use App\Data\Mail\MailContent;
 use App\Data\Mail\MailSendResult;
 use App\Data\Reminder\ReminderEvent;
@@ -74,6 +75,28 @@ test('MailChannel normalizes string and array recipient routes', function () {
     };
 
     $channel->send($notifiable, $notification);
+});
+
+test('MailChannel forwards attachments to the mail manager', function () {
+    $attachment = new MailAttachment('%PDF-test', 'invoice.pdf', 'application/pdf');
+    $managerMock = Mockery::mock(MailManager::class);
+    $managerMock->shouldReceive('send')
+        ->once()
+        ->withArgs(fn ($message): bool => $message->attachments === [$attachment])
+        ->andReturn(new MailSendResult('test-id', 'Sent'));
+
+    $channel = new MailChannel($managerMock);
+    $notification = new class($attachment) extends Notification implements MailChannelNotification
+    {
+        public function __construct(private MailAttachment $attachment) {}
+
+        public function toMailChannel(object $notifiable): MailContent
+        {
+            return new MailContent('Subject', 'Body', attachments: [$this->attachment]);
+        }
+    };
+
+    $channel->send((object) ['email' => 'user@example.com'], $notification);
 });
 
 test('RentReminder via returns only configured channels', function () {


### PR DESCRIPTION
## Summary

- add PDF attachment support to the custom mail pipeline
- attach the matching invoice PDF to scheduled and manual mail reminders
- preserve WhatsApp and log reminder behavior

## Verification

- `php artisan test --compact tests/Unit/Notifications/MailChannelTest.php tests/Feature/Notifications/MailMultipartTest.php tests/Feature/SendRentRemindersTest.php`
- `php artisan test --compact tests/Feature/TenantInvoicePdfTest.php tests/Unit/Services/MailManagerTest.php`
- 42 tests passed