### PR TITLE
feat(billing): queue invoice PDF artifacts

### DIFF
--- a/app/Http/Controllers/LeaseInvoiceController.php
+++ b/app/Http/Controllers/LeaseInvoiceController.php
@@ -2,15 +2,22 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\PaymentStatus;
 use App\Models\Invoice;
 use App\Models\Lease;
+use App\Models\Setting;
+use App\Services\Invoices\InvoicePdfArtifact;
 use App\Tables\Column;
 use App\Tables\Filter;
 use App\Tables\Table;
+use Illuminate\Contracts\View\View as ViewContract;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
 use Inertia\Inertia;
 use Inertia\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class LeaseInvoiceController extends Controller
 {
@@ -48,7 +55,7 @@ class LeaseInvoiceController extends Controller
         ]);
     }
 
-    public function show(Lease $lease, Invoice $invoice): Response
+    public function show(Lease $lease, Invoice $invoice, InvoicePdfArtifact $artifact): Response
     {
         abort_if($invoice->lease_id !== $lease->id, 404);
 
@@ -56,10 +63,68 @@ class LeaseInvoiceController extends Controller
 
         $invoice->load(['lineItems', 'payments.confirmedBy:id,name', 'payments.proofs']);
         $invoice->append(['outstanding', 'display_status']);
+        $invoicePdfStatus = $artifact->status($invoice);
+        if ($invoicePdfStatus === 'pending') {
+            $artifact->ensureQueued($invoice);
+        }
 
         return Inertia::render('leases/invoice-detail', [
             'lease' => $lease->only('id', 'reference', 'status'),
             'invoice' => $invoice,
+            'invoicePdf' => ['status' => $invoicePdfStatus],
         ]);
+    }
+
+    public function print(Lease $lease, Invoice $invoice): ViewContract
+    {
+        abort_if($invoice->lease_id !== $lease->id, 404);
+
+        $this->authorize('view', $lease);
+
+        $invoice->load([
+            'lease.primaryTenant.user',
+            'lease.unit.property.city',
+            'lease.unit.property.region',
+            'lineItems',
+            'payments' => fn ($query) => $query
+                ->where('status', PaymentStatus::Confirmed)
+                ->orderBy('payment_date')
+                ->orderBy('id'),
+        ]);
+        $invoice->append(['outstanding', 'display_status']);
+        $settings = Setting::some(['site_name', 'locale', 'currency']);
+
+        return view('invoices.pdf', [
+            'autoPrint' => true,
+            'currency' => $settings['currency'] ?? 'IDR',
+            'invoice' => $invoice,
+            'locale' => $settings['locale'] ?? 'id',
+            'siteName' => $settings['site_name'] ?? config('app.name'),
+        ]);
+    }
+
+    public function download(Lease $lease, Invoice $invoice, InvoicePdfArtifact $artifact): StreamedResponse|RedirectResponse
+    {
+        abort_if($invoice->lease_id !== $lease->id, 404);
+
+        $this->authorize('view', $lease);
+
+        if ($artifact->status($invoice) !== 'available') {
+            $artifact->ensureQueued($invoice);
+
+            return redirect()->route('leases.workspace.invoices.show', [$lease, $invoice]);
+        }
+
+        $reference = preg_replace(
+            '/[^A-Za-z0-9_-]/',
+            '-',
+            $invoice->reference ?? (string) $invoice->getKey(),
+        );
+
+        return Storage::disk('local')->download(
+            $artifact->path($invoice),
+            "invoice-{$reference}.pdf",
+            ['Content-Type' => 'application/pdf'],
+        );
     }
 }

--- a/app/Http/Controllers/Settings/GeneralController.php
+++ b/app/Http/Controllers/Settings/GeneralController.php
@@ -28,6 +28,7 @@ class GeneralController extends Controller
                 'timezone',
                 'lease_id_prefix',
                 'invoice_id_prefix',
+                'invoice_pdf_enabled',
             ]),
             'timezone_list' => timezone_identifiers_list(),
         ]);
@@ -43,6 +44,7 @@ class GeneralController extends Controller
             'timezone' => ['sometimes', 'required', 'string', Rule::in(timezone_identifiers_list())],
             'lease_id_prefix' => ['sometimes', 'required', 'string', 'max:10', 'regex:/^[A-Z]+$/'],
             'invoice_id_prefix' => ['sometimes', 'required', 'string', 'max:10', 'regex:/^[A-Z]+$/'],
+            'invoice_pdf_enabled' => ['sometimes', 'boolean'],
         ]);
 
         $this->updateSettings->execute($validated, $request->user());

--- a/app/Http/Controllers/TenantPortal/PaymentController.php
+++ b/app/Http/Controllers/TenantPortal/PaymentController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers\TenantPortal;
 
-use App\Actions\Invoices\GenerateInvoicePdf;
 use App\Actions\Payments\RecordPayment;
 use App\Data\Payment\RecordPaymentData;
 use App\Enums\InvoiceStatus;
@@ -12,9 +11,13 @@ use App\Exceptions\PaymentOverflowException;
 use App\Http\Requests\Payment\StoreTenantPortalPaymentRequest;
 use App\Models\Invoice;
 use App\Models\Payment;
+use App\Models\Setting;
+use App\Services\Invoices\InvoicePdfArtifact;
+use Illuminate\Contracts\View\View as ViewContract;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
 use Inertia\Inertia;
 use Inertia\Response;
 use OpenKOS\Core\Events\PaymentRecorded as PlatformPaymentRecorded;
@@ -149,15 +152,20 @@ class PaymentController extends TenantPortalController
         ]);
     }
 
-    public function invoice(Request $request, Invoice $invoice): Response
+    public function invoice(Request $request, Invoice $invoice, InvoicePdfArtifact $artifact): Response
     {
         $this->ensureTenantOwnsInvoice($request, $invoice);
 
         $invoice->load(['lease.unit.property', 'lineItems', 'payments']);
         $invoice->append(['outstanding', 'display_status']);
+        $invoicePdfStatus = $artifact->status($invoice);
+        if ($invoicePdfStatus === 'pending') {
+            $artifact->ensureQueued($invoice);
+        }
 
         return Inertia::render('tenant-portal/payments/invoice', [
             'invoice' => $invoice,
+            'invoicePdf' => ['status' => $invoicePdfStatus],
             'lease' => [
                 'reference' => $invoice->lease->reference,
                 'unit_name' => $invoice->lease->unit?->name,
@@ -166,35 +174,53 @@ class PaymentController extends TenantPortalController
         ]);
     }
 
-    public function download(Request $request, Invoice $invoice, GenerateInvoicePdf $action): StreamedResponse
+    public function download(Request $request, Invoice $invoice, InvoicePdfArtifact $artifact): StreamedResponse|RedirectResponse
     {
         $this->ensureTenantOwnsInvoice($request, $invoice);
 
-        $invoice->load([
-            'lease.primaryTenant.user',
-            'lease.unit.property',
-            'lineItems',
-            'payments' => fn ($query) => $query
-                ->where('status', PaymentStatus::Confirmed->value)
-                ->orderBy('payment_date')
-                ->orderBy('id'),
-        ]);
-        $invoice->append(['outstanding', 'display_status']);
+        if ($artifact->status($invoice) !== 'available') {
+            $artifact->ensureQueued($invoice);
 
-        $pdf = $action->execute($invoice);
+            return redirect()->route('portal.billing.invoices.show', $invoice);
+        }
+
         $reference = preg_replace(
             '/[^A-Za-z0-9_-]/',
             '-',
             $invoice->reference ?? (string) $invoice->getKey(),
         );
 
-        return response()->streamDownload(
-            static function () use ($pdf): void {
-                echo $pdf;
-            },
+        return Storage::disk('local')->download(
+            $artifact->path($invoice),
             "invoice-{$reference}.pdf",
             ['Content-Type' => 'application/pdf'],
         );
+    }
+
+    public function print(Request $request, Invoice $invoice): ViewContract
+    {
+        $this->ensureTenantOwnsInvoice($request, $invoice);
+
+        $invoice->load([
+            'lease.primaryTenant.user',
+            'lease.unit.property.city',
+            'lease.unit.property.region',
+            'lineItems',
+            'payments' => fn ($query) => $query
+                ->where('status', PaymentStatus::Confirmed)
+                ->orderBy('payment_date')
+                ->orderBy('id'),
+        ]);
+        $invoice->append(['outstanding', 'display_status']);
+        $settings = Setting::some(['site_name', 'locale', 'currency']);
+
+        return view('invoices.pdf', [
+            'autoPrint' => true,
+            'currency' => $settings['currency'] ?? 'IDR',
+            'invoice' => $invoice,
+            'locale' => $settings['locale'] ?? 'id',
+            'siteName' => $settings['site_name'] ?? config('app.name'),
+        ]);
     }
 
     public function store(StoreTenantPortalPaymentRequest $request, RecordPayment $action): RedirectResponse

--- a/app/Jobs/GenerateInvoicePdfArtifact.php
+++ b/app/Jobs/GenerateInvoicePdfArtifact.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Actions\Invoices\GenerateInvoicePdf;
+use App\Models\Invoice;
+use App\Models\Setting;
+use App\Services\Invoices\InvoicePdfArtifact;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class GenerateInvoicePdfArtifact implements ShouldBeUnique, ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(
+        public int $invoiceId,
+        public string $fingerprint,
+    ) {}
+
+    public function uniqueId(): string
+    {
+        return "invoice-pdf:{$this->invoiceId}:{$this->fingerprint}";
+    }
+
+    public function handle(InvoicePdfArtifact $artifact, GenerateInvoicePdf $renderer): void
+    {
+        if (! Setting::get('invoice_pdf_enabled')) {
+            return;
+        }
+
+        $invoice = Invoice::find($this->invoiceId);
+
+        if (! $invoice) {
+            return;
+        }
+
+        $currentFingerprint = $artifact->fingerprint($invoice);
+        if ($currentFingerprint !== $this->fingerprint) {
+            self::dispatch($invoice->getKey(), $currentFingerprint);
+
+            return;
+        }
+
+        $artifact->generate($invoice, $this->fingerprint, $renderer->execute($invoice));
+    }
+}

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -21,6 +21,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
     'status',
     'total',
     'amount_paid',
+    'invoice_pdf_fingerprint',
 ])]
 class Invoice extends Model
 {

--- a/app/Notifications/RentReminder.php
+++ b/app/Notifications/RentReminder.php
@@ -2,7 +2,6 @@
 
 namespace App\Notifications;
 
-use App\Actions\Invoices\GenerateInvoicePdf;
 use App\Data\Reminder\ReminderEvent;
 use App\Enums\ReminderType;
 use App\Models\Invoice;
@@ -11,6 +10,7 @@ use App\Models\Tenant;
 use App\Notifications\Channels\LogChannel;
 use App\Notifications\Channels\MailChannel;
 use App\Notifications\Channels\WhatsAppChannel;
+use App\Services\Invoices\InvoicePdfArtifact;
 use Carbon\Carbon;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -87,11 +87,13 @@ class RentReminder extends Notification implements MailChannelNotification, Shou
                 $invoice->reference ?? (string) $invoice->getKey(),
             );
 
-            $attachments[] = new MailAttachment(
-                content: $this->invoicePdfContent($invoice),
-                filename: 'invoice-'.($reference ?: $invoice->getKey()).'.pdf',
-                mimeType: 'application/pdf',
-            );
+            if ($content = $this->invoicePdfContent($invoice)) {
+                $attachments[] = new MailAttachment(
+                    content: $content,
+                    filename: 'invoice-'.($reference ?: $invoice->getKey()).'.pdf',
+                    mimeType: 'application/pdf',
+                );
+            }
         }
 
         return new MailContent(
@@ -107,7 +109,7 @@ class RentReminder extends Notification implements MailChannelNotification, Shou
         $attachment = null;
         $invoice = $this->invoice();
 
-        if ($invoice) {
+        if ($invoice && ($content = $this->invoicePdfContent($invoice))) {
             $reference = preg_replace(
                 '/[^A-Za-z0-9_-]/',
                 '-',
@@ -115,7 +117,7 @@ class RentReminder extends Notification implements MailChannelNotification, Shou
             );
 
             $attachment = new WhatsAppAttachment(
-                content: $this->invoicePdfContent($invoice),
+                content: $content,
                 filename: 'invoice-'.($reference ?: $invoice->getKey()).'.pdf',
                 mimeType: 'application/pdf',
             );
@@ -232,8 +234,8 @@ class RentReminder extends Notification implements MailChannelNotification, Shou
             : route('portal.billing.index');
     }
 
-    private function invoicePdfContent(Invoice $invoice): string
+    private function invoicePdfContent(Invoice $invoice): ?string
     {
-        return $this->invoicePdfContent ??= app(GenerateInvoicePdf::class)->execute($invoice);
+        return $this->invoicePdfContent ??= app(InvoicePdfArtifact::class)->content($invoice);
     }
 }

--- a/app/Services/Invoices/InvoicePdfArtifact.php
+++ b/app/Services/Invoices/InvoicePdfArtifact.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace App\Services\Invoices;
+
+use App\Jobs\GenerateInvoicePdfArtifact;
+use App\Models\Invoice;
+use App\Models\Setting;
+use Illuminate\Support\Facades\Storage;
+
+final class InvoicePdfArtifact
+{
+    private const DISK = 'local';
+
+    public function status(Invoice $invoice): string
+    {
+        if (! Setting::get('invoice_pdf_enabled')) {
+            return 'disabled';
+        }
+
+        return $this->available($invoice) ? 'available' : 'pending';
+    }
+
+    public function available(Invoice $invoice): bool
+    {
+        if (! Setting::get('invoice_pdf_enabled')) {
+            return false;
+        }
+
+        return Invoice::query()->whereKey($invoice->getKey())->value('invoice_pdf_fingerprint') === $this->fingerprint($invoice)
+            && Storage::disk(self::DISK)->exists($this->path($invoice));
+    }
+
+    public function content(Invoice $invoice): ?string
+    {
+        if (! $this->available($invoice)) {
+            $this->ensureQueued($invoice);
+
+            return null;
+        }
+
+        return Storage::disk(self::DISK)->get($this->path($invoice));
+    }
+
+    public function ensureQueued(Invoice $invoice): void
+    {
+        if (! Setting::get('invoice_pdf_enabled')) {
+            return;
+        }
+
+        $fingerprint = $this->fingerprint($invoice);
+
+        if (Invoice::query()->whereKey($invoice->getKey())->value('invoice_pdf_fingerprint') === $fingerprint
+            && Storage::disk(self::DISK)->exists($this->path($invoice))) {
+            return;
+        }
+
+        GenerateInvoicePdfArtifact::dispatch($invoice->getKey(), $fingerprint);
+    }
+
+    public function generate(Invoice $invoice, string $fingerprint, string $pdf): void
+    {
+        if (! Setting::get('invoice_pdf_enabled')) {
+            return;
+        }
+
+        $currentFingerprint = $this->fingerprint($invoice);
+        if ($currentFingerprint !== $fingerprint) {
+            GenerateInvoicePdfArtifact::dispatch($invoice->getKey(), $currentFingerprint);
+
+            return;
+        }
+
+        if (! Storage::disk(self::DISK)->put($this->path($invoice), $pdf)) {
+            throw new \RuntimeException('Unable to store the generated invoice PDF.');
+        }
+
+        $invoice->forceFill(['invoice_pdf_fingerprint' => $fingerprint])->saveQuietly();
+    }
+
+    public function path(Invoice $invoice): string
+    {
+        return "invoice-pdfs/{$invoice->getKey()}.pdf";
+    }
+
+    public function fingerprint(Invoice $invoice): string
+    {
+        $invoice = Invoice::query()->findOrFail($invoice->getKey());
+        $invoice->load([
+            'lease.primaryTenant.user',
+            'lease.unit.property.city',
+            'lease.unit.property.region',
+            'lineItems',
+            'payments' => fn ($query) => $query
+                ->where('status', 'confirmed')
+                ->orderBy('payment_date')
+                ->orderBy('id'),
+        ]);
+
+        $payload = [
+            'settings' => Setting::some(['site_name', 'locale', 'currency']),
+            'invoice' => $this->attributes($invoice, [
+                'id', 'reference', 'created_at', 'period_start', 'period_end',
+                'due_date', 'status', 'total', 'amount_paid',
+            ]),
+            'lease' => $this->attributes($invoice->lease, ['id', 'reference']),
+            'unit' => $this->attributes($invoice->lease?->unit, ['id', 'name']),
+            'property' => $this->attributes($invoice->lease?->unit?->property, [
+                'id', 'name', 'address', 'postal_code',
+            ]),
+            'city' => $this->attributes($invoice->lease?->unit?->property?->city, ['id', 'name']),
+            'region' => $this->attributes($invoice->lease?->unit?->property?->region, ['id', 'name']),
+            'tenant' => $this->attributes($invoice->lease?->primaryTenant, ['id', 'name', 'phone']),
+            'user' => $this->attributes($invoice->lease?->primaryTenant?->user, ['id', 'email']),
+            'line_items' => $invoice->lineItems->map(fn ($item) => $this->attributes($item, [
+                'id', 'type', 'description', 'amount', 'updated_at',
+            ]))->values()->all(),
+            'payments' => $invoice->payments->map(fn ($payment) => $this->attributes($payment, [
+                'id', 'amount', 'payment_date', 'payment_method', 'reference_number', 'verified_at', 'updated_at',
+            ]))->values()->all(),
+        ];
+
+        return hash('sha256', json_encode($payload, JSON_THROW_ON_ERROR));
+    }
+
+    /** @return array<string, mixed>|null */
+    private function attributes(?object $model, array $keys): ?array
+    {
+        if (! $model) {
+            return null;
+        }
+
+        return collect($keys)->mapWithKeys(fn (string $key): array => [$key => $model->{$key}])->all();
+    }
+}

--- a/config/settings.php
+++ b/config/settings.php
@@ -8,6 +8,7 @@ return [
     'currency' => ['default' => 'IDR', 'cast' => 'string'],
     'timezone' => ['default' => 'Asia/Jakarta', 'cast' => 'string'],
     'lease_id_prefix' => ['default' => 'LSX', 'cast' => 'string'],
+    'invoice_pdf_enabled' => ['default' => false, 'cast' => 'boolean'],
     'reminder_enabled' => ['default' => true, 'cast' => 'boolean'],
     'reminder_days_before' => ['default' => 3, 'cast' => 'integer'],
     'reminder_overdue_intervals' => ['default' => [1, 3, 7], 'cast' => 'array'],

--- a/database/migrations/2026_08_13_000000_add_invoice_pdf_fingerprint_to_invoices.php
+++ b/database/migrations/2026_08_13_000000_add_invoice_pdf_fingerprint_to_invoices.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('invoices', function (Blueprint $table): void {
+            $table->string('invoice_pdf_fingerprint', 64)->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('invoices', function (Blueprint $table): void {
+            $table->dropColumn('invoice_pdf_fingerprint');
+        });
+    }
+};

--- a/resources/js/pages/leases/invoice-detail.tsx
+++ b/resources/js/pages/leases/invoice-detail.tsx
@@ -5,6 +5,7 @@ import { PaymentDetailSheet } from '@/components/features';
 import { DocumentPreview } from '@/components/shared';
 import { StatusBadge } from '@/components/shared/status-badge';
 import { Button } from '@/components/ui/button';
+import { PAYMENT_METHOD_LABELS } from '@/lib/constants/billing';
 import { formatDate, formatPeriod, formatPrice } from '@/lib/formatters';
 import invoiceRoutes from '@/routes/leases/workspace/invoices';
 import paymentRoutes from '@/routes/payments';
@@ -202,40 +203,60 @@ export default function InvoiceDetail({
                     </div>
                 )}
 
-                {/* Allocated payments */}
-                {invoice.payments && invoice.payments.length > 0 && (
-                    <div className="rounded-lg border">
-                        <div className="border-b px-4 py-3">
-                            <h3 className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
-                                Payments
-                            </h3>
-                        </div>
+                {/* Activity timeline */}
+                <section className="rounded-lg border">
+                    <div className="border-b px-4 py-3">
+                        <h3 className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
+                            Activity timeline
+                        </h3>
+                    </div>
+                    {invoice.payments && invoice.payments.length > 0 ? (
                         <div className="divide-y">
                             {invoice.payments.map((payment) => (
                                 <div
                                     key={payment.id}
-                                    className="flex cursor-pointer items-center justify-between px-4 py-3 text-sm hover:bg-muted/30"
+                                    className="flex cursor-pointer gap-3 px-4 py-3 text-sm hover:bg-muted/30"
                                     onClick={() => {
                                         setSelectedPaymentId(payment.id);
                                     }}
                                 >
-                                    <div>
-                                        <p className="font-medium tabular-nums">
+                                    <div className="flex w-3 shrink-0 justify-center">
+                                        <div className="mt-1.5 size-2 rounded-full bg-primary" />
+                                    </div>
+                                    <div className="min-w-0 flex-1">
+                                        <div className="flex items-center justify-between gap-3">
+                                            <p className="font-medium">
+                                                {payment.status === 'confirmed'
+                                                    ? 'Payment confirmed'
+                                                    : payment.status ===
+                                                        'cancelled'
+                                                      ? 'Payment cancelled'
+                                                      : 'Payment submitted'}
+                                            </p>
+                                            <StatusBadge
+                                                domain="payment"
+                                                value={payment.status}
+                                            />
+                                        </div>
+                                        <p className="mt-1 text-xs text-muted-foreground">
+                                            {formatDate(payment.payment_date)} ·{' '}
+                                            {PAYMENT_METHOD_LABELS[
+                                                payment.payment_method
+                                            ] ?? payment.payment_method}
+                                        </p>
+                                        <p className="mt-1 font-medium tabular-nums">
                                             {formatPrice(payment.amount)}
                                         </p>
-                                        <p className="text-xs text-muted-foreground">
-                                            {formatDate(payment.payment_date)}
-                                        </p>
                                     </div>
-                                    <StatusBadge
-                                        domain="payment"
-                                        value={payment.status}
-                                    />
                                 </div>
                             ))}
                         </div>
-                    </div>
-                )}
+                    ) : (
+                        <p className="px-4 py-6 text-sm text-muted-foreground">
+                            No payment activity yet.
+                        </p>
+                    )}
+                </section>
 
                 {invoicePdf.status === 'pending' && (
                     <p className="text-right text-xs text-muted-foreground">

--- a/resources/js/pages/leases/invoice-detail.tsx
+++ b/resources/js/pages/leases/invoice-detail.tsx
@@ -1,19 +1,25 @@
 import { Head, Link, router, usePage } from '@inertiajs/react';
-import { ChevronLeft } from 'lucide-react';
+import { ChevronLeft, Download, Printer } from 'lucide-react';
 import { useState } from 'react';
 import { PaymentDetailSheet } from '@/components/features';
 import { DocumentPreview } from '@/components/shared';
 import { StatusBadge } from '@/components/shared/status-badge';
+import { Button } from '@/components/ui/button';
 import { formatDate, formatPeriod, formatPrice } from '@/lib/formatters';
+import invoiceRoutes from '@/routes/leases/workspace/invoices';
 import paymentRoutes from '@/routes/payments';
 import type { Invoice, Payment, PaymentProof, WorkspaceLease } from '@/types';
 
 export default function InvoiceDetail({
     lease,
     invoice,
+    invoicePdf,
 }: {
     lease: WorkspaceLease;
     invoice: Invoice;
+    invoicePdf: {
+        status: 'disabled' | 'pending' | 'available';
+    };
 }) {
     const { auth } = usePage<{ auth: { permissions: string[] } }>().props;
     const [verifyingId, setVerifyingId] = useState<number | null>(null);
@@ -80,7 +86,7 @@ export default function InvoiceDetail({
             <div className="flex-1 space-y-6">
                 {/* Summary card */}
                 <div className="rounded-lg border p-6">
-                    <div className="flex items-start justify-between">
+                    <div className="flex items-start justify-between gap-4">
                         <div>
                             <h2 className="text-lg font-semibold">
                                 {invoice.reference ?? 'Invoice'}
@@ -89,10 +95,43 @@ export default function InvoiceDetail({
                                 {formatPeriod(invoice.period_start, 'id-ID')}
                             </p>
                         </div>
-                        <StatusBadge
-                            domain="invoice"
-                            value={invoice.display_status ?? invoice.status}
-                        />
+                        <div className="flex flex-col items-end gap-3">
+                            <StatusBadge
+                                domain="invoice"
+                                value={invoice.display_status ?? invoice.status}
+                            />
+                            {invoicePdf.status === 'available' ? (
+                                <Button asChild size="sm" variant="outline">
+                                    <a
+                                        href={invoiceRoutes.download.url([
+                                            lease,
+                                            invoice,
+                                        ])}
+                                    >
+                                        <Download className="size-4" />
+                                        Download PDF
+                                    </a>
+                                </Button>
+                            ) : invoicePdf.status === 'pending' ? (
+                                <Button disabled size="sm" variant="outline">
+                                    PDF pending
+                                </Button>
+                            ) : (
+                                <Button asChild size="sm" variant="outline">
+                                    <a
+                                        href={invoiceRoutes.print.url([
+                                            lease,
+                                            invoice,
+                                        ])}
+                                        rel="noreferrer"
+                                        target="_blank"
+                                    >
+                                        <Printer className="size-4" />
+                                        Print / Save as PDF
+                                    </a>
+                                </Button>
+                            )}
+                        </div>
                     </div>
 
                     <div className="mt-6 grid grid-cols-3 gap-4 text-sm">
@@ -198,10 +237,12 @@ export default function InvoiceDetail({
                     </div>
                 )}
 
-                {/* Timeline placeholder */}
-                <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
-                    Activity timeline, reminders, and PDF download coming soon.
-                </div>
+                {invoicePdf.status === 'pending' && (
+                    <p className="text-right text-xs text-muted-foreground">
+                        A queue worker is preparing this PDF. Refresh this page
+                        when it is ready.
+                    </p>
+                )}
             </div>
 
             <PaymentDetailSheet

--- a/resources/js/pages/settings/general.tsx
+++ b/resources/js/pages/settings/general.tsx
@@ -17,6 +17,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
 import {
     edit as editGeneral,
     update as updateGeneral,
@@ -34,6 +35,7 @@ export default function General({
         timezone: string;
         lease_id_prefix: string;
         invoice_id_prefix: string;
+        invoice_pdf_enabled: boolean;
     };
     timezone_list: string[];
 }) {
@@ -51,6 +53,10 @@ export default function General({
     const referenceForm = useForm({
         lease_id_prefix: settings.lease_id_prefix,
         invoice_id_prefix: settings.invoice_id_prefix,
+    });
+
+    const invoicePdfForm = useForm({
+        invoice_pdf_enabled: settings.invoice_pdf_enabled,
     });
 
     return (
@@ -249,6 +255,58 @@ export default function General({
                             <AppearanceTabs />
                         </CardContent>
                     </Card>
+
+                    <form
+                        onSubmit={(e) => {
+                            e.preventDefault();
+                            invoicePdfForm.transform((data) => ({
+                                invoice_pdf_enabled: data.invoice_pdf_enabled
+                                    ? '1'
+                                    : '0',
+                            }));
+                            invoicePdfForm.submit(updateGeneral());
+                        }}
+                    >
+                        <Card>
+                            <CardHeader>
+                                <CardTitle>Invoice PDFs</CardTitle>
+                                <CardDescription>
+                                    PDF generation runs in the queue and needs a
+                                    running worker when enabled.
+                                </CardDescription>
+                            </CardHeader>
+                            <CardContent className="space-y-4">
+                                <div className="flex items-center gap-3">
+                                    <Switch
+                                        id="invoice_pdf_enabled"
+                                        checked={
+                                            invoicePdfForm.data
+                                                .invoice_pdf_enabled
+                                        }
+                                        onCheckedChange={(checked) =>
+                                            invoicePdfForm.setData(
+                                                'invoice_pdf_enabled',
+                                                checked,
+                                            )
+                                        }
+                                    />
+                                    <Label htmlFor="invoice_pdf_enabled">
+                                        {invoicePdfForm.data.invoice_pdf_enabled
+                                            ? 'Invoice PDF generation is enabled'
+                                            : 'Invoice PDF generation is disabled'}
+                                    </Label>
+                                </div>
+                                <p className="text-sm text-muted-foreground">
+                                    {invoicePdfForm.data.invoice_pdf_enabled
+                                        ? 'Invoice PDFs are generated in the background, stored privately, and reused for downloads and supported reminders.'
+                                        : 'Invoices remain available as web pages. Use the browser print or save-as-PDF flow; reminders include the invoice link without an attachment.'}
+                                </p>
+                                <Button disabled={invoicePdfForm.processing}>
+                                    Save
+                                </Button>
+                            </CardContent>
+                        </Card>
+                    </form>
 
                     <form
                         onSubmit={(e) => {

--- a/resources/js/pages/tenant-portal/payments/invoice.tsx
+++ b/resources/js/pages/tenant-portal/payments/invoice.tsx
@@ -1,5 +1,5 @@
 import { Head, Link } from '@inertiajs/react';
-import { ChevronLeft, Download } from 'lucide-react';
+import { ChevronLeft, Download, Printer } from 'lucide-react';
 import { useState } from 'react';
 import SubmitPortalPaymentSheet from '@/components/features/payments/submit-portal-payment-sheet';
 import { StatusBadge } from '@/components/shared/status-badge';
@@ -8,7 +8,7 @@ import { Button } from '@/components/ui/button';
 import { PAYMENT_METHOD_LABELS } from '@/lib/constants/billing';
 import { formatDate, formatPeriod, formatPrice } from '@/lib/formatters';
 import { index } from '@/routes/portal/billing';
-import { download } from '@/routes/portal/billing/invoices';
+import { download, print } from '@/routes/portal/billing/invoices';
 import type { Invoice, Payment } from '@/types';
 
 type InvoiceLease = {
@@ -20,9 +20,13 @@ type InvoiceLease = {
 export default function InvoiceDetail({
     invoice,
     lease,
+    invoicePdf,
 }: {
     invoice: Invoice;
     lease: InvoiceLease;
+    invoicePdf: {
+        status: 'disabled' | 'pending' | 'available';
+    };
 }) {
     const [paymentOpen, setPaymentOpen] = useState(false);
     const isPayable = ['pending', 'partial'].includes(invoice.status);
@@ -213,16 +217,47 @@ export default function InvoiceDetail({
                                     Pay invoice
                                 </Button>
                             )}
-                            <Button
-                                asChild
-                                className="w-full"
-                                variant="outline"
-                            >
-                                <a href={download.url(invoice)}>
-                                    <Download className="size-4" />
-                                    Download PDF
-                                </a>
-                            </Button>
+                            {invoicePdf.status === 'available' ? (
+                                <Button
+                                    asChild
+                                    className="w-full"
+                                    variant="outline"
+                                >
+                                    <a href={download.url(invoice)}>
+                                        <Download className="size-4" />
+                                        Download PDF
+                                    </a>
+                                </Button>
+                            ) : invoicePdf.status === 'pending' ? (
+                                <>
+                                    <Button
+                                        className="w-full"
+                                        variant="outline"
+                                        disabled
+                                    >
+                                        PDF pending
+                                    </Button>
+                                    <p className="text-xs text-muted-foreground">
+                                        A queue worker is preparing this PDF.
+                                        Refresh this page when it is ready.
+                                    </p>
+                                </>
+                            ) : (
+                                <Button
+                                    asChild
+                                    className="w-full"
+                                    variant="outline"
+                                >
+                                    <a
+                                        href={print.url(invoice)}
+                                        rel="noreferrer"
+                                        target="_blank"
+                                    >
+                                        <Printer className="size-4" />
+                                        Print / Save as PDF
+                                    </a>
+                                </Button>
+                            )}
                         </div>
                     </aside>
                 </div>

--- a/resources/views/invoices/pdf.blade.php
+++ b/resources/views/invoices/pdf.blade.php
@@ -200,5 +200,10 @@
 @endif
 
 <p class="footer">Generated on {{ $generatedAt }} WIB. This document reflects the invoice status at the time it was generated.</p>
+@if ($autoPrint ?? false)
+    <script>
+        window.addEventListener('load', () => window.print());
+    </script>
+@endif
 </body>
 </html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -146,6 +146,8 @@ Route::middleware(['auth', 'verified', 'permission:dashboard.view'])->group(func
             Route::get('documents', [LeaseController::class, 'documents'])->name('workspace.documents')->middleware('permission:leases.view');
             Route::get('invoices', [LeaseInvoiceController::class, 'index'])->name('workspace.invoices')->middleware('permission:leases.view');
             Route::get('invoices/{invoice}', [LeaseInvoiceController::class, 'show'])->name('workspace.invoices.show')->middleware('permission:leases.view');
+            Route::get('invoices/{invoice}/print', [LeaseInvoiceController::class, 'print'])->name('workspace.invoices.print')->middleware('permission:leases.view');
+            Route::get('invoices/{invoice}/download', [LeaseInvoiceController::class, 'download'])->name('workspace.invoices.download')->middleware('permission:leases.view');
             Route::get('rent-schedule', LeaseRentScheduleController::class)->name('rent-schedule')->middleware('permission:leases.view');
             Route::post('move-out', [LeaseController::class, 'moveOut'])->name('move-out')->middleware('permission:leases.move_out');
             Route::post('renew', [LeaseController::class, 'renew'])->name('renew')->middleware('permission:leases.renew');

--- a/routes/web.php
+++ b/routes/web.php
@@ -48,6 +48,7 @@ Route::middleware(['auth', 'verified'])->prefix('portal')->name('portal.')->grou
         Route::get('history/invoices', [TenantPortalPaymentController::class, 'invoiceHistory'])->name('history.invoices');
         Route::get('history/payments', [TenantPortalPaymentController::class, 'paymentHistory'])->name('history.payments');
         Route::get('invoices/{invoice}', [TenantPortalPaymentController::class, 'invoice'])->name('invoices.show');
+        Route::get('invoices/{invoice}/print', [TenantPortalPaymentController::class, 'print'])->name('invoices.print');
         Route::get('invoices/{invoice}/download', [TenantPortalPaymentController::class, 'download'])->name('invoices.download');
     });
 

--- a/tests/Feature/InvoiceWorkspaceTest.php
+++ b/tests/Feature/InvoiceWorkspaceTest.php
@@ -1,19 +1,36 @@
 <?php
 
 use App\Enums\InvoiceStatus;
+use App\Jobs\GenerateInvoicePdfArtifact;
 use App\Models\Invoice;
 use App\Models\InvoiceLineItem;
 use App\Models\Lease;
 use App\Models\Payment;
 use App\Models\PaymentProof;
+use App\Models\Setting;
 use App\Models\User;
+use App\Services\Invoices\InvoicePdfArtifact;
 use Database\Seeders\RegionAndCitySeeder;
 use Database\Seeders\RoleAndPermissionSeeder;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Storage;
 
 uses()->beforeEach(function () {
     $this->seed([RoleAndPermissionSeeder::class, RegionAndCitySeeder::class]);
     $this->owner = User::factory()->owner()->create();
+    Setting::set('invoice_pdf_enabled', true, 'boolean');
+    Storage::fake('local');
 });
+
+function prepareWorkspaceInvoicePdf(Invoice $invoice): void
+{
+    $artifact = app(InvoicePdfArtifact::class);
+
+    GenerateInvoicePdfArtifact::dispatchSync(
+        $invoice->getKey(),
+        $artifact->fingerprint($invoice),
+    );
+}
 
 describe('invoice workspace index', function () {
     it('lists invoices for a lease', function () {
@@ -124,5 +141,56 @@ describe('invoice workspace show', function () {
         $this->actingAs($this->owner)
             ->get(route('leases.workspace.invoices.show', [$lease, $invoice]))
             ->assertNotFound();
+    });
+
+    it('queues and exposes invoice PDF status', function () {
+        Bus::fake();
+        $lease = Lease::factory()->create();
+        $invoice = Invoice::factory()->create(['lease_id' => $lease->id]);
+
+        $this->actingAs($this->owner)
+            ->get(route('leases.workspace.invoices.show', [$lease, $invoice]))
+            ->assertInertia(fn ($page) => $page->where('invoicePdf.status', 'pending'));
+
+        Bus::assertDispatched(GenerateInvoicePdfArtifact::class);
+    });
+
+    it('downloads a generated invoice PDF', function () {
+        $lease = Lease::factory()->create();
+        $invoice = Invoice::factory()->create(['lease_id' => $lease->id]);
+        prepareWorkspaceInvoicePdf($invoice);
+
+        $response = $this->actingAs($this->owner)
+            ->get(route('leases.workspace.invoices.download', [$lease, $invoice]));
+
+        $response
+            ->assertOk()
+            ->assertStreamed()
+            ->assertDownload("invoice-{$invoice->reference}.pdf")
+            ->assertHeader('content-type', 'application/pdf');
+    });
+
+    it('opens a print-ready invoice PDF page', function () {
+        $lease = Lease::factory()->create();
+        $invoice = Invoice::factory()->create(['lease_id' => $lease->id]);
+
+        $this->actingAs($this->owner)
+            ->get(route('leases.workspace.invoices.print', [$lease, $invoice]))
+            ->assertOk()
+            ->assertSee($invoice->reference)
+            ->assertSee('window.print()');
+    });
+
+    it('uses print fallback when invoice PDF generation is disabled', function () {
+        Setting::set('invoice_pdf_enabled', false, 'boolean');
+        Bus::fake();
+        $lease = Lease::factory()->create();
+        $invoice = Invoice::factory()->create(['lease_id' => $lease->id]);
+
+        $this->actingAs($this->owner)
+            ->get(route('leases.workspace.invoices.show', [$lease, $invoice]))
+            ->assertInertia(fn ($page) => $page->where('invoicePdf.status', 'disabled'));
+
+        Bus::assertNotDispatched(GenerateInvoicePdfArtifact::class);
     });
 });

--- a/tests/Feature/SendRentRemindersTest.php
+++ b/tests/Feature/SendRentRemindersTest.php
@@ -5,6 +5,8 @@ use App\Actions\Reminders\SendRentReminders;
 use App\Business\Reminders\PaymentReminderScheduler;
 use App\Data\Reminder\ReminderSettings;
 use App\Enums\InvoiceStatus;
+use App\Jobs\GenerateInvoicePdfArtifact;
+use App\Models\Invoice;
 use App\Models\Lease;
 use App\Models\Property;
 use App\Models\ReminderLog;
@@ -13,12 +15,26 @@ use App\Models\Tenant;
 use App\Models\Unit;
 use App\Models\User;
 use App\Notifications\RentReminder;
+use App\Services\Invoices\InvoicePdfArtifact;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Storage;
 
 uses()->beforeEach(function () {
     $this->seed(RoleAndPermissionSeeder::class);
+    Setting::set('invoice_pdf_enabled', true, 'boolean');
+    Storage::fake('local');
 });
+
+function prepareReminderInvoicePdf(Invoice $invoice): void
+{
+    $artifact = app(InvoicePdfArtifact::class);
+
+    GenerateInvoicePdfArtifact::dispatchSync(
+        $invoice->getKey(),
+        $artifact->fingerprint($invoice),
+    );
+}
 
 function createLeaseWithTenant(array $overrides = []): Lease
 {
@@ -307,6 +323,7 @@ describe('SendRentRemindersAction', function () {
         $lease->load(['primaryTenant.user']);
         $tenant = $lease->primaryTenant;
         $invoice = $lease->invoices()->payable()->orderBy('period_start')->firstOrFail();
+        prepareReminderInvoicePdf($invoice);
 
         app(SendRentReminders::class)->execute($lease);
 
@@ -345,6 +362,7 @@ describe('SendRentRemindersAction', function () {
         $lease->load(['primaryTenant']);
         $tenant = $lease->primaryTenant;
         $invoice = $lease->invoices()->payable()->orderBy('period_start')->firstOrFail();
+        prepareReminderInvoicePdf($invoice);
 
         app(SendRentReminders::class)->execute($lease);
 
@@ -369,6 +387,36 @@ describe('SendRentRemindersAction', function () {
                 expect($attachment->filename)->toBe("invoice-{$invoice->reference}.pdf");
                 expect($attachment->mimeType)->toBe('application/pdf');
                 expect($attachment->content)->toStartWith('%PDF-');
+
+                return true;
+            },
+        );
+
+        Carbon::setTestNow();
+    });
+
+    it('omits invoice attachments when PDF generation is disabled', function () {
+        Carbon::setTestNow(Carbon::parse('2026-07-01'));
+        Setting::set('invoice_pdf_enabled', false, 'boolean');
+        Setting::set('reminder_channels', ['mail'], 'array');
+        Notification::fake();
+
+        $user = User::factory()->create(['email' => 'tenant@example.com']);
+        $lease = createLeaseWithTenant(['rent_due_day' => 1, 'start_date' => '2026-07-01']);
+        $lease->primaryTenant->update([
+            'phone' => null,
+            'user_id' => $user->id,
+        ]);
+        $lease->load(['primaryTenant.user']);
+        $tenant = $lease->primaryTenant;
+
+        app(SendRentReminders::class)->execute($lease);
+
+        Notification::assertSentTo(
+            $tenant,
+            RentReminder::class,
+            function (RentReminder $notification) use ($tenant): bool {
+                expect($notification->toMailChannel($tenant)->attachments)->toBeEmpty();
 
                 return true;
             },
@@ -537,6 +585,7 @@ describe('Manual Send via Controller', function () {
         $lease->load(['primaryTenant.user']);
         $tenant = $lease->primaryTenant;
         $invoice = $lease->invoices()->payable()->orderBy('period_start')->firstOrFail();
+        prepareReminderInvoicePdf($invoice);
 
         $this->actingAs($owner)
             ->post(route('leases.send-reminder', $lease))

--- a/tests/Feature/Settings/GeneralSettingsTest.php
+++ b/tests/Feature/Settings/GeneralSettingsTest.php
@@ -59,6 +59,7 @@ describe('General settings page', function () {
                 ->has('settings.timezone')
                 ->has('settings.lease_id_prefix')
                 ->has('settings.invoice_id_prefix')
+                ->has('settings.invoice_pdf_enabled')
                 ->has('timezone_list')
             );
     });
@@ -75,6 +76,7 @@ describe('General settings page', function () {
                 'timezone' => 'America/New_York',
                 'lease_id_prefix' => 'LSE',
                 'invoice_id_prefix' => 'INV',
+                'invoice_pdf_enabled' => true,
             ])
             ->assertRedirect(route('settings.general.edit'));
 
@@ -85,6 +87,7 @@ describe('General settings page', function () {
         expect(Setting::get('timezone'))->toBe('America/New_York');
         expect(Setting::get('lease_id_prefix'))->toBe('LSE');
         expect(Setting::get('invoice_id_prefix'))->toBe('INV');
+        expect(Setting::get('invoice_pdf_enabled'))->toBeTrue();
     });
 
     it('validates country_code is 2 uppercase letters', function () {

--- a/tests/Feature/TenantInvoicePdfTest.php
+++ b/tests/Feature/TenantInvoicePdfTest.php
@@ -2,14 +2,34 @@
 
 use App\Actions\Invoices\GenerateInvoicePdf;
 use App\Enums\InvoiceStatus;
+use App\Jobs\GenerateInvoicePdfArtifact;
 use App\Models\Invoice;
 use App\Models\Lease;
 use App\Models\Payment;
 use App\Models\Property;
+use App\Models\Setting;
 use App\Models\Tenant;
 use App\Models\Unit;
 use App\Models\User;
+use App\Services\Invoices\InvoicePdfArtifact;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Number;
+
+uses()->beforeEach(function () {
+    Setting::set('invoice_pdf_enabled', true, 'boolean');
+    Storage::fake('local');
+});
+
+function prepareTenantInvoicePdf(Invoice $invoice): void
+{
+    $artifact = app(InvoicePdfArtifact::class);
+
+    GenerateInvoicePdfArtifact::dispatchSync(
+        $invoice->getKey(),
+        $artifact->fingerprint($invoice),
+    );
+}
 
 function createTenantInvoicePdfFixture(?User $user = null): array
 {
@@ -62,6 +82,7 @@ test('tenant downloads their current invoice as a PDF', function () {
         'description' => 'Rent August 2026',
         'amount' => $invoice->total,
     ]);
+    prepareTenantInvoicePdf($invoice);
 
     $response = $this->actingAs($fixture['user'])
         ->get(route('portal.billing.invoices.download', $invoice));
@@ -87,6 +108,85 @@ test('invoice PDF download preserves tenant ownership rules', function () {
     $this->actingAs(User::factory()->create())
         ->get(route('portal.billing.invoices.download', $fixture['invoice']))
         ->assertForbidden();
+});
+
+test('tenant can open a print-ready invoice page', function () {
+    $fixture = createTenantInvoicePdfFixture();
+    $invoice = $fixture['invoice'];
+    $invoice->lineItems()->create([
+        'type' => 'rent',
+        'description' => 'Rent August 2026',
+        'amount' => $invoice->total,
+    ]);
+
+    $this->actingAs($fixture['user'])
+        ->get(route('portal.billing.invoices.print', $invoice))
+        ->assertOk()
+        ->assertSee($invoice->reference)
+        ->assertSee('Rent August 2026')
+        ->assertSee('window.print()');
+});
+
+test('invoice print page preserves tenant ownership rules', function () {
+    $fixture = createTenantInvoicePdfFixture();
+    $otherUser = User::factory()->create();
+    Tenant::factory()->withUser($otherUser)->create();
+
+    $this->actingAs($otherUser)
+        ->get(route('portal.billing.invoices.print', $fixture['invoice']))
+        ->assertNotFound();
+});
+
+test('disabled invoice PDFs leave the invoice page usable without queueing work', function () {
+    Setting::set('invoice_pdf_enabled', false, 'boolean');
+    Bus::fake();
+    $fixture = createTenantInvoicePdfFixture();
+
+    $this->actingAs($fixture['user'])
+        ->get(route('portal.billing.invoices.show', $fixture['invoice']))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page->where('invoicePdf.status', 'disabled'));
+
+    Bus::assertNotDispatched(GenerateInvoicePdfArtifact::class);
+
+    $this->actingAs($fixture['user'])
+        ->get(route('portal.billing.invoices.download', $fixture['invoice']))
+        ->assertRedirect(route('portal.billing.invoices.show', $fixture['invoice']));
+});
+
+test('enabled invoice PDFs queue when the private artifact is missing', function () {
+    Bus::fake();
+    $fixture = createTenantInvoicePdfFixture();
+
+    $this->actingAs($fixture['user'])
+        ->get(route('portal.billing.invoices.show', $fixture['invoice']))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page->where('invoicePdf.status', 'pending'));
+
+    Bus::assertDispatched(GenerateInvoicePdfArtifact::class);
+});
+
+test('invoice PDF artifacts are reused until rendered invoice data changes', function () {
+    $fixture = createTenantInvoicePdfFixture();
+    $invoice = $fixture['invoice'];
+    prepareTenantInvoicePdf($invoice);
+
+    $this->actingAs($fixture['user'])
+        ->get(route('portal.billing.invoices.download', $invoice))
+        ->assertOk();
+
+    $invoice->lineItems()->create([
+        'type' => 'rent',
+        'description' => 'Updated charge',
+        'amount' => '100.00',
+    ]);
+
+    Bus::fake();
+    $this->actingAs($fixture['user'])
+        ->get(route('portal.billing.invoices.show', $invoice))
+        ->assertInertia(fn ($page) => $page->where('invoicePdf.status', 'pending'));
+
+    Bus::assertDispatched(GenerateInvoicePdfArtifact::class);
 });
 
 test('invoice PDF view reflects the current aggregate for each payable state', function (
@@ -204,6 +304,7 @@ test('invoice PDF handles missing references and line items', function () {
     $invoice->update(['reference' => null]);
     $invoice->load(['lease.unit.property', 'lineItems']);
     $invoice->append(['outstanding', 'display_status']);
+    prepareTenantInvoicePdf($invoice);
 
     expect(renderTenantInvoicePdfView($invoice))
         ->toContain("#{$invoice->id}")


### PR DESCRIPTION
## Summary
- Add optional, queue-backed invoice PDF generation with fingerprinted private artifacts
- Add tenant and admin download/print flows, including browser-native print fallback
- Add admin invoice payment activity timeline

## Verification
- 677 Pest tests passed
- npm run build
- npm run types:check
- npm run lint:check
- vendor/bin/pint --test

Refs OPE-128