### PR TITLE
feat(mail): support plugin Laravel mailers

### DIFF
--- a/app/Providers/NotificationServiceProvider.php
+++ b/app/Providers/NotificationServiceProvider.php
@@ -8,6 +8,7 @@ use App\Services\WhatsAppManager;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
+use OpenKOS\Platform\Notification\NotificationRegistry;
 
 class NotificationServiceProvider extends ServiceProvider
 {
@@ -50,6 +51,33 @@ class NotificationServiceProvider extends ServiceProvider
 
     private function resolveLaravelMailer(string $driver): string
     {
+        $registration = $this->app->make(NotificationRegistry::class)->driver('mail', $driver);
+
+        if ($registration) {
+            if ($registration->laravelMailer === null) {
+                Log::warning('OpenKOS mail driver has no Laravel mailer capability; falling back to Laravel log mailer.', [
+                    'driver' => $driver,
+                    'fallback' => 'log',
+                    'reason' => 'missing_capability',
+                ]);
+
+                return 'log';
+            }
+
+            if (array_key_exists($registration->laravelMailer, config('mail.mailers', []))) {
+                return $registration->laravelMailer;
+            }
+
+            Log::warning('Configured Laravel mailer for OpenKOS mail driver is unavailable; falling back to Laravel log mailer.', [
+                'driver' => $driver,
+                'mailer' => $registration->laravelMailer,
+                'fallback' => 'log',
+                'reason' => 'invalid_capability',
+            ]);
+
+            return 'log';
+        }
+
         $mailer = match ($driver) {
             'openkos/smtp', 'smtp' => 'smtp',
             'openkos/log', 'log' => 'log',
@@ -63,6 +91,7 @@ class NotificationServiceProvider extends ServiceProvider
         Log::warning('Unknown mail driver; falling back to Laravel log mailer.', [
             'driver' => $driver,
             'fallback' => 'log',
+            'reason' => 'unknown_driver',
         ]);
 
         return 'log';

--- a/composer.lock
+++ b/composer.lock
@@ -3311,16 +3311,16 @@
         },
         {
             "name": "openkos/platform",
-            "version": "0.1.1",
+            "version": "0.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/senatroxx/openkos-platform.git",
-                "reference": "31db53d706184f4caba70bac1da331028b96fd59"
+                "reference": "1cddafa76ad5a83c8f496f7d1fe71bc0d671e13b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/senatroxx/openkos-platform/zipball/31db53d706184f4caba70bac1da331028b96fd59",
-                "reference": "31db53d706184f4caba70bac1da331028b96fd59",
+                "url": "https://api.github.com/repos/senatroxx/openkos-platform/zipball/1cddafa76ad5a83c8f496f7d1fe71bc0d671e13b",
+                "reference": "1cddafa76ad5a83c8f496f7d1fe71bc0d671e13b",
                 "shasum": ""
             },
             "require": {
@@ -3351,28 +3351,16 @@
                     "OpenKOS\\": "src/"
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "Tests\\": "tests/"
-                }
-            },
-            "scripts": {
-                "test": [
-                    "pest --compact"
-                ],
-                "lint": [
-                    "pint"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "Apache-2.0"
             ],
             "description": "The OpenKOS platform and plugin SDK.",
             "support": {
-                "source": "https://github.com/senatroxx/openkos-platform/tree/v0.1.1",
-                "issues": "https://github.com/senatroxx/openkos-platform/issues"
+                "issues": "https://github.com/senatroxx/openkos-platform/issues",
+                "source": "https://github.com/senatroxx/openkos-platform/tree/v0.1.2"
             },
-            "time": "2026-08-11T14:23:41+00:00"
+            "time": "2026-08-13T11:04:37+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",

--- a/docs/platform.md
+++ b/docs/platform.md
@@ -37,7 +37,7 @@ Nine singletons, each bound as a **container singleton** in `PlatformServiceProv
 | `SettingsRegistry`     | Settings pages + setting definitions             | `SettingsPage(key, title, href, permission?, group?, routeName?, order?)` — `group` renders under a nav section; `routeName` is resolved lazily in `toArray()` (safe for plugin `boot()`); pages sort by `order` (default 500) |
 | `SettingsManager`      | Settings storage (read/write by key)             | Injected class with `get(key)`, `set(key, value)`, `some(keys)` methods; persistence is supplied by the host through `SettingsStore`                                                                                             |
 | `PermissionRegistry`   | Plugin-declared permissions                      | `register(key, label)` — persisted to Spatie permissions table via `platform:permissions:sync`                                                                                                                                 |
-| `NotificationRegistry` | Notification drivers by name                     | `NotificationDriverRegistration(name, channel, driverClass, label, config[])`                                                                                                                                                  |
+| `NotificationRegistry` | Notification drivers by name                     | `NotificationDriverRegistration(name, channel, driverClass, label, config[], laravelMailer?)`                                                                                                                                  |
 | `PaymentRegistry`      | Payment gateways by key                          | class-string or instance of `PaymentGateway`                                                                                                                                                                                   |
 | `OpenKOSManager`       | Central manager — entry point for all registries | Injected into plugins; facade exposes `OpenKOS::navigation()->...`, `OpenKOS::dashboard()->...`, etc.                                                                                                                           |
 
@@ -299,6 +299,20 @@ monolith; it would only matter for untrusted third-party marketplace plugins.
 - **The WhatsApp settings page** (`WhatsAppController`) lists drivers via `$registry->forChannel('whatsapp')` and validates the selection against it.
 
 `NotificationDriverRegistration.driverClass` is a plain class-string, not a typed contract, because each channel brings its own driver interface shaped to its needs — WhatsApp drivers implement the stateful `OpenKOS\Core\Contracts\WhatsAppDriver` (pairing/health). A future SMS/Telegram/push channel follows the same pattern: define a channel-specific driver contract in the package, register implementations into `NotificationRegistry` with that `channel`, and add a small app-side manager that resolves and calls them. The registry, registration, and settings-page listing are channel-agnostic and reused as-is; only the per-channel contract and manager are new.
+
+### Mail drivers
+
+Mail drivers may optionally advertise the Laravel mailer they support:
+
+    $platform->notifications()->registerDriver(new NotificationDriverRegistration(
+        name: 'openkos/resend',
+        channel: 'mail',
+        driverClass: ResendDriver::class,
+        label: 'Resend',
+        laravelMailer: 'resend',
+    ));
+
+The plugin owns registration of the actual Laravel mailer and transport. Omitting `laravelMailer` keeps the driver valid for OpenKOS custom notifications through `MailManager`, but native Laravel notifications use the Laravel `log` fallback with an explicit warning. The platform does not contain provider-specific mappings.
 
 ## Payment Contracts — interface only
 

--- a/src/Plugins/Mail/MailPlugin.php
+++ b/src/Plugins/Mail/MailPlugin.php
@@ -29,6 +29,7 @@ class MailPlugin extends Plugin
             channel: 'mail',
             driverClass: LogMailDriver::class,
             label: 'Log (Local / Testing)',
+            laravelMailer: 'log',
         ));
 
         $platform->notifications()->registerDriver(new NotificationDriverRegistration(
@@ -36,6 +37,7 @@ class MailPlugin extends Plugin
             channel: 'mail',
             driverClass: SmtpMailDriver::class,
             label: 'SMTP Server',
+            laravelMailer: 'smtp',
         ));
     }
 }

--- a/tests/Feature/Providers/ServiceProviderTest.php
+++ b/tests/Feature/Providers/ServiceProviderTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\Setting;
+use App\Notifications\Drivers\LogMailDriver;
 use App\Notifications\UserInvitation;
 use App\Providers\NotificationServiceProvider;
 use App\Services\MailManager;
@@ -12,6 +13,8 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Notification;
 use OpenKOS\Core\Contracts\PluginDiscovery;
 use OpenKOS\Core\Contracts\SettingsStore;
+use OpenKOS\Platform\Notification\NotificationDriverRegistration;
+use OpenKOS\Platform\Notification\NotificationRegistry;
 
 it('registers application services through dedicated providers', function () {
     expect(app(SettingManager::class))
@@ -35,6 +38,76 @@ it('maps OpenKOS mail drivers to valid Laravel mailers', function () {
         ->and(config('mail.mailers'))->toHaveKey(config('mail.default'));
 });
 
+it('uses an advertised Laravel mailer for a registered OpenKOS driver', function () {
+    config(['mail.mailers.resend' => ['transport' => 'log']]);
+    app(NotificationRegistry::class)->registerDriver(new NotificationDriverRegistration(
+        name: 'openkos/resend',
+        channel: 'mail',
+        driverClass: LogMailDriver::class,
+        label: 'Resend',
+        laravelMailer: 'resend',
+    ));
+    Setting::set('mail_config', ['driver' => 'openkos/resend']);
+
+    (new NotificationServiceProvider(app()))->boot();
+
+    expect(config('mail.default'))->toBe('resend')
+        ->and(config('mail.mailers'))->toHaveKey(config('mail.default'));
+
+    Notification::route('mail', 'user@example.com')
+        ->notify(new UserInvitation('https://example.com/invitation'));
+});
+
+it('falls back with a capability warning for an OpenKOS-only mail driver', function () {
+    Log::shouldReceive('warning')
+        ->once()
+        ->with('OpenKOS mail driver has no Laravel mailer capability; falling back to Laravel log mailer.', [
+            'driver' => 'openkos/acme',
+            'fallback' => 'log',
+            'reason' => 'missing_capability',
+        ]);
+    app(NotificationRegistry::class)->registerDriver(new NotificationDriverRegistration(
+        name: 'openkos/acme',
+        channel: 'mail',
+        driverClass: LogMailDriver::class,
+        label: 'Acme',
+    ));
+    Setting::set('mail_config', ['driver' => 'openkos/acme']);
+
+    (new NotificationServiceProvider(app()))->boot();
+
+    expect(config('mail.default'))->toBe('log')
+        ->and(config('mail.mailers'))->toHaveKey(config('mail.default'));
+});
+
+it('falls back with an invalid-capability warning when the advertised mailer is unavailable', function () {
+    $mailers = config('mail.mailers');
+    unset($mailers['resend']);
+    config(['mail.mailers' => $mailers]);
+
+    Log::shouldReceive('warning')
+        ->once()
+        ->with('Configured Laravel mailer for OpenKOS mail driver is unavailable; falling back to Laravel log mailer.', [
+            'driver' => 'openkos/resend',
+            'mailer' => 'resend',
+            'fallback' => 'log',
+            'reason' => 'invalid_capability',
+        ]);
+    app(NotificationRegistry::class)->registerDriver(new NotificationDriverRegistration(
+        name: 'openkos/resend',
+        channel: 'mail',
+        driverClass: LogMailDriver::class,
+        label: 'Resend',
+        laravelMailer: 'resend',
+    ));
+    Setting::set('mail_config', ['driver' => 'openkos/resend']);
+
+    (new NotificationServiceProvider(app()))->boot();
+
+    expect(config('mail.default'))->toBe('log')
+        ->and(config('mail.mailers'))->toHaveKey(config('mail.default'));
+});
+
 it('preserves configured native Laravel mailers', function () {
     config(['mail.mailers.ses' => ['transport' => 'log']]);
     Setting::set('mail_config', ['driver' => 'ses']);
@@ -54,6 +127,7 @@ it('warns and falls back to Laravel log for unknown mail drivers', function () {
         ->with('Unknown mail driver; falling back to Laravel log mailer.', [
             'driver' => 'openkos/resend',
             'fallback' => 'log',
+            'reason' => 'unknown_driver',
         ]);
     Setting::set('mail_config', ['driver' => 'openkos/resend']);
 


### PR DESCRIPTION
## Summary

- Consume `openkos/platform` v0.1.2 with optional Laravel mailer metadata.
- Resolve registered OpenKOS mail capabilities for native Laravel notifications.
- Preserve native Laravel mailers and provide explicit fallback diagnostics.
- Keep OpenKOS custom notifications on `MailManager`.

## Verification

- Platform v0.1.2 PR merged and tagged before this change.
- Targeted mail/registry tests: 14 passed.
- Full app suite: 686 passed.
- Frontend build and lint checks pass.

Closes OPE-137.