### PR TITLE
feat(platform): add Composer plugin discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,5 @@ testing_test_*
 /data/
 DESIGN.md
 PRODUCT.md
+/FINDINGS.md
 /.impeccable/

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -12,6 +12,7 @@ use App\Models\MaintenanceTicket;
 use App\Models\Setting;
 use App\Notifications\RentReminder;
 use App\Notifications\TenantPortalNotification;
+use App\Services\Platform\ComposerPluginDiscovery;
 use App\Services\Settings\PlatformSettingsStore;
 use App\Services\Settings\SettingManager;
 use App\Services\WhatsAppManager;
@@ -24,6 +25,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Validation\Rules\Password;
+use OpenKOS\Core\Contracts\PluginDiscovery;
 use OpenKOS\Core\Contracts\SettingsStore;
 use OpenKOS\Platform\OpenKOSManager;
 use OpenKOS\Platform\Settings\SettingsPage;
@@ -33,6 +35,7 @@ class AppServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->singleton(SettingManager::class);
+        $this->app->singleton(PluginDiscovery::class, ComposerPluginDiscovery::class);
         $this->app->singleton(SettingsStore::class, PlatformSettingsStore::class);
         $this->app->singleton(MailManager::class);
         $this->app->singleton(WhatsAppManager::class);

--- a/app/Services/Platform/ComposerPluginDiscovery.php
+++ b/app/Services/Platform/ComposerPluginDiscovery.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Services\Platform;
+
+use Composer\InstalledVersions;
+use InvalidArgumentException;
+use OpenKOS\Core\Contracts\PluginDiscovery;
+use OpenKOS\Platform\Plugin\Plugin;
+
+final class ComposerPluginDiscovery implements PluginDiscovery
+{
+    /**
+     * @return array<int, class-string<Plugin>>
+     */
+    public function discover(): array
+    {
+        $disabledPackages = config('platform.discovery.disabled_packages', []);
+        $packages = InstalledVersions::getInstalledPackages();
+
+        sort($packages, SORT_STRING);
+
+        $plugins = [];
+
+        foreach ($packages as $package) {
+            if (in_array($package, $disabledPackages, true)) {
+                continue;
+            }
+
+            $installPath = InstalledVersions::getInstallPath($package);
+
+            if (! is_string($installPath)) {
+                continue;
+            }
+
+            $composerFile = $installPath.'/composer.json';
+
+            if (! is_file($composerFile)) {
+                continue;
+            }
+
+            $metadata = $this->readMetadata($package, $composerFile);
+            $openkos = $metadata['extra']['openkos'] ?? null;
+
+            if (! is_array($openkos) || ! array_key_exists('plugin', $openkos)) {
+                continue;
+            }
+
+            $plugin = $openkos['plugin'];
+
+            if (! is_string($plugin) || trim($plugin) === '') {
+                throw new InvalidArgumentException(
+                    "Package [{$package}] must declare a non-empty string in extra.openkos.plugin.",
+                );
+            }
+
+            $plugins[] = trim($plugin);
+        }
+
+        return array_values(array_unique($plugins));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readMetadata(string $package, string $composerFile): array
+    {
+        try {
+            $metadata = json_decode(
+                file_get_contents($composerFile),
+                true,
+                512,
+                JSON_THROW_ON_ERROR,
+            );
+        } catch (\Throwable $exception) {
+            throw new InvalidArgumentException(
+                "Could not read Composer metadata for package [{$package}].",
+                previous: $exception,
+            );
+        }
+
+        if (! is_array($metadata)) {
+            throw new InvalidArgumentException(
+                "Composer metadata for package [{$package}] must be an object.",
+            );
+        }
+
+        return $metadata;
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -3311,16 +3311,16 @@
         },
         {
             "name": "openkos/platform",
-            "version": "0.1.0",
+            "version": "0.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/senatroxx/openkos-platform.git",
-                "reference": "9875a67041d54339c5ae1b9daa0c0767e429e0aa"
+                "reference": "31db53d706184f4caba70bac1da331028b96fd59"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/senatroxx/openkos-platform/zipball/9875a67041d54339c5ae1b9daa0c0767e429e0aa",
-                "reference": "9875a67041d54339c5ae1b9daa0c0767e429e0aa",
+                "url": "https://api.github.com/repos/senatroxx/openkos-platform/zipball/31db53d706184f4caba70bac1da331028b96fd59",
+                "reference": "31db53d706184f4caba70bac1da331028b96fd59",
                 "shasum": ""
             },
             "require": {
@@ -3351,16 +3351,28 @@
                     "OpenKOS\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest --compact"
+                ],
+                "lint": [
+                    "pint"
+                ]
+            },
             "license": [
                 "Apache-2.0"
             ],
             "description": "The OpenKOS platform and plugin SDK.",
             "support": {
-                "issues": "https://github.com/senatroxx/openkos-platform/issues",
-                "source": "https://github.com/senatroxx/openkos-platform/tree/v0.1.0"
+                "source": "https://github.com/senatroxx/openkos-platform/tree/v0.1.1",
+                "issues": "https://github.com/senatroxx/openkos-platform/issues"
             },
-            "time": "2026-08-10T10:09:51+00:00"
+            "time": "2026-08-11T14:23:41+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",

--- a/config/platform.php
+++ b/config/platform.php
@@ -21,14 +21,20 @@ return [
 
     'version' => InstalledVersions::getPrettyVersion('openkos/platform') ?: '0.1.0',
 
+    'discovery' => [
+        // External plugin discovery is host policy and is enabled explicitly here.
+        'enabled' => true,
+        'disabled_packages' => [],
+    ],
+
     /*
     |--------------------------------------------------------------------------
     | Plugins
     |--------------------------------------------------------------------------
     |
-    | Plugin classes booted by the PlatformServiceProvider. Each must extend
-    | OpenKOS\Platform\Plugin\Plugin. Composer-based discovery may replace
-    | this list later (see OpenKOS\Core\Contracts\PluginDiscovery).
+    | Explicit plugin classes are merged with trusted Composer-discovered
+    | plugins when discovery is enabled. Each must extend
+    | OpenKOS\Platform\Plugin\Plugin.
     |
     */
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,7 +48,7 @@ app/
 └── Tables/           Reusable table/filter/column builders
 
 src/
-└── Plugins/          Application-owned plugin implementations (config/platform.php lists enabled plugins)
+└── Plugins/          Application-owned plugin implementations (explicit and discovered plugins share the platform lifecycle)
 
 openkos-platform/src/
 ├── Core/             Platform contracts, DTOs, and events

--- a/docs/architecture/adr/005-plugin-philosophy.md
+++ b/docs/architecture/adr/005-plugin-philosophy.md
@@ -15,11 +15,11 @@ OpenKOS must be extensible (navigation, dashboards, workspace tabs, settings pag
 
 We will treat plugins as **trusted, in-process extensions registering into typed platform registries** — the trust boundary is installation, not a runtime sandbox.
 
-- A plugin extends `OpenKOS\Platform\Plugin\Plugin`, declares a `PluginManifest` (id, version, `coreVersion` constraint, dependencies), and registers into container-singleton registries via the `OpenKOSManager`. Enabled plugins are listed explicitly in `config/platform.php`.
+- A plugin extends `OpenKOS\Platform\Plugin\Plugin`, declares a `PluginManifest` (id, version, `coreVersion` constraint, dependencies), and registers into container-singleton registries via the `OpenKOSManager`. In-repo plugins are listed explicitly in `config/platform.php`; trusted Composer plugins may be discovered by the host.
 - Extension is **additive only**: plugins own their tables via their own migrations, declare their own permissions, and must not alter core schema or behavior.
 - Plugins react to core through **platform-level domain events** (`OpenKOS\Core\Events`, see [docs/domain-events.md](../../domain-events.md)) — the stable plugin API — never by patching core code. Application events remain a compatibility surface for host-only subscribers.
 - The loader fail-fasts on incompatible core versions, missing dependencies, and cycles; a broken plugin never half-boots.
-- Dormant seams are interface-only until a real consumer forces their shape (e.g. `PaymentGateway` waits for the first real gateway; `PluginDiscovery` waits for Composer-based distribution).
+- Dormant seams are interface-only until a real consumer forces their shape (e.g. `PaymentGateway` waits for the first real gateway).
 
 Full mechanics: [docs/platform.md](../../platform.md).
 
@@ -28,4 +28,4 @@ Full mechanics: [docs/platform.md](../../platform.md).
 - Plugins get real types, IDE navigation, DI, and the whole framework — no capability API to design or maintain.
 - Users must vet plugins like Composer dependencies; there is no protection from a malicious plugin by design.
 - An untrusted-plugin marketplace would require sandboxing this architecture deliberately does not provide — that is a superseding ADR, not an increment.
-- **Revisit trigger:** demand for third-party plugins distributed outside the repo (the frontend bundling problem) or from untrusted authors (the sandbox problem).
+- **Revisit trigger:** demand for third-party plugin frontend bundling or support for untrusted authors (the sandbox problem).

--- a/docs/platform.md
+++ b/docs/platform.md
@@ -23,7 +23,7 @@ openkos/src/Plugins/
 
 The package exposes host-agnostic contracts and events such as `OpenKOS\Core\Events\PaymentRecorded`. OpenKOS may also dispatch its legacy `App\Events` counterparts for application subscribers; the package never imports application events or models.
 
-Composer package auto-discovery registers `PlatformServiceProvider`; the application does not list it again in `bootstrap/providers.php`. Plugin classes remain explicitly listed in `config/platform.php`. Composer-based plugin discovery is deferred to a follow-up ticket.
+Composer package auto-discovery registers `PlatformServiceProvider`; the application does not list it again in `bootstrap/providers.php`. The host merges explicit plugin classes from `config/platform.php` with trusted Composer-discovered plugins when `platform.discovery.enabled` is true.
 
 ## The Registries
 
@@ -187,7 +187,7 @@ class MyPlugin extends Plugin
 }
 ```
 
-Then list it in `config/platform.php` (order doesn't matter — dependencies decide it):
+Then list it in `config/platform.php` (explicit entries are processed first; dependencies decide the final lifecycle order):
 
 ```php
 'plugins' => [
@@ -209,16 +209,18 @@ src/Plugins/MyPlugin/
 
 The package `PlatformServiceProvider::boot()`:
 
-1. Instantiates every configured plugin through the container (so plugins can
-   constructor-inject dependencies).
-2. **Validates & orders** them with `PluginLoader`: checks each `coreVersion`
+1. Merges explicit plugin classes with the host's `PluginDiscovery` result and
+   removes duplicate class names.
+2. Resolves and validates **every** class before loading any plugin resources or
+   running lifecycle methods. Each class must extend `Plugin`.
+3. **Validates & orders** them with `PluginLoader`: checks each `coreVersion`
    against `config('platform.version')`, verifies declared `dependencies` exist,
    and topologically sorts so each plugin loads after its dependencies. Throws on
    an incompatible version, missing dependency, dependency cycle, or duplicate id.
-3. **Loads resources** — each plugin's `routes/web.php` and `database/migrations/`.
-4. Runs **two passes**: every plugin's `register()`, then every plugin's `boot()`
+4. **Loads resources** — each plugin's `routes/web.php` and `database/migrations/`.
+5. Runs **two passes**: every plugin's `register()`, then every plugin's `boot()`
    (so `boot()` can rely on all plugins having registered).
-5. **Wires event listeners** from each plugin's `listens()` onto Laravel's dispatcher.
+6. **Wires event listeners** from each plugin's `listens()` onto Laravel's dispatcher.
 
 ### Manifest, versioning & dependencies
 
@@ -243,12 +245,27 @@ legacy `App\Events` for host-only subscribers.
 
 ### Discovery
 
-Plugins are listed explicitly in `config/platform.php`. `OpenKOS\Core\Contracts\PluginDiscovery`
-(`discover(): array` of plugin class-strings) is the seam for future Composer-package
-discovery — interface only, no implementation. Note that shipping a plugin's **frontend**
-code (React pages/regions) still requires it to live in-repo under `resources/js/plugins/`;
-a bundling story (build-time registration or module federation) is the open problem
-that gates true external plugins.
+The standalone package exposes `OpenKOS\Core\Contracts\PluginDiscovery`, but does not
+scan Composer itself. OpenKOS provides the host implementation, which enumerates installed
+packages and accepts exactly one plugin class per package through this metadata:
+
+```json
+{
+    "extra": {
+        "openkos": {
+            "plugin": "Vendor\\Package\\MyPlugin"
+        }
+    }
+}
+```
+
+The host merges explicit classes first, then discovered classes, and removes duplicates.
+`PluginLoader` still controls dependency order. `platform.discovery.disabled_packages`
+accepts Composer package names for an explicit opt-out. Discovery is disabled by default
+in the standalone package and enabled by the OpenKOS application.
+
+Installing a Composer plugin grants trusted in-process PHP execution; disabled packages
+are not sandboxed. Frontend assets remain out of scope and must still be handled by the host.
 
 ### Security & permission boundaries
 
@@ -271,9 +288,7 @@ Composer dependency. What the platform **does** enforce:
   plugin from partially booting.
 
 Sandboxing (capability limits, resource isolation) is explicitly out of scope for the
-monolith; it would only matter for untrusted third-party marketplace plugins, which is a
-Composer plugin discovery is deferred to a follow-up ticket; configured plugins remain
-explicit in `config/platform.php` for this package extraction.
+monolith; it would only matter for untrusted third-party marketplace plugins.
 
 ## Notifications (WhatsApp) — consumed
 
@@ -313,7 +328,7 @@ The backend and client halves are independent: registry entries + route + listen
 ### Future work
 
 1. Move built-in nav/tabs into a core plugin so built-ins and plugins go through one path (only if the dual path starts to hurt).
-2. Composer-based `PluginDiscovery` implementation, including a story for shipping plugin frontend code (today it must live in-repo under `resources/js/plugins/`).
+2. A story for shipping plugin frontend code (today it must live in-repo under `resources/js/plugins/`).
 3. `PaymentGateway`/`PaymentRegistry` wiring once a real gateway (Midtrans/Xendit) is chosen.
 
 ## Testing

--- a/tests/Feature/Platform/ComposerPluginDiscoveryTest.php
+++ b/tests/Feature/Platform/ComposerPluginDiscoveryTest.php
@@ -1,0 +1,210 @@
+<?php
+
+use App\Services\Platform\ComposerPluginDiscovery;
+use Composer\InstalledVersions;
+use OpenKOS\Core\Contracts\PluginDiscovery;
+use OpenKOS\Platform\OpenKOSManager;
+use OpenKOS\Platform\PlatformServiceProvider;
+use OpenKOS\Platform\Plugin\Plugin;
+use OpenKOS\Platform\Plugin\PluginManifest;
+
+class ComposerDiscoveryFixturePlugin extends Plugin
+{
+    public static int $registerCalls = 0;
+
+    public function manifest(): PluginManifest
+    {
+        return new PluginManifest(
+            id: 'fixture/composer-plugin',
+            name: 'Composer Fixture',
+            version: '1.0.0',
+        );
+    }
+
+    public function register(OpenKOSManager $platform): void
+    {
+        self::$registerCalls++;
+    }
+}
+
+class ComposerDiscoverySecondFixturePlugin extends Plugin
+{
+    public function manifest(): PluginManifest
+    {
+        return new PluginManifest(
+            id: 'fixture/composer-plugin-second',
+            name: 'Composer Second Fixture',
+            version: '1.0.0',
+        );
+    }
+
+    public function register(OpenKOSManager $platform): void {}
+}
+
+/**
+ * @param  array<string, array<string, mixed>>  $packages
+ */
+function withComposerDiscoveryFixtures(array $packages, Closure $callback): mixed
+{
+    $original = require base_path('vendor/composer/installed.php');
+    $versions = [];
+    $directories = [];
+
+    try {
+        foreach ($packages as $name => $metadata) {
+            $directory = sys_get_temp_dir().'/openkos-plugin-'.str_replace('/', '-', $name).'-'.uniqid('', true);
+            mkdir($directory, 0755, true);
+            file_put_contents(
+                $directory.'/composer.json',
+                json_encode(['name' => $name, ...$metadata], JSON_THROW_ON_ERROR),
+            );
+
+            $directories[] = $directory;
+            $versions[$name] = [
+                'pretty_version' => '1.0.0',
+                'version' => '1.0.0.0',
+                'reference' => null,
+                'type' => 'library',
+                'install_path' => $directory,
+                'aliases' => [],
+                'dev_requirement' => false,
+            ];
+        }
+
+        InstalledVersions::reload([
+            'root' => [
+                'name' => 'openkos/openkos',
+                'pretty_version' => 'dev-test',
+                'version' => 'dev-test',
+                'reference' => null,
+                'type' => 'project',
+                'install_path' => base_path(),
+                'aliases' => [],
+                'dev' => true,
+            ],
+            'versions' => $versions,
+        ]);
+
+        return $callback();
+    } finally {
+        InstalledVersions::reload($original);
+
+        foreach ($directories as $directory) {
+            unlink($directory.'/composer.json');
+            rmdir($directory);
+        }
+    }
+}
+
+it('discovers a plugin declared by Composer metadata', function () {
+    $plugins = withComposerDiscoveryFixtures([
+        'acme/composer-plugin' => [
+            'extra' => [
+                'openkos' => ['plugin' => ComposerDiscoveryFixturePlugin::class],
+            ],
+        ],
+    ], fn (): array => app(ComposerPluginDiscovery::class)->discover());
+
+    expect($plugins)->toContain(ComposerDiscoveryFixturePlugin::class);
+});
+
+it('ignores packages without OpenKOS plugin metadata', function () {
+    $plugins = withComposerDiscoveryFixtures([
+        'acme/ordinary-package' => [],
+    ], fn (): array => app(ComposerPluginDiscovery::class)->discover());
+
+    expect($plugins)->not->toContain(ComposerDiscoveryFixturePlugin::class);
+});
+
+it('skips disabled Composer packages', function () {
+    config(['platform.discovery.disabled_packages' => ['acme/composer-plugin']]);
+
+    $plugins = withComposerDiscoveryFixtures([
+        'acme/composer-plugin' => [
+            'extra' => [
+                'openkos' => ['plugin' => ComposerDiscoveryFixturePlugin::class],
+            ],
+        ],
+    ], fn (): array => app(ComposerPluginDiscovery::class)->discover());
+
+    expect($plugins)->not->toContain(ComposerDiscoveryFixturePlugin::class);
+});
+
+it('rejects malformed OpenKOS plugin metadata', function () {
+    withComposerDiscoveryFixtures([
+        'acme/malformed-plugin' => [
+            'extra' => [
+                'openkos' => ['plugin' => [ComposerDiscoveryFixturePlugin::class]],
+            ],
+        ],
+    ], fn (): array => app(ComposerPluginDiscovery::class)->discover());
+})->throws(InvalidArgumentException::class, 'extra.openkos.plugin');
+
+it('leaves plugin class validation to the platform bootstrap', function () {
+    $plugins = withComposerDiscoveryFixtures([
+        'acme/missing-plugin' => [
+            'extra' => [
+                'openkos' => ['plugin' => 'Acme\\MissingPlugin'],
+            ],
+        ],
+    ], fn (): array => app(ComposerPluginDiscovery::class)->discover());
+
+    expect($plugins)->toContain('Acme\\MissingPlugin');
+});
+
+it('boots a Composer-discovered plugin through the normal lifecycle', function () {
+    ComposerDiscoveryFixturePlugin::$registerCalls = 0;
+
+    withComposerDiscoveryFixtures([
+        'acme/composer-plugin' => [
+            'extra' => [
+                'openkos' => ['plugin' => ComposerDiscoveryFixturePlugin::class],
+            ],
+        ],
+    ], function (): null {
+        config(['platform.plugins' => []]);
+        (new PlatformServiceProvider(app()))->boot();
+
+        return null;
+    });
+
+    expect(ComposerDiscoveryFixturePlugin::$registerCalls)->toBe(1);
+});
+
+it('does not run any plugin lifecycle when discovery finds an invalid class', function () {
+    ComposerDiscoveryFixturePlugin::$registerCalls = 0;
+    app()->instance(PluginDiscovery::class, new class implements PluginDiscovery
+    {
+        public function discover(): array
+        {
+            return [ComposerDiscoveryFixturePlugin::class, 'Acme\\MissingPlugin'];
+        }
+    });
+
+    config(['platform.plugins' => []]);
+
+    expect(fn () => (new PlatformServiceProvider(app()))->boot())
+        ->toThrow(InvalidArgumentException::class, 'Plugin class [Acme\\MissingPlugin] does not exist.');
+
+    expect(ComposerDiscoveryFixturePlugin::$registerCalls)->toBe(0);
+});
+
+it('loads discovered plugins in deterministic package order', function () {
+    $plugins = withComposerDiscoveryFixtures([
+        'zeta/plugin' => [
+            'extra' => [
+                'openkos' => ['plugin' => ComposerDiscoveryFixturePlugin::class],
+            ],
+        ],
+        'acme/plugin' => [
+            'extra' => [
+                'openkos' => ['plugin' => ComposerDiscoverySecondFixturePlugin::class],
+            ],
+        ],
+    ], fn (): array => app(ComposerPluginDiscovery::class)->discover());
+
+    expect($plugins)->toBe([
+        ComposerDiscoverySecondFixturePlugin::class,
+        ComposerDiscoveryFixturePlugin::class,
+    ]);
+});


### PR DESCRIPTION
## Summary
- add host-side Composer plugin discovery through `PluginDiscovery`
- merge explicit and discovered plugins with duplicate removal
- validate every plugin before lifecycle boot to keep startup atomic
- add discovery configuration, tests, and architecture documentation
- update `openkos/platform` to `v0.1.1`

## Verification
- `composer validate --strict --no-check-publish`
- `composer install --dry-run --no-interaction`
- `vendor/bin/pint --dirty --format agent`
- `php -d memory_limit=512M vendor/bin/pest --compact` (654 tests, 2,944 assertions)
