### PR TITLE
feat(notifications): add tenant center

### DIFF
--- a/app/Console/Commands/SendLeaseExpirationNotifications.php
+++ b/app/Console/Commands/SendLeaseExpirationNotifications.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\LeaseStatus;
+use App\Models\Lease;
+use App\Notifications\TenantPortalNotification;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+use Illuminate\Notifications\DatabaseNotification;
+
+#[Signature('app:send-lease-expiration-notifications')]
+#[Description('Notify tenants about leases ending in 30 days')]
+class SendLeaseExpirationNotifications extends Command
+{
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        Lease::query()
+            ->where('status', LeaseStatus::Active)
+            ->whereDate('end_date', today()->addDays(30))
+            ->with('primaryTenant')
+            ->each(function (Lease $lease): void {
+                $tenant = $lease->primaryTenant;
+                if (! $tenant) {
+                    return;
+                }
+
+                $alreadySent = $tenant->notifications()
+                    ->where('type', 'lease_expiring')
+                    ->get()
+                    ->contains(fn (DatabaseNotification $notification): bool => ($notification->data['lease_id'] ?? null) === $lease->id);
+
+                if ($alreadySent) {
+                    return;
+                }
+
+                $tenant->notify(new TenantPortalNotification([
+                    'type' => 'lease_expiring',
+                    'title' => __('Lease expiration reminder'),
+                    'message' => __('Your lease ends on :date.', ['date' => $lease->end_date->format('d M Y')]),
+                    'url' => route('portal.lease.show', $lease),
+                    'lease_id' => $lease->id,
+                ]));
+            });
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Events/Maintenance/MaintenanceTicketUpdated.php
+++ b/app/Events/Maintenance/MaintenanceTicketUpdated.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Events\Maintenance;
+
+use App\Models\MaintenanceTicket;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class MaintenanceTicketUpdated
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly MaintenanceTicket $ticket,
+        public readonly ?int $actorId = null,
+    ) {}
+}

--- a/app/Http/Controllers/MaintenanceTicketController.php
+++ b/app/Http/Controllers/MaintenanceTicketController.php
@@ -9,6 +9,7 @@ use App\Enums\LeaseStatus;
 use App\Enums\MaintenanceStatus;
 use App\Events\Maintenance\MaintenanceResolved;
 use App\Events\Maintenance\MaintenanceTicketCreated;
+use App\Events\Maintenance\MaintenanceTicketUpdated;
 use App\Events\Unit\UnitStatusChanged;
 use App\Http\Requests\Maintenance\StoreMaintenanceTicketRequest;
 use App\Http\Requests\Maintenance\UpdateMaintenanceTicketRequest;
@@ -214,6 +215,8 @@ class MaintenanceTicketController extends Controller
         unset($validated['restore_unit'], $validated['move_back']);
 
         $ticket->update($validated);
+
+        MaintenanceTicketUpdated::dispatch($ticket, actorId: Auth::id());
 
         if (($statusChangedToResolved ?? false)) {
             MaintenanceResolved::dispatch($ticket, actorId: Auth::id());

--- a/app/Http/Controllers/MaintenanceTicketController.php
+++ b/app/Http/Controllers/MaintenanceTicketController.php
@@ -216,7 +216,9 @@ class MaintenanceTicketController extends Controller
 
         $ticket->update($validated);
 
-        MaintenanceTicketUpdated::dispatch($ticket, actorId: Auth::id());
+        if ($ticket->wasChanged()) {
+            MaintenanceTicketUpdated::dispatch($ticket, actorId: Auth::id());
+        }
 
         if (($statusChangedToResolved ?? false)) {
             MaintenanceResolved::dispatch($ticket, actorId: Auth::id());

--- a/app/Http/Controllers/TenantPortal/NotificationController.php
+++ b/app/Http/Controllers/TenantPortal/NotificationController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Controllers\TenantPortal;
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Notifications\DatabaseNotification;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class NotificationController extends TenantPortalController
+{
+    public function index(Request $request): Response
+    {
+        $tenant = $this->tenant($request);
+
+        return Inertia::render('tenant-portal/notifications/index', [
+            'notifications' => $tenant->notifications()
+                ->latest()
+                ->paginate(20)
+                ->through(fn (DatabaseNotification $notification) => [
+                    'id' => $notification->id,
+                    'type' => $notification->data['type'] ?? $notification->type,
+                    'title' => $notification->data['title'] ?? '',
+                    'message' => $notification->data['message'] ?? '',
+                    'url' => $notification->data['url'] ?? null,
+                    'created_at' => $notification->created_at->toIso8601String(),
+                    'read_at' => $notification->read_at?->toIso8601String(),
+                ]),
+            'unreadCount' => $tenant->unreadNotifications()->count(),
+        ]);
+    }
+
+    public function markAsRead(Request $request, string $notification): RedirectResponse
+    {
+        $this->tenant($request)->notifications()->whereKey($notification)->firstOrFail()->markAsRead();
+
+        return back();
+    }
+
+    public function markAllAsRead(Request $request): RedirectResponse
+    {
+        $this->tenant($request)->unreadNotifications()->update(['read_at' => now()]);
+
+        return back();
+    }
+}

--- a/app/Notifications/RentReminder.php
+++ b/app/Notifications/RentReminder.php
@@ -41,7 +41,7 @@ class RentReminder extends Notification implements MailChannelNotification, Shou
 
         $channels = Setting::get('reminder_channels') ?? ['log'];
 
-        return array_merge(['database'], array_values(array_intersect_key($map, array_flip($channels))));
+        return array_values(array_intersect_key($map, array_flip(['database', ...$channels])));
     }
 
     public function shouldSend(object $notifiable, string $channel): bool

--- a/app/Notifications/RentReminder.php
+++ b/app/Notifications/RentReminder.php
@@ -33,6 +33,7 @@ class RentReminder extends Notification implements MailChannelNotification, Shou
     public function via(object $notifiable): array
     {
         $map = [
+            'database' => 'database',
             'log' => LogChannel::class,
             'whatsapp' => WhatsAppChannel::class,
             'mail' => MailChannel::class,
@@ -40,7 +41,7 @@ class RentReminder extends Notification implements MailChannelNotification, Shou
 
         $channels = Setting::get('reminder_channels') ?? ['log'];
 
-        return array_values(array_intersect_key($map, array_flip($channels)));
+        return array_merge(['database'], array_values(array_intersect_key($map, array_flip($channels))));
     }
 
     public function shouldSend(object $notifiable, string $channel): bool
@@ -127,6 +128,26 @@ class RentReminder extends Notification implements MailChannelNotification, Shou
     public function toLog(object $notifiable): string
     {
         return $this->renderMessage($notifiable);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        $invoice = $this->invoice();
+
+        return [
+            'type' => 'rent_reminder',
+            'title' => __('Rent reminder'),
+            'message' => $this->renderMessage($notifiable),
+            'url' => $invoice ? route('portal.billing.invoices.show', $invoice) : route('portal.billing.index'),
+        ];
+    }
+
+    public function databaseType(object $notifiable): string
+    {
+        return 'rent_reminder';
     }
 
     public function toWhatsApp(object $notifiable): string

--- a/app/Notifications/TenantPortalNotification.php
+++ b/app/Notifications/TenantPortalNotification.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Notifications\Notification;
+
+class TenantPortalNotification extends Notification
+{
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function __construct(private array $data) {}
+
+    public function via(object $notifiable): array
+    {
+        return ['database'];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return $this->data;
+    }
+
+    public function databaseType(object $notifiable): string
+    {
+        return (string) $this->data['type'];
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,9 +3,15 @@
 namespace App\Providers;
 
 use App\Database\PostgresConnection;
+use App\Enums\PaymentStatus;
+use App\Events\Maintenance\MaintenanceTicketCreated;
+use App\Events\Maintenance\MaintenanceTicketUpdated;
+use App\Events\Payment\PaymentStatusChanged;
 use App\Events\Reminder\InvoiceReminderDispatched;
+use App\Models\MaintenanceTicket;
 use App\Models\Setting;
 use App\Notifications\RentReminder;
+use App\Notifications\TenantPortalNotification;
 use App\Services\Settings\SettingManager;
 use App\Services\WhatsAppManager;
 use Carbon\CarbonImmutable;
@@ -91,6 +97,33 @@ class AppServiceProvider extends ServiceProvider
 
     protected function configureDomainEvents(): void
     {
+        Event::listen(MaintenanceTicketCreated::class, function (MaintenanceTicketCreated $event): void {
+            $this->notifyMaintenanceTenant($event->ticket, 'maintenance_created');
+        });
+
+        Event::listen(MaintenanceTicketUpdated::class, function (MaintenanceTicketUpdated $event): void {
+            $this->notifyMaintenanceTenant($event->ticket, 'maintenance_updated');
+        });
+
+        Event::listen(PaymentStatusChanged::class, function (PaymentStatusChanged $event): void {
+            if ($event->to !== PaymentStatus::Confirmed) {
+                return;
+            }
+
+            $invoice = $event->payment->invoice()->with('lease.primaryTenant')->first();
+            $tenant = $invoice?->lease?->primaryTenant;
+            if (! $tenant) {
+                return;
+            }
+
+            $tenant->notify(new TenantPortalNotification([
+                'type' => 'payment_confirmed',
+                'title' => __('Payment confirmed'),
+                'message' => __('Your payment has been confirmed.'),
+                'url' => route('portal.billing.invoices.show', $invoice),
+            ]));
+        });
+
         Event::listen(InvoiceReminderDispatched::class, function (InvoiceReminderDispatched $event): void {
             $lease = $event->event->lease;
             $lease->loadMissing('primaryTenant.user');
@@ -104,5 +137,20 @@ class AppServiceProvider extends ServiceProvider
 
             $tenant->notify(new RentReminder($event->event));
         });
+    }
+
+    private function notifyMaintenanceTenant(MaintenanceTicket $ticket, string $type): void
+    {
+        $tenant = $ticket->creator?->tenant;
+        if (! $tenant) {
+            return;
+        }
+
+        $tenant->notify(new TenantPortalNotification([
+            'type' => $type,
+            'title' => __('Maintenance update'),
+            'message' => $ticket->title,
+            'url' => route('portal.maintenance-tickets.show', $ticket),
+        ]));
     }
 }

--- a/database/migrations/2026_08_07_034312_create_notifications_table.php
+++ b/database/migrations/2026_08_07_034312_create_notifications_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('notifications', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('type');
+            $table->morphs('notifiable');
+            $table->text('data');
+            $table->timestamp('read_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('notifications');
+    }
+};

--- a/resources/js/layouts/tenant-portal-layout.tsx
+++ b/resources/js/layouts/tenant-portal-layout.tsx
@@ -22,6 +22,7 @@ import { cn } from '@/lib/utils';
 import { dashboard } from '@/routes/portal';
 import { index as billing } from '@/routes/portal/billing';
 import { index as leases } from '@/routes/portal/lease';
+import { index as notifications } from '@/routes/portal/notifications';
 import type { Auth } from '@/types/auth';
 import type { AppLayoutProps } from '@/types/ui';
 
@@ -30,6 +31,7 @@ const navigationItems = [
     { title: 'Leases', href: leases() },
     { title: 'Billing', href: billing() },
     { title: 'Maintenance', href: '/portal/maintenance-tickets' },
+    { title: 'Notifications', href: notifications() },
 ];
 
 export default function TenantPortalLayout({ children }: AppLayoutProps) {

--- a/resources/js/pages/tenant-portal/notifications/index.tsx
+++ b/resources/js/pages/tenant-portal/notifications/index.tsx
@@ -1,0 +1,132 @@
+import { Head, Link, router } from '@inertiajs/react';
+import { Bell, CheckCheck } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { formatDate } from '@/lib/formatters';
+import { read, readAll } from '@/routes/portal/notifications';
+
+type Notification = {
+    id: string;
+    type: string;
+    title: string;
+    message: string;
+    url: string | null;
+    created_at: string;
+    read_at: string | null;
+};
+
+type Props = {
+    notifications: {
+        data: Notification[];
+        links: { url: string | null; label: string; active: boolean }[];
+    };
+    unreadCount: number;
+};
+
+export default function Notifications({ notifications, unreadCount }: Props) {
+    return (
+        <>
+            <Head title="Notifications" />
+            <div className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-5 p-4">
+                <div className="flex items-center justify-between gap-4">
+                    <div>
+                        <h1 className="text-xl font-semibold">Notifications</h1>
+                        <p className="mt-1 text-sm text-muted-foreground">
+                            Stay up to date with your tenancy.
+                        </p>
+                    </div>
+                    {unreadCount > 0 && (
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => router.post(readAll.url())}
+                        >
+                            <CheckCheck />
+                            Mark all as read
+                        </Button>
+                    )}
+                </div>
+
+                <Card>
+                    <CardHeader>
+                        <CardTitle className="flex items-center gap-2">
+                            <Bell className="size-5" />
+                            History
+                            {unreadCount > 0 && (
+                                <Badge variant="secondary">{unreadCount} unread</Badge>
+                            )}
+                        </CardTitle>
+                    </CardHeader>
+                    <CardContent className="p-0">
+                        {notifications.data.length === 0 ? (
+                            <div className="flex min-h-40 items-center justify-center p-6 text-sm text-muted-foreground">
+                                No notifications yet.
+                            </div>
+                        ) : (
+                            <div className="divide-y">
+                                {notifications.data.map((notification) => (
+                                    <div
+                                        key={notification.id}
+                                        className={`flex gap-4 p-5 ${!notification.read_at ? 'bg-muted/30' : ''}`}
+                                    >
+                                        <div className="min-w-0 flex-1 space-y-1">
+                                            <div className="flex items-center gap-2">
+                                                <p className="font-medium">{notification.title}</p>
+                                                {!notification.read_at && (
+                                                    <Badge variant="default">Unread</Badge>
+                                                )}
+                                            </div>
+                                            <p className="text-sm text-muted-foreground">
+                                                {notification.message}
+                                            </p>
+                                            <p className="text-xs text-muted-foreground">
+                                                {formatDate(notification.created_at)}
+                                            </p>
+                                        </div>
+                                        <div className="flex shrink-0 items-start gap-2">
+                                            {notification.url && (
+                                                <Button asChild size="sm" variant="outline">
+                                                    <Link href={notification.url}>View</Link>
+                                                </Button>
+                                            )}
+                                            {!notification.read_at && (
+                                                <Button
+                                                    size="sm"
+                                                    variant="ghost"
+                                                    onClick={() =>
+                                                        router.post(read.url(notification.id), {}, {
+                                                            preserveScroll: true,
+                                                        })
+                                                    }
+                                                >
+                                                    Read
+                                                </Button>
+                                            )}
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+                    </CardContent>
+                </Card>
+
+                {notifications.links.length > 3 && (
+                    <div className="flex flex-wrap justify-center gap-2">
+                        {notifications.links.map((link, index) => (
+                            <Button
+                                key={`${link.label}-${index}`}
+                                asChild={Boolean(link.url)}
+                                variant={link.active ? 'default' : 'outline'}
+                                size="sm"
+                                disabled={!link.url}
+                            >
+                                {link.url ? <Link href={link.url}>{link.label}</Link> : link.label}
+                            </Button>
+                        ))}
+                    </div>
+                )}
+            </div>
+        </>
+    );
+}

--- a/routes/console.php
+++ b/routes/console.php
@@ -15,3 +15,7 @@ Schedule::command('invoices:generate')
 Schedule::command('rent:send-reminders')
     ->dailyAt('08:00')
     ->withoutOverlapping(60);
+
+Schedule::command('app:send-lease-expiration-notifications')
+    ->dailyAt('08:05')
+    ->withoutOverlapping(60);

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,6 +16,7 @@ use App\Http\Controllers\TenantDocumentController;
 use App\Http\Controllers\TenantInvitationController;
 use App\Http\Controllers\TenantPortal\DashboardController as TenantPortalDashboardController;
 use App\Http\Controllers\TenantPortal\LeaseController as TenantPortalLeaseController;
+use App\Http\Controllers\TenantPortal\NotificationController as TenantPortalNotificationController;
 use App\Http\Controllers\TenantPortal\PaymentController as TenantPortalPaymentController;
 use App\Http\Controllers\UnitController;
 use App\Http\Controllers\UserController;
@@ -36,6 +37,11 @@ Route::prefix('tenants/invitations')->name('tenants.invitations.')->middleware('
 Route::middleware(['auth', 'verified'])->prefix('portal')->name('portal.')->group(function () {
     Route::redirect('/', '/portal/dashboard');
     Route::get('dashboard', TenantPortalDashboardController::class)->name('dashboard');
+    Route::prefix('notifications')->name('notifications.')->group(function () {
+        Route::get('/', [TenantPortalNotificationController::class, 'index'])->name('index');
+        Route::post('{notification}/read', [TenantPortalNotificationController::class, 'markAsRead'])->name('read');
+        Route::post('read-all', [TenantPortalNotificationController::class, 'markAllAsRead'])->name('read-all');
+    });
     Route::prefix('billing')->name('billing.')->group(function () {
         Route::get('/', [TenantPortalPaymentController::class, 'index'])->name('index');
         Route::post('/', [TenantPortalPaymentController::class, 'store'])->name('store');

--- a/tests/Feature/TenantNotificationTest.php
+++ b/tests/Feature/TenantNotificationTest.php
@@ -1,0 +1,120 @@
+<?php
+
+use App\Enums\PaymentStatus;
+use App\Events\Payment\PaymentStatusChanged;
+use App\Models\Invoice;
+use App\Models\Lease;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Notifications\TenantPortalNotification;
+use Database\Seeders\RoleAndPermissionSeeder;
+
+uses()->beforeEach(function () {
+    $this->seed(RoleAndPermissionSeeder::class);
+});
+
+test('tenant can view and mark notifications as read', function () {
+    $user = User::factory()->create();
+    $tenant = Tenant::factory()->withUser($user)->create();
+    $tenant->notify(new TenantPortalNotification([
+        'type' => 'maintenance_created',
+        'title' => 'Maintenance update',
+        'message' => 'Leaking faucet',
+        'url' => null,
+    ]));
+
+    $notification = $tenant->notifications()->first();
+
+    $this->actingAs($user)
+        ->get(route('portal.notifications.index'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('tenant-portal/notifications/index')
+            ->where('unreadCount', 1)
+            ->where('notifications.data.0.title', 'Maintenance update'));
+
+    $this->post(route('portal.notifications.read', $notification->id))
+        ->assertRedirect();
+
+    expect($notification->fresh()->read_at)->not->toBeNull();
+});
+
+test('tenant cannot mark another tenants notification as read', function () {
+    $user = User::factory()->create();
+    Tenant::factory()->withUser($user)->create();
+    $otherTenant = Tenant::factory()->withUser()->create();
+    $otherTenant->notify(new TenantPortalNotification([
+        'type' => 'maintenance_created',
+        'title' => 'Private',
+        'message' => 'Private',
+    ]));
+    $notification = $otherTenant->notifications()->first();
+
+    $this->actingAs($user)
+        ->post(route('portal.notifications.read', $notification->id))
+        ->assertNotFound();
+});
+
+test('tenant can mark all notifications as read', function () {
+    $user = User::factory()->create();
+    $tenant = Tenant::factory()->withUser($user)->create();
+
+    foreach (['First', 'Second'] as $title) {
+        $tenant->notify(new TenantPortalNotification([
+            'type' => 'maintenance_created',
+            'title' => $title,
+            'message' => $title,
+        ]));
+    }
+
+    $this->actingAs($user)
+        ->post(route('portal.notifications.read-all'))
+        ->assertRedirect();
+
+    expect($tenant->unreadNotifications()->count())->toBe(0);
+});
+
+test('payment confirmation creates a tenant notification', function () {
+    $user = User::factory()->create();
+    $tenant = Tenant::factory()->withUser($user)->create();
+    $lease = Lease::factory()->create(['primary_tenant_id' => $tenant->id]);
+    $invoice = Invoice::factory()->create(['lease_id' => $lease->id]);
+    $payment = $invoice->payments()->create([
+        'amount' => 100000,
+        'payment_date' => now(),
+        'status' => PaymentStatus::Confirmed,
+    ]);
+
+    PaymentStatusChanged::dispatch($payment, PaymentStatus::Pending, PaymentStatus::Confirmed);
+
+    expect($tenant->notifications()->where('type', 'payment_confirmed')->exists())->toBeTrue();
+});
+
+test('maintenance ticket creation creates a tenant notification', function () {
+    $user = User::factory()->create();
+    $tenant = Tenant::factory()->withUser($user)->create();
+    $lease = Lease::factory()->create(['primary_tenant_id' => $tenant->id]);
+
+    $this->actingAs($user)
+        ->post(route('portal.maintenance-tickets.store'), [
+            'title' => 'Leaking faucet',
+            'location_type' => 'unit',
+        ])
+        ->assertRedirect();
+
+    expect($tenant->notifications()->where('type', 'maintenance_created')->exists())->toBeTrue();
+});
+
+test('lease expiration command creates only one notification at thirty days', function () {
+    $user = User::factory()->create();
+    $tenant = Tenant::factory()->withUser($user)->create();
+    Lease::factory()->create([
+        'primary_tenant_id' => $tenant->id,
+        'end_date' => today()->addDays(30),
+    ]);
+
+    $this->artisan('app:send-lease-expiration-notifications')->assertSuccessful();
+    $this->artisan('app:send-lease-expiration-notifications')->assertSuccessful();
+
+    expect($tenant->notifications()->where('type', 'lease_expiring')->count())->toBe(1);
+});

--- a/tests/Feature/TenantNotificationTest.php
+++ b/tests/Feature/TenantNotificationTest.php
@@ -1,13 +1,21 @@
 <?php
 
+use App\Data\Reminder\ReminderEvent;
 use App\Enums\PaymentStatus;
+use App\Enums\ReminderType;
+use App\Events\Maintenance\MaintenanceTicketUpdated;
 use App\Events\Payment\PaymentStatusChanged;
 use App\Models\Invoice;
 use App\Models\Lease;
+use App\Models\MaintenanceTicket;
+use App\Models\Setting;
 use App\Models\Tenant;
 use App\Models\User;
+use App\Notifications\Channels\LogChannel;
+use App\Notifications\RentReminder;
 use App\Notifications\TenantPortalNotification;
 use Database\Seeders\RoleAndPermissionSeeder;
+use Illuminate\Support\Facades\Event;
 
 uses()->beforeEach(function () {
     $this->seed(RoleAndPermissionSeeder::class);
@@ -88,6 +96,37 @@ test('payment confirmation creates a tenant notification', function () {
     PaymentStatusChanged::dispatch($payment, PaymentStatus::Pending, PaymentStatus::Confirmed);
 
     expect($tenant->notifications()->where('type', 'payment_confirmed')->exists())->toBeTrue();
+});
+
+test('rent reminder channels contain database only once', function () {
+    Setting::set('reminder_channels', ['database', 'log'], 'array');
+    $lease = Lease::factory()->create();
+    $reminder = new RentReminder(new ReminderEvent(
+        lease: $lease,
+        type: ReminderType::Upcoming,
+        periodStart: today()->toDateString(),
+        periodEnd: today()->addMonth()->toDateString(),
+        dueDate: today()->addDays(3)->toDateString(),
+        amount: 100000,
+    ));
+
+    expect($reminder->via($lease->primaryTenant))->toHaveCount(2)
+        ->and($reminder->via($lease->primaryTenant))->toEqual(['database', LogChannel::class]);
+});
+
+test('maintenance no-op updates do not notify tenants', function () {
+    $ticket = MaintenanceTicket::factory()->create();
+    $owner = User::factory()->owner()->create();
+    $owner->properties()->attach($ticket->property_id);
+    Event::fake([MaintenanceTicketUpdated::class]);
+
+    $this->actingAs($owner)
+        ->put(route('maintenance-tickets.update', $ticket), [
+            'title' => $ticket->title,
+        ])
+        ->assertRedirect();
+
+    Event::assertNotDispatched(MaintenanceTicketUpdated::class);
 });
 
 test('maintenance ticket creation creates a tenant notification', function () {

--- a/tests/Unit/Notifications/MailChannelTest.php
+++ b/tests/Unit/Notifications/MailChannelTest.php
@@ -115,7 +115,7 @@ test('RentReminder via returns only configured channels', function () {
     $reminder = new RentReminder($event);
     $via = $reminder->via((object) []);
 
-    expect($via)->toBe([LogChannel::class, MailChannel::class]);
+    expect($via)->toBe(['database', LogChannel::class, MailChannel::class]);
 });
 
 test('RentReminder still renders events without invoice context', function () {


### PR DESCRIPTION
## Summary

- Add tenant notification history with unread/read state
- Notify tenants about rent, payment, maintenance, and lease events
- Add 30-day lease-expiration scheduling

## Verification

- `TenantNotificationTest`: 6 passed
- Related notification and maintenance tests: 33 passed
- TypeScript check passed
- Frontend build passed
- Pint passed

Note: repository-wide lint still reports existing errors in `resources/js/pages/settings/whatsapp.tsx`.