### PR TITLE
feat(reminders): add typed message templates

### DIFF
--- a/app/Http/Controllers/Settings/ReminderController.php
+++ b/app/Http/Controllers/Settings/ReminderController.php
@@ -41,6 +41,18 @@ class ReminderController extends Controller
 
         return Inertia::render('settings/reminders', [
             'settings' => $settings,
+            'defaultTemplates' => collect(ReminderType::cases())
+                ->mapWithKeys(fn (ReminderType $type): array => [
+                    $type->value => __("notifications.rent.{$type->value}"),
+                ])
+                ->all(),
+            'previewInvoiceContext' => __('notifications.rent.invoice_context', [
+                'reference' => 'INV-2026-07',
+                'period' => '01 Jul 2026 – 31 Jul 2026',
+                'date' => '01 Jul 2026',
+                'amount' => '1,500,000',
+            ]),
+            'previewInvoiceLink' => __('notifications.rent.view_invoice').': https://example.test/portal/billing/invoices/1',
         ]);
     }
 

--- a/app/Http/Controllers/Settings/ReminderController.php
+++ b/app/Http/Controllers/Settings/ReminderController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Settings;
 
 use App\Actions\Settings\UpdateSettings;
+use App\Enums\ReminderType;
 use App\Http\Controllers\Controller;
 use App\Models\Setting;
 use Illuminate\Http\RedirectResponse;
@@ -22,10 +23,20 @@ class ReminderController extends Controller
             'reminder_enabled',
             'reminder_days_before',
             'reminder_overdue_intervals',
-            'reminder_message_template',
+            'reminder_message_templates',
             'reminder_channels',
         ]);
 
+        $legacyTemplate = Setting::get('reminder_message_template');
+        $templates = is_array($settings['reminder_message_templates'])
+            ? $settings['reminder_message_templates']
+            : [];
+
+        $settings['reminder_message_templates'] = collect(ReminderType::cases())
+            ->mapWithKeys(fn (ReminderType $type): array => [
+                $type->value => $templates[$type->value] ?? $legacyTemplate ?? '',
+            ])
+            ->all();
         $settings['reminder_channels'] ??= ['log'];
 
         return Inertia::render('settings/reminders', [
@@ -39,7 +50,10 @@ class ReminderController extends Controller
             'reminder_enabled' => ['boolean'],
             'reminder_days_before' => ['required', 'integer', 'min:0', 'max:30'],
             'reminder_overdue_intervals' => ['required', 'string', 'regex:/^\d+(?:\s*,\s*\d+)*$/'],
-            'reminder_message_template' => ['nullable', 'string', 'max:1000'],
+            'reminder_message_templates' => ['required', 'array:upcoming,due_today,overdue'],
+            'reminder_message_templates.upcoming' => ['nullable', 'string', 'max:1000'],
+            'reminder_message_templates.due_today' => ['nullable', 'string', 'max:1000'],
+            'reminder_message_templates.overdue' => ['nullable', 'string', 'max:1000'],
             'reminder_channels' => ['required', 'array', 'min:1'],
             'reminder_channels.*' => ['string', 'in:log,whatsapp,mail'],
         ]);

--- a/app/Notifications/RentReminder.php
+++ b/app/Notifications/RentReminder.php
@@ -143,7 +143,7 @@ class RentReminder extends Notification implements MailChannelNotification, Shou
             'type' => 'rent_reminder',
             'title' => __('Rent reminder'),
             'message' => $this->renderMessage($notifiable),
-            'url' => $invoice ? route('portal.billing.invoices.show', $invoice) : route('portal.billing.index'),
+            'url' => $this->portalUrl($notifiable, $invoice),
         ];
     }
 
@@ -212,11 +212,24 @@ class RentReminder extends Notification implements MailChannelNotification, Shou
 
     private function invoiceUrl(object $notifiable): ?string
     {
-        $invoice = $this->invoice();
+        return $this->portalUrl($notifiable, $this->invoice());
+    }
 
-        return $invoice && $notifiable instanceof Tenant && $notifiable->user_id
+    private function portalUrl(object $notifiable, ?Invoice $invoice = null): ?string
+    {
+        if (! ($notifiable instanceof Tenant)) {
+            return null;
+        }
+
+        $user = $notifiable->user;
+
+        if (! $user?->is_active || ! $user->hasVerifiedEmail()) {
+            return null;
+        }
+
+        return $invoice
             ? route('portal.billing.invoices.show', $invoice)
-            : null;
+            : route('portal.billing.index');
     }
 
     private function invoicePdfContent(Invoice $invoice): string

--- a/app/Notifications/RentReminder.php
+++ b/app/Notifications/RentReminder.php
@@ -64,18 +64,20 @@ class RentReminder extends Notification implements MailChannelNotification, Shou
         };
 
         $messageText = $this->renderMessage($notifiable);
-        $invoice = $this->invoice();
-        $invoiceUrl = $invoice && $notifiable instanceof Tenant && $notifiable->user_id
-            ? route('portal.billing.invoices.show', $invoice)
-            : null;
-        $htmlBody = '<div>'.nl2br(e($messageText)).'</div>';
-        $plainTextBody = $messageText;
+        $invoiceUrl = $this->invoiceUrl($notifiable);
+        $escapedMessage = e($messageText);
 
         if ($invoiceUrl) {
-            $label = __('notifications.rent.view_invoice');
-            $htmlBody .= '<p><a href="'.e($invoiceUrl).'">'.e($label).'</a></p>';
-            $plainTextBody .= "\n\n{$label}: {$invoiceUrl}";
+            $escapedMessage = str_replace(
+                e($invoiceUrl),
+                '<a href="'.e($invoiceUrl).'">'.e($invoiceUrl).'</a>',
+                $escapedMessage,
+            );
         }
+
+        $htmlBody = '<div>'.nl2br($escapedMessage).'</div>';
+        $plainTextBody = $messageText;
+        $invoice = $this->invoice();
 
         $attachments = [];
         if ($invoice && $notifiable instanceof Tenant && $notifiable->user?->email) {
@@ -163,12 +165,31 @@ class RentReminder extends Notification implements MailChannelNotification, Shou
         $amount = number_format($this->event->amount / 100, 0);
         $date = Carbon::parse($this->event->dueDate)->format('d M Y');
 
-        $template = Setting::get('reminder_message_template');
+        $templates = Setting::get('reminder_message_templates');
+        $template = is_array($templates)
+            ? ($templates[$this->event->type->value] ?? null)
+            : null;
+        $template ??= Setting::get('reminder_message_template');
+
+        $invoice = $this->invoice();
+        $invoiceContext = $invoice
+            ? __('notifications.rent.invoice_context', [
+                'reference' => $invoice->reference,
+                'period' => Carbon::parse($this->event->periodStart)->format('d M Y')
+                    .' – '.Carbon::parse($this->event->periodEnd)->format('d M Y'),
+                'date' => $date,
+                'amount' => $amount,
+            ])
+            : '';
+        $invoiceUrl = $this->invoiceUrl($notifiable);
+        $invoiceLink = $invoiceUrl
+            ? __('notifications.rent.view_invoice').': '.$invoiceUrl
+            : '';
 
         $message = $template
             ? str_replace(
-                [':name', ':unit', ':days', ':amount', ':date'],
-                [$notifiable->name, $this->event->lease->unit?->name ?? '—', $days, $amount, $date],
+                [':name', ':unit', ':days', ':amount', ':date', ':invoice_context', ':invoice_link'],
+                [$notifiable->name, $this->event->lease->unit?->name ?? '—', $days, $amount, $date, $invoiceContext, $invoiceLink],
                 $template,
             )
             : __("notifications.rent.{$this->event->type->value}", [
@@ -177,26 +198,25 @@ class RentReminder extends Notification implements MailChannelNotification, Shou
                 'days' => $days,
                 'amount' => $amount,
                 'date' => $date,
+                'invoice_context' => $invoiceContext,
+                'invoice_link' => $invoiceLink,
             ]);
 
-        $invoice = $this->invoice();
-
-        if (! $invoice) {
-            return $message;
-        }
-
-        return $message."\n\n".__('notifications.rent.invoice_context', [
-            'reference' => $invoice->reference,
-            'period' => Carbon::parse($this->event->periodStart)->format('d M Y')
-                .' – '.Carbon::parse($this->event->periodEnd)->format('d M Y'),
-            'date' => $date,
-            'amount' => $amount,
-        ]);
+        return trim(preg_replace('/\n{3,}/', "\n\n", $message) ?? $message);
     }
 
     private function invoice(): ?Invoice
     {
         return isset($this->event->invoice) ? $this->event->invoice : null;
+    }
+
+    private function invoiceUrl(object $notifiable): ?string
+    {
+        $invoice = $this->invoice();
+
+        return $invoice && $notifiable instanceof Tenant && $notifiable->user_id
+            ? route('portal.billing.invoices.show', $invoice)
+            : null;
     }
 
     private function invoicePdfContent(Invoice $invoice): string

--- a/config/settings.php
+++ b/config/settings.php
@@ -11,6 +11,7 @@ return [
     'reminder_enabled' => ['default' => true, 'cast' => 'boolean'],
     'reminder_days_before' => ['default' => 3, 'cast' => 'integer'],
     'reminder_overdue_intervals' => ['default' => [1, 3, 7], 'cast' => 'array'],
+    'reminder_message_templates' => ['default' => [], 'cast' => 'array'],
     'reminder_channels' => ['default' => ['log'], 'cast' => 'array'],
     'mail_config' => ['default' => [], 'cast' => 'encrypted:array'],
     'whatsapp_config' => ['default' => [], 'cast' => 'encrypted:array'],

--- a/lang/en/notifications.php
+++ b/lang/en/notifications.php
@@ -2,9 +2,9 @@
 
 return [
     'rent' => [
-        'upcoming' => "Hi :name,\n\nRent for :unit is due in :days days.\n\nAmount: :amount\nDue date: :date",
-        'due_today' => "Hi :name,\n\nRent for :unit is due today.\n\nAmount: :amount",
-        'overdue' => "Hi :name,\n\nRent for :unit is overdue by :days day(s).\n\nAmount: :amount",
+        'upcoming' => "Hi :name,\n\nRent for :unit is due in :days days.\n\nAmount: :amount\nDue date: :date\n\n:invoice_context\n\n:invoice_link",
+        'due_today' => "Hi :name,\n\nRent for :unit is due today.\n\nAmount: :amount\n\n:invoice_context\n\n:invoice_link",
+        'overdue' => "Hi :name,\n\nRent for :unit is overdue by :days day(s).\n\nAmount: :amount\n\n:invoice_context\n\n:invoice_link",
         'invoice_context' => "Invoice: :reference\nPeriod: :period\nDue date: :date\nOutstanding: :amount",
         'view_invoice' => 'View invoice',
     ],

--- a/lang/id/notifications.php
+++ b/lang/id/notifications.php
@@ -2,9 +2,9 @@
 
 return [
     'rent' => [
-        'upcoming' => "Halo :name,\n\nSewa kamar :unit akan jatuh tempo dalam :days hari.\n\nJumlah: :amount\nTanggal jatuh tempo: :date",
-        'due_today' => "Halo :name,\n\nSewa kamar :unit jatuh tempo hari ini.\n\nJumlah: :amount",
-        'overdue' => "Halo :name,\n\nPembayaran sewa kamar :unit terlambat :days hari.\n\nJumlah: :amount",
+        'upcoming' => "Halo :name,\n\nSewa kamar :unit akan jatuh tempo dalam :days hari.\n\nJumlah: :amount\nTanggal jatuh tempo: :date\n\n:invoice_context\n\n:invoice_link",
+        'due_today' => "Halo :name,\n\nSewa kamar :unit jatuh tempo hari ini.\n\nJumlah: :amount\n\n:invoice_context\n\n:invoice_link",
+        'overdue' => "Halo :name,\n\nPembayaran sewa kamar :unit terlambat :days hari.\n\nJumlah: :amount\n\n:invoice_context\n\n:invoice_link",
         'invoice_context' => "Invoice: :reference\nPeriode: :period\nTanggal jatuh tempo: :date\nSisa tagihan: :amount",
         'view_invoice' => 'Lihat invoice',
     ],

--- a/resources/js/pages/settings/reminders.tsx
+++ b/resources/js/pages/settings/reminders.tsx
@@ -29,12 +29,6 @@ const templateOptions = [
     { value: 'overdue', label: 'Overdue reminder' },
 ] as const;
 
-const defaultTemplates = {
-    upcoming: `Hi :name,\n\nRent for :unit is due in :days days.\n\nAmount: :amount\nDue date: :date\n\n:invoice_context\n\n:invoice_link`,
-    due_today: `Hi :name,\n\nRent for :unit is due today.\n\nAmount: :amount\n\n:invoice_context\n\n:invoice_link`,
-    overdue: `Hi :name,\n\nRent for :unit is overdue by :days day(s).\n\nAmount: :amount\n\n:invoice_context\n\n:invoice_link`,
-} as const;
-
 function renderTemplate(
     template: string | null,
     data: Record<string, string | number>,
@@ -51,6 +45,9 @@ function renderTemplate(
 
 export default function Reminders({
     settings,
+    defaultTemplates,
+    previewInvoiceContext,
+    previewInvoiceLink,
 }: {
     settings: {
         reminder_enabled: boolean;
@@ -59,6 +56,9 @@ export default function Reminders({
         reminder_message_templates: Record<string, string | null>;
         reminder_channels: string[];
     };
+    defaultTemplates: Record<string, string>;
+    previewInvoiceContext: string;
+    previewInvoiceLink: string;
 }) {
     const { data, setData, submit, transform, processing, errors } = useForm({
         reminder_enabled: settings.reminder_enabled,
@@ -91,16 +91,19 @@ export default function Reminders({
         overdueDays: 3,
     };
 
-    const previewData = {
+    const previewInvoiceData = {
         name: preview.name,
         unit: preview.unit,
-        days: preview.overdueDays,
         amount: preview.amount,
         date: preview.date,
-        invoice_context:
-            'Invoice: INV-2026-07\nPeriod: 01 Jul 2026 – 31 Jul 2026\nDue date: 01 Jul 2026\nOutstanding: 1,500,000',
-        invoice_link:
-            'View invoice: https://example.test/portal/billing/invoices/1',
+        invoice_context: previewInvoiceContext,
+        invoice_link: previewInvoiceLink,
+    };
+
+    const previewData = {
+        upcoming: { ...previewInvoiceData, days: preview.days },
+        due_today: { ...previewInvoiceData, days: 0 },
+        overdue: { ...previewInvoiceData, days: preview.overdueDays },
     };
 
     return (
@@ -184,7 +187,33 @@ export default function Reminders({
                                             data.reminder_message_templates
                                                 .upcoming ||
                                                 defaultTemplates.upcoming,
-                                            previewData,
+                                            previewData.upcoming,
+                                        )}
+                                    </pre>
+                                </div>
+                            )}
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Due Today</CardTitle>
+                            <CardDescription>
+                                Preview the reminder sent on the rent due date.
+                            </CardDescription>
+                        </CardHeader>
+                        <CardContent>
+                            {data.reminder_enabled && (
+                                <div className="rounded-lg border bg-muted/50 p-4">
+                                    <p className="mb-2 text-xs font-medium tracking-wider text-muted-foreground uppercase">
+                                        Preview (due today)
+                                    </p>
+                                    <pre className="text-sm whitespace-pre-wrap">
+                                        {renderTemplate(
+                                            data.reminder_message_templates
+                                                .due_today ||
+                                                defaultTemplates.due_today,
+                                            previewData.due_today,
                                         )}
                                     </pre>
                                 </div>
@@ -237,7 +266,7 @@ export default function Reminders({
                                             data.reminder_message_templates
                                                 .overdue ||
                                                 defaultTemplates.overdue,
-                                            previewData,
+                                            previewData.overdue,
                                         )}
                                     </pre>
                                 </div>

--- a/resources/js/pages/settings/reminders.tsx
+++ b/resources/js/pages/settings/reminders.tsx
@@ -23,6 +23,18 @@ const channelOptions = [
     { value: 'mail', label: 'Email' },
 ] as const;
 
+const templateOptions = [
+    { value: 'upcoming', label: 'Upcoming reminder' },
+    { value: 'due_today', label: 'Due today reminder' },
+    { value: 'overdue', label: 'Overdue reminder' },
+] as const;
+
+const defaultTemplates = {
+    upcoming: `Hi :name,\n\nRent for :unit is due in :days days.\n\nAmount: :amount\nDue date: :date\n\n:invoice_context\n\n:invoice_link`,
+    due_today: `Hi :name,\n\nRent for :unit is due today.\n\nAmount: :amount\n\n:invoice_context\n\n:invoice_link`,
+    overdue: `Hi :name,\n\nRent for :unit is overdue by :days day(s).\n\nAmount: :amount\n\n:invoice_context\n\n:invoice_link`,
+} as const;
+
 function renderTemplate(
     template: string | null,
     data: Record<string, string | number>,
@@ -32,7 +44,7 @@ function renderTemplate(
     }
 
     return Object.entries(data).reduce(
-        (str, [key, val]) => str.replace(`:${key}`, String(val)),
+        (str, [key, val]) => str.split(`:${key}`).join(String(val)),
         template,
     );
 }
@@ -44,7 +56,7 @@ export default function Reminders({
         reminder_enabled: boolean;
         reminder_days_before: number;
         reminder_overdue_intervals: number[];
-        reminder_message_template: string | null;
+        reminder_message_templates: Record<string, string | null>;
         reminder_channels: string[];
     };
 }) {
@@ -54,7 +66,11 @@ export default function Reminders({
         reminder_overdue_intervals:
             settings.reminder_overdue_intervals.join(', '),
         reminder_channels: settings.reminder_channels ?? ['log'],
-        reminder_message_template: settings.reminder_message_template ?? '',
+        reminder_message_templates: {
+            upcoming: settings.reminder_message_templates.upcoming ?? '',
+            due_today: settings.reminder_message_templates.due_today ?? '',
+            overdue: settings.reminder_message_templates.overdue ?? '',
+        },
     });
 
     function handleSubmit(e: React.FormEvent) {
@@ -75,17 +91,17 @@ export default function Reminders({
         overdueDays: 3,
     };
 
-    const renderedUpcoming = renderTemplate(data.reminder_message_template, {
-        name: preview.name,
-        unit: preview.unit,
-    });
-    const renderedOverdue = renderTemplate(data.reminder_message_template, {
+    const previewData = {
         name: preview.name,
         unit: preview.unit,
         days: preview.overdueDays,
         amount: preview.amount,
         date: preview.date,
-    });
+        invoice_context:
+            'Invoice: INV-2026-07\nPeriod: 01 Jul 2026 – 31 Jul 2026\nDue date: 01 Jul 2026\nOutstanding: 1,500,000',
+        invoice_link:
+            'View invoice: https://example.test/portal/billing/invoices/1',
+    };
 
     return (
         <div className="space-y-6">
@@ -164,13 +180,12 @@ export default function Reminders({
                                         Preview (upcoming)
                                     </p>
                                     <pre className="text-sm whitespace-pre-wrap">
-                                        {renderedUpcoming ??
-                                            `Hi ${preview.name},
-
-Rent for ${preview.unit} is due in ${preview.days} days.
-
-Amount: ${preview.amount}
-Due date: ${preview.date}`}
+                                        {renderTemplate(
+                                            data.reminder_message_templates
+                                                .upcoming ||
+                                                defaultTemplates.upcoming,
+                                            previewData,
+                                        )}
                                     </pre>
                                 </div>
                             )}
@@ -218,12 +233,12 @@ Due date: ${preview.date}`}
                                         Preview (overdue)
                                     </p>
                                     <pre className="text-sm whitespace-pre-wrap">
-                                        {renderedOverdue ??
-                                            `Hi ${preview.name},
-
-Rent for ${preview.unit} is overdue by ${preview.overdueDays} day(s).
-
-Amount: ${preview.amount}`}
+                                        {renderTemplate(
+                                            data.reminder_message_templates
+                                                .overdue ||
+                                                defaultTemplates.overdue,
+                                            previewData,
+                                        )}
                                     </pre>
                                 </div>
                             )}
@@ -276,44 +291,58 @@ Amount: ${preview.amount}`}
 
                     <Card>
                         <CardHeader>
-                            <CardTitle>Message Template</CardTitle>
+                            <CardTitle>Message Templates</CardTitle>
                             <CardDescription>
-                                Customize the reminder message. Available
+                                Customize each reminder message. Available
                                 placeholders: <code>:name</code>,{' '}
                                 <code>:unit</code>, <code>:days</code>,{' '}
-                                <code>:amount</code>, <code>:date</code>. Leave
-                                empty to use defaults.
+                                <code>:amount</code>, <code>:date</code>,{' '}
+                                <code>:invoice_context</code>, and{' '}
+                                <code>:invoice_link</code>. The invoice
+                                placeholders are optional.
                             </CardDescription>
                         </CardHeader>
-                        <CardContent>
-                            <div className="grid gap-2">
-                                <Label htmlFor="reminder_message_template">
-                                    Template
-                                </Label>
-                                <Textarea
-                                    id="reminder_message_template"
-                                    name="reminder_message_template"
-                                    className="min-h-[120px]"
-                                    placeholder={`Hi :name,
-
-Rent for :unit is due in :days days.
-
-Amount: :amount
-Due date: :date`}
-                                    value={data.reminder_message_template}
-                                    onChange={(e) =>
-                                        setData(
-                                            'reminder_message_template',
-                                            e.target.value,
-                                        )
-                                    }
-                                />
-                                {errors.reminder_message_template && (
-                                    <p className="text-sm text-red-600">
-                                        {errors.reminder_message_template}
-                                    </p>
-                                )}
-                            </div>
+                        <CardContent className="grid gap-6">
+                            {templateOptions.map(({ value, label }) => (
+                                <div key={value} className="grid gap-2">
+                                    <Label
+                                        htmlFor={`reminder_${value}_template`}
+                                    >
+                                        {label}
+                                    </Label>
+                                    <Textarea
+                                        id={`reminder_${value}_template`}
+                                        name={`reminder_message_templates[${value}]`}
+                                        className="min-h-[120px]"
+                                        placeholder={defaultTemplates[value]}
+                                        value={
+                                            data.reminder_message_templates[
+                                                value
+                                            ]
+                                        }
+                                        onChange={(e) =>
+                                            setData(
+                                                'reminder_message_templates',
+                                                {
+                                                    ...data.reminder_message_templates,
+                                                    [value]: e.target.value,
+                                                },
+                                            )
+                                        }
+                                    />
+                                    {errors[
+                                        `reminder_message_templates.${value}`
+                                    ] && (
+                                        <p className="text-sm text-red-600">
+                                            {
+                                                errors[
+                                                    `reminder_message_templates.${value}`
+                                                ]
+                                            }
+                                        </p>
+                                    )}
+                                </div>
+                            ))}
                         </CardContent>
                     </Card>
 

--- a/tests/Feature/SendRentRemindersTest.php
+++ b/tests/Feature/SendRentRemindersTest.php
@@ -376,6 +376,62 @@ describe('SendRentRemindersAction', function () {
 
         Carbon::setTestNow();
     });
+
+    it('uses a custom scheduled template without optional invoice sections', function () {
+        Carbon::setTestNow(Carbon::parse('2026-06-28'));
+        Setting::set('reminder_message_templates', [
+            'upcoming' => 'Custom reminder for :name',
+            'due_today' => '',
+            'overdue' => '',
+        ], 'array');
+        Notification::fake();
+
+        $lease = createLeaseWithTenant(['rent_due_day' => 1, 'start_date' => '2026-07-01']);
+        $lease->load(['primaryTenant']);
+        $tenant = $lease->primaryTenant;
+
+        app(SendRentReminders::class)->execute($lease);
+
+        Notification::assertSentTo(
+            $tenant,
+            RentReminder::class,
+            function (RentReminder $notification) use ($tenant): bool {
+                expect($notification->toWhatsAppChannel($tenant)->message)
+                    ->toBe('Custom reminder for '.$tenant->name);
+
+                return true;
+            },
+        );
+
+        Carbon::setTestNow();
+    });
+
+    it('includes the portal link in scheduled whatsapp reminders for portal tenants', function () {
+        Carbon::setTestNow(Carbon::parse('2026-07-01'));
+        Notification::fake();
+
+        $user = User::factory()->create();
+        $lease = createLeaseWithTenant(['rent_due_day' => 1, 'start_date' => '2026-07-01']);
+        $lease->primaryTenant->update(['user_id' => $user->id]);
+        $lease->load(['primaryTenant.user']);
+        $tenant = $lease->primaryTenant;
+        $invoice = $lease->invoices()->payable()->orderBy('period_start')->firstOrFail();
+
+        app(SendRentReminders::class)->execute($lease);
+
+        Notification::assertSentTo(
+            $tenant,
+            RentReminder::class,
+            function (RentReminder $notification) use ($invoice, $tenant): bool {
+                expect($notification->toWhatsAppChannel($tenant)->message)
+                    ->toContain(route('portal.billing.invoices.show', $invoice));
+
+                return true;
+            },
+        );
+
+        Carbon::setTestNow();
+    });
 });
 
 describe('Command', function () {
@@ -468,6 +524,77 @@ describe('Manual Send via Controller', function () {
                 expect($content->attachments)->toHaveCount(1);
                 expect($content->attachments[0]->filename)->toBe("invoice-{$invoice->reference}.pdf");
                 expect($content->attachments[0]->content)->toStartWith('%PDF-');
+
+                return true;
+            },
+        );
+
+        Carbon::setTestNow();
+    });
+
+    it('includes the portal link in a manual whatsapp reminder for portal tenants', function () {
+        Carbon::setTestNow(Carbon::parse('2026-06-20'));
+        Setting::set('reminder_channels', ['whatsapp'], 'array');
+        Notification::fake();
+
+        $owner = User::factory()->owner()->create();
+        $tenantUser = User::factory()->create();
+        $lease = createLeaseWithTenant(['rent_due_day' => 1, 'start_date' => '2026-07-01']);
+        $lease->primaryTenant->update(['user_id' => $tenantUser->id]);
+        $lease->unit->property->users()->attach($owner);
+        $lease->load(['primaryTenant.user']);
+        $tenant = $lease->primaryTenant;
+        $invoice = $lease->invoices()->payable()->orderBy('period_start')->firstOrFail();
+
+        $this->actingAs($owner)
+            ->post(route('leases.send-reminder', $lease))
+            ->assertRedirect();
+
+        Notification::assertSentTo(
+            $tenant,
+            RentReminder::class,
+            function (RentReminder $notification) use ($invoice, $tenant): bool {
+                expect($notification->toWhatsAppChannel($tenant)->message)
+                    ->toContain(route('portal.billing.invoices.show', $invoice));
+
+                return true;
+            },
+        );
+
+        Carbon::setTestNow();
+    });
+
+    it('uses a custom manual template without optional invoice sections', function () {
+        Carbon::setTestNow(Carbon::parse('2026-06-20'));
+        Setting::set('reminder_channels', ['mail'], 'array');
+        Setting::set('reminder_message_templates', [
+            'upcoming' => 'Manual reminder for :name',
+            'due_today' => '',
+            'overdue' => '',
+        ], 'array');
+        Notification::fake();
+
+        $owner = User::factory()->owner()->create();
+        $tenantUser = User::factory()->create(['email' => 'tenant@example.com']);
+        $lease = createLeaseWithTenant(['rent_due_day' => 1, 'start_date' => '2026-07-01']);
+        $lease->primaryTenant->update([
+            'phone' => null,
+            'user_id' => $tenantUser->id,
+        ]);
+        $lease->unit->property->users()->attach($owner);
+        $lease->load(['primaryTenant.user']);
+        $tenant = $lease->primaryTenant;
+
+        $this->actingAs($owner)
+            ->post(route('leases.send-reminder', $lease))
+            ->assertRedirect();
+
+        Notification::assertSentTo(
+            $tenant,
+            RentReminder::class,
+            function (RentReminder $notification) use ($tenant): bool {
+                expect($notification->toMailChannel($tenant)->plainTextBody)
+                    ->toBe('Manual reminder for '.$tenant->name);
 
                 return true;
             },

--- a/tests/Feature/SendRentRemindersTest.php
+++ b/tests/Feature/SendRentRemindersTest.php
@@ -432,6 +432,37 @@ describe('SendRentRemindersAction', function () {
 
         Carbon::setTestNow();
     });
+
+    it('omits portal links for users without portal access', function (array $userAttributes) {
+        Carbon::setTestNow(Carbon::parse('2026-07-01'));
+        Notification::fake();
+
+        $user = User::factory()->create($userAttributes);
+        $lease = createLeaseWithTenant(['rent_due_day' => 1, 'start_date' => '2026-07-01']);
+        $lease->primaryTenant->update(['user_id' => $user->id]);
+        $lease->load(['primaryTenant.user']);
+        $tenant = $lease->primaryTenant;
+        $invoice = $lease->invoices()->payable()->orderBy('period_start')->firstOrFail();
+
+        app(SendRentReminders::class)->execute($lease);
+
+        Notification::assertSentTo(
+            $tenant,
+            RentReminder::class,
+            function (RentReminder $notification) use ($invoice, $tenant): bool {
+                expect($notification->toWhatsAppChannel($tenant)->message)
+                    ->not->toContain(route('portal.billing.invoices.show', $invoice));
+                expect($notification->toArray($tenant)['url'])->toBeNull();
+
+                return true;
+            },
+        );
+
+        Carbon::setTestNow();
+    })->with([
+        'unverified user' => [['email_verified_at' => null]],
+        'inactive user' => [['is_active' => false]],
+    ]);
 });
 
 describe('Command', function () {

--- a/tests/Feature/Settings/ReminderSettingsTest.php
+++ b/tests/Feature/Settings/ReminderSettingsTest.php
@@ -27,6 +27,7 @@ describe('Reminder settings page', function () {
                 'reminder_enabled' => true,
                 'reminder_days_before' => 3,
                 'reminder_overdue_intervals' => '1, 3, 7',
+                'reminder_message_templates' => reminderTemplates(),
                 'reminder_channels' => ['log'],
             ])
             ->assertForbidden();
@@ -43,6 +44,9 @@ describe('Reminder settings page', function () {
                 ->has('settings.reminder_enabled')
                 ->has('settings.reminder_days_before')
                 ->has('settings.reminder_overdue_intervals')
+                ->has('settings.reminder_message_templates.upcoming')
+                ->has('settings.reminder_message_templates.due_today')
+                ->has('settings.reminder_message_templates.overdue')
             );
     });
 
@@ -54,6 +58,7 @@ describe('Reminder settings page', function () {
                 'reminder_enabled' => true,
                 'reminder_days_before' => 5,
                 'reminder_overdue_intervals' => '2, 5, 10',
+                'reminder_message_templates' => reminderTemplates(),
                 'reminder_channels' => ['log'],
             ])
             ->assertRedirect(route('settings.reminders.edit'));
@@ -74,6 +79,7 @@ describe('Reminder settings page', function () {
             ->patch(route('settings.reminders.update'), [
                 'reminder_days_before' => 3,
                 'reminder_overdue_intervals' => '1, 3, 7',
+                'reminder_message_templates' => reminderTemplates(),
                 'reminder_channels' => ['log', 'whatsapp', 'mail'],
             ])
             ->assertRedirect();
@@ -88,6 +94,7 @@ describe('Reminder settings page', function () {
             ->patch(route('settings.reminders.update'), [
                 'reminder_days_before' => 3,
                 'reminder_overdue_intervals' => '1, 3, 7',
+                'reminder_message_templates' => reminderTemplates(),
                 'reminder_channels' => [],
             ])
             ->assertSessionHasErrors(['reminder_channels']);
@@ -100,8 +107,38 @@ describe('Reminder settings page', function () {
             ->patch(route('settings.reminders.update'), [
                 'reminder_days_before' => 100,
                 'reminder_overdue_intervals' => 'invalid',
+                'reminder_message_templates' => reminderTemplates(),
                 'reminder_channels' => ['log'],
             ])
             ->assertSessionHasErrors(['reminder_days_before', 'reminder_overdue_intervals']);
     });
+
+    it('updates reminder templates by reminder type', function () {
+        $owner = User::factory()->owner()->create();
+        $templates = [
+            'upcoming' => 'Upcoming :name :invoice_context :invoice_link',
+            'due_today' => 'Due today :name',
+            'overdue' => 'Overdue :name :days',
+        ];
+
+        $this->actingAs($owner)
+            ->patch(route('settings.reminders.update'), [
+                'reminder_days_before' => 3,
+                'reminder_overdue_intervals' => '1, 3, 7',
+                'reminder_message_templates' => $templates,
+                'reminder_channels' => ['log'],
+            ])
+            ->assertRedirect();
+
+        expect(Setting::get('reminder_message_templates'))->toBe($templates);
+    });
 });
+
+function reminderTemplates(): array
+{
+    return [
+        'upcoming' => '',
+        'due_today' => '',
+        'overdue' => '',
+    ];
+}

--- a/tests/Feature/Settings/ReminderSettingsTest.php
+++ b/tests/Feature/Settings/ReminderSettingsTest.php
@@ -47,6 +47,11 @@ describe('Reminder settings page', function () {
                 ->has('settings.reminder_message_templates.upcoming')
                 ->has('settings.reminder_message_templates.due_today')
                 ->has('settings.reminder_message_templates.overdue')
+                ->has('defaultTemplates.upcoming')
+                ->has('defaultTemplates.due_today')
+                ->has('defaultTemplates.overdue')
+                ->has('previewInvoiceContext')
+                ->has('previewInvoiceLink')
             );
     });
 

--- a/tests/Unit/Notifications/MailChannelTest.php
+++ b/tests/Unit/Notifications/MailChannelTest.php
@@ -158,3 +158,55 @@ test('RentReminder replaces every documented custom template placeholder', funct
 
     expect($content->plainTextBody)->toBe('Ayu|A-01|3|1,500,000|01 Aug 2026');
 });
+
+test('RentReminder selects templates by reminder type', function () {
+    Setting::set('reminder_message_templates', [
+        'upcoming' => 'Upcoming :name',
+        'due_today' => 'Due today :name',
+        'overdue' => 'Overdue :name :days',
+    ]);
+
+    $lease = new Lease;
+    $lease->setRelation('unit', new Unit(['name' => 'A-01']));
+
+    foreach ([
+        [ReminderType::Upcoming, 'Upcoming Ayu'],
+        [ReminderType::DueToday, 'Due today Ayu'],
+        [ReminderType::Overdue, 'Overdue Ayu 3'],
+    ] as [$type, $expected]) {
+        $event = new ReminderEvent(
+            lease: $lease,
+            type: $type,
+            periodStart: '2026-08-01',
+            periodEnd: '2026-08-31',
+            dueDate: '2026-08-01',
+            amount: 150000000,
+            overdueDays: $type === ReminderType::Overdue ? 3 : null,
+        );
+
+        expect((new RentReminder($event))->toLog((object) ['name' => 'Ayu']))
+            ->toBe($expected);
+    }
+});
+
+test('RentReminder only includes optional invoice placeholders when configured', function () {
+    Setting::set('reminder_message_templates', [
+        'upcoming' => ':name|:invoice_context|:invoice_link',
+        'due_today' => '',
+        'overdue' => '',
+    ]);
+
+    $lease = new Lease;
+    $lease->setRelation('unit', new Unit(['name' => 'A-01']));
+    $event = new ReminderEvent(
+        lease: $lease,
+        type: ReminderType::Upcoming,
+        periodStart: '2026-08-01',
+        periodEnd: '2026-08-31',
+        dueDate: '2026-08-01',
+        amount: 150000000,
+    );
+
+    expect((new RentReminder($event))->toLog((object) ['name' => 'Ayu']))
+        ->toBe('Ayu||');
+});


### PR DESCRIPTION
## Summary
- Add separate upcoming, due-today, and overdue reminder templates
- Support optional invoice context and tenant portal invoice links
- Align settings previews with translated defaults and portal access rules

## Verification
- Focused Pest tests: 44 passed
- Type check, lint, Pint, and production build passed

Refs OPE-122