### PR TITLE
feat(mail): support plugin mail drivers

### DIFF
--- a/app/Actions/Settings/UpdateSettings.php
+++ b/app/Actions/Settings/UpdateSettings.php
@@ -53,7 +53,7 @@ class UpdateSettings
                 $data[$key] = '[REDACTED]';
             } elseif (in_array($key, ['mail_config', 'whatsapp_config'], true) && is_array($value)) {
                 array_walk_recursive($data[$key], function (&$v, $k): void {
-                    if (is_string($v) && in_array($k, ['password', 'api_key', 'token', 'access_token', 'secret'], true)) {
+                    if (is_string($v) && in_array($k, ['key', 'password', 'api_key', 'token', 'access_token', 'secret'], true)) {
                         $v = '[REDACTED]';
                     }
                 });

--- a/app/Http/Controllers/Settings/MailController.php
+++ b/app/Http/Controllers/Settings/MailController.php
@@ -44,13 +44,40 @@ class MailController extends Controller
             })
             ->values();
 
+        $storedMailConfig = Setting::get('mail_config') ?? [];
+        $storedMailConfig = is_array($storedMailConfig) ? $storedMailConfig : [];
         $mailConfig = Setting::effectiveMailConfig();
+        $credentialStatus = [];
         unset($mailConfig['password']);
+
+        foreach ($storedMailConfig['drivers'] ?? [] as $driver => $driverConfig) {
+            if (! is_array($driverConfig)) {
+                continue;
+            }
+
+            $credentialStatus[$driver] = collect(['key', 'api_key', 'password', 'token', 'secret'])
+                ->contains(fn (string $field) => filled($driverConfig[$field] ?? null));
+
+            foreach (['key', 'api_key', 'password', 'token', 'secret'] as $field) {
+                unset($mailConfig['drivers'][$driver][$field]);
+            }
+        }
+
+        foreach ($mailConfig['drivers'] ?? [] as $driver => $driverConfig) {
+            if (! is_array($driverConfig)) {
+                continue;
+            }
+
+            foreach (['key', 'api_key', 'password', 'token', 'secret'] as $field) {
+                unset($mailConfig['drivers'][$driver][$field]);
+            }
+        }
 
         return Inertia::render('settings/mail', [
             'drivers' => $drivers,
             'settings' => [
                 'mail_config' => $mailConfig,
+                'credential_status' => $credentialStatus,
             ],
         ]);
     }
@@ -72,15 +99,40 @@ class MailController extends Controller
             'mail_config.encryption' => ['nullable', 'string', 'in:tls,ssl,null'],
             'mail_config.from_address' => ['nullable', 'email', 'max:255'],
             'mail_config.from_name' => ['nullable', 'string', 'max:255'],
+            'mail_config.drivers' => ['nullable', 'array'],
         ]);
 
-        $data = $validated['mail_config'] ?? [];
-
+        $submitted = $validated['mail_config'] ?? [];
         $existing = Setting::get('mail_config') ?? [];
-        if (blank($data['password'] ?? null)) {
-            unset($data['password']);
+
+        if (blank($submitted['password'] ?? null)) {
+            unset($submitted['password']);
         }
-        $data = array_merge($existing, $data);
+
+        $data = array_merge($existing, $submitted);
+
+        if (isset($submitted['drivers']) && is_array($submitted['drivers'])) {
+            $drivers = is_array($existing['drivers'] ?? null) ? $existing['drivers'] : [];
+
+            foreach ($submitted['drivers'] as $driver => $driverConfig) {
+                if (! is_array($driverConfig)) {
+                    continue;
+                }
+
+                foreach (['key', 'api_key', 'password', 'token', 'secret'] as $field) {
+                    if (blank($driverConfig[$field] ?? null)) {
+                        unset($driverConfig[$field]);
+                    }
+                }
+
+                $drivers[$driver] = array_merge(
+                    is_array($drivers[$driver] ?? null) ? $drivers[$driver] : [],
+                    $driverConfig,
+                );
+            }
+
+            $data['drivers'] = $drivers;
+        }
 
         $this->updateSettings->execute(['mail_config' => $data], $request->user());
 

--- a/app/Providers/NotificationServiceProvider.php
+++ b/app/Providers/NotificationServiceProvider.php
@@ -31,7 +31,8 @@ class NotificationServiceProvider extends ServiceProvider
             return;
         }
 
-        config()->set('mail.default', $this->resolveLaravelMailer($config['driver'] ?? 'log'));
+        $driver = $config['driver'] ?? 'log';
+        config()->set('mail.default', $this->resolveLaravelMailer($driver));
 
         config()->set('mail.mailers.smtp.host', $config['host'] ?? '');
         config()->set('mail.mailers.smtp.port', $config['port'] ?? 587);
@@ -47,6 +48,8 @@ class NotificationServiceProvider extends ServiceProvider
             config()->set('mail.from.address', $fromAddress);
             config()->set('mail.from.name', $config['from_name'] ?? '');
         }
+
+        $this->configureLaravelMailer($driver, $config);
     }
 
     private function resolveLaravelMailer(string $driver): string
@@ -95,5 +98,26 @@ class NotificationServiceProvider extends ServiceProvider
         ]);
 
         return 'log';
+    }
+
+    private function configureLaravelMailer(string $driver, array $config): void
+    {
+        $registration = $this->app->make(NotificationRegistry::class)->driver('mail', $driver);
+
+        if (! $registration?->laravelMailer) {
+            return;
+        }
+
+        $driverConfig = $config['drivers'][$driver] ?? [];
+
+        if (! is_array($driverConfig) || $driverConfig === []) {
+            return;
+        }
+
+        $mailer = $registration->laravelMailer;
+        config()->set("mail.mailers.{$mailer}", array_replace(
+            config("mail.mailers.{$mailer}", []),
+            $driverConfig,
+        ));
     }
 }

--- a/app/Services/MailManager.php
+++ b/app/Services/MailManager.php
@@ -67,9 +67,12 @@ class MailManager
             throw MailDriverNotFoundException::for($normalizedId);
         }
 
-        $driverConfig = $effectiveConfig['drivers'][$normalizedId] ?? [];
+        $driverConfig = array_merge(
+            $registration->config,
+            $effectiveConfig['drivers'][$normalizedId] ?? [],
+        );
 
-        if (! isset($driverConfig['from']) && isset($effectiveConfig['from'])) {
+        if (isset($effectiveConfig['from'])) {
             $driverConfig['from'] = $effectiveConfig['from'];
         }
 

--- a/app/Services/Settings/SettingManager.php
+++ b/app/Services/Settings/SettingManager.php
@@ -126,6 +126,11 @@ class SettingManager
             ];
         }
 
+        $config['from'] ??= array_filter([
+            'address' => $fromAddress ?: null,
+            'name' => $fromName ?: null,
+        ], static fn ($value) => $value !== null);
+
         foreach ($config['drivers'] ?? [] as $key => $driverConfig) {
             if (
                 isset($driverConfig['encryption']) &&

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Exceptions\MailDeliveryException;
 use App\Http\Middleware\EnsureUserIsActive;
 use App\Http\Middleware\HandleAppearance;
 use App\Http\Middleware\HandleInertiaRequests;
@@ -13,6 +14,7 @@ use Inertia\Inertia;
 use Spatie\Permission\Middleware\PermissionMiddleware;
 use Spatie\Permission\Middleware\RoleMiddleware;
 use Spatie\Permission\Middleware\RoleOrPermissionMiddleware;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -48,6 +50,21 @@ return Application::configure(basePath: dirname(__DIR__))
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
+        $exceptions->render(function (MailDeliveryException|TransportExceptionInterface $exception, Request $request) {
+            if ($request->expectsJson()) {
+                return response()->json([
+                    'message' => __('Email could not be sent. Check your mail settings and try again.'),
+                ], 503);
+            }
+
+            Inertia::flash('toast', [
+                'type' => 'error',
+                'message' => __('Email could not be sent. Check your mail settings and try again.'),
+            ]);
+
+            return redirect()->back();
+        });
+
         $exceptions->render(function (QueryException $e) {
             if ($e->getCode() === '23503') {
                 if (request()->isMethod('delete')) {

--- a/config/mail.php
+++ b/config/mail.php
@@ -30,7 +30,7 @@ return [
     | your mailers below. You may also add additional mailers if needed.
     |
     | Supported: "smtp", "sendmail", "mailgun", "ses", "ses-v2",
-    |            "postmark", "resend", "log", "array",
+    |            "postmark", "log", "array",
     |            "failover", "roundrobin"
     |
     */
@@ -59,10 +59,6 @@ return [
             // 'client' => [
             //     'timeout' => 5,
             // ],
-        ],
-
-        'resend' => [
-            'transport' => 'resend',
         ],
 
         'sendmail' => [

--- a/config/services.php
+++ b/config/services.php
@@ -8,10 +8,6 @@ return [
         'key' => env('POSTMARK_API_KEY'),
     ],
 
-    'resend' => [
-        'key' => env('RESEND_API_KEY'),
-    ],
-
     'ses' => [
         'key' => env('AWS_ACCESS_KEY_ID'),
         'secret' => env('AWS_SECRET_ACCESS_KEY'),

--- a/docs/platform.md
+++ b/docs/platform.md
@@ -305,11 +305,11 @@ monolith; it would only matter for untrusted third-party marketplace plugins.
 Mail drivers may optionally advertise the Laravel mailer they support:
 
     $platform->notifications()->registerDriver(new NotificationDriverRegistration(
-        name: 'openkos/resend',
+        name: 'third-party/acme-mail',
         channel: 'mail',
-        driverClass: ResendDriver::class,
-        label: 'Resend',
-        laravelMailer: 'resend',
+        driverClass: AcmeMailDriver::class,
+        label: 'Acme Mail',
+        laravelMailer: 'acme-mail',
     ));
 
 The plugin owns registration of the actual Laravel mailer and transport. Omitting `laravelMailer` keeps the driver valid for OpenKOS custom notifications through `MailManager`, but native Laravel notifications use the Laravel `log` fallback with an explicit warning. The platform does not contain provider-specific mappings.

--- a/resources/js/pages/settings/mail.tsx
+++ b/resources/js/pages/settings/mail.tsx
@@ -33,6 +33,7 @@ interface MailConfig {
     from_address?: string;
     from_name?: string;
     from?: { address?: string; name?: string };
+    drivers?: Record<string, Record<string, string>>;
 }
 
 export default function Mail({
@@ -40,7 +41,10 @@ export default function Mail({
     settings,
 }: {
     drivers?: Driver[];
-    settings: { mail_config: MailConfig | null };
+    settings: {
+        mail_config: MailConfig | null;
+        credential_status?: Record<string, boolean>;
+    };
 }) {
     const config = settings.mail_config ?? {};
 
@@ -56,12 +60,22 @@ export default function Mail({
             encryption: config.encryption ?? 'null',
             from_address: config.from_address ?? config.from?.address ?? '',
             from_name: config.from_name ?? config.from?.name ?? '',
+            drivers: config.drivers ?? {},
         },
     });
 
     const activeDriverName = data.mail_config.driver;
     const currentDriver = drivers.find((d) => d.name === activeDriverName) ?? drivers.find((d) => d.name === 'openkos/smtp');
     const fields = currentDriver?.configuration_schema ?? {};
+    const rawDriverKey = activeDriverName.replace(/^openkos\//, '');
+    const driverConfig =
+        data.mail_config.drivers[activeDriverName] ??
+        data.mail_config.drivers[rawDriverKey] ??
+        {};
+    const hasSavedCredentials =
+        settings.credential_status?.[activeDriverName] ??
+        settings.credential_status?.[rawDriverKey] ??
+        false;
 
     function handleSubmit(e: React.FormEvent) {
         e.preventDefault();
@@ -120,14 +134,13 @@ export default function Mail({
 
                         {Object.keys(fields).length > 0 && (
                             <div className="rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-800">
-                                Values saved below override environment defaults. Leave fields blank to use environment variable fallbacks.
+                                Values saved below override environment defaults. Leave password fields blank to preserve saved values or use environment fallbacks.
                             </div>
                         )}
 
                         {Object.keys(fields).length > 0 ? (
                             Object.entries(fields).map(([key, field]) => {
-                                const fieldKey = key as keyof typeof data.mail_config;
-                                const errorKey = `mail_config.${key}` as keyof typeof errors;
+                                const errorKey = `mail_config.drivers.${activeDriverName}.${key}` as keyof typeof errors;
 
                                 if (field.type === 'select' && field.options) {
                                     return (
@@ -137,11 +150,17 @@ export default function Mail({
                                                 {field.required && <span className="text-destructive"> *</span>}
                                             </Label>
                                             <Select
-                                                value={(data.mail_config[fieldKey] as string) || 'null'}
+                                                value={driverConfig[key] || 'null'}
                                                 onValueChange={(val) =>
                                                     setData('mail_config', {
                                                         ...data.mail_config,
-                                                        [key]: val,
+                                                        drivers: {
+                                                            ...data.mail_config.drivers,
+                                                            [activeDriverName]: {
+                                                                ...driverConfig,
+                                                                [key]: val,
+                                                            },
+                                                        },
                                                     })
                                                 }
                                             >
@@ -173,7 +192,7 @@ export default function Mail({
                                         </Label>
                                         <Input
                                             id={`mail_config_${key}`}
-                                            name={`mail_config[${key}]`}
+                                            name={`mail_config[drivers][${activeDriverName}][${key}]`}
                                             type={
                                                 field.type === 'password'
                                                     ? 'password'
@@ -181,15 +200,30 @@ export default function Mail({
                                                       ? 'number'
                                                       : 'text'
                                             }
-                                            value={(data.mail_config[fieldKey] as string) ?? ''}
+                                            value={driverConfig[key] ?? ''}
                                             onChange={(e) =>
                                                 setData('mail_config', {
                                                     ...data.mail_config,
-                                                    [key]: e.target.value,
+                                                    drivers: {
+                                                        ...data.mail_config.drivers,
+                                                        [activeDriverName]: {
+                                                            ...driverConfig,
+                                                            [key]: e.target.value,
+                                                        },
+                                                    },
                                                 })
                                             }
-                                            placeholder={field.placeholder ?? ''}
+                                            placeholder={
+                                                field.type === 'password' && hasSavedCredentials
+                                                    ? '••••••••••••'
+                                                    : field.placeholder ?? ''
+                                            }
                                         />
+                                        {field.type === 'password' && hasSavedCredentials && (
+                                            <p className="text-xs text-muted-foreground">
+                                                A value is saved. Leave blank to keep it.
+                                            </p>
+                                        )}
                                         {errors[errorKey] && (
                                             <p className="text-sm text-red-600">
                                                 {errors[errorKey]}
@@ -200,7 +234,7 @@ export default function Mail({
                             })
                         ) : (
                             <p className="text-sm text-muted-foreground">
-                                The Log driver does not require any credential configuration. Outgoing emails will be logged to storage/logs/mail.log.
+                                This driver has no additional settings in this form.
                             </p>
                         )}
 

--- a/tests/Feature/Providers/ServiceProviderTest.php
+++ b/tests/Feature/Providers/ServiceProviderTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Exceptions\MailDriverNotFoundException;
 use App\Models\Setting;
 use App\Notifications\Drivers\LogMailDriver;
 use App\Notifications\UserInvitation;
@@ -13,6 +14,8 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Notification;
 use OpenKOS\Core\Contracts\PluginDiscovery;
 use OpenKOS\Core\Contracts\SettingsStore;
+use OpenKOS\Core\Data\Mail\MailAddress;
+use OpenKOS\Core\Data\Mail\MailMessage;
 use OpenKOS\Platform\Notification\NotificationDriverRegistration;
 use OpenKOS\Platform\Notification\NotificationRegistry;
 
@@ -39,19 +42,19 @@ it('maps OpenKOS mail drivers to valid Laravel mailers', function () {
 });
 
 it('uses an advertised Laravel mailer for a registered OpenKOS driver', function () {
-    config(['mail.mailers.resend' => ['transport' => 'log']]);
+    config(['mail.mailers.test-advertised' => ['transport' => 'log']]);
     app(NotificationRegistry::class)->registerDriver(new NotificationDriverRegistration(
-        name: 'openkos/resend',
+        name: 'test/advertised',
         channel: 'mail',
         driverClass: LogMailDriver::class,
-        label: 'Resend',
-        laravelMailer: 'resend',
+        label: 'Test Advertised',
+        laravelMailer: 'test-advertised',
     ));
-    Setting::set('mail_config', ['driver' => 'openkos/resend']);
+    Setting::set('mail_config', ['driver' => 'test/advertised']);
 
     (new NotificationServiceProvider(app()))->boot();
 
-    expect(config('mail.default'))->toBe('resend')
+    expect(config('mail.default'))->toBe('test-advertised')
         ->and(config('mail.mailers'))->toHaveKey(config('mail.default'));
 
     Notification::route('mail', 'user@example.com')
@@ -82,25 +85,25 @@ it('falls back with a capability warning for an OpenKOS-only mail driver', funct
 
 it('falls back with an invalid-capability warning when the advertised mailer is unavailable', function () {
     $mailers = config('mail.mailers');
-    unset($mailers['resend']);
+    unset($mailers['test-advertised']);
     config(['mail.mailers' => $mailers]);
 
     Log::shouldReceive('warning')
         ->once()
         ->with('Configured Laravel mailer for OpenKOS mail driver is unavailable; falling back to Laravel log mailer.', [
-            'driver' => 'openkos/resend',
-            'mailer' => 'resend',
+            'driver' => 'test/advertised',
+            'mailer' => 'test-advertised',
             'fallback' => 'log',
             'reason' => 'invalid_capability',
         ]);
     app(NotificationRegistry::class)->registerDriver(new NotificationDriverRegistration(
-        name: 'openkos/resend',
+        name: 'test/advertised',
         channel: 'mail',
         driverClass: LogMailDriver::class,
-        label: 'Resend',
-        laravelMailer: 'resend',
+        label: 'Test Advertised',
+        laravelMailer: 'test-advertised',
     ));
-    Setting::set('mail_config', ['driver' => 'openkos/resend']);
+    Setting::set('mail_config', ['driver' => 'test/advertised']);
 
     (new NotificationServiceProvider(app()))->boot();
 
@@ -121,18 +124,34 @@ it('preserves configured native Laravel mailers', function () {
         ->notify(new UserInvitation('https://example.com/invitation'));
 });
 
-it('warns and falls back to Laravel log for unknown mail drivers', function () {
+it('warns and falls back to Laravel log when a persisted external driver is absent', function () {
+    app()->instance(NotificationRegistry::class, new NotificationRegistry);
+
     Log::shouldReceive('warning')
         ->once()
         ->with('Unknown mail driver; falling back to Laravel log mailer.', [
-            'driver' => 'openkos/resend',
+            'driver' => 'openkos/acme',
             'fallback' => 'log',
             'reason' => 'unknown_driver',
         ]);
-    Setting::set('mail_config', ['driver' => 'openkos/resend']);
+    Setting::set('mail_config', ['driver' => 'openkos/acme']);
 
     (new NotificationServiceProvider(app()))->boot();
 
     expect(config('mail.default'))->toBe('log')
         ->and(config('mail.mailers'))->toHaveKey(config('mail.default'));
+});
+
+it('fails deterministically for custom delivery when a persisted external driver is absent', function () {
+    app()->instance(NotificationRegistry::class, new NotificationRegistry);
+    Setting::set('mail_config', ['driver' => 'openkos/acme']);
+
+    $message = new MailMessage(
+        to: [new MailAddress('user@example.com')],
+        subject: 'Test Subject',
+        htmlBody: '<p>Hello</p>',
+    );
+
+    expect(fn () => app(MailManager::class)->send($message))
+        ->toThrow(MailDriverNotFoundException::class, 'openkos/acme');
 });

--- a/tests/Feature/Settings/MailSettingsTest.php
+++ b/tests/Feature/Settings/MailSettingsTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\AuditLog;
 use App\Models\Setting;
 use App\Models\User;
 
@@ -60,6 +61,45 @@ describe('Mail settings page', function () {
         $config = Setting::get('mail_config');
 
         expect($config['password'])->toBe('secret123');
+    });
+
+    it('stores driver credentials in the encrypted driver settings', function () {
+        $owner = User::factory()->owner()->create();
+
+        $this->from(route('settings.mail.edit'))->actingAs($owner)
+            ->patch(route('settings.mail.update'), [
+                'mail_config' => [
+                    'driver' => 'openkos/smtp',
+                    'drivers' => [
+                        'openkos/smtp' => ['password' => 'secret123'],
+                    ],
+                ],
+            ])
+            ->assertRedirect(route('settings.mail.edit'));
+
+        $config = Setting::get('mail_config');
+        $audit = AuditLog::where('operation', 'settings.update')->latest('id')->first();
+
+        expect($config['drivers']['openkos/smtp']['password'])->toBe('secret123')
+            ->and($audit->after['mail_config']['drivers']['openkos/smtp']['password'])->toBe('[REDACTED]');
+    });
+
+    it('does not return saved driver credentials to the settings page', function () {
+        Setting::set('mail_config', [
+            'driver' => 'openkos/smtp',
+            'drivers' => [
+                'openkos/smtp' => ['password' => 'secret123'],
+            ],
+        ]);
+
+        $owner = User::factory()->owner()->create();
+        $props = $this->actingAs($owner)
+            ->get(route('settings.mail.edit'))
+            ->viewData('page')['props'];
+
+        expect(data_get($props, 'settings.mail_config.drivers.openkos/smtp.password'))->toBeNull()
+            ->and(data_get($props, 'settings.credential_status.openkos/smtp'))->toBeTrue()
+            ->and(json_encode($props))->not->toContain('secret123');
     });
 
     it('validates mail settings', function () {

--- a/tests/Feature/TenantInvoicePdfTest.php
+++ b/tests/Feature/TenantInvoicePdfTest.php
@@ -228,7 +228,7 @@ test('invoice PDF view reflects the current aggregate for each payable state', f
         ->toContain('Kos Sriwijaya')
         ->toContain('Unit A-01')
         ->toContain('Bill To')
-        ->toContain($fixture['tenant']->name)
+        ->toContain(e($fixture['tenant']->name))
         ->toContain('Tenant ID '.$fixture['tenant']->id)
         ->toContain('john@example.com')
         ->toContain('+62 812 3456 7890')

--- a/tests/Feature/UserManagementTest.php
+++ b/tests/Feature/UserManagementTest.php
@@ -10,8 +10,10 @@ use App\Notifications\UserInvitation;
 use Database\Seeders\RegionAndCitySeeder;
 use Database\Seeders\RoleAndPermissionSeeder;
 use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Str;
+use Symfony\Component\Mailer\Exception\TransportException;
 
 uses()->beforeEach(function () {
     $this->seed(RoleAndPermissionSeeder::class);
@@ -112,6 +114,48 @@ test('owner can invite user with multiple roles', function () {
 
     expect($user->hasRole('admin'))->toBeTrue()
         ->and($user->hasRole('staff'))->toBeTrue();
+});
+
+test('handles invitation mail failures without exposing transport errors', function () {
+    $owner = User::factory()->owner()->create();
+    RoleModel::findOrCreate('admin');
+
+    Mail::shouldReceive('mailer')
+        ->once()
+        ->andThrow(new TransportException('The example.com domain is not verified.'));
+
+    $this->from(route('users.index'))->actingAs($owner)
+        ->post(route('users.store'), [
+            'name' => 'Mail Failure User',
+            'email' => 'mail-failure@example.com',
+            'roles' => ['admin'],
+        ])
+        ->assertRedirect(route('users.index'))
+        ->assertSessionHas('inertia.flash_data.toast.type', 'error')
+        ->assertSessionHas('inertia.flash_data.toast.message', 'Email could not be sent. Check your mail settings and try again.');
+
+    expect(User::where('email', 'mail-failure@example.com')->exists())->toBeFalse();
+});
+
+test('returns a generic JSON response for invitation mail failures', function () {
+    $owner = User::factory()->owner()->create();
+    RoleModel::findOrCreate('admin');
+
+    Mail::shouldReceive('mailer')
+        ->once()
+        ->andThrow(new TransportException('The example.com domain is not verified.'));
+
+    $this->actingAs($owner)
+        ->withHeader('Accept', 'application/json')
+        ->post(route('users.store'), [
+            'name' => 'JSON Mail Failure User',
+            'email' => 'json-mail-failure@example.com',
+            'roles' => ['admin'],
+        ])
+        ->assertStatus(503)
+        ->assertJson([
+            'message' => 'Email could not be sent. Check your mail settings and try again.',
+        ]);
 });
 
 test('owner can invite user with custom role', function () {

--- a/tests/Unit/Services/MailManagerTest.php
+++ b/tests/Unit/Services/MailManagerTest.php
@@ -9,11 +9,47 @@ use App\Notifications\Drivers\SmtpMailDriver;
 use App\Services\MailManager;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
+use OpenKOS\Core\Contracts\MailDriver;
+use OpenKOS\Core\Data\Mail\DriverHealthResult;
 use OpenKOS\Core\Data\Mail\MailAddress;
 use OpenKOS\Core\Data\Mail\MailMessage;
+use OpenKOS\Core\Data\Mail\MailSendResult;
+use OpenKOS\Platform\Notification\NotificationDriverRegistration;
+use OpenKOS\Platform\Notification\NotificationRegistry;
 use Tests\TestCase;
 
 uses(TestCase::class, RefreshDatabase::class);
+
+class MailManagerConfigProbeDriver implements MailDriver
+{
+    public static array $configs = [];
+
+    public function __construct(private array $config = [])
+    {
+        self::$configs[] = $config;
+    }
+
+    public function send(MailMessage $message): MailSendResult
+    {
+        return new MailSendResult;
+    }
+
+    public function health(): DriverHealthResult
+    {
+        return new DriverHealthResult(true);
+    }
+}
+
+function registerMailManagerConfigProbe(array $config = []): void
+{
+    app(NotificationRegistry::class)->registerDriver(new NotificationDriverRegistration(
+        name: 'test/config-probe',
+        channel: 'mail',
+        driverClass: MailManagerConfigProbeDriver::class,
+        label: 'Config Probe',
+        config: $config,
+    ));
+}
 
 test('mail manager resolves driver using normalizeDriverId alias mapping', function () {
     Setting::set('mail_config', ['driver' => 'smtp', 'host' => '127.0.0.1', 'port' => 1025]);
@@ -22,6 +58,52 @@ test('mail manager resolves driver using normalizeDriverId alias mapping', funct
     $driver = $manager->driver();
 
     expect($driver)->toBeInstanceOf(SmtpMailDriver::class);
+});
+
+test('mail manager passes registration defaults to third-party drivers', function () {
+    MailManagerConfigProbeDriver::$configs = [];
+    registerMailManagerConfigProbe(['api_key' => 'registration-key']);
+    Setting::set('mail_config', ['driver' => 'test/config-probe']);
+
+    app(MailManager::class)->driver();
+
+    expect(MailManagerConfigProbeDriver::$configs[0]['api_key'])->toBe('registration-key');
+});
+
+test('stored driver configuration overrides registration defaults', function () {
+    MailManagerConfigProbeDriver::$configs = [];
+    registerMailManagerConfigProbe(['api_key' => 'registration-key']);
+    Setting::set('mail_config', [
+        'driver' => 'test/config-probe',
+        'drivers' => [
+            'test/config-probe' => ['api_key' => 'stored-key'],
+        ],
+        'from' => ['address' => 'global@example.com'],
+    ]);
+
+    app(MailManager::class)->driver();
+
+    expect(MailManagerConfigProbeDriver::$configs[0]['api_key'])->toBe('stored-key');
+});
+
+test('effective global sender configuration overrides driver-specific sender configuration', function () {
+    MailManagerConfigProbeDriver::$configs = [];
+    registerMailManagerConfigProbe([
+        'from' => ['address' => 'registration@example.com'],
+    ]);
+    Setting::set('mail_config', [
+        'driver' => 'test/config-probe',
+        'drivers' => [
+            'test/config-probe' => [
+                'from' => ['address' => 'driver@example.com'],
+            ],
+        ],
+        'from' => ['address' => 'global@example.com'],
+    ]);
+
+    app(MailManager::class)->driver();
+
+    expect(MailManagerConfigProbeDriver::$configs[0]['from'])->toBe(['address' => 'global@example.com']);
 });
 
 test('mail manager dispatches MailSent event on successful send', function () {


### PR DESCRIPTION
## Summary

- add provider-agnostic OpenKOS mail driver configuration and Laravel mailer capability support
- add nested driver credential storage with masking and sender precedence
- centralize mail delivery error handling for web and JSON responses
- keep third-party integrations outside the core app

## Validation

- `php -d memory_limit=-1 artisan test tests/Feature/UserManagementTest.php tests/Feature/Providers/ServiceProviderTest.php tests/Feature/Settings/MailSettingsTest.php tests/Unit/Services/MailManagerTest.php`
- 42 tests passed, 193 assertions
- `composer validate --no-check-publish`

Refs OPE-138