### PR TITLE
perf(payments): batch invoice status recalculation

### DIFF
--- a/app/Actions/Invoices/AllocatePayment.php
+++ b/app/Actions/Invoices/AllocatePayment.php
@@ -45,9 +45,9 @@ class AllocatePayment
                 ->lockForUpdate()
                 ->get();
 
-            foreach ($invoices as $invoice) {
-                $invoice->recalculateStatus();
+            Invoice::recalculateStatuses($invoices);
 
+            foreach ($invoices as $invoice) {
                 if ($invoice->status === InvoiceStatus::Paid
                     && ($priorStatuses[$invoice->id] ?? null) !== InvoiceStatus::Paid->value
                 ) {

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -143,11 +143,11 @@ class PaymentController extends Controller
                     'verified_at' => now(),
                 ]);
 
-                Invoice::whereIn('id', $affectedInvoiceIds)
+                $affectedInvoices = Invoice::whereIn('id', $affectedInvoiceIds)
                     ->lockForUpdate()
-                    ->get()
-                    ->each
-                    ->recalculateStatus();
+                    ->get();
+
+                Invoice::recalculateStatuses($affectedInvoices);
             }
         });
 

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -7,6 +7,7 @@ use App\Enums\InvoiceStatus;
 use App\Enums\PaymentStatus;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -116,13 +117,36 @@ class Invoice extends Model
         $query->payable()->whereDate('due_date', '<', now());
     }
 
-    public function recalculateStatus(): void
+    /**
+     * Recalculate a collection of already-locked invoices from confirmed payments.
+     *
+     * @param  Collection<int, self>  $invoices
+     */
+    public static function recalculateStatuses(Collection $invoices): void
+    {
+        if ($invoices->isEmpty()) {
+            return;
+        }
+
+        $confirmedTotals = Payment::query()
+            ->whereIn('invoice_id', $invoices->modelKeys())
+            ->where('status', PaymentStatus::Confirmed->value)
+            ->selectRaw('invoice_id, SUM(amount) as total')
+            ->groupBy('invoice_id')
+            ->pluck('total', 'invoice_id');
+
+        foreach ($invoices as $invoice) {
+            $invoice->recalculateStatus((float) ($confirmedTotals[$invoice->getKey()] ?? 0));
+        }
+    }
+
+    public function recalculateStatus(?float $confirmedPaymentTotal = null): void
     {
         if (in_array($this->status, [InvoiceStatus::Cancelled, InvoiceStatus::Void], true)) {
             return;
         }
 
-        $paid = (float) $this->payments()
+        $paid = $confirmedPaymentTotal ?? (float) $this->payments()
             ->where('status', PaymentStatus::Confirmed->value)
             ->sum('amount');
 

--- a/database/migrations/2026_08_19_082942_add_invoice_status_index_to_payments_table.php
+++ b/database/migrations/2026_08_19_082942_add_invoice_status_index_to_payments_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('payments', function (Blueprint $table): void {
+            $table->index(['invoice_id', 'status']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('payments', function (Blueprint $table): void {
+            $table->dropIndex('payments_invoice_id_status_index');
+        });
+    }
+};

--- a/tests/Feature/PaymentAllocationTest.php
+++ b/tests/Feature/PaymentAllocationTest.php
@@ -6,8 +6,11 @@ use App\Enums\PaymentStatus;
 use App\Models\Invoice;
 use App\Models\Lease;
 use App\Models\Payment;
+use App\Models\PaymentAllocation;
 use App\Models\User;
 use Database\Seeders\RoleAndPermissionSeeder;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Support\Facades\DB;
 
 uses()->beforeEach(function () {
     $this->seed(RoleAndPermissionSeeder::class);
@@ -110,6 +113,74 @@ it('keeps a payment on its recorded invoice instead of settling an older one', f
         ->and((int) $payment->allocations()->first()->invoice_id)->toBe($targetInvoice->id)
         ->and($olderInvoice->fresh()->status)->toBe(InvoiceStatus::Pending)
         ->and((float) $olderInvoice->fresh()->amount_paid)->toBe(0.0)
+        ->and($targetInvoice->fresh()->status)->toBe(InvoiceStatus::Paid)
+        ->and((float) $targetInvoice->fresh()->amount_paid)->toBe(1000000.0);
+});
+
+it('recalculates affected invoices with one confirmed payment aggregate', function () {
+    $lease = Lease::factory()->create();
+    $invoiceA = Invoice::factory()->create([
+        'lease_id' => $lease->id,
+        'period_start' => '2026-01-01',
+        'period_end' => '2026-01-31',
+        'due_date' => '2026-01-05',
+        'total' => 1_000_000,
+    ]);
+    $invoiceB = Invoice::factory()->create([
+        'lease_id' => $lease->id,
+        'period_start' => '2026-02-01',
+        'period_end' => '2026-02-28',
+        'due_date' => '2026-02-05',
+        'total' => 1_000_000,
+    ]);
+    $targetInvoice = Invoice::factory()->create([
+        'lease_id' => $lease->id,
+        'period_start' => '2026-03-01',
+        'period_end' => '2026-03-31',
+        'due_date' => '2026-03-05',
+        'total' => 1_000_000,
+    ]);
+
+    Payment::factory()->create([
+        'invoice_id' => $invoiceA->id,
+        'amount' => 250_000,
+    ]);
+    Payment::factory()->create([
+        'invoice_id' => $invoiceB->id,
+        'amount' => 500_000,
+    ]);
+    $payment = Payment::factory()->create([
+        'invoice_id' => $targetInvoice->id,
+        'amount' => 1_000_000,
+    ]);
+
+    PaymentAllocation::create([
+        'payment_id' => $payment->id,
+        'invoice_id' => $invoiceA->id,
+        'amount' => 500_000,
+    ]);
+    PaymentAllocation::create([
+        'payment_id' => $payment->id,
+        'invoice_id' => $invoiceB->id,
+        'amount' => 500_000,
+    ]);
+
+    $aggregateQueries = 0;
+    DB::listen(function (QueryExecuted $query) use (&$aggregateQueries): void {
+        $sql = strtolower($query->sql);
+
+        if (str_contains($sql, 'sum(') && str_contains($sql, 'payments')) {
+            $aggregateQueries++;
+        }
+    });
+
+    app(AllocatePayment::class)->execute($payment);
+
+    expect($aggregateQueries)->toBe(1)
+        ->and($invoiceA->fresh()->status)->toBe(InvoiceStatus::Partial)
+        ->and((float) $invoiceA->fresh()->amount_paid)->toBe(250000.0)
+        ->and($invoiceB->fresh()->status)->toBe(InvoiceStatus::Partial)
+        ->and((float) $invoiceB->fresh()->amount_paid)->toBe(500000.0)
         ->and($targetInvoice->fresh()->status)->toBe(InvoiceStatus::Paid)
         ->and((float) $targetInvoice->fresh()->amount_paid)->toBe(1000000.0);
 });

--- a/tests/Feature/PaymentTest.php
+++ b/tests/Feature/PaymentTest.php
@@ -14,6 +14,8 @@ use App\Models\Unit;
 use App\Models\User;
 use Database\Seeders\RegionAndCitySeeder;
 use Database\Seeders\RoleAndPermissionSeeder;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
 
 uses()->beforeEach(function () {
@@ -365,10 +367,20 @@ describe('invoice settlement', function () {
             'amount_paid' => 500_000,
         ]);
 
+        $aggregateQueries = 0;
+        DB::listen(function (QueryExecuted $query) use (&$aggregateQueries): void {
+            $sql = strtolower($query->sql);
+
+            if (str_contains($sql, 'sum(') && str_contains($sql, 'payments')) {
+                $aggregateQueries++;
+            }
+        });
+
         $this->actingAs($user)
             ->post(route('payments.verify', $payment), ['action' => 'reject']);
 
-        expect($payment->fresh()->status)->toBe(PaymentStatus::Cancelled)
+        expect($aggregateQueries)->toBe(1)
+            ->and($payment->fresh()->status)->toBe(PaymentStatus::Cancelled)
             ->and($payment->fresh()->confirmed_by)->toBeNull()
             ->and((int) $payment->allocations()->count())->toBe(0)
             ->and($olderInvoice->fresh()->status)->toBe(InvoiceStatus::Pending)


### PR DESCRIPTION
## Summary

- Batch confirmed payment totals for all locked affected invoices in one aggregate query.
- Preserve payment-based accounting, the single-invoice fallback, locking, and after-commit events.
- Cover both allocation and rejection paths and add the payments `(invoice_id, status)` index.
- Keep allocation-based accounting explicitly out of scope per `5f65ebc`.

## Testing

- `php -d memory_limit=512M vendor/bin/pest --compact` — 777 passed, 3,561 assertions
- `git diff --check`

Refs OPE-100