### PR TITLE
refactor(providers): extract application bindings

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,56 +2,29 @@
 
 namespace App\Providers;
 
-use App\Database\PostgresConnection;
 use App\Enums\PaymentStatus;
 use App\Events\Maintenance\MaintenanceTicketCreated;
 use App\Events\Maintenance\MaintenanceTicketUpdated;
 use App\Events\Payment\PaymentStatusChanged;
 use App\Events\Reminder\InvoiceReminderDispatched;
 use App\Models\MaintenanceTicket;
-use App\Models\Setting;
 use App\Notifications\RentReminder;
 use App\Notifications\TenantPortalNotification;
-use App\Services\Platform\ComposerPluginDiscovery;
-use App\Services\Settings\PlatformSettingsStore;
-use App\Services\Settings\SettingManager;
-use App\Services\WhatsAppManager;
 use Carbon\CarbonImmutable;
 use Illuminate\Auth\Events\Login;
-use Illuminate\Database\Connection;
-use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Validation\Rules\Password;
-use OpenKOS\Core\Contracts\PluginDiscovery;
-use OpenKOS\Core\Contracts\SettingsStore;
-use OpenKOS\Platform\OpenKOSManager;
-use OpenKOS\Platform\Settings\SettingsPage;
 
 class AppServiceProvider extends ServiceProvider
 {
-    public function register(): void
-    {
-        $this->app->singleton(SettingManager::class);
-        $this->app->singleton(PluginDiscovery::class, ComposerPluginDiscovery::class);
-        $this->app->singleton(SettingsStore::class, PlatformSettingsStore::class);
-        $this->app->singleton(MailManager::class);
-        $this->app->singleton(WhatsAppManager::class);
-
-        Connection::resolverFor('pgsql', fn ($pdo, $database, $prefix, $config) => new PostgresConnection($pdo, $database, $prefix, $config));
-    }
-
     public function boot(): void
     {
         $this->configureDefaults();
         $this->configureAuthEvents();
-        $this->configureMail();
         $this->configureDomainEvents();
-        $this->app->booted(function (): void {
-            $this->registerPlatformSettingsPages();
-        });
     }
 
     protected function configureDefaults(): void
@@ -78,32 +51,6 @@ class AppServiceProvider extends ServiceProvider
         Event::listen(Login::class, function (Login $event): void {
             $event->user->forceFill(['last_login_at' => now()])->save();
         });
-    }
-
-    protected function configureMail(): void
-    {
-        try {
-            $config = Setting::effectiveMailConfig();
-        } catch (QueryException) {
-            return;
-        }
-
-        config()->set('mail.default', $config['driver'] ?? 'log');
-
-        config()->set('mail.mailers.smtp.host', $config['host'] ?? '');
-        config()->set('mail.mailers.smtp.port', $config['port'] ?? 587);
-        config()->set('mail.mailers.smtp.username', $config['username'] ?? '');
-        config()->set('mail.mailers.smtp.password', $config['password'] ?? '');
-        $encryption = $config['encryption'] ?? null;
-        if ($encryption === 'null') {
-            $encryption = null;
-        }
-        config()->set('mail.mailers.smtp.encryption', $encryption);
-
-        if ($fromAddress = $config['from_address'] ?? null) {
-            config()->set('mail.from.address', $fromAddress);
-            config()->set('mail.from.name', $config['from_name'] ?? '');
-        }
     }
 
     protected function configureDomainEvents(): void
@@ -148,17 +95,6 @@ class AppServiceProvider extends ServiceProvider
 
             $tenant->notify(new RentReminder($event->event));
         });
-    }
-
-    private function registerPlatformSettingsPages(): void
-    {
-        app(OpenKOSManager::class)->settings()
-            ->registerPage(new SettingsPage('profile', 'Profile', '/settings/profile', ownerOnly: false, group: 'Account', order: 100, routeName: 'profile.edit'))
-            ->registerPage(new SettingsPage('security', 'Security', '/settings/security', ownerOnly: false, group: 'Account', order: 200, routeName: 'security.edit'))
-            ->registerPage(new SettingsPage('general', 'General', '/settings/general', group: 'Preferences', order: 100, routeName: 'settings.general.edit'))
-            ->registerPage(new SettingsPage('reminders', 'Reminders', '/settings/reminders', group: 'Preferences', order: 300, routeName: 'settings.reminders.edit'))
-            ->registerPage(new SettingsPage('property-types', 'Property Types', '/settings/property-types', group: 'Property', order: 100, routeName: 'settings.property-types.index'))
-            ->registerPage(new SettingsPage('mail', 'Mail', '/settings/mail', group: 'Integrations', order: 100, routeName: 'settings.mail.edit'));
     }
 
     private function notifyMaintenanceTenant(MaintenanceTicket $ticket, string $type): void

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -8,6 +8,7 @@ use App\Events\Maintenance\MaintenanceTicketUpdated;
 use App\Events\Payment\PaymentStatusChanged;
 use App\Events\Reminder\InvoiceReminderDispatched;
 use App\Models\MaintenanceTicket;
+use App\Models\Setting;
 use App\Notifications\RentReminder;
 use App\Notifications\TenantPortalNotification;
 use Carbon\CarbonImmutable;

--- a/app/Providers/DatabaseServiceProvider.php
+++ b/app/Providers/DatabaseServiceProvider.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Providers;
+
+use App\Database\PostgresConnection;
+use Illuminate\Database\Connection;
+use Illuminate\Support\ServiceProvider;
+
+class DatabaseServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        Connection::resolverFor('pgsql', fn ($pdo, $database, $prefix, $config) => new PostgresConnection($pdo, $database, $prefix, $config));
+    }
+}

--- a/app/Providers/NotificationServiceProvider.php
+++ b/app/Providers/NotificationServiceProvider.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Providers;
+
+use App\Models\Setting;
+use App\Services\MailManager;
+use App\Services\WhatsAppManager;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\ServiceProvider;
+
+class NotificationServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->singleton(MailManager::class);
+        $this->app->singleton(WhatsAppManager::class);
+    }
+
+    public function boot(): void
+    {
+        $this->configureMail();
+    }
+
+    protected function configureMail(): void
+    {
+        try {
+            $config = Setting::effectiveMailConfig();
+        } catch (QueryException) {
+            return;
+        }
+
+        config()->set('mail.default', $config['driver'] ?? 'log');
+
+        config()->set('mail.mailers.smtp.host', $config['host'] ?? '');
+        config()->set('mail.mailers.smtp.port', $config['port'] ?? 587);
+        config()->set('mail.mailers.smtp.username', $config['username'] ?? '');
+        config()->set('mail.mailers.smtp.password', $config['password'] ?? '');
+        $encryption = $config['encryption'] ?? null;
+        if ($encryption === 'null') {
+            $encryption = null;
+        }
+        config()->set('mail.mailers.smtp.encryption', $encryption);
+
+        if ($fromAddress = $config['from_address'] ?? null) {
+            config()->set('mail.from.address', $fromAddress);
+            config()->set('mail.from.name', $config['from_name'] ?? '');
+        }
+    }
+}

--- a/app/Providers/PlatformBindingsServiceProvider.php
+++ b/app/Providers/PlatformBindingsServiceProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Providers;
+
+use App\Services\Platform\ComposerPluginDiscovery;
+use Illuminate\Support\ServiceProvider;
+use OpenKOS\Core\Contracts\PluginDiscovery;
+use OpenKOS\Platform\OpenKOSManager;
+use OpenKOS\Platform\Settings\SettingsPage;
+
+class PlatformBindingsServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->singleton(PluginDiscovery::class, ComposerPluginDiscovery::class);
+    }
+
+    public function boot(): void
+    {
+        $this->app->booted(function (): void {
+            $this->registerPlatformSettingsPages();
+        });
+    }
+
+    private function registerPlatformSettingsPages(): void
+    {
+        app(OpenKOSManager::class)->settings()
+            ->registerPage(new SettingsPage('profile', 'Profile', '/settings/profile', ownerOnly: false, group: 'Account', order: 100, routeName: 'profile.edit'))
+            ->registerPage(new SettingsPage('security', 'Security', '/settings/security', ownerOnly: false, group: 'Account', order: 200, routeName: 'security.edit'))
+            ->registerPage(new SettingsPage('general', 'General', '/settings/general', group: 'Preferences', order: 100, routeName: 'settings.general.edit'))
+            ->registerPage(new SettingsPage('reminders', 'Reminders', '/settings/reminders', group: 'Preferences', order: 300, routeName: 'settings.reminders.edit'))
+            ->registerPage(new SettingsPage('property-types', 'Property Types', '/settings/property-types', group: 'Property', order: 100, routeName: 'settings.property-types.index'))
+            ->registerPage(new SettingsPage('mail', 'Mail', '/settings/mail', group: 'Integrations', order: 100, routeName: 'settings.mail.edit'));
+    }
+}

--- a/app/Providers/SettingsServiceProvider.php
+++ b/app/Providers/SettingsServiceProvider.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Providers;
+
+use App\Services\Settings\PlatformSettingsStore;
+use App\Services\Settings\SettingManager;
+use Illuminate\Support\ServiceProvider;
+use OpenKOS\Core\Contracts\SettingsStore;
+
+class SettingsServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->singleton(SettingManager::class);
+        $this->app->singleton(SettingsStore::class, PlatformSettingsStore::class);
+    }
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -2,9 +2,17 @@
 
 use App\Providers\AppServiceProvider;
 use App\Providers\AuthServiceProvider;
+use App\Providers\DatabaseServiceProvider;
 use App\Providers\FortifyServiceProvider;
+use App\Providers\NotificationServiceProvider;
+use App\Providers\PlatformBindingsServiceProvider;
+use App\Providers\SettingsServiceProvider;
 
 return [
+    DatabaseServiceProvider::class,
+    SettingsServiceProvider::class,
+    NotificationServiceProvider::class,
+    PlatformBindingsServiceProvider::class,
     AppServiceProvider::class,
     AuthServiceProvider::class,
     FortifyServiceProvider::class,

--- a/tests/Feature/Providers/ServiceProviderTest.php
+++ b/tests/Feature/Providers/ServiceProviderTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use App\Services\MailManager;
+use App\Services\Platform\ComposerPluginDiscovery;
+use App\Services\Settings\PlatformSettingsStore;
+use App\Services\Settings\SettingManager;
+use App\Services\WhatsAppManager;
+use OpenKOS\Core\Contracts\PluginDiscovery;
+use OpenKOS\Core\Contracts\SettingsStore;
+
+it('registers application services through dedicated providers', function () {
+    expect(app(SettingManager::class))
+        ->toBe(app(SettingManager::class))
+        ->and(app(SettingsStore::class))
+        ->toBeInstanceOf(PlatformSettingsStore::class)
+        ->and(app(PluginDiscovery::class))
+        ->toBeInstanceOf(ComposerPluginDiscovery::class)
+        ->and(app(MailManager::class))
+        ->toBe(app(MailManager::class))
+        ->and(app(WhatsAppManager::class))
+        ->toBe(app(WhatsAppManager::class));
+});


### PR DESCRIPTION
## Summary
- Extract application bindings into dedicated database, settings, notification, and platform providers.
- Keep AppServiceProvider focused on defaults and domain/auth events.
- Preserve platform boot timing and add provider wiring coverage.
- Restore the Setting model import required by the reminder listener.

## Verification
- `php -d memory_limit=512M vendor/bin/pest --compact` — 667 tests, 2,982 assertions passed.
- PHP lint, Pint, ESLint, and TypeScript checks passed.
- `npm run build` passed.
- Prettier still reports three pre-existing files: `resources/js/pages/settings/mail.tsx`, `resources/js/pages/settings/whatsapp.tsx`, and `resources/js/pages/tenant-portal/notifications/index.tsx`.
- `npm install` reports four existing dependency vulnerabilities; no lockfile upgrades were applied.