### PR TITLE
feat(whatsapp): add document attachments

### DIFF
--- a/app/Actions/Invoices/GenerateInvoicePdf.php
+++ b/app/Actions/Invoices/GenerateInvoicePdf.php
@@ -37,6 +37,10 @@ final class GenerateInvoicePdf
         $pdf->setPaper('A4');
         $pdf->render();
 
-        return $pdf->output();
+        $output = $pdf->output();
+        unset($pdf);
+        gc_collect_cycles();
+
+        return $output;
     }
 }

--- a/app/Contracts/WhatsAppDriver.php
+++ b/app/Contracts/WhatsAppDriver.php
@@ -9,6 +9,8 @@ interface WhatsAppDriver
 {
     public function send(WhatsAppMessage $message): void;
 
+    public function supportsAttachments(): bool;
+
     public function health(): DriverHealthResult;
 
     public function supportsPairing(): bool;

--- a/app/Data/WhatsApp/WhatsAppAttachment.php
+++ b/app/Data/WhatsApp/WhatsAppAttachment.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Data\WhatsApp;
+
+final readonly class WhatsAppAttachment
+{
+    public function __construct(
+        public string $content,
+        public string $filename,
+        public string $mimeType,
+    ) {}
+}

--- a/app/Data/WhatsApp/WhatsAppContent.php
+++ b/app/Data/WhatsApp/WhatsAppContent.php
@@ -7,5 +7,6 @@ final readonly class WhatsAppContent
     public function __construct(
         public string $message,
         public ?string $mediaUrl = null,
+        public ?WhatsAppAttachment $attachment = null,
     ) {}
 }

--- a/app/Data/WhatsApp/WhatsAppMessage.php
+++ b/app/Data/WhatsApp/WhatsAppMessage.php
@@ -8,5 +8,6 @@ class WhatsAppMessage
         public readonly string $phone,
         public readonly string $message,
         public readonly ?string $sender = null,
+        public readonly ?WhatsAppAttachment $attachment = null,
     ) {}
 }

--- a/app/Notifications/Drivers/BaileysDriver.php
+++ b/app/Notifications/Drivers/BaileysDriver.php
@@ -13,10 +13,25 @@ class BaileysDriver implements WhatsAppDriver
 
     public function send(WhatsAppMessage $message): void
     {
-        $this->signedRequest('POST', '/api/send', [
+        $payload = [
             'to' => $this->normalizePhone($message->phone),
             'text' => $message->message,
-        ]);
+        ];
+
+        if ($message->attachment) {
+            $payload['document'] = [
+                'data' => base64_encode($message->attachment->content),
+                'filename' => $message->attachment->filename,
+                'mimeType' => $message->attachment->mimeType,
+            ];
+        }
+
+        $this->signedRequest('POST', '/api/send', $payload);
+    }
+
+    public function supportsAttachments(): bool
+    {
+        return true;
     }
 
     public function health(): DriverHealthResult

--- a/app/Notifications/Drivers/FonnteDriver.php
+++ b/app/Notifications/Drivers/FonnteDriver.php
@@ -19,18 +19,33 @@ class FonnteDriver implements WhatsAppDriver
             throw new \RuntimeException('Fonnte token is not configured.');
         }
 
-        $response = Http::withToken($token, '')
-            ->asMultipart()
-            ->post('https://api.fonnte.com/send', [
-                'target' => $this->normalizePhone($message->phone),
-                'message' => $message->message,
-            ]);
+        $request = Http::withToken($token, '');
+
+        if ($message->attachment) {
+            $request = $request->attach(
+                'file',
+                $message->attachment->content,
+                $message->attachment->filename,
+                ['Content-Type' => $message->attachment->mimeType],
+            );
+        }
+
+        $response = $request->asMultipart()->post('https://api.fonnte.com/send', array_filter([
+            'target' => $this->normalizePhone($message->phone),
+            'message' => $message->message,
+            'filename' => $message->attachment?->filename,
+        ], fn ($value): bool => $value !== null));
 
         $body = $response->json();
 
         if (! ($body['status'] ?? false)) {
             throw new \RuntimeException($body['reason'] ?? 'Fonnte send failed');
         }
+    }
+
+    public function supportsAttachments(): bool
+    {
+        return true;
     }
 
     public function health(): DriverHealthResult

--- a/app/Notifications/Drivers/WhatsAppCloudApiDriver.php
+++ b/app/Notifications/Drivers/WhatsAppCloudApiDriver.php
@@ -20,18 +20,57 @@ class WhatsAppCloudApiDriver implements WhatsAppDriver
         $phoneNumberId = $this->config['phone_number_id'] ?? throw new \RuntimeException('WhatsApp Cloud API phone_number_id is not configured.');
         $token = $this->config['access_token'] ?? throw new \RuntimeException('WhatsApp Cloud API access_token is not configured.');
 
-        $response = Http::withToken($token)->post(self::GRAPH_API_BASE.'/'.$phoneNumberId.'/messages', [
-            'messaging_product' => 'whatsapp',
-            'to' => $this->normalizePhone($message->phone),
-            'type' => 'text',
-            'text' => ['body' => $message->message],
-        ]);
+        if ($message->attachment) {
+            $mediaResponse = Http::withToken($token)
+                ->attach(
+                    'file',
+                    $message->attachment->content,
+                    $message->attachment->filename,
+                    ['Content-Type' => $message->attachment->mimeType],
+                )
+                ->post(self::GRAPH_API_BASE.'/'.$phoneNumberId.'/media', [
+                    'messaging_product' => 'whatsapp',
+                ]);
+
+            if ($mediaResponse->failed()) {
+                throw new \RuntimeException($mediaResponse->json('error.message') ?? 'WhatsApp Cloud API media upload failed');
+            }
+
+            $mediaId = $mediaResponse->json('id');
+
+            if (! $mediaId) {
+                throw new \RuntimeException($mediaResponse->json('error.message') ?? 'WhatsApp Cloud API media upload failed');
+            }
+
+            $response = Http::withToken($token)->post(self::GRAPH_API_BASE.'/'.$phoneNumberId.'/messages', [
+                'messaging_product' => 'whatsapp',
+                'to' => $this->normalizePhone($message->phone),
+                'type' => 'document',
+                'document' => [
+                    'id' => $mediaId,
+                    'caption' => $message->message,
+                    'filename' => $message->attachment->filename,
+                ],
+            ]);
+        } else {
+            $response = Http::withToken($token)->post(self::GRAPH_API_BASE.'/'.$phoneNumberId.'/messages', [
+                'messaging_product' => 'whatsapp',
+                'to' => $this->normalizePhone($message->phone),
+                'type' => 'text',
+                'text' => ['body' => $message->message],
+            ]);
+        }
 
         $body = $response->json();
 
-        if (isset($body['error'])) {
+        if ($response->failed() || isset($body['error'])) {
             throw new \RuntimeException($body['error']['message'] ?? 'WhatsApp Cloud API send failed');
         }
+    }
+
+    public function supportsAttachments(): bool
+    {
+        return true;
     }
 
     public function health(): DriverHealthResult

--- a/app/Notifications/Drivers/WhatsappLogDriver.php
+++ b/app/Notifications/Drivers/WhatsappLogDriver.php
@@ -13,7 +13,18 @@ class WhatsappLogDriver implements WhatsAppDriver
 
     public function send(WhatsAppMessage $message): void
     {
-        Log::channel('reminders')->info('[WhatsApp] To: '.$message->phone.' — '.$message->message);
+        Log::channel('reminders')->info('[WhatsApp] To: '.$message->phone.' — '.$message->message, [
+            'attachment' => $message->attachment ? [
+                'filename' => $message->attachment->filename,
+                'mime_type' => $message->attachment->mimeType,
+                'bytes' => strlen($message->attachment->content),
+            ] : null,
+        ]);
+    }
+
+    public function supportsAttachments(): bool
+    {
+        return true;
     }
 
     public function health(): DriverHealthResult

--- a/app/Notifications/RentReminder.php
+++ b/app/Notifications/RentReminder.php
@@ -8,6 +8,7 @@ use App\Contracts\WhatsAppChannelNotification;
 use App\Data\Mail\MailAttachment;
 use App\Data\Mail\MailContent;
 use App\Data\Reminder\ReminderEvent;
+use App\Data\WhatsApp\WhatsAppAttachment;
 use App\Data\WhatsApp\WhatsAppContent;
 use App\Enums\ReminderType;
 use App\Models\Invoice;
@@ -98,8 +99,26 @@ class RentReminder extends Notification implements MailChannelNotification, Shou
 
     public function toWhatsAppChannel(object $notifiable): WhatsAppContent
     {
+        $attachment = null;
+        $invoice = $this->invoice();
+
+        if ($invoice) {
+            $reference = preg_replace(
+                '/[^A-Za-z0-9_-]/',
+                '-',
+                $invoice->reference ?? (string) $invoice->getKey(),
+            );
+
+            $attachment = new WhatsAppAttachment(
+                content: app(GenerateInvoicePdf::class)->execute($invoice),
+                filename: 'invoice-'.($reference ?: $invoice->getKey()).'.pdf',
+                mimeType: 'application/pdf',
+            );
+        }
+
         return new WhatsAppContent(
             message: $this->renderMessage($notifiable),
+            attachment: $attachment,
         );
     }
 

--- a/app/Notifications/RentReminder.php
+++ b/app/Notifications/RentReminder.php
@@ -26,6 +26,8 @@ class RentReminder extends Notification implements MailChannelNotification, Shou
 {
     use Queueable;
 
+    private ?string $invoicePdfContent = null;
+
     public function __construct(private ReminderEvent $event) {}
 
     public function via(object $notifiable): array
@@ -83,7 +85,7 @@ class RentReminder extends Notification implements MailChannelNotification, Shou
             );
 
             $attachments[] = new MailAttachment(
-                content: app(GenerateInvoicePdf::class)->execute($invoice),
+                content: $this->invoicePdfContent($invoice),
                 filename: 'invoice-'.($reference ?: $invoice->getKey()).'.pdf',
                 mimeType: 'application/pdf',
             );
@@ -110,7 +112,7 @@ class RentReminder extends Notification implements MailChannelNotification, Shou
             );
 
             $attachment = new WhatsAppAttachment(
-                content: app(GenerateInvoicePdf::class)->execute($invoice),
+                content: $this->invoicePdfContent($invoice),
                 filename: 'invoice-'.($reference ?: $invoice->getKey()).'.pdf',
                 mimeType: 'application/pdf',
             );
@@ -174,5 +176,10 @@ class RentReminder extends Notification implements MailChannelNotification, Shou
     private function invoice(): ?Invoice
     {
         return isset($this->event->invoice) ? $this->event->invoice : null;
+    }
+
+    private function invoicePdfContent(Invoice $invoice): string
+    {
+        return $this->invoicePdfContent ??= app(GenerateInvoicePdf::class)->execute($invoice);
     }
 }

--- a/app/Services/WhatsAppManager.php
+++ b/app/Services/WhatsAppManager.php
@@ -34,9 +34,14 @@ class WhatsAppManager
 
         $message = is_string($content) ? $content : $content->message;
         $mediaUrl = $content instanceof WhatsAppContent ? $content->mediaUrl : null;
+        $attachment = $content instanceof WhatsAppContent ? $content->attachment : null;
 
         try {
-            $driver->send(new WhatsAppMessage($phone, $message));
+            if ($attachment && ! $driver->supportsAttachments()) {
+                throw new \RuntimeException("WhatsApp driver [{$driverId}] does not support document attachments.");
+            }
+
+            $driver->send(new WhatsAppMessage($phone, $message, attachment: $attachment));
 
             event(new WhatsAppSent($driverId, $phone, $mediaUrl));
         } catch (\Throwable $exception) {

--- a/tests/Feature/Notifications/Drivers/BaileysDriverTest.php
+++ b/tests/Feature/Notifications/Drivers/BaileysDriverTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Data\WhatsApp\WhatsAppAttachment;
 use App\Data\WhatsApp\WhatsAppMessage;
 use App\Notifications\Drivers\BaileysDriver;
 use Illuminate\Support\Facades\Http;
@@ -44,6 +45,27 @@ it('includes HMAC signature headers', function () {
         return $request->hasHeader('X-Timestamp')
             && $request->hasHeader('X-Signature')
             && $request->header('X-Key-Id') === [];
+    });
+});
+
+it('sends a document payload', function () {
+    Http::fake([
+        '*/api/send' => fakeResponse(),
+    ]);
+
+    $driver = new BaileysDriver(['url' => 'http://localhost:3000', 'api_key' => 'secret']);
+    $driver->send(new WhatsAppMessage(
+        '+628123456789',
+        'Invoice',
+        attachment: new WhatsAppAttachment('%PDF-test', 'invoice.pdf', 'application/pdf'),
+    ));
+
+    Http::assertSent(function ($request) {
+        $body = json_decode($request->body(), true);
+
+        return ($body['document']['filename'] ?? null) === 'invoice.pdf'
+            && ($body['document']['mimeType'] ?? null) === 'application/pdf'
+            && ($body['document']['data'] ?? null) === base64_encode('%PDF-test');
     });
 });
 

--- a/tests/Feature/Notifications/Drivers/FonnteDriverTest.php
+++ b/tests/Feature/Notifications/Drivers/FonnteDriverTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Data\WhatsApp\WhatsAppAttachment;
 use App\Data\WhatsApp\WhatsAppMessage;
 use App\Notifications\Drivers\FonnteDriver;
 use Illuminate\Support\Facades\Http;
@@ -27,6 +28,31 @@ it('throws on failed send', function () {
 
     expect(fn () => $driver->send(new WhatsAppMessage('+628123456789', 'Hello')))
         ->toThrow(RuntimeException::class, 'insufficient quota');
+});
+
+it('sends a document as a multipart file', function () {
+    Http::fake([
+        'api.fonnte.com/send' => Http::response(['status' => true]),
+    ]);
+
+    $driver = new FonnteDriver(['token' => 'valid-token']);
+    $driver->send(new WhatsAppMessage(
+        '+628123456789',
+        'Invoice',
+        attachment: new WhatsAppAttachment('%PDF-test', 'invoice.pdf', 'application/pdf'),
+    ));
+
+    Http::assertSent(fn ($request) => str_contains($request->body(), 'invoice.pdf'));
+});
+
+it('preserves an empty text message', function () {
+    Http::fake([
+        'api.fonnte.com/send' => Http::response(['status' => true]),
+    ]);
+
+    (new FonnteDriver(['token' => 'valid-token']))->send(new WhatsAppMessage('+628123456789', ''));
+
+    Http::assertSent(fn ($request) => str_contains($request->body(), 'name="message"'));
 });
 
 it('throws when token missing on send', function () {

--- a/tests/Feature/Notifications/Drivers/WhatsAppCloudApiDriverTest.php
+++ b/tests/Feature/Notifications/Drivers/WhatsAppCloudApiDriverTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Data\WhatsApp\WhatsAppAttachment;
 use App\Data\WhatsApp\WhatsAppMessage;
 use App\Notifications\Drivers\WhatsAppCloudApiDriver;
 use Illuminate\Support\Facades\Http;
@@ -30,6 +31,48 @@ it('sends message via WhatsApp Cloud API', function () {
             && ($body['type'] ?? null) === 'text'
             && ($body['text']['body'] ?? null) === 'Hello';
     });
+});
+
+it('uploads and sends a document via WhatsApp Cloud API', function () {
+    Http::fake([
+        'graph.facebook.com/v22.0/123456789/media' => Http::response(['id' => 'media-123']),
+        'graph.facebook.com/v22.0/123456789/messages' => Http::response(['messages' => [['id' => 'wamid.doc']]]),
+    ]);
+
+    $driver = new WhatsAppCloudApiDriver([
+        'phone_number_id' => '123456789',
+        'access_token' => 'valid-token',
+    ]);
+
+    $driver->send(new WhatsAppMessage(
+        '+628123456789',
+        'Invoice',
+        attachment: new WhatsAppAttachment('%PDF-test', 'invoice.pdf', 'application/pdf'),
+    ));
+
+    Http::assertSent(fn ($request) => $request->url() === 'https://graph.facebook.com/v22.0/123456789/messages'
+        && $request->data()['type'] === 'document'
+        && $request->data()['document']['id'] === 'media-123'
+        && $request->data()['document']['filename'] === 'invoice.pdf');
+});
+
+it('fails when document upload is rejected', function () {
+    Http::fake([
+        'graph.facebook.com/v22.0/123456789/media' => Http::response([
+            'error' => ['message' => 'Unsupported document'],
+        ], 400),
+    ]);
+
+    $driver = new WhatsAppCloudApiDriver([
+        'phone_number_id' => '123456789',
+        'access_token' => 'valid-token',
+    ]);
+
+    expect(fn () => $driver->send(new WhatsAppMessage(
+        '+628123456789',
+        'Invoice',
+        attachment: new WhatsAppAttachment('%PDF-test', 'invoice.pdf', 'application/pdf'),
+    )))->toThrow(RuntimeException::class, 'Unsupported document');
 });
 
 it('throws on Graph API error', function () {

--- a/tests/Feature/Notifications/Drivers/WhatsappLogDriverTest.php
+++ b/tests/Feature/Notifications/Drivers/WhatsappLogDriverTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Data\WhatsApp\WhatsAppAttachment;
 use App\Data\WhatsApp\WhatsAppMessage;
 use App\Notifications\Drivers\WhatsappLogDriver;
 
@@ -7,6 +8,18 @@ it('sends without exception', function () {
     $driver = new WhatsappLogDriver;
 
     $driver->send(new WhatsAppMessage('08123456789', 'Test message'));
+
+    expect(true)->toBeTrue();
+});
+
+it('sends documents without logging their contents', function () {
+    $driver = new WhatsappLogDriver;
+
+    $driver->send(new WhatsAppMessage(
+        '08123456789',
+        'Invoice',
+        attachment: new WhatsAppAttachment('%PDF-test', 'invoice.pdf', 'application/pdf'),
+    ));
 
     expect(true)->toBeTrue();
 });

--- a/tests/Feature/SendRentRemindersTest.php
+++ b/tests/Feature/SendRentRemindersTest.php
@@ -362,6 +362,13 @@ describe('SendRentRemindersAction', function () {
                     ->toContain(number_format((float) $invoice->outstanding, 0))
                     ->not->toContain(route('portal.billing.invoices.show', $invoice));
 
+                $attachment = $notification->toWhatsAppChannel($tenant)->attachment;
+
+                expect($attachment)->not->toBeNull();
+                expect($attachment->filename)->toBe("invoice-{$invoice->reference}.pdf");
+                expect($attachment->mimeType)->toBe('application/pdf');
+                expect($attachment->content)->toStartWith('%PDF-');
+
                 return true;
             },
         );

--- a/tests/Feature/SendRentRemindersTest.php
+++ b/tests/Feature/SendRentRemindersTest.php
@@ -352,7 +352,8 @@ describe('SendRentRemindersAction', function () {
             $tenant,
             RentReminder::class,
             function (RentReminder $notification) use ($invoice, $tenant): bool {
-                $message = $notification->toWhatsAppChannel($tenant)->message;
+                $content = $notification->toWhatsAppChannel($tenant);
+                $message = $content->message;
 
                 expect($message)
                     ->toContain($invoice->reference)
@@ -362,7 +363,7 @@ describe('SendRentRemindersAction', function () {
                     ->toContain(number_format((float) $invoice->outstanding, 0))
                     ->not->toContain(route('portal.billing.invoices.show', $invoice));
 
-                $attachment = $notification->toWhatsAppChannel($tenant)->attachment;
+                $attachment = $content->attachment;
 
                 expect($attachment)->not->toBeNull();
                 expect($attachment->filename)->toBe("invoice-{$invoice->reference}.pdf");

--- a/tests/Feature/Services/WhatsAppManagerTest.php
+++ b/tests/Feature/Services/WhatsAppManagerTest.php
@@ -82,6 +82,11 @@ class TestWhatsAppDriver implements WhatsAppDriver
         self::$sentMessages[] = $message->phone;
     }
 
+    public function supportsAttachments(): bool
+    {
+        return true;
+    }
+
     public function health(): DriverHealthResult
     {
         return new DriverHealthResult(true);

--- a/tests/Feature/TenantInvoicePdfTest.php
+++ b/tests/Feature/TenantInvoicePdfTest.php
@@ -93,6 +93,8 @@ test('invoice PDF view reflects the current aggregate for each payable state', f
     string $paymentAmount,
     InvoiceStatus $expectedStatus,
 ) {
+    $this->travelTo('2026-08-01');
+
     $fixture = createTenantInvoicePdfFixture();
     $invoice = $fixture['invoice'];
     if ($expectedStatus === InvoiceStatus::Cancelled) {

--- a/tests/Unit/Data/WhatsApp/WhatsAppMessageTest.php
+++ b/tests/Unit/Data/WhatsApp/WhatsAppMessageTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Data\WhatsApp\WhatsAppAttachment;
 use App\Data\WhatsApp\WhatsAppMessage;
 
 it('creates with phone and message', function () {
@@ -25,4 +26,11 @@ it('properties are readonly', function () {
     $message = new WhatsAppMessage('08123456789', 'Hello');
 
     expect(fn () => $message->phone = '123')->toThrow(Error::class);
+});
+
+it('supports an optional document attachment', function () {
+    $attachment = new WhatsAppAttachment('%PDF-test', 'invoice.pdf', 'application/pdf');
+    $message = new WhatsAppMessage('08123456789', 'Hello', attachment: $attachment);
+
+    expect($message->attachment)->toBe($attachment);
 });

--- a/tests/Unit/Services/WhatsAppManagerTest.php
+++ b/tests/Unit/Services/WhatsAppManagerTest.php
@@ -2,6 +2,8 @@
 
 use App\Contracts\WhatsAppDriver;
 use App\Data\WhatsApp\DriverHealthResult;
+use App\Data\WhatsApp\WhatsAppAttachment;
+use App\Data\WhatsApp\WhatsAppContent;
 use App\Data\WhatsApp\WhatsAppMessage;
 use App\Events\WhatsApp\WhatsAppFailed;
 use App\Events\WhatsApp\WhatsAppSent;
@@ -67,6 +69,36 @@ describe('WhatsAppManager', function () {
         });
     });
 
+    it('forwards document attachments to the driver', function () {
+        app(NotificationRegistry::class)->registerDriver(new NotificationDriverRegistration(
+            name: 'test/capture',
+            channel: 'whatsapp',
+            driverClass: UnitTestWhatsAppDriver::class,
+            label: 'Capture Driver',
+        ));
+        Setting::set('whatsapp_driver', 'test/capture');
+        $attachment = new WhatsAppAttachment('%PDF-test', 'invoice.pdf', 'application/pdf');
+
+        app(WhatsAppManager::class)->send('628123456789', new WhatsAppContent('Invoice', attachment: $attachment));
+
+        expect(UnitTestWhatsAppDriver::$lastMessage?->attachment)->toBe($attachment);
+    });
+
+    it('fails explicitly when a driver does not support attachments', function () {
+        app(NotificationRegistry::class)->registerDriver(new NotificationDriverRegistration(
+            name: 'test/unsupported',
+            channel: 'whatsapp',
+            driverClass: UnitTestUnsupportedWhatsAppDriver::class,
+            label: 'Unsupported Driver',
+        ));
+        Setting::set('whatsapp_driver', 'test/unsupported');
+
+        expect(fn () => app(WhatsAppManager::class)->send(
+            '628123456789',
+            new WhatsAppContent('Invoice', attachment: new WhatsAppAttachment('%PDF-test', 'invoice.pdf', 'application/pdf')),
+        ))->toThrow(WhatsAppDeliveryException::class, 'does not support document attachments');
+    });
+
     it('dispatches WhatsAppFailed event and throws WhatsAppDeliveryException on failure', function () {
         Event::fake([WhatsAppFailed::class]);
 
@@ -94,9 +126,19 @@ describe('WhatsAppManager', function () {
 
 class UnitTestWhatsAppDriver implements WhatsAppDriver
 {
+    public static ?WhatsAppMessage $lastMessage = null;
+
     public function __construct(public array $config = []) {}
 
-    public function send(WhatsAppMessage $message): void {}
+    public function send(WhatsAppMessage $message): void
+    {
+        self::$lastMessage = $message;
+    }
+
+    public function supportsAttachments(): bool
+    {
+        return true;
+    }
 
     public function health(): DriverHealthResult
     {
@@ -132,9 +174,50 @@ class UnitTestFailingWhatsAppDriver implements WhatsAppDriver
         throw new RuntimeException('Network connection failed');
     }
 
+    public function supportsAttachments(): bool
+    {
+        return true;
+    }
+
     public function health(): DriverHealthResult
     {
         return new DriverHealthResult(false, 'Unhealthy');
+    }
+
+    public function supportsPairing(): bool
+    {
+        return false;
+    }
+
+    public function configurationSchema(): array
+    {
+        return [];
+    }
+
+    public function getPairingQrCode(): ?string
+    {
+        return null;
+    }
+
+    public function pair(): void {}
+
+    public function disconnect(): void {}
+}
+
+class UnitTestUnsupportedWhatsAppDriver implements WhatsAppDriver
+{
+    public function __construct(public array $config = []) {}
+
+    public function send(WhatsAppMessage $message): void {}
+
+    public function supportsAttachments(): bool
+    {
+        return false;
+    }
+
+    public function health(): DriverHealthResult
+    {
+        return new DriverHealthResult(true);
     }
 
     public function supportsPairing(): bool


### PR DESCRIPTION
## Summary
- add provider-neutral WhatsApp document attachments
- deliver invoice PDFs through WhatsApp reminders
- add explicit driver capability checks and provider failure handling

## Verification
- 81 focused Pest tests passed
- 197 assertions passed
- Pint passed
- git diff --check passed

Refs OPE-116