### PR TITLE
feat(payments): add gateway payment attempts

### DIFF
--- a/app/Business/Payments/PaymentAttemptStatusValidator.php
+++ b/app/Business/Payments/PaymentAttemptStatusValidator.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Business\Payments;
+
+use InvalidArgumentException;
+use OpenKOS\Core\Enums\PaymentStatus;
+
+class PaymentAttemptStatusValidator
+{
+    public function validate(PaymentStatus $current, PaymentStatus $next): void
+    {
+        $allowed = match ($current) {
+            PaymentStatus::Pending => [
+                PaymentStatus::Settled,
+                PaymentStatus::Failed,
+                PaymentStatus::Expired,
+                PaymentStatus::Canceled,
+            ],
+            default => [],
+        };
+
+        if (! in_array($next, $allowed, true)) {
+            throw new InvalidArgumentException("Cannot transition payment attempt from {$current->value} to {$next->value}.");
+        }
+    }
+}

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -80,6 +80,11 @@ class Invoice extends Model
         return $this->hasMany(Payment::class);
     }
 
+    public function paymentAttempts(): HasMany
+    {
+        return $this->hasMany(PaymentAttempt::class);
+    }
+
     public function allocations(): HasMany
     {
         return $this->hasMany(PaymentAllocation::class);

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 #[Fillable([
     'invoice_id',
@@ -40,6 +41,11 @@ class Payment extends Model
     public function invoice(): BelongsTo
     {
         return $this->belongsTo(Invoice::class);
+    }
+
+    public function paymentAttempt(): HasOne
+    {
+        return $this->hasOne(PaymentAttempt::class);
     }
 
     public function allocations(): HasMany

--- a/app/Models/PaymentAttempt.php
+++ b/app/Models/PaymentAttempt.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\Auditable;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use InvalidArgumentException;
+use LogicException;
+use OpenKOS\Core\Enums\PaymentStatus;
+
+#[Fillable([
+    'invoice_id',
+    'payment_id',
+    'gateway_key',
+    'reference',
+    'provider_reference',
+    'amount',
+    'currency',
+    'status',
+    'expires_at',
+    'metadata',
+    'initiated_at',
+    'settled_at',
+    'failed_at',
+    'expired_at',
+    'canceled_at',
+])]
+class PaymentAttempt extends Model
+{
+    use Auditable, HasFactory;
+
+    protected static function booted(): void
+    {
+        static::creating(function (PaymentAttempt $attempt): void {
+            $attempt->initiated_at ??= now();
+        });
+
+        static::updating(function (PaymentAttempt $attempt): void {
+            if ($attempt->isDirty(['amount', 'currency'])) {
+                throw new LogicException('Payment attempt amount and currency cannot be changed after creation.');
+            }
+        });
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'amount' => 'decimal:2',
+            'status' => PaymentStatus::class,
+            'expires_at' => 'datetime',
+            'metadata' => 'array',
+            'initiated_at' => 'datetime',
+            'settled_at' => 'datetime',
+            'failed_at' => 'datetime',
+            'expired_at' => 'datetime',
+            'canceled_at' => 'datetime',
+        ];
+    }
+
+    public function invoice(): BelongsTo
+    {
+        return $this->belongsTo(Invoice::class);
+    }
+
+    public function payment(): BelongsTo
+    {
+        return $this->belongsTo(Payment::class);
+    }
+
+    public function setCurrencyAttribute(string $currency): void
+    {
+        $currency = strtoupper($currency);
+
+        if (! preg_match('/\A[A-Z]{3}\z/D', $currency)) {
+            throw new InvalidArgumentException('Currency must be a three-letter ISO 4217 code.');
+        }
+
+        $this->attributes['currency'] = $currency;
+    }
+
+    public function setMetadataAttribute(?array $metadata): void
+    {
+        if ($metadata === null) {
+            $this->attributes['metadata'] = null;
+
+            return;
+        }
+
+        foreach ($metadata as $key => $value) {
+            if (! is_string($key) || (! is_bool($value) && ! is_int($value) && ! is_string($value) && $value !== null)) {
+                throw new InvalidArgumentException('Payment attempt metadata must contain only scalar values.');
+            }
+        }
+
+        $this->attributes['metadata'] = json_encode($metadata, JSON_THROW_ON_ERROR);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "laravel/framework": "^13.7",
         "laravel/tinker": "^3.0",
         "laravel/wayfinder": "^0.1.14",
-        "openkos/platform": "^0.1",
+        "openkos/platform": "^0.2",
         "spatie/laravel-permission": "^7.4",
         "spatie/laravel-query-builder": "^7.3"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e0e50a400bbd0f9faff972d6cd6d3d91",
+    "content-hash": "cc14fd20e308f5a78e8af127fa465cdc",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -3311,16 +3311,16 @@
         },
         {
             "name": "openkos/platform",
-            "version": "0.1.2",
+            "version": "0.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/senatroxx/openkos-platform.git",
-                "reference": "1cddafa76ad5a83c8f496f7d1fe71bc0d671e13b"
+                "reference": "6ac5694b98bb5df540ba70f720d1aed9fb9ea0a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/senatroxx/openkos-platform/zipball/1cddafa76ad5a83c8f496f7d1fe71bc0d671e13b",
-                "reference": "1cddafa76ad5a83c8f496f7d1fe71bc0d671e13b",
+                "url": "https://api.github.com/repos/senatroxx/openkos-platform/zipball/6ac5694b98bb5df540ba70f720d1aed9fb9ea0a5",
+                "reference": "6ac5694b98bb5df540ba70f720d1aed9fb9ea0a5",
                 "shasum": ""
             },
             "require": {
@@ -3358,9 +3358,9 @@
             "description": "The OpenKOS platform and plugin SDK.",
             "support": {
                 "issues": "https://github.com/senatroxx/openkos-platform/issues",
-                "source": "https://github.com/senatroxx/openkos-platform/tree/v0.1.2"
+                "source": "https://github.com/senatroxx/openkos-platform/tree/v0.2.0"
             },
-            "time": "2026-08-13T11:04:37+00:00"
+            "time": "2026-08-14T15:43:47+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",

--- a/config/platform.php
+++ b/config/platform.php
@@ -19,7 +19,7 @@ return [
     |
     */
 
-    'version' => InstalledVersions::getPrettyVersion('openkos/platform') ?: '0.1.0',
+    'version' => InstalledVersions::getPrettyVersion('openkos/platform') ?: '0.2.0',
 
     'discovery' => [
         // External plugin discovery is host policy and is enabled explicitly here.

--- a/database/factories/PaymentAttemptFactory.php
+++ b/database/factories/PaymentAttemptFactory.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Invoice;
+use App\Models\PaymentAttempt;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use OpenKOS\Core\Enums\PaymentStatus;
+
+/**
+ * @extends Factory<PaymentAttempt>
+ */
+class PaymentAttemptFactory extends Factory
+{
+    protected $model = PaymentAttempt::class;
+
+    public function definition(): array
+    {
+        return [
+            'invoice_id' => Invoice::factory(),
+            'payment_id' => null,
+            'gateway_key' => 'test-gateway',
+            'reference' => fake()->unique()->uuid(),
+            'provider_reference' => fake()->unique()->uuid(),
+            'amount' => fake()->numberBetween(500_000, 3_000_000),
+            'currency' => 'IDR',
+            'status' => PaymentStatus::Pending,
+            'expires_at' => now()->addHour(),
+            'metadata' => ['source' => 'test'],
+            'initiated_at' => now(),
+            'settled_at' => null,
+            'failed_at' => null,
+            'expired_at' => null,
+            'canceled_at' => null,
+        ];
+    }
+
+    public function settled(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => PaymentStatus::Settled,
+            'settled_at' => now(),
+        ]);
+    }
+
+    public function failed(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => PaymentStatus::Failed,
+            'failed_at' => now(),
+        ]);
+    }
+
+    public function expired(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => PaymentStatus::Expired,
+            'expired_at' => now(),
+        ]);
+    }
+
+    public function canceled(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => PaymentStatus::Canceled,
+            'canceled_at' => now(),
+        ]);
+    }
+}

--- a/database/migrations/2026_08_14_000000_create_payment_attempts_table.php
+++ b/database/migrations/2026_08_14_000000_create_payment_attempts_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('payment_attempts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('invoice_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('payment_id')->nullable()->unique()->constrained()->nullOnDelete();
+            $table->string('gateway_key', 100);
+            $table->string('reference', 100)->unique();
+            $table->string('provider_reference')->nullable();
+            $table->decimal('amount', 12, 2);
+            $table->char('currency', 3);
+            $table->string('status', 32)->default('pending');
+            $table->timestamp('expires_at')->nullable();
+            $table->json('metadata')->nullable();
+            $table->timestamp('initiated_at');
+            $table->timestamp('settled_at')->nullable();
+            $table->timestamp('failed_at')->nullable();
+            $table->timestamp('expired_at')->nullable();
+            $table->timestamp('canceled_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['gateway_key', 'provider_reference']);
+            $table->index(['invoice_id', 'status']);
+            $table->index(['gateway_key', 'status']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('payment_attempts');
+    }
+};

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -251,6 +251,8 @@ Created as `Confirmed` (auto-verify or no proof) or `Pending` (proof uploaded, c
 - **Validator:** `App\Business\Payments\PaymentStatusValidator`
 - **Cast on** `Payment.status`
 
+Gateway payment attempts use the provider-independent `OpenKOS\Core\Enums\PaymentStatus` lifecycle in `PaymentAttempt`. An attempt is not a canonical `Payment`: pending, failed, expired, canceled, and settled attempts do not affect invoice totals. OPE-132 must transition a settled attempt, create/link exactly one canonical payment through existing payment logic, and recalculate the invoice in one database transaction. Gateway amount conversion to platform minor units is deferred to the OPE-131 gateway boundary and must use the currency's actual minor-unit scale.
+
 ### Maintenance Ticket Lifecycle
 
 ```

--- a/docs/architecture/adr/007-invoice-aggregate.md
+++ b/docs/architecture/adr/007-invoice-aggregate.md
@@ -15,6 +15,7 @@ We introduce an `invoices` aggregate between Lease and Payment: `Lease → Invoi
 
 - An invoice is the billing obligation: period, due date, `total`, `amount_paid`, status. Snapshot detail lives in `invoice_line_items` (currently a single `rent` line), so historical invoices stay accurate when lease pricing changes.
 - A payment settles exactly one invoice (`payments.invoice_id`, NOT NULL). The `paymentable` polymorph and payment period columns are gone. Payment proofs stay attached to payments.
+- Gateway checkout attempts are separate `payment_attempts` records. They snapshot the requested amount/currency, provider references, normalized provider status, expiry, and safe metadata, but never contribute to invoice totals. OPE-132 must atomically transition a settled attempt, create/link its canonical `Payment` through existing payment logic, and recalculate the invoice so a crash cannot leave a settled attempt without its accounting record.
 - Invoices are **materialized upfront by the scheduler**: `invoices:generate` runs daily at 01:00 and creates Pending invoices for each active lease up to a 2-month horizon, backed by a unique `(lease_id, period_start)` index for idempotency. Lease creation, renewal, and unit transfer generate synchronously so the UI never waits for the scheduler. Move-out cancels future untouched Pending invoices.
 - **Invariant:** the generation horizon (2 months) must stay ≥ the reminder lookahead, and the generator is scheduled before the 08:00 reminder run — reminders read only from invoices and must never encounter an un-invoiced period.
 - Due dates support **advance** (default: due within the billed period, on `rent_due_day`) and **arrears** (due one billing period after consumption) via `leases.billing_strategy`. The strategy only shifts due-date derivation in `Lease::schedule()`; the generation engine is strategy-agnostic.
@@ -31,4 +32,4 @@ Harder: invoice rows must exist before payment (the generator and its invariant 
 
 Given up: multi-invoice payments (one transfer covering several months needs splitting into one payment per invoice), and `Lease::schedule()` remains only as the period calculator feeding generation.
 
-Revisit when: deposits or non-rent charges become invoice types, a gateway needs webhook-driven settlement, or one-payment-many-invoices becomes a real workflow (introduce a payment allocation table then).
+Revisit when: deposits or non-rent charges become invoice types, or one-payment-many-invoices becomes a real workflow (introduce a payment allocation table then).

--- a/docs/platform.md
+++ b/docs/platform.md
@@ -145,7 +145,7 @@ class MyPlugin extends Plugin
             id: 'acme/my-plugin',      // unique, vendor-namespaced
             name: 'My Plugin',
             version: '1.0.0',
-            coreVersion: '^0.1',        // constraint against config('platform.version')
+            coreVersion: '^0.2',        // constraint against config('platform.version')
             dependencies: [],           // ids of plugins that must load first
         );
     }
@@ -228,7 +228,7 @@ The package `PlatformServiceProvider::boot()`:
   `coreVersion`, `dependencies`. It's a PHP value object, not a JSON file — type-safe
   and IDE-navigable; a JSON manifest can wrap it later if external discovery needs one.
 - **Version compatibility**: `coreVersion` is checked against `config('platform.version')`
-  (currently `0.1.0`). Supported constraints: any Composer semver constraint supported by `composer/semver`
+  (currently `0.2.0`). Supported constraints: any Composer semver constraint supported by `composer/semver`
   (`*`, `^`, `~`, ranges, wildcards like `1.*`, `||`, …). Incompatible plugins fail fast at boot rather than
   half-loading.
 - **Dependencies**: a plugin lists other plugin **ids**; the loader guarantees they're
@@ -314,9 +314,9 @@ Mail drivers may optionally advertise the Laravel mailer they support:
 
 The plugin owns registration of the actual Laravel mailer and transport. Omitting `laravelMailer` keeps the driver valid for OpenKOS custom notifications through `MailManager`, but native Laravel notifications use the Laravel `log` fallback with an explicit warning. The platform does not contain provider-specific mappings.
 
-## Payment Contracts — interface only
+## Payment Contracts
 
-`PaymentGateway` (`key()`, `displayName()`, `createPayment(array): array`, `handleCallback(array): array`, `configurationSchema()`) and `PaymentRegistry` exist but have no implementations. Deliberately dormant until a real gateway (Midtrans/Xendit) forces the payload shape — the first integration should define the interface, not a guess.
+`PaymentGateway` is the typed, provider-independent contract for creating payments and normalizing webhook results. `PaymentRegistry` resolves gateways by key. Gateway-specific attempt persistence belongs to the app: `PaymentAttempt` records the local invoice checkout lifecycle, while the existing canonical `Payment` remains the only source used for invoice accounting.
 
 ## How Registrations Reach the UI
 

--- a/src/Plugins/Example/ExamplePlugin.php
+++ b/src/Plugins/Example/ExamplePlugin.php
@@ -29,7 +29,7 @@ class ExamplePlugin extends Plugin
             name: 'Example Plugin',
             version: '1.0.0',
             description: 'Reference plugin demonstrating every extension point.',
-            coreVersion: '^0.1',
+            coreVersion: '^0.2',
         );
     }
 

--- a/src/Plugins/Mail/MailPlugin.php
+++ b/src/Plugins/Mail/MailPlugin.php
@@ -18,7 +18,7 @@ class MailPlugin extends Plugin
             name: 'Mail Notifications',
             version: '1.0.0',
             description: 'Registers built-in SMTP and Log mail drivers.',
-            coreVersion: '^0.1',
+            coreVersion: '^0.2',
         );
     }
 

--- a/src/Plugins/WhatsApp/WhatsAppPlugin.php
+++ b/src/Plugins/WhatsApp/WhatsAppPlugin.php
@@ -25,7 +25,7 @@ class WhatsAppPlugin extends Plugin
             name: 'WhatsApp Notifications',
             version: '1.0.0',
             description: 'Registers the built-in WhatsApp drivers as notification channels.',
-            coreVersion: '^0.1',
+            coreVersion: '^0.2',
         );
     }
 

--- a/tests/Feature/PaymentAttemptTest.php
+++ b/tests/Feature/PaymentAttemptTest.php
@@ -1,0 +1,138 @@
+<?php
+
+use App\Business\Payments\PaymentAttemptStatusValidator;
+use App\Models\Invoice;
+use App\Models\Payment;
+use App\Models\PaymentAttempt;
+use Illuminate\Database\QueryException;
+use OpenKOS\Core\Enums\PaymentStatus;
+
+it('persists gateway attempts against invoices without creating canonical payments', function () {
+    $invoice = Invoice::factory()->create(['total' => 1_000_000, 'amount_paid' => 0]);
+    $attempt = PaymentAttempt::factory()->for($invoice)->create([
+        'currency' => 'idr',
+        'metadata' => ['channel' => 'qris', 'is_test' => true],
+    ]);
+
+    expect($attempt->invoice->is($invoice))->toBeTrue()
+        ->and($invoice->paymentAttempts)->toHaveCount(1)
+        ->and($attempt->currency)->toBe('IDR')
+        ->and($attempt->status)->toBe(PaymentStatus::Pending)
+        ->and($attempt->metadata)->toBe(['channel' => 'qris', 'is_test' => true])
+        ->and($invoice->payments)->toHaveCount(0);
+});
+
+it('allows multiple attempts for one invoice', function () {
+    $invoice = Invoice::factory()->create();
+
+    PaymentAttempt::factory()->count(3)->for($invoice)->create();
+
+    expect($invoice->paymentAttempts)->toHaveCount(3);
+});
+
+it('enforces local and provider reference uniqueness', function () {
+    $invoice = Invoice::factory()->create();
+
+    PaymentAttempt::factory()->for($invoice)->create([
+        'reference' => 'attempt-1',
+        'gateway_key' => 'xendit',
+        'provider_reference' => 'provider-1',
+    ]);
+
+    expect(fn () => PaymentAttempt::factory()->for($invoice)->create([
+        'reference' => 'attempt-1',
+        'gateway_key' => 'midtrans',
+        'provider_reference' => 'provider-2',
+    ]))->toThrow(QueryException::class);
+
+    expect(fn () => PaymentAttempt::factory()->for($invoice)->create([
+        'reference' => 'attempt-2',
+        'gateway_key' => 'xendit',
+        'provider_reference' => 'provider-1',
+    ]))->toThrow(QueryException::class);
+
+    PaymentAttempt::factory()->for($invoice)->create([
+        'reference' => 'attempt-3',
+        'gateway_key' => 'midtrans',
+        'provider_reference' => 'provider-1',
+    ]);
+
+    expect($invoice->paymentAttempts)->toHaveCount(2);
+});
+
+it('does not let gateway attempt statuses affect invoice accounting', function () {
+    $invoice = Invoice::factory()->create([
+        'total' => 1_000_000,
+        'amount_paid' => 0,
+    ]);
+
+    PaymentAttempt::factory()->for($invoice)->create();
+    PaymentAttempt::factory()->for($invoice)->failed()->create();
+    PaymentAttempt::factory()->for($invoice)->expired()->create();
+    PaymentAttempt::factory()->for($invoice)->canceled()->create();
+    PaymentAttempt::factory()->for($invoice)->settled()->create();
+
+    $invoice->recalculateStatus();
+
+    expect($invoice->fresh()->amount_paid)->toBe('0.00')
+        ->and($invoice->fresh()->status->value)->toBe('pending')
+        ->and($invoice->payments)->toHaveCount(0);
+});
+
+it('validates the gateway attempt lifecycle', function () {
+    $validator = app(PaymentAttemptStatusValidator::class);
+
+    foreach ([PaymentStatus::Settled, PaymentStatus::Failed, PaymentStatus::Expired, PaymentStatus::Canceled] as $next) {
+        expect(fn () => $validator->validate(PaymentStatus::Pending, $next))->not->toThrow(Exception::class);
+    }
+
+    expect(fn () => $validator->validate(PaymentStatus::Settled, PaymentStatus::Failed))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+it('records the timestamp for each terminal lifecycle state', function () {
+    expect(PaymentAttempt::factory()->settled()->create()->settled_at)->not->toBeNull()
+        ->and(PaymentAttempt::factory()->failed()->create()->failed_at)->not->toBeNull()
+        ->and(PaymentAttempt::factory()->expired()->create()->expired_at)->not->toBeNull()
+        ->and(PaymentAttempt::factory()->canceled()->create()->canceled_at)->not->toBeNull();
+});
+
+it('keeps the financial snapshot immutable after creation', function () {
+    $attempt = PaymentAttempt::factory()->create(['amount' => 125_000]);
+
+    expect(fn () => $attempt->update(['amount' => 250_000]))
+        ->toThrow(LogicException::class);
+
+    expect(fn () => $attempt->update(['currency' => 'USD']))
+        ->toThrow(LogicException::class);
+
+    expect($attempt->fresh()->amount)->toBe('125000.00');
+});
+
+it('normalizes and validates currencies', function () {
+    expect(PaymentAttempt::factory()->create(['currency' => 'idr'])->currency)->toBe('IDR');
+
+    expect(fn () => PaymentAttempt::factory()->create(['currency' => 'ID']))
+        ->toThrow(InvalidArgumentException::class);
+
+    expect(fn () => PaymentAttempt::factory()->create(['currency' => 'EURO']))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+it('rejects nested attempt metadata', function () {
+    expect(fn () => PaymentAttempt::factory()->create([
+        'metadata' => ['provider_payload' => ['secret' => 'value']],
+    ]))->toThrow(InvalidArgumentException::class);
+});
+
+it('links at most one attempt to a canonical payment', function () {
+    $invoice = Invoice::factory()->create();
+    $payment = Payment::factory()->for($invoice)->create();
+
+    PaymentAttempt::factory()->for($invoice)->create(['payment_id' => $payment->id]);
+
+    expect($payment->fresh()->paymentAttempt)->toBeInstanceOf(PaymentAttempt::class);
+
+    expect(fn () => PaymentAttempt::factory()->for($invoice)->create(['payment_id' => $payment->id]))
+        ->toThrow(QueryException::class);
+});

--- a/tests/Feature/Schema/ForeignKeyDeleteStrategyTest.php
+++ b/tests/Feature/Schema/ForeignKeyDeleteStrategyTest.php
@@ -38,6 +38,7 @@ $expected = [
 
     // SET NULL — nullable audit/user references, record survives
     'payments' => ['invoice_id' => 'CASCADE', 'confirmed_by' => 'SET NULL', 'recorded_by' => 'SET NULL', 'verified_by' => 'SET NULL'],
+    'payment_attempts' => ['invoice_id' => 'CASCADE', 'payment_id' => 'SET NULL'],
     'invoices' => ['lease_id' => 'CASCADE'],
     'invoice_line_items' => ['invoice_id' => 'CASCADE'],
     'properties' => ['region_id' => 'SET NULL', 'city_id' => 'SET NULL'],

--- a/tests/Unit/Platform/PaymentRegistryTest.php
+++ b/tests/Unit/Platform/PaymentRegistryTest.php
@@ -1,6 +1,12 @@
 <?php
 
 use OpenKOS\Core\Contracts\PaymentGateway;
+use OpenKOS\Core\Data\Payment\CheckoutInstructions;
+use OpenKOS\Core\Data\Payment\PaymentCreationResult;
+use OpenKOS\Core\Data\Payment\PaymentRequest;
+use OpenKOS\Core\Data\Payment\PaymentWebhookRequest;
+use OpenKOS\Core\Data\Payment\PaymentWebhookResult;
+use OpenKOS\Core\Enums\PaymentStatus;
 use OpenKOS\Platform\Payment\PaymentRegistry;
 
 function fakePaymentGateway(): PaymentGateway
@@ -17,14 +23,23 @@ function fakePaymentGateway(): PaymentGateway
             return 'Fake Gateway';
         }
 
-        public function createPayment(array $payload): array
+        public function createPayment(PaymentRequest $request): PaymentCreationResult
         {
-            return [];
+            return new PaymentCreationResult(
+                providerReference: 'provider-reference',
+                status: PaymentStatus::Pending,
+                amount: $request->amount,
+                instructions: new CheckoutInstructions,
+            );
         }
 
-        public function handleCallback(array $payload): array
+        public function handleCallback(PaymentWebhookRequest $request): PaymentWebhookResult
         {
-            return [];
+            return new PaymentWebhookResult(
+                eventReference: 'event-reference',
+                providerReference: 'provider-reference',
+                status: PaymentStatus::Pending,
+            );
         }
 
         public function configurationSchema(): array


### PR DESCRIPTION
## Summary
- add persistent gateway payment attempts separate from canonical payments
- enforce lifecycle, references, currency, metadata, and immutable financial snapshots
- align the app and bundled plugins with openkos/platform v0.2.0

## Verification
- 63 unit tests passed
- 641 feature tests passed
- TypeScript, Composer validation, Pint, and build passed

Refs OPE-130