### PR TITLE
perf(settings): cache settings reads

### DIFF
--- a/app/Providers/SettingsServiceProvider.php
+++ b/app/Providers/SettingsServiceProvider.php
@@ -11,7 +11,7 @@ class SettingsServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
-        $this->app->singleton(SettingManager::class);
+        $this->app->scoped(SettingManager::class);
         $this->app->singleton(SettingsStore::class, PlatformSettingsStore::class);
     }
 }

--- a/app/Services/Settings/PlatformSettingsStore.php
+++ b/app/Services/Settings/PlatformSettingsStore.php
@@ -2,19 +2,20 @@
 
 namespace App\Services\Settings;
 
+use Illuminate\Contracts\Container\Container;
 use OpenKOS\Core\Contracts\SettingsStore;
 
 class PlatformSettingsStore implements SettingsStore
 {
-    public function __construct(private SettingManager $settings) {}
+    public function __construct(private Container $container) {}
 
     public function get(string $key): mixed
     {
-        return $this->settings->get($key);
+        return $this->container->make(SettingManager::class)->get($key);
     }
 
     public function set(string $key, mixed $value, string $type): void
     {
-        $this->settings->set($key, $value, $type);
+        $this->container->make(SettingManager::class)->set($key, $value, $type);
     }
 }

--- a/app/Services/Settings/SettingManager.php
+++ b/app/Services/Settings/SettingManager.php
@@ -6,6 +6,18 @@ use App\Models\Setting;
 
 class SettingManager
 {
+    /**
+     * @var array<string, array{value: mixed, type: string}>
+     */
+    private array $storedSettings = [];
+
+    /**
+     * @var array<string, mixed>
+     */
+    private array $resolvedSettings = [];
+
+    private bool $snapshotLoaded = false;
+
     public function __construct(
         private SettingRegistry $registry,
         private SettingCaster $caster,
@@ -17,10 +29,10 @@ class SettingManager
             return $this->allWithDefaults();
         }
 
-        $setting = Setting::where('key', $key)->first();
+        $this->loadSnapshot();
 
-        if ($setting) {
-            return $setting->resolveValue();
+        if (array_key_exists($key, $this->storedSettings)) {
+            return $this->resolveStoredSetting($key);
         }
 
         $def = $this->registry->get($key);
@@ -34,10 +46,27 @@ class SettingManager
 
         $stored = $this->caster->serialize($value, $cast);
 
-        return Setting::updateOrCreate(
+        $setting = Setting::updateOrCreate(
             ['key' => $key],
             ['value' => $stored, 'type' => $cast],
         );
+
+        if ($this->snapshotLoaded) {
+            $this->storedSettings[$key] = [
+                'value' => $stored,
+                'type' => $cast,
+            ];
+            unset($this->resolvedSettings[$key]);
+        }
+
+        $connection = $setting->getConnection();
+        if ($connection->transactionLevel() > 0) {
+            $connection->afterRollBack(function (): void {
+                $this->forgetSnapshot();
+            });
+        }
+
+        return $setting;
     }
 
     public function some(array $keys): array
@@ -149,11 +178,51 @@ class SettingManager
 
     private function allWithDefaults(): array
     {
+        $this->loadSnapshot();
+
         $defaults = [];
         foreach ($this->registry->all() as $key => $def) {
             $defaults[$key] = $this->caster->serialize($def['default'], $def['cast']);
         }
 
-        return array_merge($defaults, Setting::pluck('value', 'key')->all());
+        $stored = [];
+        foreach ($this->storedSettings as $key => $setting) {
+            $stored[$key] = $setting['value'];
+        }
+
+        return array_merge($defaults, $stored);
+    }
+
+    private function loadSnapshot(): void
+    {
+        if ($this->snapshotLoaded) {
+            return;
+        }
+
+        foreach (Setting::query()->select(['key', 'value', 'type'])->get() as $setting) {
+            $this->storedSettings[$setting->key] = [
+                'value' => $setting->value,
+                'type' => $setting->type,
+            ];
+        }
+
+        $this->snapshotLoaded = true;
+    }
+
+    private function resolveStoredSetting(string $key): mixed
+    {
+        if (! array_key_exists($key, $this->resolvedSettings)) {
+            $setting = $this->storedSettings[$key];
+            $this->resolvedSettings[$key] = $this->caster->deserialize($setting['value'], $setting['type']);
+        }
+
+        return $this->resolvedSettings[$key];
+    }
+
+    private function forgetSnapshot(): void
+    {
+        $this->storedSettings = [];
+        $this->resolvedSettings = [];
+        $this->snapshotLoaded = false;
     }
 }

--- a/tests/Feature/SettingTest.php
+++ b/tests/Feature/SettingTest.php
@@ -1,6 +1,10 @@
 <?php
 
 use App\Models\Setting;
+use App\Services\Settings\SettingManager;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Support\Facades\DB;
+use OpenKOS\Core\Contracts\SettingsStore;
 
 describe('Setting', function () {
     it('sets and gets values', function () {
@@ -45,6 +49,99 @@ describe('Setting', function () {
         expect($result)->not->toHaveKey('country_code');
         expect($result['site_name'])->toBe('Kos Budi');
         expect($result['locale'])->toBe('id');
+    });
+
+    it('loads stored settings once per lifecycle', function () {
+        Setting::set('site_name', 'Kos Ku');
+        Setting::set('reminder_enabled', true, 'boolean');
+
+        $settingsQueries = 0;
+        DB::listen(function (QueryExecuted $query) use (&$settingsQueries): void {
+            $sql = strtolower($query->sql);
+
+            if (
+                str_contains($sql, ' from "settings"') ||
+                str_contains($sql, ' from `settings`') ||
+                str_contains($sql, ' from settings')
+            ) {
+                $settingsQueries++;
+            }
+        });
+
+        expect(Setting::get('site_name'))->toBe('Kos Ku')
+            ->and(Setting::get('reminder_enabled'))->toBeTrue()
+            ->and(Setting::some(['site_name', 'reminder_enabled']))->toMatchArray([
+                'site_name' => 'Kos Ku',
+                'reminder_enabled' => true,
+            ])
+            ->and(Setting::get())->toBeArray()
+            ->and($settingsQueries)->toBe(1);
+    });
+
+    it('keeps raw values for all settings and typed values for keyed reads', function () {
+        Setting::set('reminder_enabled', true, 'boolean');
+        Setting::set('reminder_overdue_intervals', [1, 3], 'array');
+
+        $all = Setting::get();
+
+        expect($all['reminder_enabled'])->toBe('true')
+            ->and($all['reminder_overdue_intervals'])->toBe('[1,3]')
+            ->and(Setting::get('reminder_enabled'))->toBeTrue()
+            ->and(Setting::get('reminder_overdue_intervals'))->toBe([1, 3]);
+    });
+
+    it('clears the snapshot after a rolled back setting mutation', function () {
+        Setting::set('site_name', 'Before');
+
+        try {
+            DB::transaction(function (): void {
+                Setting::set('site_name', 'After');
+
+                expect(Setting::get('site_name'))->toBe('After');
+
+                throw new RuntimeException('rollback');
+            });
+        } catch (RuntimeException $exception) {
+            expect($exception->getMessage())->toBe('rollback');
+        }
+
+        expect(Setting::get('site_name'))->toBe('Before');
+    });
+
+    it('preserves outer transaction values after a nested rollback', function () {
+        Setting::set('site_name', 'Before');
+        Setting::get('site_name');
+
+        DB::transaction(function (): void {
+            Setting::set('site_name', 'Outer');
+
+            try {
+                DB::transaction(function (): void {
+                    Setting::set('site_name', 'Inner');
+
+                    throw new RuntimeException('nested rollback');
+                });
+            } catch (RuntimeException $exception) {
+                expect($exception->getMessage())->toBe('nested rollback');
+            }
+
+            expect(Setting::get('site_name'))->toBe('Outer');
+        });
+
+        expect(Setting::get('site_name'))->toBe('Outer');
+    });
+
+    it('resolves the current scoped manager through the platform store', function () {
+        $manager = app(SettingManager::class);
+        $store = app(SettingsStore::class);
+
+        app()->forgetScopedInstances();
+
+        expect(app(SettingManager::class))->not->toBe($manager);
+
+        Setting::set('site_name', 'Scoped');
+
+        expect($store->get('site_name'))->toBe('Scoped');
     });
 
     it('includes defaults when getting all', function () {


### PR DESCRIPTION
## Summary

- Load `key`, `value`, and `type` from `settings` once per request/job lifecycle.
- Preserve raw full-map reads and typed/decrypted keyed reads.
- Keep rollback-safe snapshot invalidation and scoped platform-store resolution.
- Defer persistent Redis L2 caching; the default cache is database-backed and safe invalidation needs versioning or locking.

## Verification

- `php -d memory_limit=-1 vendor/bin/pest --compact` — 785 passed
- `vendor/bin/pint --dirty --format agent`

Refs OPE-139