### PR TITLE
refactor(events): extract domain listeners

### DIFF
--- a/app/Listeners/NotifyMaintenanceTenant.php
+++ b/app/Listeners/NotifyMaintenanceTenant.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\Maintenance\MaintenanceTicketCreated;
+use App\Events\Maintenance\MaintenanceTicketUpdated;
+use App\Models\MaintenanceTicket;
+use App\Notifications\TenantPortalNotification;
+
+class NotifyMaintenanceTenant
+{
+    public function handleCreated(MaintenanceTicketCreated $event): void
+    {
+        $this->notify($event->ticket, 'maintenance_created');
+    }
+
+    public function handleUpdated(MaintenanceTicketUpdated $event): void
+    {
+        $this->notify($event->ticket, 'maintenance_updated');
+    }
+
+    private function notify(MaintenanceTicket $ticket, string $type): void
+    {
+        $tenant = $ticket->creator?->tenant;
+        if (! $tenant) {
+            return;
+        }
+
+        $tenant->notify(new TenantPortalNotification([
+            'type' => $type,
+            'title' => __('Maintenance update'),
+            'message' => $ticket->title,
+            'url' => route('portal.maintenance-tickets.show', $ticket),
+        ]));
+    }
+}

--- a/app/Listeners/NotifyTenantOfPaymentConfirmation.php
+++ b/app/Listeners/NotifyTenantOfPaymentConfirmation.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Enums\PaymentStatus;
+use App\Events\Payment\PaymentStatusChanged;
+use App\Notifications\TenantPortalNotification;
+
+class NotifyTenantOfPaymentConfirmation
+{
+    public function handle(PaymentStatusChanged $event): void
+    {
+        if ($event->to !== PaymentStatus::Confirmed) {
+            return;
+        }
+
+        $invoice = $event->payment->invoice()->with('lease.primaryTenant')->first();
+        $tenant = $invoice?->lease?->primaryTenant;
+        if (! $tenant) {
+            return;
+        }
+
+        $tenant->notify(new TenantPortalNotification([
+            'type' => 'payment_confirmed',
+            'title' => __('Payment confirmed'),
+            'message' => __('Your payment has been confirmed.'),
+            'url' => route('portal.billing.invoices.show', $invoice),
+        ]));
+    }
+}

--- a/app/Listeners/SendInvoiceReminder.php
+++ b/app/Listeners/SendInvoiceReminder.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\Reminder\InvoiceReminderDispatched;
+use App\Models\Setting;
+use App\Notifications\RentReminder;
+
+class SendInvoiceReminder
+{
+    public function handle(InvoiceReminderDispatched $event): void
+    {
+        $lease = $event->event->lease;
+        $lease->loadMissing('primaryTenant.user');
+        $tenant = $lease->primaryTenant;
+
+        $channels = Setting::get('reminder_channels') ?? ['log'];
+
+        if (! $tenant?->hasReminderRoute($channels)) {
+            return;
+        }
+
+        $tenant->notify(new RentReminder($event->event));
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,15 +2,6 @@
 
 namespace App\Providers;
 
-use App\Enums\PaymentStatus;
-use App\Events\Maintenance\MaintenanceTicketCreated;
-use App\Events\Maintenance\MaintenanceTicketUpdated;
-use App\Events\Payment\PaymentStatusChanged;
-use App\Events\Reminder\InvoiceReminderDispatched;
-use App\Models\MaintenanceTicket;
-use App\Models\Setting;
-use App\Notifications\RentReminder;
-use App\Notifications\TenantPortalNotification;
 use Carbon\CarbonImmutable;
 use Illuminate\Auth\Events\Login;
 use Illuminate\Support\Facades\Date;
@@ -25,7 +16,6 @@ class AppServiceProvider extends ServiceProvider
     {
         $this->configureDefaults();
         $this->configureAuthEvents();
-        $this->configureDomainEvents();
     }
 
     protected function configureDefaults(): void
@@ -52,64 +42,5 @@ class AppServiceProvider extends ServiceProvider
         Event::listen(Login::class, function (Login $event): void {
             $event->user->forceFill(['last_login_at' => now()])->save();
         });
-    }
-
-    protected function configureDomainEvents(): void
-    {
-        Event::listen(MaintenanceTicketCreated::class, function (MaintenanceTicketCreated $event): void {
-            $this->notifyMaintenanceTenant($event->ticket, 'maintenance_created');
-        });
-
-        Event::listen(MaintenanceTicketUpdated::class, function (MaintenanceTicketUpdated $event): void {
-            $this->notifyMaintenanceTenant($event->ticket, 'maintenance_updated');
-        });
-
-        Event::listen(PaymentStatusChanged::class, function (PaymentStatusChanged $event): void {
-            if ($event->to !== PaymentStatus::Confirmed) {
-                return;
-            }
-
-            $invoice = $event->payment->invoice()->with('lease.primaryTenant')->first();
-            $tenant = $invoice?->lease?->primaryTenant;
-            if (! $tenant) {
-                return;
-            }
-
-            $tenant->notify(new TenantPortalNotification([
-                'type' => 'payment_confirmed',
-                'title' => __('Payment confirmed'),
-                'message' => __('Your payment has been confirmed.'),
-                'url' => route('portal.billing.invoices.show', $invoice),
-            ]));
-        });
-
-        Event::listen(InvoiceReminderDispatched::class, function (InvoiceReminderDispatched $event): void {
-            $lease = $event->event->lease;
-            $lease->loadMissing('primaryTenant.user');
-            $tenant = $lease->primaryTenant;
-
-            $channels = Setting::get('reminder_channels') ?? ['log'];
-
-            if (! $tenant?->hasReminderRoute($channels)) {
-                return;
-            }
-
-            $tenant->notify(new RentReminder($event->event));
-        });
-    }
-
-    private function notifyMaintenanceTenant(MaintenanceTicket $ticket, string $type): void
-    {
-        $tenant = $ticket->creator?->tenant;
-        if (! $tenant) {
-            return;
-        }
-
-        $tenant->notify(new TenantPortalNotification([
-            'type' => $type,
-            'title' => __('Maintenance update'),
-            'message' => $ticket->title,
-            'url' => route('portal.maintenance-tickets.show', $ticket),
-        ]));
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -157,7 +157,7 @@ Payments settle invoices — `payments` has an `invoice_id` FK (not polymorphic)
 
 ### Reminders
 
-Reminders are scheduled by `SendRentRemindersCommand` (daily at 08:00), which calls `SendRentReminders` Action. The Action iterates active leases, calls `PaymentReminderScheduler` to generate events, records them in `reminder_logs` (deduped via unique constraint), and dispatches `RentReminder` via WhatsApp. Manual sending from the lease detail sheet bypasses the scheduler — sends one reminder immediately via `notifyNow()`. See `docs/rent-reminders.md`.
+Reminders are scheduled by `SendRentRemindersCommand` (daily at 08:00), which calls `SendRentReminders` Action. The Action iterates active leases, calls `PaymentReminderScheduler` to generate events, records them in `reminder_logs` (deduped via unique constraint), and dispatches `InvoiceReminderDispatched`. The `SendInvoiceReminder` listener sends `RentReminder` through the configured channels. Manual sending from the lease detail sheet bypasses the scheduler but uses the same event and listener pipeline. See `docs/rent-reminders.md`.
 
 ## Authentication & Authorization
 

--- a/docs/domain-events.md
+++ b/docs/domain-events.md
@@ -76,7 +76,7 @@ public readonly ?int $actorId;      // ID of the acting user, null for system-tr
 | -------------------------------------- | ----------------------- | ------------------------------------- |
 | `Reminder\InvoiceReminderDispatched`   | `ReminderEvent $event`  | `SendRentReminders`, `ForceSendReminder` |
 
-`InvoiceReminderDispatched` fires to trigger a rent reminder notification — one event per reminder log entry created. The actual notification delivery (WhatsApp, mail, etc.) is handled by a listener in `AppServiceProvider`. Plugin consumers can use this event for analytics, tenant-facing notification history, or cross-channel relay, but should note it fires before delivery completes — it is not a delivery confirmation.
+`InvoiceReminderDispatched` fires to trigger a rent reminder notification — one event per reminder log entry created. The actual notification delivery (WhatsApp, mail, etc.) is handled by `App\Listeners\SendInvoiceReminder`. Plugin consumers can use this event for analytics, tenant-facing notification history, or cross-channel relay, but should note it fires before delivery completes — it is not a delivery confirmation.
 
 ### Settings
 

--- a/docs/rent-reminders.md
+++ b/docs/rent-reminders.md
@@ -36,7 +36,7 @@ Initially built with a feature folder (`app/Reminders/`), then refactored into l
 
 `PaymentReminderScheduler` is pure logic — takes a `Lease` and `ReminderSettings`, returns an array of `ReminderEvent` value objects. It knows nothing about persistence or notifications.
 
-`SendRentReminders` Action calls the scheduler, feeds events to `ReminderRepository::recordIfAbsent()`, and dispatches `RentReminder` notification only for events that were successfully recorded (not duplicates).
+`SendRentReminders` Action calls the scheduler, feeds events to `ReminderRepository::recordIfAbsent()`, and dispatches `InvoiceReminderDispatched` only for events that were successfully recorded (not duplicates). `App\Listeners\SendInvoiceReminder` handles the event and sends the `RentReminder` notification through the configured channels.
 
 **Rationale:** Separates concerns — scheduler is testable without DB, repository handles dedup, action orchestrates the pipeline.
 
@@ -84,7 +84,7 @@ Scheduler methods accept `CarbonInterface` instead of `Carbon`.
 
 ### 11. Manual Send Goes Through ForceSendReminder Action
 
-`LeaseController::sendReminder()` delegates to `ForceSendReminder` Action, which first tries `PaymentReminderScheduler::pendingFor()` to find already-scheduled but unlogged events. If none exist, it falls back to the first payable invoice and creates a one-off `ReminderEvent`. In either case it records the log via `ReminderRepository::recordIfAbsent()` and dispatches `InvoiceReminderDispatched`. A listener in `AppServiceProvider` picks up that event and performs the actual notification delivery.
+`LeaseController::sendReminder()` delegates to `ForceSendReminder` Action, which first tries `PaymentReminderScheduler::pendingFor()` to find already-scheduled but unlogged events. If none exist, it falls back to the first payable invoice and creates a one-off `ReminderEvent`. In either case it records the log via `ReminderRepository::recordIfAbsent()` and dispatches `InvoiceReminderDispatched`. `App\Listeners\SendInvoiceReminder` picks up that event and performs the actual notification delivery.
 
 **Rationale:** Manual send is a one-off action for the landlord — send one reminder right now, regardless of whether the automated scheduler would have sent one. The scheduled-path fallback ensures consistency: manual send reuses the same event types, dedup, and logging as the automated path. Dispatching `InvoiceReminderDispatched` instead of calling `notifyNow()` directly lets the same listener handle both scheduled and manual sends, keeping channel resolution in one place.
 
@@ -106,7 +106,7 @@ Schedule (routes/console.php)
             │    └─ $lease->invoices()->payable()
             ├─ ReminderRepository::recordIfAbsent()
             └─ InvoiceReminderDispatched::dispatch()
-                 └─ AppServiceProvider listener
+                 └─ SendInvoiceReminder listener
                       └─ Notification delivery (WhatsApp, mail, etc.)
 
 Manual Send (LeaseController)
@@ -116,7 +116,7 @@ Manual Send (LeaseController)
             │    └─ $lease->invoices()->payable()
             ├─ ReminderRepository::recordIfAbsent()
             └─ InvoiceReminderDispatched::dispatch()
-                 └─ AppServiceProvider listener
+                 └─ SendInvoiceReminder listener
                       └─ Notification delivery (WhatsApp, mail, etc.)
 ```
 

--- a/tests/Feature/TenantNotificationTest.php
+++ b/tests/Feature/TenantNotificationTest.php
@@ -5,6 +5,7 @@ use App\Enums\PaymentStatus;
 use App\Enums\ReminderType;
 use App\Events\Maintenance\MaintenanceTicketUpdated;
 use App\Events\Payment\PaymentStatusChanged;
+use App\Events\Reminder\InvoiceReminderDispatched;
 use App\Models\Invoice;
 use App\Models\Lease;
 use App\Models\MaintenanceTicket;
@@ -16,6 +17,7 @@ use App\Notifications\RentReminder;
 use App\Notifications\TenantPortalNotification;
 use Database\Seeders\RoleAndPermissionSeeder;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Notification;
 
 uses()->beforeEach(function () {
     $this->seed(RoleAndPermissionSeeder::class);
@@ -98,6 +100,21 @@ test('payment confirmation creates a tenant notification', function () {
     expect($tenant->notifications()->where('type', 'payment_confirmed')->exists())->toBeTrue();
 });
 
+test('non-confirmed payment status changes do not notify tenants', function () {
+    $tenant = Tenant::factory()->withUser()->create();
+    $lease = Lease::factory()->create(['primary_tenant_id' => $tenant->id]);
+    $invoice = Invoice::factory()->create(['lease_id' => $lease->id]);
+    $payment = $invoice->payments()->create([
+        'amount' => 100000,
+        'payment_date' => now(),
+        'status' => PaymentStatus::Pending,
+    ]);
+
+    PaymentStatusChanged::dispatch($payment, PaymentStatus::Pending, PaymentStatus::Pending);
+
+    expect($tenant->notifications()->where('type', 'payment_confirmed')->exists())->toBeFalse();
+});
+
 test('rent reminder channels contain database only once', function () {
     Setting::set('reminder_channels', ['database', 'log'], 'array');
     $lease = Lease::factory()->create();
@@ -142,6 +159,39 @@ test('maintenance ticket creation creates a tenant notification', function () {
         ->assertRedirect();
 
     expect($tenant->notifications()->where('type', 'maintenance_created')->exists())->toBeTrue();
+});
+
+test('maintenance ticket updates create a tenant notification', function () {
+    $user = User::factory()->create();
+    $tenant = Tenant::factory()->withUser($user)->create();
+    $ticket = MaintenanceTicket::factory()->create([
+        'created_by' => $user->id,
+        'title' => 'Leaking faucet',
+    ]);
+
+    MaintenanceTicketUpdated::dispatch($ticket);
+
+    expect($tenant->notifications()->where('type', 'maintenance_updated')->exists())->toBeTrue();
+});
+
+test('invoice reminder events notify tenants with a configured route', function () {
+    Notification::fake();
+    Setting::set('reminder_channels', ['log'], 'array');
+
+    $lease = Lease::factory()->create();
+    $tenant = $lease->primaryTenant;
+    $event = new ReminderEvent(
+        lease: $lease,
+        type: ReminderType::Upcoming,
+        periodStart: today()->toDateString(),
+        periodEnd: today()->addMonth()->toDateString(),
+        dueDate: today()->addDays(3)->toDateString(),
+        amount: 100000,
+    );
+
+    InvoiceReminderDispatched::dispatch($event);
+
+    Notification::assertSentTo($tenant, RentReminder::class);
 });
 
 test('lease expiration command creates only one notification at thirty days', function () {


### PR DESCRIPTION
## Summary
- extract maintenance, payment confirmation, and invoice reminder handlers into auto-discovered listeners
- remove notification workflow closures from AppServiceProvider
- add notification flow coverage

## Verification
- `php -d memory_limit=-1 vendor/bin/pest --compact`
- `vendor/bin/pint --test`
- `npm run build`