### PR TITLE
perf(properties): remove global eager loading

### DIFF
--- a/app/Http/Controllers/LeaseController.php
+++ b/app/Http/Controllers/LeaseController.php
@@ -147,6 +147,7 @@ class LeaseController extends Controller
     {
         $this->authorize('viewAny', [Lease::class, $property]);
 
+        $property->load('city');
         $unit->load('property.city');
 
         $leases = $unit->leases()

--- a/app/Http/Controllers/PropertyController.php
+++ b/app/Http/Controllers/PropertyController.php
@@ -74,6 +74,7 @@ class PropertyController extends Controller
                 'users',
                 fn (Builder $q) => $q->whereKey($request->user()->id),
             ))
+            ->with(['city', 'region', 'propertyType'])
             ->withCount('units')
             ->withOccupiedUnitsCount()
             ->withTenantsCount();

--- a/app/Models/Property.php
+++ b/app/Models/Property.php
@@ -35,8 +35,6 @@ class Property extends Model
 
     protected array $auditableMask = ['phone'];
 
-    protected $with = ['region', 'city', 'propertyType'];
-
     protected $appends = ['type_label'];
 
     protected function casts(): array
@@ -57,12 +55,13 @@ class Property extends Model
     }
 
     /**
-     * Human-readable type name, falling back to the raw slug if the type row
-     * is missing (e.g. deleted).
+     * Human-readable type name when the relation is explicitly loaded.
      */
     protected function typeLabel(): Attribute
     {
-        return Attribute::get(fn () => $this->propertyType?->label ?? $this->type);
+        return Attribute::get(fn () => $this->relationLoaded('propertyType')
+            ? $this->propertyType?->label ?? $this->type
+            : $this->type);
     }
 
     protected static function booted(): void
@@ -110,7 +109,7 @@ class Property extends Model
      */
     public function scopeWithWorkspaceStats(Builder $query): void
     {
-        $query->with(['city', 'region'])
+        $query->with(['city', 'region', 'propertyType'])
             ->withCount('units')
             ->withOccupiedUnitsCount()
             ->withTenantsCount();

--- a/tests/Feature/PropertyTest.php
+++ b/tests/Feature/PropertyTest.php
@@ -8,6 +8,7 @@ use App\Models\Unit;
 use App\Models\User;
 use Database\Seeders\RegionAndCitySeeder;
 use Database\Seeders\RoleAndPermissionSeeder;
+use Illuminate\Support\Facades\DB;
 
 uses()->beforeEach(function () {
     $this->seed([RoleAndPermissionSeeder::class, RegionAndCitySeeder::class]);
@@ -54,7 +55,9 @@ describe('authorization', function () {
 describe('CRUD', function () {
     it('lists properties on the index page', function () {
         $user = User::factory()->owner()->create();
-        Property::factory()->count(3)->create();
+        Property::factory()->create(['name' => 'Alpha Residence']);
+        Property::factory()->create(['name' => 'Beta Residence']);
+        $villa = Property::factory()->create(['name' => 'Villa Bali', 'type' => 'villa']);
 
         $this->actingAs($user)
             ->get(route('properties.index'))
@@ -62,7 +65,42 @@ describe('CRUD', function () {
             ->assertInertia(fn ($page) => $page
                 ->component('properties/index')
                 ->has('properties.data', 3)
+                ->where('properties.data.2.type_label', 'Villa')
+                ->where('properties.data.2.city.id', $villa->city_id)
+                ->where('properties.data.2.region.id', $villa->region_id)
             );
+    });
+
+    it('does not automatically load property relations for light queries', function () {
+        Property::factory()->create();
+
+        DB::connection()->enableQueryLog();
+        DB::connection()->flushQueryLog();
+
+        $property = Property::query()->get(['id', 'name'])->first();
+
+        expect($property)->not->toBeNull()
+            ->and($property->relationLoaded('region'))->toBeFalse()
+            ->and($property->relationLoaded('city'))->toBeFalse()
+            ->and($property->relationLoaded('propertyType'))->toBeFalse()
+            ->and(DB::connection()->getQueryLog())->toHaveCount(1);
+    });
+
+    it('keeps scalar property queries relation-free', function () {
+        Property::factory()->create();
+
+        DB::connection()->enableQueryLog();
+
+        foreach ([
+            fn () => Property::query()->pluck('id'),
+            fn () => Property::query()->count(),
+            fn () => Property::query()->exists(),
+        ] as $query) {
+            DB::connection()->flushQueryLog();
+            $query();
+
+            expect(DB::connection()->getQueryLog())->toHaveCount(1);
+        }
     });
 
     it('creates a property', function () {
@@ -137,10 +175,21 @@ describe('type', function () {
             'type' => 'villa',
         ]);
 
-        $property = Property::first();
+        $property = Property::with('propertyType')->first();
 
         expect($property->type)->toBe('villa')
             ->and($property->type_label)->toBe('Villa');
+    });
+
+    it('falls back to the raw type without lazy loading propertyType', function () {
+        $property = Property::factory()->create(['type' => 'villa']);
+
+        DB::connection()->enableQueryLog();
+        DB::connection()->flushQueryLog();
+
+        expect($property->type_label)->toBe('villa')
+            ->and($property->relationLoaded('propertyType'))->toBeFalse()
+            ->and(DB::connection()->getQueryLog())->toHaveCount(0);
     });
 
     it('updates the type', function () {
@@ -202,6 +251,9 @@ describe('workspace tabs', function () {
             ->assertInertia(fn ($page) => $page
                 ->component('properties/leases')
                 ->where('property.id', $property->id)
+                ->where('property.type_label', 'Boarding House')
+                ->where('property.city.id', $property->city_id)
+                ->where('property.region.id', $property->region_id)
                 ->has('property.units_count')
                 ->has('property.occupied_units_count')
                 ->has('property.tenants_count'));


### PR DESCRIPTION
## Summary

- Remove the global `Property::$with` relation loading.
- Keep `type_label` query-free when `propertyType` is not explicitly loaded.
- Add explicit property relations to list/workspace consumers and the lease summary city field.
- Add regression coverage for light, scalar, fallback, and display-label behavior.

## Tests

- `php artisan test --compact tests/Feature/PropertyTest.php`
- Related feature suites: 177 passed, 1,181 assertions
- `php -d memory_limit=512M vendor/bin/pest --compact` — 783 passed, 3,586 assertions

The default Artisan full-suite wrapper hit its 128 MB Dompdf memory limit; the direct Pest run passed with the repository's 512 MB test limit.