### PR TITLE
fix(properties): assign creator on create

### DIFF
--- a/app/Http/Controllers/PropertyController.php
+++ b/app/Http/Controllers/PropertyController.php
@@ -96,7 +96,10 @@ class PropertyController extends Controller
 
     public function store(StorePropertyRequest $request): RedirectResponse
     {
-        $property = Property::create($request->validated());
+        DB::transaction(function () use ($request): void {
+            $property = Property::create($request->validated());
+            $property->users()->attach($request->user());
+        });
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Property created.')]);
 

--- a/tests/Feature/PropertyTest.php
+++ b/tests/Feature/PropertyTest.php
@@ -122,6 +122,35 @@ describe('CRUD', function () {
         expect($property->city->name)->toBe('Kota Jakarta Selatan');
     });
 
+    it('assigns a created property to a non-owner creator', function () {
+        $user = User::factory()->admin()->create();
+
+        $this->actingAs($user)
+            ->post(route('properties.store'), [
+                'name' => 'Kos Melati',
+            ])
+            ->assertRedirect();
+
+        $property = Property::firstOrFail();
+
+        $this->assertDatabaseHas('property_user', [
+            'user_id' => $user->id,
+            'property_id' => $property->id,
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('properties.index'))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('properties/index')
+                ->has('properties.data', 1)
+                ->where('properties.data.0.id', $property->id));
+
+        $this->actingAs($user)
+            ->get(route('properties.show', $property))
+            ->assertOk();
+    });
+
     it('validates required fields on create', function () {
         $user = User::factory()->owner()->create();
 


### PR DESCRIPTION
## Summary

- attach the authenticated creator to newly created properties
- keep creation and assignment transactional
- cover admin visibility and workspace access with a regression test

## Verification

- `php artisan test --compact tests/Feature/PropertyTest.php`
- `vendor/bin/pint --dirty --format agent`