### PR TITLE
fix(mail): align native mailer resolution

### DIFF
--- a/app/Providers/NotificationServiceProvider.php
+++ b/app/Providers/NotificationServiceProvider.php
@@ -6,6 +6,7 @@ use App\Models\Setting;
 use App\Services\MailManager;
 use App\Services\WhatsAppManager;
 use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
 
 class NotificationServiceProvider extends ServiceProvider
@@ -29,7 +30,7 @@ class NotificationServiceProvider extends ServiceProvider
             return;
         }
 
-        config()->set('mail.default', $config['driver'] ?? 'log');
+        config()->set('mail.default', $this->resolveLaravelMailer($config['driver'] ?? 'log'));
 
         config()->set('mail.mailers.smtp.host', $config['host'] ?? '');
         config()->set('mail.mailers.smtp.port', $config['port'] ?? 587);
@@ -45,5 +46,25 @@ class NotificationServiceProvider extends ServiceProvider
             config()->set('mail.from.address', $fromAddress);
             config()->set('mail.from.name', $config['from_name'] ?? '');
         }
+    }
+
+    private function resolveLaravelMailer(string $driver): string
+    {
+        $mailer = match ($driver) {
+            'openkos/smtp', 'smtp' => 'smtp',
+            'openkos/log', 'log' => 'log',
+            default => $driver,
+        };
+
+        if (array_key_exists($mailer, config('mail.mailers', []))) {
+            return $mailer;
+        }
+
+        Log::warning('Unknown mail driver; falling back to Laravel log mailer.', [
+            'driver' => $driver,
+            'fallback' => 'log',
+        ]);
+
+        return 'log';
     }
 }

--- a/tests/Feature/Providers/ServiceProviderTest.php
+++ b/tests/Feature/Providers/ServiceProviderTest.php
@@ -1,10 +1,15 @@
 <?php
 
+use App\Models\Setting;
+use App\Notifications\UserInvitation;
+use App\Providers\NotificationServiceProvider;
 use App\Services\MailManager;
 use App\Services\Platform\ComposerPluginDiscovery;
 use App\Services\Settings\PlatformSettingsStore;
 use App\Services\Settings\SettingManager;
 use App\Services\WhatsAppManager;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Notification;
 use OpenKOS\Core\Contracts\PluginDiscovery;
 use OpenKOS\Core\Contracts\SettingsStore;
 
@@ -19,4 +24,41 @@ it('registers application services through dedicated providers', function () {
         ->toBe(app(MailManager::class))
         ->and(app(WhatsAppManager::class))
         ->toBe(app(WhatsAppManager::class));
+});
+
+it('maps OpenKOS mail drivers to valid Laravel mailers', function () {
+    Setting::set('mail_config', ['driver' => 'openkos/smtp']);
+
+    (new NotificationServiceProvider(app()))->boot();
+
+    expect(config('mail.default'))->toBe('smtp')
+        ->and(config('mail.mailers'))->toHaveKey(config('mail.default'));
+});
+
+it('preserves configured native Laravel mailers', function () {
+    config(['mail.mailers.ses' => ['transport' => 'log']]);
+    Setting::set('mail_config', ['driver' => 'ses']);
+
+    (new NotificationServiceProvider(app()))->boot();
+
+    expect(config('mail.default'))->toBe('ses')
+        ->and(config('mail.mailers'))->toHaveKey(config('mail.default'));
+
+    Notification::route('mail', 'user@example.com')
+        ->notify(new UserInvitation('https://example.com/invitation'));
+});
+
+it('warns and falls back to Laravel log for unknown mail drivers', function () {
+    Log::shouldReceive('warning')
+        ->once()
+        ->with('Unknown mail driver; falling back to Laravel log mailer.', [
+            'driver' => 'openkos/resend',
+            'fallback' => 'log',
+        ]);
+    Setting::set('mail_config', ['driver' => 'openkos/resend']);
+
+    (new NotificationServiceProvider(app()))->boot();
+
+    expect(config('mail.default'))->toBe('log')
+        ->and(config('mail.mailers'))->toHaveKey(config('mail.default'));
 });


### PR DESCRIPTION
## Summary

- map OpenKOS mail aliases to valid Laravel mailers
- preserve configured native Laravel mailers
- warn and fall back to Laravel log for unknown drivers
- add native notification and default-mailer invariant coverage

## Verification

- vendor/bin/pint --test app/Providers/NotificationServiceProvider.php tests/Feature/Providers/ServiceProviderTest.php
- php artisan test --compact tests/Feature/Providers/ServiceProviderTest.php tests/Unit/Services/MailManagerTest.php tests/Unit/Notifications/MailChannelTest.php tests/Feature/Notifications/MailMultipartTest.php

Refs OPE-125