### PR TITLE
feat(payments): add reconciliation and recovery

### DIFF
--- a/app/Actions/Payments/ApplyGatewayPaymentResult.php
+++ b/app/Actions/Payments/ApplyGatewayPaymentResult.php
@@ -90,7 +90,16 @@ class ApplyGatewayPaymentResult
                 );
             }
 
-            if ($attempt->status !== PaymentStatus::Pending) {
+            $canRecoverTerminalAttempt = $source === 'webhook'
+                && $result->status === PaymentStatus::Settled
+                && $attempt->payment_id === null
+                && in_array($attempt->status, [
+                    PaymentStatus::Failed,
+                    PaymentStatus::Expired,
+                    PaymentStatus::Canceled,
+                ], true);
+
+            if ($attempt->status !== PaymentStatus::Pending && ! $canRecoverTerminalAttempt) {
                 return $this->applyTerminalCallback($gatewayKey, $attempt, $result, $source);
             }
 
@@ -132,7 +141,9 @@ class ApplyGatewayPaymentResult
                 );
             }
 
-            $this->statuses->validate($attempt->status, PaymentStatus::Settled);
+            if ($attempt->status === PaymentStatus::Pending) {
+                $this->statuses->validate($attempt->status, PaymentStatus::Settled);
+            }
 
             $payment = $invoice->payments()->create([
                 'amount' => $attempt->amount,

--- a/app/Actions/Payments/ApplyGatewayPaymentResult.php
+++ b/app/Actions/Payments/ApplyGatewayPaymentResult.php
@@ -15,7 +15,7 @@ use App\Services\Payments\MoneyConverter;
 use Brick\Math\BigDecimal;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
-use OpenKOS\Core\Data\Payment\PaymentWebhookResult;
+use OpenKOS\Core\Data\Payment\PaymentProviderResult;
 use OpenKOS\Core\Enums\PaymentStatus;
 use OpenKOS\Core\Events\PaymentRecorded as PlatformPaymentRecorded;
 
@@ -27,12 +27,15 @@ class ApplyGatewayPaymentResult
         private PaymentAttemptStatusValidator $statuses,
     ) {}
 
-    public function execute(string $gatewayKey, PaymentWebhookResult $result): ApplyGatewayPaymentResultData
-    {
+    public function execute(
+        string $gatewayKey,
+        PaymentProviderResult $result,
+        string $source = 'webhook',
+    ): ApplyGatewayPaymentResultData {
         $located = $this->locate($gatewayKey, $result);
 
         if ($located['status'] !== 'found') {
-            $this->logAnomaly($gatewayKey, $result, $located['status']);
+            $this->logAnomaly($gatewayKey, $result, $located['status'], source: $source);
 
             return new ApplyGatewayPaymentResultData(
                 status: $located['status'] === 'unknown'
@@ -41,7 +44,7 @@ class ApplyGatewayPaymentResult
             );
         }
 
-        $processed = DB::transaction(function () use ($gatewayKey, $result, $located): ApplyGatewayPaymentResultData {
+        $processed = DB::transaction(function () use ($gatewayKey, $result, $located, $source): ApplyGatewayPaymentResultData {
             // Keep lock order aligned with payment initiation and manual payment recording.
             $invoice = Invoice::query()->lockForUpdate()->find($located['attempt']->invoice_id);
 
@@ -52,7 +55,7 @@ class ApplyGatewayPaymentResult
             $locked = $this->locate($gatewayKey, $result);
 
             if ($locked['status'] !== 'found') {
-                $this->logAnomaly($gatewayKey, $result, $locked['status']);
+                $this->logAnomaly($gatewayKey, $result, $locked['status'], source: $source);
 
                 return new ApplyGatewayPaymentResultData(
                     status: $locked['status'] === 'unknown'
@@ -70,7 +73,7 @@ class ApplyGatewayPaymentResult
             }
 
             if ($reason = $this->invalidPaymentLinkReason($attempt)) {
-                $this->logAnomaly($gatewayKey, $result, $reason, $attempt);
+                $this->logAnomaly($gatewayKey, $result, $reason, $attempt, $source);
 
                 return new ApplyGatewayPaymentResultData(
                     status: ApplyGatewayPaymentResultData::ANOMALY,
@@ -79,7 +82,7 @@ class ApplyGatewayPaymentResult
             }
 
             if ($reason = $this->invalidCallbackReason($attempt, $result)) {
-                $this->logAnomaly($gatewayKey, $result, $reason, $attempt);
+                $this->logAnomaly($gatewayKey, $result, $reason, $attempt, $source);
 
                 return new ApplyGatewayPaymentResultData(
                     status: ApplyGatewayPaymentResultData::ANOMALY,
@@ -88,10 +91,10 @@ class ApplyGatewayPaymentResult
             }
 
             if ($attempt->status !== PaymentStatus::Pending) {
-                return $this->applyTerminalCallback($gatewayKey, $attempt, $result);
+                return $this->applyTerminalCallback($gatewayKey, $attempt, $result, $source);
             }
 
-            $metadata = $this->webhookMetadata($attempt->metadata ?? [], $result);
+            $metadata = $this->resultMetadata($attempt->metadata ?? [], $result, $source);
 
             if ($result->status !== PaymentStatus::Settled) {
                 $timestampColumn = match ($result->status) {
@@ -121,7 +124,7 @@ class ApplyGatewayPaymentResult
             }
 
             if ($this->cannotSettle($invoice, $attempt)) {
-                $this->logAnomaly($gatewayKey, $result, 'invoice_balance_conflict', $attempt);
+                $this->logAnomaly($gatewayKey, $result, 'invoice_balance_conflict', $attempt, $source);
 
                 return new ApplyGatewayPaymentResultData(
                     status: ApplyGatewayPaymentResultData::ANOMALY,
@@ -168,7 +171,7 @@ class ApplyGatewayPaymentResult
     /**
      * @return array{status: 'found'|'unknown'|'conflict', attempt?: PaymentAttempt}
      */
-    private function locate(string $gatewayKey, PaymentWebhookResult $result): array
+    private function locate(string $gatewayKey, PaymentProviderResult $result): array
     {
         $byProviderReference = PaymentAttempt::query()
             ->where('gateway_key', $gatewayKey)
@@ -202,7 +205,7 @@ class ApplyGatewayPaymentResult
         return ['status' => 'found', 'attempt' => $attempt];
     }
 
-    private function invalidCallbackReason(PaymentAttempt $attempt, PaymentWebhookResult $result): ?string
+    private function invalidCallbackReason(PaymentAttempt $attempt, PaymentProviderResult $result): ?string
     {
         if ($result->reference !== null && $result->reference !== $attempt->reference) {
             return 'openkos_reference_mismatch';
@@ -264,7 +267,8 @@ class ApplyGatewayPaymentResult
     private function applyTerminalCallback(
         string $gatewayKey,
         PaymentAttempt $attempt,
-        PaymentWebhookResult $result,
+        PaymentProviderResult $result,
+        string $source,
     ): ApplyGatewayPaymentResultData {
         if ($attempt->status === PaymentStatus::Settled && $result->status === PaymentStatus::Settled) {
             return new ApplyGatewayPaymentResultData(
@@ -281,7 +285,7 @@ class ApplyGatewayPaymentResult
             );
         }
 
-        $this->logAnomaly($gatewayKey, $result, 'terminal_state_conflict', $attempt);
+        $this->logAnomaly($gatewayKey, $result, 'terminal_state_conflict', $attempt, $source);
 
         return new ApplyGatewayPaymentResultData(
             status: ApplyGatewayPaymentResultData::ANOMALY,
@@ -293,31 +297,37 @@ class ApplyGatewayPaymentResult
      * @param  array<string, bool|int|string|null>  $metadata
      * @return array<string, bool|int|string|null>
      */
-    private function webhookMetadata(array $metadata, PaymentWebhookResult $result): array
+    private function resultMetadata(array $metadata, PaymentProviderResult $result, string $source): array
     {
+        $prefix = $source === 'webhook' ? 'webhook_' : 'reconciliation_';
+
         foreach ($result->metadata as $key => $value) {
-            $metadata['webhook_'.$key] = $value;
+            $metadata[$prefix.$key] = $value;
         }
 
-        $metadata['webhook_event_reference'] = $result->eventReference;
+        if ($result->eventReference !== null) {
+            $metadata[$prefix.'event_reference'] = $result->eventReference;
+        }
 
         return $metadata;
     }
 
     private function logAnomaly(
         string $gatewayKey,
-        PaymentWebhookResult $result,
+        PaymentProviderResult $result,
         string $reason,
         ?PaymentAttempt $attempt = null,
+        string $source = 'webhook',
     ): void {
-        Log::warning('Payment webhook anomaly.', [
+        Log::warning('Payment gateway result anomaly.', [
             'gateway' => $gatewayKey,
+            'source' => $source,
             'attempt_id' => $attempt?->id,
             'attempt_status' => $attempt?->status->value,
             'provider_reference' => $result->providerReference,
             'openkos_reference' => $result->reference,
             'event_reference' => $result->eventReference,
-            'callback_status' => $result->status->value,
+            'provider_status' => $result->status->value,
             'reason' => $reason,
         ]);
     }

--- a/app/Actions/Payments/ReconcilePaymentAttempt.php
+++ b/app/Actions/Payments/ReconcilePaymentAttempt.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Actions\Payments;
+
+use App\Models\PaymentAttempt;
+use App\Results\Payment\ApplyGatewayPaymentResult as ApplyGatewayPaymentResultData;
+use App\Results\Payment\ReconcilePaymentAttemptResult;
+use App\Services\Payments\PaymentGatewayManager;
+use Illuminate\Support\Facades\Log;
+use OpenKOS\Core\Contracts\PaymentGatewayStatusLookup;
+use OpenKOS\Core\Data\Payment\PaymentStatusLookupRequest;
+use OpenKOS\Core\Enums\PaymentStatus;
+use Throwable;
+
+final class ReconcilePaymentAttempt
+{
+    public function __construct(
+        private PaymentGatewayManager $gateways,
+        private ApplyGatewayPaymentResult $apply,
+    ) {}
+
+    public function execute(PaymentAttempt $attempt): ReconcilePaymentAttemptResult
+    {
+        $attempt->refresh();
+
+        if ($attempt->status !== PaymentStatus::Pending) {
+            return new ReconcilePaymentAttemptResult(
+                status: ReconcilePaymentAttemptResult::TERMINAL,
+                attempt: $attempt,
+            );
+        }
+
+        if ($attempt->provider_reference === null) {
+            return new ReconcilePaymentAttemptResult(
+                status: ReconcilePaymentAttemptResult::UNSUPPORTED,
+                attempt: $attempt,
+                message: 'The provider reference is unavailable for status lookup.',
+            );
+        }
+
+        $gateway = $this->gateways->find($attempt->gateway_key);
+
+        if ($gateway === null) {
+            return new ReconcilePaymentAttemptResult(
+                status: ReconcilePaymentAttemptResult::UNAVAILABLE,
+                attempt: $attempt,
+                message: 'The payment gateway is unavailable.',
+            );
+        }
+
+        if (! $gateway instanceof PaymentGatewayStatusLookup) {
+            return new ReconcilePaymentAttemptResult(
+                status: ReconcilePaymentAttemptResult::UNSUPPORTED,
+                attempt: $attempt,
+                message: 'This payment gateway does not support status lookup.',
+            );
+        }
+
+        try {
+            $providerResult = $gateway->lookupPaymentStatus(new PaymentStatusLookupRequest(
+                providerReference: $attempt->provider_reference,
+                reference: $attempt->reference,
+                metadata: $attempt->metadata ?? [],
+            ));
+            $applied = $this->apply->execute(
+                $attempt->gateway_key,
+                $providerResult,
+                source: 'reconciliation',
+            );
+        } catch (Throwable $exception) {
+            Log::warning('Payment attempt reconciliation failed.', [
+                'attempt_id' => $attempt->id,
+                'attempt_reference' => $attempt->reference,
+                'gateway_key' => $attempt->gateway_key,
+                'provider_reference' => $attempt->provider_reference,
+                'exception_class' => $exception::class,
+            ]);
+
+            return new ReconcilePaymentAttemptResult(
+                status: ReconcilePaymentAttemptResult::FAILED,
+                attempt: $attempt->fresh(),
+                message: 'The payment provider status could not be checked.',
+            );
+        }
+
+        $freshAttempt = $applied->attempt?->fresh() ?? $attempt->fresh();
+
+        $status = match (true) {
+            $applied->status === ApplyGatewayPaymentResultData::ANOMALY => ReconcilePaymentAttemptResult::ANOMALY,
+            $freshAttempt?->status === PaymentStatus::Settled => ReconcilePaymentAttemptResult::SETTLED,
+            $freshAttempt?->status === PaymentStatus::Pending => ReconcilePaymentAttemptResult::PENDING,
+            default => ReconcilePaymentAttemptResult::TERMINAL,
+        };
+
+        Log::info('Payment attempt reconciliation completed.', [
+            'attempt_id' => $freshAttempt?->id ?? $attempt->id,
+            'attempt_reference' => $attempt->reference,
+            'gateway_key' => $attempt->gateway_key,
+            'provider_reference' => $attempt->provider_reference,
+            'result' => $status,
+        ]);
+
+        return new ReconcilePaymentAttemptResult(
+            status: $status,
+            attempt: $freshAttempt,
+            payment: $applied->payment,
+        );
+    }
+}

--- a/app/Actions/Payments/StartGatewayPayment.php
+++ b/app/Actions/Payments/StartGatewayPayment.php
@@ -219,7 +219,16 @@ class StartGatewayPayment
             );
         }
 
-        if ($result->status === PaymentStatus::Pending && ! $this->hasUsableInstructions($result->instructions)) {
+        if ($result->status !== PaymentStatus::Pending) {
+            $this->markCreationUncertain($attempt, $result->providerReference);
+
+            throw new PaymentGatewayCreationException(
+                'Payment gateway returned a terminal checkout status that requires confirmation.',
+                ambiguous: true,
+            );
+        }
+
+        if (! $this->hasUsableInstructions($result->instructions)) {
             $this->markFailed($attempt);
 
             throw new PaymentGatewayCreationException(
@@ -271,22 +280,6 @@ class StartGatewayPayment
                     $result->metadata,
                 ),
             ];
-
-            if ($result->status !== PaymentStatus::Pending) {
-                $this->statuses->validate($locked->status, $result->status);
-                $updates['status'] = $result->status;
-                $timestampColumn = match ($result->status) {
-                    PaymentStatus::Pending => null,
-                    PaymentStatus::Settled => 'settled_at',
-                    PaymentStatus::Failed => 'failed_at',
-                    PaymentStatus::Expired => 'expired_at',
-                    PaymentStatus::Canceled => 'canceled_at',
-                };
-
-                if ($timestampColumn !== null) {
-                    $updates[$timestampColumn] = now();
-                }
-            }
 
             $locked->update($updates);
             $attempt->refresh();

--- a/app/Actions/Payments/StartGatewayPayment.php
+++ b/app/Actions/Payments/StartGatewayPayment.php
@@ -230,6 +230,8 @@ class StartGatewayPayment
         try {
             $this->persistResult($attempt, $result);
         } catch (Throwable $exception) {
+            $this->markCreationUncertain($attempt, $result->providerReference);
+
             throw new PaymentGatewayCreationException(
                 'Payment checkout response could not be saved.',
                 ambiguous: true,
@@ -291,18 +293,24 @@ class StartGatewayPayment
         });
     }
 
-    private function markCreationUncertain(PaymentAttempt $attempt): void
+    private function markCreationUncertain(PaymentAttempt $attempt, ?string $providerReference = null): void
     {
-        DB::transaction(function () use ($attempt): void {
+        DB::transaction(function () use ($attempt, $providerReference): void {
             $locked = PaymentAttempt::query()->lockForUpdate()->findOrFail($attempt->id);
 
             if ($locked->status === PaymentStatus::Pending) {
-                $locked->update([
+                $updates = [
                     'metadata' => array_merge($locked->metadata ?? [], [
                         'provider_creation_state' => 'uncertain',
                         'provider_creation_uncertain' => true,
                     ]),
-                ]);
+                ];
+
+                if ($providerReference !== null && $locked->provider_reference === null) {
+                    $updates['provider_reference'] = $providerReference;
+                }
+
+                $locked->update($updates);
             }
         });
     }

--- a/app/Actions/Payments/StartGatewayPayment.php
+++ b/app/Actions/Payments/StartGatewayPayment.php
@@ -32,6 +32,7 @@ class StartGatewayPayment
         private MoneyConverter $money,
         private CheckoutInstructionsMapper $instructions,
         private PaymentAttemptStatusValidator $statuses,
+        private ReconcilePaymentAttempt $reconcile,
     ) {}
 
     public function execute(Invoice $invoice, User $actor): StartGatewayPaymentResult
@@ -48,6 +49,7 @@ class StartGatewayPayment
 
     private function start(Invoice $invoice): StartGatewayPaymentResult
     {
+        $this->reconcileStaleAttempt($invoice);
         $currency = strtoupper((string) (Setting::get('currency') ?? 'IDR'));
         $state = DB::transaction(function () use ($invoice, $currency) {
             $locked = Invoice::query()->lockForUpdate()->findOrFail($invoice->id);
@@ -81,7 +83,10 @@ class StartGatewayPayment
                 ->get();
 
             foreach ($pending as $attempt) {
-                if ($attempt->expires_at?->isPast()) {
+                if ($attempt->expires_at?->isPast()
+                    && ($attempt->provider_reference === null
+                        || ! $this->gateways->supportsStatusLookup($attempt->gateway_key))
+                ) {
                     $this->statuses->validate($attempt->status, PaymentStatus::Expired);
                     $attempt->update([
                         'status' => PaymentStatus::Expired,
@@ -91,9 +96,7 @@ class StartGatewayPayment
                     continue;
                 }
 
-                $creationState = ($attempt->metadata ?? [])['provider_creation_state'] ?? null;
-
-                if (in_array($creationState, ['in_progress', 'uncertain'], true)) {
+                if ($attempt->hasInProgressProviderCreation() || $attempt->hasUncertainProviderCreation()) {
                     throw new PaymentGatewayCreationException(
                         'Payment checkout creation is still being confirmed.',
                         ambiguous: true,
@@ -157,6 +160,13 @@ class StartGatewayPayment
 
         $gateway = $state['gateway'];
 
+        Log::info('Payment attempt initiated.', [
+            'invoice_id' => $invoice->id,
+            'attempt_id' => $attempt->id,
+            'attempt_reference' => $attempt->reference,
+            'gateway_key' => $attempt->gateway_key,
+        ]);
+
         try {
             $result = $gateway->createPayment(new PaymentRequest(
                 reference: $attempt->reference,
@@ -173,7 +183,7 @@ class StartGatewayPayment
                 'invoice_id' => $invoice->id,
                 'attempt_id' => $attempt->id,
                 'gateway_key' => $attempt->gateway_key,
-                'exception' => $exception,
+                'exception_class' => $exception::class,
             ]);
 
             throw new PaymentGatewayCreationException(
@@ -211,6 +221,15 @@ class StartGatewayPayment
                 previous: $exception,
             );
         }
+
+        Log::info('Payment gateway checkout created.', [
+            'invoice_id' => $invoice->id,
+            'attempt_id' => $attempt->id,
+            'attempt_reference' => $attempt->reference,
+            'gateway_key' => $attempt->gateway_key,
+            'provider_reference' => $result->providerReference,
+            'provider_status' => $result->status->value,
+        ]);
 
         return new StartGatewayPaymentResult(
             attempt: $attempt->fresh(),
@@ -294,5 +313,19 @@ class StartGatewayPayment
     private function hasUsableInstructions(CheckoutInstructions $instructions): bool
     {
         return $instructions->url !== null || $instructions->entries !== [];
+    }
+
+    private function reconcileStaleAttempt(Invoice $invoice): void
+    {
+        $now = now();
+        $attempt = $invoice->paymentAttempts()
+            ->whereNotNull('provider_reference')
+            ->reconciliationCandidate($now->copy()->subMinutes(5), $now)
+            ->latest('id')
+            ->first();
+
+        if ($attempt !== null) {
+            $this->reconcile->execute($attempt);
+        }
     }
 }

--- a/app/Actions/Payments/StartGatewayPayment.php
+++ b/app/Actions/Payments/StartGatewayPayment.php
@@ -81,6 +81,7 @@ class StartGatewayPayment
                 ->lockForUpdate()
                 ->latest('id')
                 ->get();
+            $staleBefore = now()->subMinutes(5);
 
             foreach ($pending as $attempt) {
                 if ($attempt->expires_at?->isPast()
@@ -93,6 +94,20 @@ class StartGatewayPayment
                         'expired_at' => now(),
                     ]);
 
+                    continue;
+                }
+
+                if ($attempt->hasOrphanedProviderCreation($staleBefore)) {
+                    $attempt->update([
+                        'metadata' => array_merge($attempt->metadata ?? [], [
+                            'provider_creation_state' => 'superseded',
+                        ]),
+                    ]);
+
+                    continue;
+                }
+
+                if ($attempt->hasSupersededProviderCreation()) {
                     continue;
                 }
 

--- a/app/Console/Commands/ReconcilePaymentAttemptsCommand.php
+++ b/app/Console/Commands/ReconcilePaymentAttemptsCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Actions\Payments\ReconcilePaymentAttempt;
+use App\Models\PaymentAttempt;
+use App\Results\Payment\ReconcilePaymentAttemptResult;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+
+#[Signature('payments:reconcile {--limit=100 : Maximum attempts to inspect}')]
+#[Description('Reconcile pending payment gateway attempts')]
+final class ReconcilePaymentAttemptsCommand extends Command
+{
+    public function handle(ReconcilePaymentAttempt $reconcile): int
+    {
+        $limit = max(1, min((int) $this->option('limit'), 500));
+        $now = now();
+        $attempts = PaymentAttempt::query()
+            ->whereNotNull('provider_reference')
+            ->reconciliationCandidate($now->copy()->subMinutes(5), $now)
+            ->orderBy('id')
+            ->limit($limit)
+            ->get();
+        $counts = [];
+
+        foreach ($attempts as $attempt) {
+            try {
+                $result = $reconcile->execute($attempt);
+                $counts[$result->status] = ($counts[$result->status] ?? 0) + 1;
+            } catch (\Throwable $exception) {
+                $counts[ReconcilePaymentAttemptResult::FAILED] = ($counts[ReconcilePaymentAttemptResult::FAILED] ?? 0) + 1;
+                report($exception);
+            }
+        }
+
+        $this->info(sprintf(
+            'Reconciled %d payment attempt(s): %s.',
+            $attempts->count(),
+            collect($counts)->map(fn (int $count, string $status): string => "{$status}={$count}")->implode(', ') ?: 'none',
+        ));
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/ReconcilePaymentAttemptsCommand.php
+++ b/app/Console/Commands/ReconcilePaymentAttemptsCommand.php
@@ -13,10 +13,13 @@ use Illuminate\Console\Command;
 #[Description('Reconcile pending payment gateway attempts')]
 final class ReconcilePaymentAttemptsCommand extends Command
 {
+    private const MAX_RUNTIME_SECONDS = 240;
+
     public function handle(ReconcilePaymentAttempt $reconcile): int
     {
         $limit = max(1, min((int) $this->option('limit'), 500));
         $now = now();
+        $deadline = microtime(true) + self::MAX_RUNTIME_SECONDS;
         $attempts = PaymentAttempt::query()
             ->whereNotNull('provider_reference')
             ->reconciliationCandidate($now->copy()->subMinutes(5), $now)
@@ -24,8 +27,13 @@ final class ReconcilePaymentAttemptsCommand extends Command
             ->limit($limit)
             ->get();
         $counts = [];
+        $processed = 0;
 
         foreach ($attempts as $attempt) {
+            if (microtime(true) >= $deadline) {
+                break;
+            }
+
             try {
                 $result = $reconcile->execute($attempt);
                 $counts[$result->status] = ($counts[$result->status] ?? 0) + 1;
@@ -33,11 +41,13 @@ final class ReconcilePaymentAttemptsCommand extends Command
                 $counts[ReconcilePaymentAttemptResult::FAILED] = ($counts[ReconcilePaymentAttemptResult::FAILED] ?? 0) + 1;
                 report($exception);
             }
+
+            $processed++;
         }
 
         $this->info(sprintf(
             'Reconciled %d payment attempt(s): %s.',
-            $attempts->count(),
+            $processed,
             collect($counts)->map(fn (int $count, string $status): string => "{$status}={$count}")->implode(', ') ?: 'none',
         ));
 

--- a/app/Http/Controllers/LeaseInvoiceController.php
+++ b/app/Http/Controllers/LeaseInvoiceController.php
@@ -6,6 +6,7 @@ use App\Enums\InvoiceStatus;
 use App\Enums\PaymentStatus;
 use App\Models\Invoice;
 use App\Models\Lease;
+use App\Models\PaymentAttempt;
 use App\Models\Setting;
 use App\Services\Invoices\InvoicePdfArtifact;
 use App\Services\Payments\SignedInvoicePaymentLink;
@@ -20,6 +21,7 @@ use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Storage;
 use Inertia\Inertia;
 use Inertia\Response;
+use OpenKOS\Core\Enums\PaymentStatus as GatewayPaymentStatus;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class LeaseInvoiceController extends Controller
@@ -70,6 +72,41 @@ class LeaseInvoiceController extends Controller
 
         $invoice->loadMissing('lease.unit');
         $invoice->load(['lineItems', 'payments.confirmedBy:id,name', 'payments.proofs']);
+        $gatewayAttempts = $invoice->paymentAttempts()
+            ->latest('id')
+            ->get([
+                'id',
+                'invoice_id',
+                'gateway_key',
+                'reference',
+                'provider_reference',
+                'amount',
+                'currency',
+                'status',
+                'expires_at',
+                'initiated_at',
+                'created_at',
+                'updated_at',
+            ])
+            ->map(fn (PaymentAttempt $attempt): array => [
+                'id' => $attempt->id,
+                'invoice_id' => $attempt->invoice_id,
+                'gateway' => $attempt->gateway_key,
+                'reference' => $attempt->reference,
+                'provider_reference' => $attempt->provider_reference,
+                'amount' => $attempt->amount,
+                'currency' => $attempt->currency,
+                'status' => $attempt->status->value,
+                'expires_at' => $attempt->expires_at,
+                'initiated_at' => $attempt->initiated_at,
+                'created_at' => $attempt->created_at,
+                'updated_at' => $attempt->updated_at,
+                'failure_code' => $this->failureCode($attempt),
+                'failure_message' => $this->failureMessage($attempt),
+                'recheckable' => $attempt->status === GatewayPaymentStatus::Pending
+                    && $attempt->provider_reference !== null,
+            ])
+            ->values();
         $invoice->append(['outstanding', 'display_status']);
         $invoicePdfStatus = $artifact->status($invoice);
         if ($invoicePdfStatus === 'pending') {
@@ -86,7 +123,28 @@ class LeaseInvoiceController extends Controller
             'invoice' => $invoice,
             'invoicePdf' => ['status' => $invoicePdfStatus],
             'paymentLink' => $paymentLink,
+            'gatewayAttempts' => $gatewayAttempts,
         ]);
+    }
+
+    private function failureCode(PaymentAttempt $attempt): ?string
+    {
+        return match ($attempt->status) {
+            GatewayPaymentStatus::Failed => 'provider_failed',
+            GatewayPaymentStatus::Expired => 'checkout_expired',
+            GatewayPaymentStatus::Canceled => 'checkout_canceled',
+            default => null,
+        };
+    }
+
+    private function failureMessage(PaymentAttempt $attempt): ?string
+    {
+        return match ($attempt->status) {
+            GatewayPaymentStatus::Failed => __('The payment provider reported a failure.'),
+            GatewayPaymentStatus::Expired => __('The checkout session expired before payment was completed.'),
+            GatewayPaymentStatus::Canceled => __('The checkout session was canceled.'),
+            default => null,
+        };
     }
 
     public function print(Lease $lease, Invoice $invoice): ViewContract

--- a/app/Http/Controllers/PaymentAttemptController.php
+++ b/app/Http/Controllers/PaymentAttemptController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Actions\Payments\ReconcilePaymentAttempt;
+use App\Models\Invoice;
+use App\Models\Lease;
+use App\Models\PaymentAttempt;
+use App\Results\Payment\ReconcilePaymentAttemptResult;
+use Illuminate\Http\RedirectResponse;
+use Inertia\Inertia;
+
+final class PaymentAttemptController extends Controller
+{
+    public function recheck(
+        Lease $lease,
+        Invoice $invoice,
+        PaymentAttempt $paymentAttempt,
+        ReconcilePaymentAttempt $reconcile,
+    ): RedirectResponse {
+        abort_if($invoice->lease_id !== $lease->id || $paymentAttempt->invoice_id !== $invoice->id, 404);
+
+        $this->authorize('view', $lease);
+        $result = $reconcile->execute($paymentAttempt);
+        $type = in_array($result->status, [
+            ReconcilePaymentAttemptResult::SETTLED,
+            ReconcilePaymentAttemptResult::TERMINAL,
+        ], true) ? 'success' : 'error';
+        $message = match ($result->status) {
+            ReconcilePaymentAttemptResult::SETTLED => __('Payment attempt settled.'),
+            ReconcilePaymentAttemptResult::PENDING => __('The provider still reports this payment as pending.'),
+            ReconcilePaymentAttemptResult::TERMINAL => __('The payment attempt is already finalized.'),
+            ReconcilePaymentAttemptResult::UNSUPPORTED => __('This payment gateway does not support status lookup.'),
+            ReconcilePaymentAttemptResult::UNAVAILABLE => __('The payment gateway is unavailable.'),
+            ReconcilePaymentAttemptResult::ANOMALY => __('The provider result could not be applied safely.'),
+            default => __('The payment provider status could not be checked.'),
+        };
+
+        Inertia::flash('toast', ['type' => $type, 'message' => $message]);
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/PaymentWebhookController.php
+++ b/app/Http/Controllers/PaymentWebhookController.php
@@ -44,6 +44,14 @@ class PaymentWebhookController extends Controller
 
         $processed = $apply->execute($gateway, $result);
 
+        Log::info('Payment webhook processed.', [
+            'gateway' => $gateway,
+            'provider_reference' => $result->providerReference,
+            'openkos_reference' => $result->reference,
+            'event_reference' => $result->eventReference,
+            'result' => $processed->status,
+        ]);
+
         $status = in_array($processed->status, [
             ApplyGatewayPaymentResultData::PROCESSED,
             ApplyGatewayPaymentResultData::DUPLICATE,

--- a/app/Models/PaymentAttempt.php
+++ b/app/Models/PaymentAttempt.php
@@ -3,7 +3,9 @@
 namespace App\Models;
 
 use App\Concerns\Auditable;
+use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -70,6 +72,38 @@ class PaymentAttempt extends Model
     public function payment(): BelongsTo
     {
         return $this->belongsTo(Payment::class);
+    }
+
+    public function providerCreationState(): ?string
+    {
+        $state = ($this->metadata ?? [])['provider_creation_state'] ?? null;
+
+        return is_string($state) ? $state : null;
+    }
+
+    public function hasUncertainProviderCreation(): bool
+    {
+        return $this->providerCreationState() === 'uncertain';
+    }
+
+    public function hasInProgressProviderCreation(): bool
+    {
+        return $this->providerCreationState() === 'in_progress';
+    }
+
+    public function scopeReconciliationCandidate(
+        Builder $query,
+        CarbonInterface $staleBefore,
+        CarbonInterface $now,
+    ): Builder {
+        return $query
+            ->where('status', PaymentStatus::Pending->value)
+            ->where(function (Builder $query) use ($staleBefore, $now): void {
+                $query
+                    ->where('updated_at', '<=', $staleBefore)
+                    ->orWhere('expires_at', '<=', $now)
+                    ->orWhereJsonContains('metadata->provider_creation_state', 'uncertain');
+            });
     }
 
     public function setCurrencyAttribute(string $currency): void

--- a/app/Models/PaymentAttempt.php
+++ b/app/Models/PaymentAttempt.php
@@ -91,6 +91,18 @@ class PaymentAttempt extends Model
         return $this->providerCreationState() === 'in_progress';
     }
 
+    public function hasOrphanedProviderCreation(CarbonInterface $staleBefore): bool
+    {
+        return $this->provider_reference === null
+            && in_array($this->providerCreationState(), ['in_progress', 'uncertain'], true)
+            && $this->updated_at?->lte($staleBefore) === true;
+    }
+
+    public function hasSupersededProviderCreation(): bool
+    {
+        return $this->providerCreationState() === 'superseded';
+    }
+
     public function scopeReconciliationCandidate(
         Builder $query,
         CarbonInterface $staleBefore,

--- a/app/Results/Payment/ReconcilePaymentAttemptResult.php
+++ b/app/Results/Payment/ReconcilePaymentAttemptResult.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Results\Payment;
+
+use App\Models\Payment;
+use App\Models\PaymentAttempt;
+
+final readonly class ReconcilePaymentAttemptResult
+{
+    public const SETTLED = 'settled';
+
+    public const PENDING = 'pending';
+
+    public const TERMINAL = 'terminal';
+
+    public const UNSUPPORTED = 'unsupported';
+
+    public const UNAVAILABLE = 'unavailable';
+
+    public const ANOMALY = 'anomaly';
+
+    public const FAILED = 'failed';
+
+    public function __construct(
+        public string $status,
+        public ?PaymentAttempt $attempt = null,
+        public ?Payment $payment = null,
+        public ?string $message = null,
+    ) {}
+}

--- a/app/Services/Payments/PaymentGatewayManager.php
+++ b/app/Services/Payments/PaymentGatewayManager.php
@@ -4,6 +4,7 @@ namespace App\Services\Payments;
 
 use Illuminate\Contracts\Container\Container;
 use OpenKOS\Core\Contracts\PaymentGateway;
+use OpenKOS\Core\Contracts\PaymentGatewayStatusLookup;
 use OpenKOS\Platform\Payment\PaymentRegistry;
 use OpenKOS\Platform\Settings\SettingsManager;
 
@@ -122,6 +123,11 @@ class PaymentGatewayManager
         } catch (\Throwable) {
             return null;
         }
+    }
+
+    public function supportsStatusLookup(string $key): bool
+    {
+        return $this->find($key) instanceof PaymentGatewayStatusLookup;
     }
 
     public function activeKey(): ?string

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "laravel/framework": "^13.7",
         "laravel/tinker": "^3.0",
         "laravel/wayfinder": "^0.1.14",
-        "openkos/platform": "^0.2",
+        "openkos/platform": "^0.2.2",
         "spatie/laravel-permission": "^7.4",
         "spatie/laravel-query-builder": "^7.3"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cc14fd20e308f5a78e8af127fa465cdc",
+    "content-hash": "14e054f5a7c4b42aab0906e456d419f3",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -3317,16 +3317,16 @@
         },
         {
             "name": "openkos/platform",
-            "version": "0.2.1",
+            "version": "0.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/senatroxx/openkos-platform.git",
-                "reference": "ec60811c333605b8132331b3386d3a2803d10025"
+                "reference": "2dc5e57cc202a9cb85d88123a8083a9ec041c747"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/senatroxx/openkos-platform/zipball/ec60811c333605b8132331b3386d3a2803d10025",
-                "reference": "ec60811c333605b8132331b3386d3a2803d10025",
+                "url": "https://api.github.com/repos/senatroxx/openkos-platform/zipball/2dc5e57cc202a9cb85d88123a8083a9ec041c747",
+                "reference": "2dc5e57cc202a9cb85d88123a8083a9ec041c747",
                 "shasum": ""
             },
             "require": {
@@ -3364,9 +3364,9 @@
             "description": "The OpenKOS platform and plugin SDK.",
             "support": {
                 "issues": "https://github.com/senatroxx/openkos-platform/issues",
-                "source": "https://github.com/senatroxx/openkos-platform/tree/v0.2.1"
+                "source": "https://github.com/senatroxx/openkos-platform/tree/v0.2.2"
             },
-            "time": "2026-08-16T07:00:49+00:00"
+            "time": "2026-08-18T10:11:16+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -255,6 +255,8 @@ Gateway payment attempts use the provider-independent `OpenKOS\Core\Enums\Paymen
 Gateway payment creation outcomes that cannot be proven are intentionally ambiguous: OPE-131 keeps the local attempt pending and marks creation as uncertain when a provider request may have reached the provider. OPE-136 must reconcile that state before any provider retry is introduced.
 Provider callbacks enter through `POST /api/webhooks/payment/{gateway}`. The route resolves the gateway by its registered key, which must match `PaymentGateway::key()`, delegates verification and normalization to the provider package, and applies the normalized result through one idempotent transaction. Invalid verification returns `401`; authenticated malformed payloads are acknowledged with `202` and logged without exposing payload data. A matching duplicate terminal callback is acknowledged without mutation; conflicting terminal states and accounting conflicts are logged as anomalies for OPE-136 without changing financial state. The `gateway` payment method is reserved for system-created canonical payments and is not accepted by manual payment forms.
 
+Providers may optionally implement status lookup through `PaymentGatewayStatusLookup`. The scheduled `payments:reconcile` command and the staff invoice recheck action use that capability for stale pending attempts, then pass the normalized provider result through the same settlement action used by webhooks. Providers without lookup support remain compatible; their pending attempts retain the existing local expiry behavior.
+
 ### Maintenance Ticket Lifecycle
 
 ```

--- a/docs/payment-reconciliation.md
+++ b/docs/payment-reconciliation.md
@@ -1,0 +1,61 @@
+# Payment reconciliation and recovery
+
+OpenKOS treats webhook settlement as authoritative, but can recheck a pending
+gateway attempt when the installed provider supports status lookup.
+
+## Reconciliation flow
+
+The scheduler runs `payments:reconcile` every five minutes and processes a
+bounded batch of pending attempts with a provider reference that are at least
+five minutes old, expired, or marked as having uncertain provider creation.
+Each attempt is handled independently so one provider failure does not stop the
+batch.
+
+Staff can also open the staff invoice detail page and select **Recheck status**
+for a pending attempt with a provider reference.
+
+The provider result is normalized and sent through the same
+`ApplyGatewayPaymentResult` path used by webhooks. This keeps invoice locking,
+amount validation, payment allocation, and duplicate protection identical for
+both flows.
+
+## Uncertain checkout creation
+
+An attempt is marked `provider_creation_state=uncertain` when the provider
+request may have succeeded but OpenKOS cannot prove the response was saved.
+OpenKOS must not create another checkout for that attempt unless the provider
+can identify it through a stored provider reference. If no provider reference
+exists, the attempt remains pending for provider/webhook investigation.
+
+## Common outcomes
+
+- `ACTIVE`: keep the attempt pending and reuse its existing checkout.
+- `COMPLETED`: settle the attempt through the canonical payment path.
+- `EXPIRED` or `CANCELED`: finalize the attempt without changing invoice accounting.
+- Provider lookup unavailable: leave the attempt unchanged and retry later.
+- Amount, currency, or reference mismatch: record an anomaly and do not settle.
+- Invoice already paid another way: record an anomaly and do not create a second payment.
+
+## Xendit setup
+
+Configure the Xendit Payment Session webhook URL in the Xendit dashboard:
+
+`https://your-public-domain.example/api/webhooks/payment/xendit`
+
+Enable the Payment Session Completed and Payment Session Expired events. The
+OpenKOS Xendit package uses `GET /sessions/{session_id}` for reconciliation and
+maps Xendit session states to the provider-independent OpenKOS attempt states.
+
+## Troubleshooting
+
+1. Check the invoice's **Gateway attempts** section for the OpenKOS and provider
+   references, lifecycle status, expiry, and safe failure message.
+2. Use **Recheck status** when the provider reference is present.
+3. Inspect application logs using the attempt reference and provider reference.
+4. Confirm the webhook URL, authentication mode, and enabled Xendit events.
+5. Do not treat browser redirect parameters as payment confirmation; wait for a
+   webhook or a successful provider status lookup.
+
+Raw webhook bodies, credentials, authorization headers, callback tokens, and
+provider secrets are not stored in payment attempts or emitted in structured
+payment logs.

--- a/resources/js/pages/leases/invoice-detail.tsx
+++ b/resources/js/pages/leases/invoice-detail.tsx
@@ -1,6 +1,14 @@
 import { Head, Link, router, usePage } from '@inertiajs/react';
-import { Check, ChevronLeft, Copy, Download, Printer } from 'lucide-react';
+import {
+    Check,
+    ChevronLeft,
+    Copy,
+    Download,
+    Printer,
+    RefreshCw,
+} from 'lucide-react';
 import { useState } from 'react';
+import { recheck as recheckPaymentAttempt } from '@/actions/App/Http/Controllers/PaymentAttemptController';
 import { PaymentDetailSheet } from '@/components/features';
 import { DocumentPreview } from '@/components/shared';
 import { StatusBadge } from '@/components/shared/status-badge';
@@ -10,13 +18,20 @@ import { PAYMENT_METHOD_LABELS } from '@/lib/constants/billing';
 import { formatDate, formatPeriod, formatPrice } from '@/lib/formatters';
 import invoiceRoutes from '@/routes/leases/workspace/invoices';
 import paymentRoutes from '@/routes/payments';
-import type { Invoice, Payment, PaymentProof, WorkspaceLease } from '@/types';
+import type {
+    GatewayPaymentAttempt,
+    Invoice,
+    Payment,
+    PaymentProof,
+    WorkspaceLease,
+} from '@/types';
 
 export default function InvoiceDetail({
     lease,
     invoice,
     invoicePdf,
     paymentLink,
+    gatewayAttempts,
 }: {
     lease: WorkspaceLease;
     invoice: Invoice;
@@ -24,10 +39,14 @@ export default function InvoiceDetail({
         status: 'disabled' | 'pending' | 'available';
     };
     paymentLink: string | null;
+    gatewayAttempts: GatewayPaymentAttempt[];
 }) {
     const { auth } = usePage<{ auth: { permissions: string[] } }>().props;
     const [copiedText, copy] = useClipboard();
     const [verifyingId, setVerifyingId] = useState<number | null>(null);
+    const [recheckingAttemptId, setRecheckingAttemptId] = useState<
+        number | null
+    >(null);
     const [selectedPaymentId, setSelectedPaymentId] = useState<number | null>(
         null,
     );
@@ -72,6 +91,18 @@ export default function InvoiceDetail({
                 preserveState: true,
                 preserveScroll: true,
                 onFinish: () => setVerifyingId(null),
+            },
+        );
+    }
+
+    function handleRecheck(attempt: GatewayPaymentAttempt) {
+        setRecheckingAttemptId(attempt.id);
+        router.post(
+            recheckPaymentAttempt.url([lease, invoice, attempt]),
+            {},
+            {
+                preserveScroll: true,
+                onFinish: () => setRecheckingAttemptId(null),
             },
         );
     }
@@ -274,6 +305,106 @@ export default function InvoiceDetail({
                     ) : (
                         <p className="px-4 py-6 text-sm text-muted-foreground">
                             No payment activity yet.
+                        </p>
+                    )}
+                </section>
+
+                {/* Gateway attempts */}
+                <section className="rounded-lg border">
+                    <div className="border-b px-4 py-3">
+                        <h3 className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
+                            Gateway attempts
+                        </h3>
+                    </div>
+                    {gatewayAttempts.length > 0 ? (
+                        <div className="divide-y">
+                            {gatewayAttempts.map((attempt) => (
+                                <div
+                                    key={attempt.id}
+                                    className="space-y-3 px-4 py-4 text-sm"
+                                >
+                                    <div className="flex items-start justify-between gap-3">
+                                        <div className="min-w-0">
+                                            <p className="font-medium">
+                                                {attempt.gateway ??
+                                                    'Payment gateway'}
+                                            </p>
+                                            <p className="mt-1 text-xs text-muted-foreground">
+                                                {formatPrice(attempt.amount)}{' '}
+                                                {attempt.currency}
+                                            </p>
+                                        </div>
+                                        <StatusBadge
+                                            domain="gateway_attempt"
+                                            value={attempt.status}
+                                        />
+                                    </div>
+
+                                    <div className="grid gap-2 text-xs text-muted-foreground sm:grid-cols-2">
+                                        <p>
+                                            OpenKOS reference:{' '}
+                                            <span className="font-mono text-foreground">
+                                                {attempt.reference ?? '—'}
+                                            </span>
+                                        </p>
+                                        <p>
+                                            Provider reference:{' '}
+                                            <span className="font-mono text-foreground">
+                                                {attempt.provider_reference ??
+                                                    '—'}
+                                            </span>
+                                        </p>
+                                        <p>
+                                            Created:{' '}
+                                            {formatDate(
+                                                attempt.created_at ??
+                                                    attempt.initiated_at,
+                                            )}
+                                        </p>
+                                        <p>
+                                            Updated:{' '}
+                                            {attempt.updated_at
+                                                ? formatDate(attempt.updated_at)
+                                                : '—'}
+                                        </p>
+                                        {attempt.expires_at && (
+                                            <p>
+                                                Expires:{' '}
+                                                {formatDate(attempt.expires_at)}
+                                            </p>
+                                        )}
+                                    </div>
+
+                                    {attempt.failure_message && (
+                                        <p className="text-xs text-destructive">
+                                            {attempt.failure_message}
+                                        </p>
+                                    )}
+
+                                    {attempt.recheckable && (
+                                        <Button
+                                            size="sm"
+                                            variant="outline"
+                                            disabled={
+                                                recheckingAttemptId ===
+                                                attempt.id
+                                            }
+                                            onClick={() =>
+                                                handleRecheck(attempt)
+                                            }
+                                        >
+                                            <RefreshCw className="size-4" />
+                                            {recheckingAttemptId === attempt.id
+                                                ? 'Checking…'
+                                                : 'Recheck status'}
+                                        </Button>
+                                    )}
+                                </div>
+                            ))}
+                        </div>
+                    ) : (
+                        <p className="px-4 py-6 text-sm text-muted-foreground">
+                            No gateway attempts yet.
                         </p>
                     )}
                 </section>

--- a/resources/js/types/models.ts
+++ b/resources/js/types/models.ts
@@ -243,6 +243,9 @@ export type PaymentAllocation = {
 export type GatewayPaymentAttempt = {
     id: number;
     invoice_id: number;
+    gateway?: string;
+    reference?: string;
+    provider_reference?: string | null;
     amount: string;
     currency: string;
     status: 'pending' | 'settled' | 'failed' | 'expired' | 'canceled';
@@ -257,6 +260,11 @@ export type GatewayPaymentAttempt = {
         }>;
     } | null;
     initiated_at: string;
+    created_at?: string;
+    updated_at?: string;
+    failure_code?: string | null;
+    failure_message?: string | null;
+    recheckable?: boolean;
 };
 
 export type Invoice = {

--- a/routes/console.php
+++ b/routes/console.php
@@ -14,7 +14,7 @@ Schedule::command('invoices:generate')
 
 Schedule::command('payments:reconcile')
     ->everyFiveMinutes()
-    ->withoutOverlapping(10);
+    ->withoutOverlapping(15);
 
 Schedule::command('rent:send-reminders')
     ->dailyAt('08:00')

--- a/routes/console.php
+++ b/routes/console.php
@@ -12,6 +12,10 @@ Schedule::command('invoices:generate')
     ->dailyAt('01:00')
     ->withoutOverlapping(60);
 
+Schedule::command('payments:reconcile')
+    ->everyFiveMinutes()
+    ->withoutOverlapping(10);
+
 Schedule::command('rent:send-reminders')
     ->dailyAt('08:00')
     ->withoutOverlapping(60);

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\LeaseController;
 use App\Http\Controllers\LeaseInvoiceController;
 use App\Http\Controllers\LeaseRentScheduleController;
 use App\Http\Controllers\MaintenanceTicketController;
+use App\Http\Controllers\PaymentAttemptController;
 use App\Http\Controllers\PaymentController;
 use App\Http\Controllers\PropertyController;
 use App\Http\Controllers\PropertyDocumentsController;
@@ -156,6 +157,10 @@ Route::middleware(['auth', 'verified', 'permission:dashboard.view'])->group(func
             Route::get('documents', [LeaseController::class, 'documents'])->name('workspace.documents')->middleware('permission:leases.view');
             Route::get('invoices', [LeaseInvoiceController::class, 'index'])->name('workspace.invoices')->middleware('permission:leases.view');
             Route::get('invoices/{invoice}', [LeaseInvoiceController::class, 'show'])->name('workspace.invoices.show')->middleware('permission:leases.view');
+            Route::post('invoices/{invoice}/payment-attempts/{paymentAttempt}/recheck', [PaymentAttemptController::class, 'recheck'])
+                ->name('workspace.invoices.payment-attempts.recheck')
+                ->scopeBindings()
+                ->middleware('permission:payments.verify');
             Route::get('invoices/{invoice}/print', [LeaseInvoiceController::class, 'print'])->name('workspace.invoices.print')->middleware('permission:leases.view');
             Route::get('invoices/{invoice}/download', [LeaseInvoiceController::class, 'download'])->name('workspace.invoices.download')->middleware('permission:leases.view');
             Route::get('rent-schedule', LeaseRentScheduleController::class)->name('rent-schedule')->middleware('permission:leases.view');

--- a/tests/Feature/InvoiceWorkspaceTest.php
+++ b/tests/Feature/InvoiceWorkspaceTest.php
@@ -6,14 +6,21 @@ use App\Models\Invoice;
 use App\Models\InvoiceLineItem;
 use App\Models\Lease;
 use App\Models\Payment;
+use App\Models\PaymentAttempt;
 use App\Models\PaymentProof;
 use App\Models\Setting;
 use App\Models\User;
 use App\Services\Invoices\InvoicePdfArtifact;
+use App\Services\Payments\PaymentGatewayManager;
 use Database\Seeders\RegionAndCitySeeder;
 use Database\Seeders\RoleAndPermissionSeeder;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Storage;
+use OpenKOS\Core\Contracts\PaymentGateway;
+use OpenKOS\Core\Contracts\PaymentGatewayStatusLookup;
+use OpenKOS\Core\Data\Payment\Money;
+use OpenKOS\Core\Data\Payment\PaymentProviderResult;
+use OpenKOS\Core\Enums\PaymentStatus as GatewayPaymentStatus;
 
 uses()->beforeEach(function () {
     $this->seed([RoleAndPermissionSeeder::class, RegionAndCitySeeder::class]);
@@ -113,8 +120,69 @@ describe('invoice workspace show', function () {
                 ->where('invoice.id', $invoice->id)
                 ->has('invoice.line_items', 1)
                 ->has('invoice.payments', 1)
+                ->has('gatewayAttempts', 0)
                 ->where('invoice.payments.0.confirmed_by.name', $this->owner->name)
                 ->has('invoice.payments.0.proofs', 1));
+    });
+
+    it('shows normalized gateway attempts without exposing provider metadata', function () {
+        $lease = Lease::factory()->create();
+        $invoice = Invoice::factory()->create(['lease_id' => $lease->id]);
+        $attempt = PaymentAttempt::factory()->for($invoice)->create([
+            'gateway_key' => 'xendit',
+            'reference' => 'attempt-1',
+            'provider_reference' => 'provider-1',
+            'metadata' => [
+                'provider_status' => 'ACTIVE',
+                'secret' => 'must-not-be-exposed',
+            ],
+        ]);
+
+        $this->actingAs($this->owner)
+            ->get(route('leases.workspace.invoices.show', [$lease, $invoice]))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->where('gatewayAttempts.0.id', $attempt->id)
+                ->where('gatewayAttempts.0.gateway', 'xendit')
+                ->where('gatewayAttempts.0.reference', 'attempt-1')
+                ->where('gatewayAttempts.0.provider_reference', 'provider-1')
+                ->where('gatewayAttempts.0.status', 'pending')
+                ->where('gatewayAttempts.0.recheckable', true)
+                ->missing('gatewayAttempts.0.metadata'));
+    });
+
+    it('rechecks a gateway attempt from invoice detail', function () {
+        $lease = Lease::factory()->create();
+        $invoice = Invoice::factory()->create([
+            'lease_id' => $lease->id,
+            'total' => 1_500_000,
+            'amount_paid' => 0,
+        ]);
+        $attempt = PaymentAttempt::factory()->for($invoice)->create([
+            'gateway_key' => 'test-gateway',
+            'reference' => 'attempt-1',
+            'provider_reference' => 'provider-1',
+            'amount' => 1_500_000,
+            'currency' => 'IDR',
+        ]);
+        $gateway = Mockery::mock(PaymentGateway::class, PaymentGatewayStatusLookup::class);
+        $gateway->shouldReceive('lookupPaymentStatus')->once()->andReturn(new PaymentProviderResult(
+            providerReference: 'provider-1',
+            status: GatewayPaymentStatus::Settled,
+            reference: 'attempt-1',
+            amount: new Money(1_500_000, 'IDR'),
+        ));
+        $manager = Mockery::mock(PaymentGatewayManager::class);
+        $manager->shouldReceive('find')->with('test-gateway')->andReturn($gateway);
+        app()->instance(PaymentGatewayManager::class, $manager);
+
+        $this->from(route('leases.workspace.invoices.show', [$lease, $invoice]))
+            ->actingAs($this->owner)
+            ->post(route('leases.workspace.invoices.payment-attempts.recheck', [$lease, $invoice, $attempt]))
+            ->assertRedirect(route('leases.workspace.invoices.show', [$lease, $invoice]));
+
+        expect($attempt->fresh()->status)->toBe(GatewayPaymentStatus::Settled)
+            ->and($invoice->fresh()->amount_paid)->toBe('1500000.00');
     });
 
     it('derives overdue display status on invoice detail', function () {

--- a/tests/Feature/PaymentWebhookTest.php
+++ b/tests/Feature/PaymentWebhookTest.php
@@ -203,13 +203,13 @@ it('applies failed callbacks without affecting invoice accounting', function () 
         ->and($invoice->fresh()->amount_paid)->toBe('0.00');
 });
 
-it('reports conflicting terminal callbacks as anomalies without mutation', function () {
-    Log::spy();
+it('applies a late settlement after a failed local attempt', function () {
     $invoice = Invoice::factory()->create(['total' => 1_500_000]);
     $attempt = PaymentAttempt::factory()->for($invoice)->failed()->create([
         'gateway_key' => 'test/gateway',
         'provider_reference' => 'provider-1',
         'reference' => 'attempt-1',
+        'amount' => 1_500_000,
     ]);
     bindWebhookGateway(gatewayWebhookResult(
         PaymentStatus::Settled,
@@ -218,13 +218,36 @@ it('reports conflicting terminal callbacks as anomalies without mutation', funct
     ));
 
     $this->postJson('/api/webhooks/payment/test/gateway', [])
-        ->assertStatus(202)
-        ->assertJson(['status' => 'anomaly']);
+        ->assertOk()
+        ->assertJson(['status' => 'processed']);
 
-    expect($attempt->fresh()->status)->toBe(PaymentStatus::Failed)
-        ->and(Payment::query()->count())->toBe(0);
+    expect($attempt->fresh()->status)->toBe(PaymentStatus::Settled)
+        ->and($attempt->fresh()->payment_id)->not->toBeNull()
+        ->and(Payment::query()->count())->toBe(1);
+});
 
-    Log::shouldHaveReceived('warning')->once();
+it('applies a late settlement after local expiry', function () {
+    $invoice = Invoice::factory()->create(['total' => 1_500_000]);
+    $attempt = PaymentAttempt::factory()->for($invoice)->expired()->create([
+        'gateway_key' => 'test/gateway',
+        'provider_reference' => 'provider-1',
+        'reference' => 'attempt-1',
+        'amount' => 1_500_000,
+    ]);
+    bindWebhookGateway(gatewayWebhookResult(
+        PaymentStatus::Settled,
+        reference: $attempt->reference,
+        amount: new Money(1_500_000, 'IDR'),
+    ));
+
+    $this->postJson('/api/webhooks/payment/test/gateway', [])
+        ->assertOk()
+        ->assertJson(['status' => 'processed']);
+
+    expect($attempt->fresh()->status)->toBe(PaymentStatus::Settled)
+        ->and($attempt->fresh()->payment_id)->not->toBeNull()
+        ->and(Payment::query()->count())->toBe(1)
+        ->and($invoice->fresh()->status)->toBe(InvoiceStatus::Paid);
 });
 
 it('fails closed for a settled attempt without a linked payment', function () {

--- a/tests/Feature/ReconcilePaymentAttemptTest.php
+++ b/tests/Feature/ReconcilePaymentAttemptTest.php
@@ -1,0 +1,112 @@
+<?php
+
+use App\Actions\Payments\ReconcilePaymentAttempt;
+use App\Enums\InvoiceStatus;
+use App\Models\Invoice;
+use App\Models\Payment;
+use App\Models\PaymentAttempt;
+use App\Results\Payment\ReconcilePaymentAttemptResult;
+use App\Services\Payments\PaymentGatewayManager;
+use OpenKOS\Core\Contracts\PaymentGateway;
+use OpenKOS\Core\Contracts\PaymentGatewayStatusLookup;
+use OpenKOS\Core\Data\Payment\Money;
+use OpenKOS\Core\Data\Payment\PaymentProviderResult;
+use OpenKOS\Core\Enums\PaymentStatus;
+
+function bindStatusLookupGateway(PaymentProviderResult $result): void
+{
+    $gateway = Mockery::mock(PaymentGateway::class, PaymentGatewayStatusLookup::class);
+    $gateway->shouldReceive('lookupPaymentStatus')->once()->andReturn($result);
+
+    $manager = Mockery::mock(PaymentGatewayManager::class);
+    $manager->shouldReceive('find')->with('test-gateway')->andReturn($gateway);
+
+    app()->instance(PaymentGatewayManager::class, $manager);
+}
+
+it('settles a provider-reported payment through the shared accounting path', function () {
+    $invoice = Invoice::factory()->create([
+        'total' => 1_500_000,
+        'amount_paid' => 0,
+    ]);
+    $attempt = PaymentAttempt::factory()->for($invoice)->create([
+        'gateway_key' => 'test-gateway',
+        'provider_reference' => 'provider-1',
+        'reference' => 'attempt-1',
+        'amount' => 1_500_000,
+        'currency' => 'IDR',
+    ]);
+    bindStatusLookupGateway(new PaymentProviderResult(
+        providerReference: 'provider-1',
+        status: PaymentStatus::Settled,
+        reference: $attempt->reference,
+        amount: new Money(1_500_000, 'IDR'),
+        metadata: ['provider_status' => 'COMPLETED'],
+    ));
+
+    $result = app(ReconcilePaymentAttempt::class)->execute($attempt);
+
+    expect($result->status)->toBe(ReconcilePaymentAttemptResult::SETTLED)
+        ->and($attempt->fresh()->status)->toBe(PaymentStatus::Settled)
+        ->and($attempt->fresh()->payment_id)->not->toBeNull()
+        ->and(Payment::query()->count())->toBe(1)
+        ->and($invoice->fresh()->status)->toBe(InvoiceStatus::Paid);
+});
+
+it('keeps an active provider payment pending without creating accounting', function () {
+    $invoice = Invoice::factory()->create(['total' => 1_500_000]);
+    $attempt = PaymentAttempt::factory()->for($invoice)->create([
+        'gateway_key' => 'test-gateway',
+        'provider_reference' => 'provider-1',
+        'reference' => 'attempt-1',
+        'amount' => 1_500_000,
+    ]);
+    bindStatusLookupGateway(new PaymentProviderResult(
+        providerReference: 'provider-1',
+        status: PaymentStatus::Pending,
+        reference: $attempt->reference,
+        amount: new Money(1_500_000, 'IDR'),
+        metadata: ['provider_status' => 'ACTIVE'],
+    ));
+
+    $result = app(ReconcilePaymentAttempt::class)->execute($attempt);
+
+    expect($result->status)->toBe(ReconcilePaymentAttemptResult::PENDING)
+        ->and($attempt->fresh()->status)->toBe(PaymentStatus::Pending)
+        ->and(Payment::query()->count())->toBe(0);
+});
+
+it('does not reconcile an attempt without a provider reference', function () {
+    $attempt = PaymentAttempt::factory()->create(['provider_reference' => null]);
+
+    $result = app(ReconcilePaymentAttempt::class)->execute($attempt);
+
+    expect($result->status)->toBe(ReconcilePaymentAttemptResult::UNSUPPORTED)
+        ->and($attempt->fresh()->status)->toBe(PaymentStatus::Pending);
+});
+
+it('does not settle a fully paid invoice through an old gateway attempt', function () {
+    $invoice = Invoice::factory()->create([
+        'total' => 1_500_000,
+        'amount_paid' => 1_500_000,
+        'status' => InvoiceStatus::Paid,
+    ]);
+    $attempt = PaymentAttempt::factory()->for($invoice)->create([
+        'gateway_key' => 'test-gateway',
+        'provider_reference' => 'provider-1',
+        'reference' => 'attempt-1',
+        'amount' => 1_500_000,
+    ]);
+    bindStatusLookupGateway(new PaymentProviderResult(
+        providerReference: 'provider-1',
+        status: PaymentStatus::Settled,
+        reference: $attempt->reference,
+        amount: new Money(1_500_000, 'IDR'),
+    ));
+
+    $result = app(ReconcilePaymentAttempt::class)->execute($attempt);
+
+    expect($result->status)->toBe(ReconcilePaymentAttemptResult::ANOMALY)
+        ->and($attempt->fresh()->status)->toBe(PaymentStatus::Pending)
+        ->and(Payment::query()->count())->toBe(0);
+});

--- a/tests/Feature/StartGatewayPaymentTest.php
+++ b/tests/Feature/StartGatewayPaymentTest.php
@@ -12,10 +12,12 @@ use App\Services\Payments\PaymentGatewayManager;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Log;
 use OpenKOS\Core\Contracts\PaymentGateway;
+use OpenKOS\Core\Contracts\PaymentGatewayStatusLookup;
 use OpenKOS\Core\Data\Payment\CheckoutInstruction;
 use OpenKOS\Core\Data\Payment\CheckoutInstructions;
 use OpenKOS\Core\Data\Payment\Money;
 use OpenKOS\Core\Data\Payment\PaymentCreationResult;
+use OpenKOS\Core\Data\Payment\PaymentProviderResult;
 use OpenKOS\Core\Data\Payment\PaymentRequest;
 use OpenKOS\Core\Enums\PaymentStatus;
 use Spatie\Permission\Models\Permission as SpatiePermission;
@@ -152,6 +154,38 @@ it('expires stale pending attempts before creating a replacement', function () {
         ->and($invoice->paymentAttempts()->count())->toBe(2);
 });
 
+it('rechecks stale provider sessions before expiring them', function () {
+    $invoice = Invoice::factory()->create();
+    $attempt = PaymentAttempt::factory()->for($invoice)->create([
+        'provider_reference' => 'existing-provider-reference',
+        'expires_at' => now()->subMinute(),
+        'checkout_instructions' => [
+            'url' => 'https://example.test/existing',
+            'entries' => [],
+        ],
+    ]);
+    $gateway = Mockery::mock(PaymentGateway::class, PaymentGatewayStatusLookup::class);
+    $gateway->shouldReceive('lookupPaymentStatus')
+        ->once()
+        ->andReturn(new PaymentProviderResult(
+            providerReference: $attempt->provider_reference,
+            status: PaymentStatus::Pending,
+            reference: $attempt->reference,
+            amount: new Money((int) $attempt->amount, $attempt->currency),
+        ));
+    $manager = Mockery::mock(PaymentGatewayManager::class);
+    $manager->shouldReceive('find')->with('test-gateway')->zeroOrMoreTimes()->andReturn($gateway);
+    $manager->shouldReceive('supportsStatusLookup')->with('test-gateway')->once()->andReturnTrue();
+    $manager->shouldNotReceive('active');
+    app()->instance(PaymentGatewayManager::class, $manager);
+
+    $result = app(StartGatewayPayment::class)->execute($invoice, User::factory()->owner()->create());
+
+    expect($result->reused)->toBeTrue()
+        ->and($result->attempt->id)->toBe($attempt->id)
+        ->and($attempt->fresh()->status)->toBe(PaymentStatus::Pending);
+});
+
 it('keeps ambiguous provider failures pending for reconciliation', function () {
     $invoice = Invoice::factory()->create();
     Log::spy();
@@ -175,8 +209,7 @@ it('keeps ambiguous provider failures pending for reconciliation', function () {
             fn (array $context): bool => $context['invoice_id'] === $invoice->id
                 && $context['attempt_id'] === $attempt->id
                 && $context['gateway_key'] === 'test-gateway'
-                && $context['exception'] instanceof RuntimeException
-                && $context['exception']->getMessage() === 'timeout from provider SDK',
+                && $context['exception_class'] === RuntimeException::class,
         ));
 });
 

--- a/tests/Feature/StartGatewayPaymentTest.php
+++ b/tests/Feature/StartGatewayPaymentTest.php
@@ -134,6 +134,29 @@ it('does not reuse an attempt while provider creation is unresolved', function (
         ->toThrow(PaymentGatewayCreationException::class);
 });
 
+it('supersedes stale provider creation attempts without references', function (string $creationState) {
+    $invoice = Invoice::factory()->create();
+    $orphaned = PaymentAttempt::factory()->for($invoice)->create([
+        'provider_reference' => null,
+        'expires_at' => null,
+        'checkout_instructions' => null,
+        'metadata' => ['provider_creation_state' => $creationState],
+        'updated_at' => now()->subMinutes(6),
+    ]);
+    $gateway = Mockery::mock(PaymentGateway::class);
+    $gateway->shouldReceive('key')->andReturn('test-gateway');
+    $gateway->shouldReceive('createPayment')
+        ->once()
+        ->andReturnUsing(fn (PaymentRequest $request) => paymentGatewayResult($request));
+
+    $result = startGatewayPaymentAction($gateway)->execute($invoice, User::factory()->owner()->create());
+
+    expect($result->reused)->toBeFalse()
+        ->and($orphaned->fresh()->status)->toBe(PaymentStatus::Pending)
+        ->and($orphaned->fresh()->metadata['provider_creation_state'])->toBe('superseded')
+        ->and($invoice->paymentAttempts()->count())->toBe(2);
+})->with(['in_progress', 'uncertain']);
+
 it('expires stale pending attempts before creating a replacement', function () {
     $invoice = Invoice::factory()->create();
     $stale = PaymentAttempt::factory()->for($invoice)->create([

--- a/tests/Feature/StartGatewayPaymentTest.php
+++ b/tests/Feature/StartGatewayPaymentTest.php
@@ -5,6 +5,7 @@ use App\Exceptions\InvoiceNotPayableException;
 use App\Exceptions\PaymentGatewayCreationException;
 use App\Models\Invoice;
 use App\Models\Lease;
+use App\Models\Payment;
 use App\Models\PaymentAttempt;
 use App\Models\Setting;
 use App\Models\User;
@@ -267,6 +268,29 @@ it('fails closed when the provider returns no usable checkout instructions', fun
         ->toThrow(PaymentGatewayCreationException::class);
 
     expect($invoice->paymentAttempts()->sole()->status)->toBe(PaymentStatus::Failed);
+});
+
+it('keeps terminal provider creation responses pending for confirmation', function () {
+    $invoice = Invoice::factory()->create();
+    $gateway = Mockery::mock(PaymentGateway::class);
+    $gateway->shouldReceive('key')->andReturn('test-gateway');
+    $gateway->shouldReceive('createPayment')
+        ->once()
+        ->andReturnUsing(fn (PaymentRequest $request) => new PaymentCreationResult(
+            providerReference: 'provider-reference',
+            status: PaymentStatus::Settled,
+            amount: $request->amount,
+            instructions: new CheckoutInstructions,
+        ));
+
+    expect(fn () => startGatewayPaymentAction($gateway)->execute($invoice, User::factory()->owner()->create()))
+        ->toThrow(PaymentGatewayCreationException::class);
+
+    $attempt = $invoice->paymentAttempts()->sole();
+    expect($attempt->status)->toBe(PaymentStatus::Pending)
+        ->and($attempt->provider_reference)->toBe('provider-reference')
+        ->and($attempt->metadata['provider_creation_state'])->toBe('uncertain')
+        ->and(Payment::query()->count())->toBe(0);
 });
 
 it('blocks a new checkout after a settled attempt', function () {


### PR DESCRIPTION
## Summary

- add provider-independent payment-attempt reconciliation
- recover stale and ambiguous checkout creation attempts
- preserve provider references when persistence fails
- bound scheduled reconciliation runtime
- defer terminal creation responses for authoritative confirmation
- accept late authoritative settlement webhooks
- lock the application to openkos/platform 0.2.2

## Verification

- 776 tests passed
- Composer validation passed
- Laravel Pint passed

Refs OPE-136