### PR TITLE
test(autoload): fix PSR-4 test doubles

### DIFF
--- a/tests/Feature/Composer/PaymentGatewayRemovalGuardTest.php
+++ b/tests/Feature/Composer/PaymentGatewayRemovalGuardTest.php
@@ -3,6 +3,7 @@
 use App\Composer\PaymentGatewayRemovalGuard;
 use App\Models\Invoice;
 use App\Models\PaymentAttempt;
+use Tests\Support\Fixtures\PackageUninstallEvent;
 
 it('blocks package removal while an active payment attempt remains', function () {
     PaymentAttempt::factory()->for(Invoice::factory())->create([
@@ -45,34 +46,3 @@ it('ignores packages without payment gateway capabilities', function () {
     expect(fn () => PaymentGatewayRemovalGuard::beforePackageUninstall(new PackageUninstallEvent))
         ->not->toThrow(Throwable::class);
 });
-
-final class PackageUninstallEvent
-{
-    public function __construct(private readonly array $extra = []) {}
-
-    public function getOperation(): object
-    {
-        return new class($this->extra)
-        {
-            public function __construct(private readonly array $extra) {}
-
-            public function getPackage(): object
-            {
-                return new class($this->extra)
-                {
-                    public function __construct(private readonly array $extra) {}
-
-                    public function getName(): string
-                    {
-                        return 'vendor/payment-package';
-                    }
-
-                    public function getExtra(): array
-                    {
-                        return $this->extra;
-                    }
-                };
-            }
-        };
-    }
-}

--- a/tests/Feature/Platform/ComposerPluginDiscoveryTest.php
+++ b/tests/Feature/Platform/ComposerPluginDiscoveryTest.php
@@ -3,43 +3,9 @@
 use App\Services\Platform\ComposerPluginDiscovery;
 use Composer\InstalledVersions;
 use OpenKOS\Core\Contracts\PluginDiscovery;
-use OpenKOS\Platform\OpenKOSManager;
 use OpenKOS\Platform\PlatformServiceProvider;
-use OpenKOS\Platform\Plugin\Plugin;
-use OpenKOS\Platform\Plugin\PluginManifest;
-
-class ComposerDiscoveryFixturePlugin extends Plugin
-{
-    public static int $registerCalls = 0;
-
-    public function manifest(): PluginManifest
-    {
-        return new PluginManifest(
-            id: 'fixture/composer-plugin',
-            name: 'Composer Fixture',
-            version: '1.0.0',
-        );
-    }
-
-    public function register(OpenKOSManager $platform): void
-    {
-        self::$registerCalls++;
-    }
-}
-
-class ComposerDiscoverySecondFixturePlugin extends Plugin
-{
-    public function manifest(): PluginManifest
-    {
-        return new PluginManifest(
-            id: 'fixture/composer-plugin-second',
-            name: 'Composer Second Fixture',
-            version: '1.0.0',
-        );
-    }
-
-    public function register(OpenKOSManager $platform): void {}
-}
+use Tests\Support\Fixtures\ComposerDiscoveryFixturePlugin;
+use Tests\Support\Fixtures\ComposerDiscoverySecondFixturePlugin;
 
 /**
  * @param  array<string, array<string, mixed>>  $packages

--- a/tests/Feature/Platform/PluginBootTest.php
+++ b/tests/Feature/Platform/PluginBootTest.php
@@ -1,49 +1,10 @@
 <?php
 
 use OpenKOS\Platform\Facades\OpenKOS;
-use OpenKOS\Platform\OpenKOSManager;
 use OpenKOS\Platform\PlatformServiceProvider;
-use OpenKOS\Platform\Plugin\Plugin;
-use OpenKOS\Platform\Plugin\PluginManifest;
 use OpenKOS\Plugins\Example\ExamplePlugin;
-
-class OrderProbePluginA extends Plugin
-{
-    public static array $calls = [];
-
-    public function manifest(): PluginManifest
-    {
-        return new PluginManifest(id: 'test/a', name: 'A', version: '1.0.0');
-    }
-
-    public function register(OpenKOSManager $platform): void
-    {
-        static::$calls[] = 'register:a';
-    }
-
-    public function boot(OpenKOSManager $platform): void
-    {
-        static::$calls[] = 'boot:a';
-    }
-}
-
-class OrderProbePluginB extends Plugin
-{
-    public function manifest(): PluginManifest
-    {
-        return new PluginManifest(id: 'test/b', name: 'B', version: '1.0.0');
-    }
-
-    public function register(OpenKOSManager $platform): void
-    {
-        OrderProbePluginA::$calls[] = 'register:b';
-    }
-
-    public function boot(OpenKOSManager $platform): void
-    {
-        OrderProbePluginA::$calls[] = 'boot:b';
-    }
-}
+use Tests\Support\Fixtures\OrderProbePluginA;
+use Tests\Support\Fixtures\OrderProbePluginB;
 
 // ExamplePlugin is disabled by default, so enable it explicitly to prove the
 // registration path. Registries are singletons, so assert "contains".

--- a/tests/Feature/Platform/PluginEventTest.php
+++ b/tests/Feature/Platform/PluginEventTest.php
@@ -10,29 +10,8 @@ use Database\Seeders\RegionAndCitySeeder;
 use Database\Seeders\RoleAndPermissionSeeder;
 use Illuminate\Support\Facades\Event;
 use OpenKOS\Core\Events\PaymentRecorded;
-use OpenKOS\Platform\OpenKOSManager;
 use OpenKOS\Platform\PlatformServiceProvider;
-use OpenKOS\Platform\Plugin\Plugin;
-use OpenKOS\Platform\Plugin\PluginManifest;
-
-class EventProbePlugin extends Plugin
-{
-    public static bool $fired = false;
-
-    public function manifest(): PluginManifest
-    {
-        return new PluginManifest(id: 'test/event', name: 'Event', version: '1.0.0');
-    }
-
-    public function register(OpenKOSManager $platform): void {}
-
-    public function listens(): array
-    {
-        return [
-            PaymentRecorded::class => fn (PaymentRecorded $event) => static::$fired = true,
-        ];
-    }
-}
+use Tests\Support\Fixtures\EventProbePlugin;
 
 it('wires a plugins event listeners at boot', function () {
     EventProbePlugin::$fired = false;

--- a/tests/Feature/Services/WhatsAppManagerTest.php
+++ b/tests/Feature/Services/WhatsAppManagerTest.php
@@ -3,10 +3,9 @@
 use App\Exceptions\WhatsAppDriverNotFoundException;
 use App\Services\WhatsAppManager;
 use OpenKOS\Core\Contracts\WhatsAppDriver;
-use OpenKOS\Core\Data\WhatsApp\DriverHealthResult;
-use OpenKOS\Core\Data\WhatsApp\WhatsAppMessage;
 use OpenKOS\Platform\Notification\NotificationDriverRegistration;
 use OpenKOS\Platform\Notification\NotificationRegistry;
+use Tests\Support\Fakes\TestWhatsAppDriver;
 
 beforeEach(function () {
     // Bundled drivers are registered by WhatsAppPlugin at boot from config;
@@ -70,44 +69,3 @@ it('getPairingQrCode delegates to resolved driver', function () {
 
     expect($result)->toBeNull();
 });
-
-class TestWhatsAppDriver implements WhatsAppDriver
-{
-    public static array $sentMessages = [];
-
-    public function __construct(private array $config = []) {}
-
-    public function send(WhatsAppMessage $message): void
-    {
-        self::$sentMessages[] = $message->phone;
-    }
-
-    public function supportsAttachments(): bool
-    {
-        return true;
-    }
-
-    public function health(): DriverHealthResult
-    {
-        return new DriverHealthResult(true);
-    }
-
-    public function supportsPairing(): bool
-    {
-        return false;
-    }
-
-    public function configurationSchema(): array
-    {
-        return [];
-    }
-
-    public function getPairingQrCode(): ?string
-    {
-        return null;
-    }
-
-    public function pair(): void {}
-
-    public function disconnect(): void {}
-}

--- a/tests/Feature/Settings/PaymentGatewaySettingsTest.php
+++ b/tests/Feature/Settings/PaymentGatewaySettingsTest.php
@@ -8,14 +8,8 @@ use App\Models\User;
 use App\Services\Payments\PaymentGatewayManager;
 use Database\Seeders\RoleAndPermissionSeeder;
 use Illuminate\Support\Collection;
-use OpenKOS\Core\Contracts\PaymentGateway;
-use OpenKOS\Core\Data\Payment\CheckoutInstructions;
-use OpenKOS\Core\Data\Payment\PaymentCreationResult;
-use OpenKOS\Core\Data\Payment\PaymentRequest;
-use OpenKOS\Core\Data\Payment\PaymentWebhookRequest;
-use OpenKOS\Core\Data\Payment\PaymentWebhookResult;
-use OpenKOS\Core\Enums\PaymentStatus;
 use OpenKOS\Platform\Payment\PaymentRegistry;
+use Tests\Support\Fakes\BillingTestPaymentGateway;
 
 uses()->beforeEach(function () {
     $this->seed(RoleAndPermissionSeeder::class);
@@ -183,57 +177,3 @@ it('forbids tenant-linked users from viewing and updating Billing settings', fun
         ])
         ->assertForbidden();
 });
-
-class BillingTestPaymentGateway implements PaymentGateway
-{
-    public function __construct(public array $config = []) {}
-
-    public function key(): string
-    {
-        return 'test/billing';
-    }
-
-    public function displayName(): string
-    {
-        return 'Billing Test Gateway';
-    }
-
-    public function createPayment(PaymentRequest $request): PaymentCreationResult
-    {
-        return new PaymentCreationResult(
-            providerReference: 'provider-reference',
-            status: PaymentStatus::Pending,
-            amount: $request->amount,
-            instructions: new CheckoutInstructions,
-        );
-    }
-
-    public function handleCallback(PaymentWebhookRequest $request): PaymentWebhookResult
-    {
-        return new PaymentWebhookResult(
-            eventReference: 'event-reference',
-            providerReference: 'provider-reference',
-            status: PaymentStatus::Pending,
-        );
-    }
-
-    public function configurationSchema(): array
-    {
-        return [
-            'environment' => [
-                'label' => 'Environment',
-                'type' => 'select',
-                'required' => true,
-                'options' => [
-                    ['value' => 'sandbox', 'label' => 'Sandbox'],
-                    ['value' => 'production', 'label' => 'Production'],
-                ],
-            ],
-            'secret_key' => [
-                'label' => 'Secret key',
-                'type' => 'password',
-                'required' => true,
-            ],
-        ];
-    }
-}

--- a/tests/Support/Fakes/BillingTestPaymentGateway.php
+++ b/tests/Support/Fakes/BillingTestPaymentGateway.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Support\Fakes;
+
+use OpenKOS\Core\Contracts\PaymentGateway;
+use OpenKOS\Core\Data\Payment\CheckoutInstructions;
+use OpenKOS\Core\Data\Payment\PaymentCreationResult;
+use OpenKOS\Core\Data\Payment\PaymentRequest;
+use OpenKOS\Core\Data\Payment\PaymentWebhookRequest;
+use OpenKOS\Core\Data\Payment\PaymentWebhookResult;
+use OpenKOS\Core\Enums\PaymentStatus;
+
+class BillingTestPaymentGateway implements PaymentGateway
+{
+    public function __construct(public array $config = []) {}
+
+    public function key(): string
+    {
+        return 'test/billing';
+    }
+
+    public function displayName(): string
+    {
+        return 'Billing Test Gateway';
+    }
+
+    public function createPayment(PaymentRequest $request): PaymentCreationResult
+    {
+        return new PaymentCreationResult(
+            providerReference: 'provider-reference',
+            status: PaymentStatus::Pending,
+            amount: $request->amount,
+            instructions: new CheckoutInstructions,
+        );
+    }
+
+    public function handleCallback(PaymentWebhookRequest $request): PaymentWebhookResult
+    {
+        return new PaymentWebhookResult(
+            eventReference: 'event-reference',
+            providerReference: 'provider-reference',
+            status: PaymentStatus::Pending,
+        );
+    }
+
+    public function configurationSchema(): array
+    {
+        return [
+            'environment' => [
+                'label' => 'Environment',
+                'type' => 'select',
+                'required' => true,
+                'options' => [
+                    ['value' => 'sandbox', 'label' => 'Sandbox'],
+                    ['value' => 'production', 'label' => 'Production'],
+                ],
+            ],
+            'secret_key' => [
+                'label' => 'Secret key',
+                'type' => 'password',
+                'required' => true,
+            ],
+        ];
+    }
+}

--- a/tests/Support/Fakes/BrokenManagerTestPaymentGateway.php
+++ b/tests/Support/Fakes/BrokenManagerTestPaymentGateway.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Support\Fakes;
+
+use OpenKOS\Core\Contracts\PaymentGateway;
+use OpenKOS\Core\Data\Payment\PaymentCreationResult;
+use OpenKOS\Core\Data\Payment\PaymentRequest;
+use OpenKOS\Core\Data\Payment\PaymentWebhookRequest;
+use OpenKOS\Core\Data\Payment\PaymentWebhookResult;
+use RuntimeException;
+
+class BrokenManagerTestPaymentGateway implements PaymentGateway
+{
+    public function __construct()
+    {
+        throw new RuntimeException('broken gateway');
+    }
+
+    public function key(): string
+    {
+        return 'broken/gateway';
+    }
+
+    public function displayName(): string
+    {
+        return 'Broken Gateway';
+    }
+
+    public function createPayment(PaymentRequest $request): PaymentCreationResult
+    {
+        throw new RuntimeException('broken gateway');
+    }
+
+    public function handleCallback(PaymentWebhookRequest $request): PaymentWebhookResult
+    {
+        throw new RuntimeException('broken gateway');
+    }
+
+    public function configurationSchema(): array
+    {
+        return [];
+    }
+}

--- a/tests/Support/Fakes/MailManagerConfigProbeDriver.php
+++ b/tests/Support/Fakes/MailManagerConfigProbeDriver.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Support\Fakes;
+
+use OpenKOS\Core\Contracts\MailDriver;
+use OpenKOS\Core\Data\Mail\DriverHealthResult;
+use OpenKOS\Core\Data\Mail\MailMessage;
+use OpenKOS\Core\Data\Mail\MailSendResult;
+
+class MailManagerConfigProbeDriver implements MailDriver
+{
+    public static array $configs = [];
+
+    public function __construct(private array $config = [])
+    {
+        self::$configs[] = $config;
+    }
+
+    public function send(MailMessage $message): MailSendResult
+    {
+        return new MailSendResult;
+    }
+
+    public function health(): DriverHealthResult
+    {
+        return new DriverHealthResult(true);
+    }
+}

--- a/tests/Support/Fakes/ManagerTestPaymentGateway.php
+++ b/tests/Support/Fakes/ManagerTestPaymentGateway.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Support\Fakes;
+
+use OpenKOS\Core\Contracts\PaymentGateway;
+use OpenKOS\Core\Data\Payment\CheckoutInstructions;
+use OpenKOS\Core\Data\Payment\PaymentCreationResult;
+use OpenKOS\Core\Data\Payment\PaymentRequest;
+use OpenKOS\Core\Data\Payment\PaymentWebhookRequest;
+use OpenKOS\Core\Data\Payment\PaymentWebhookResult;
+use OpenKOS\Core\Enums\PaymentStatus;
+
+class ManagerTestPaymentGateway implements PaymentGateway
+{
+    public function __construct(public array $config = []) {}
+
+    public function key(): string
+    {
+        return 'test/gateway';
+    }
+
+    public function displayName(): string
+    {
+        return 'Test Gateway';
+    }
+
+    public function createPayment(PaymentRequest $request): PaymentCreationResult
+    {
+        return new PaymentCreationResult(
+            providerReference: 'provider-reference',
+            status: PaymentStatus::Pending,
+            amount: $request->amount,
+            instructions: new CheckoutInstructions,
+        );
+    }
+
+    public function handleCallback(PaymentWebhookRequest $request): PaymentWebhookResult
+    {
+        return new PaymentWebhookResult(
+            eventReference: 'event-reference',
+            providerReference: 'provider-reference',
+            status: PaymentStatus::Pending,
+        );
+    }
+
+    public function configurationSchema(): array
+    {
+        return [
+            'environment' => [
+                'label' => 'Environment',
+                'type' => 'select',
+                'required' => true,
+                'presentation' => 'segmented',
+                'default' => 'sandbox',
+                'options' => [
+                    ['value' => 'sandbox', 'label' => 'Sandbox'],
+                    ['value' => 'production', 'label' => 'Production'],
+                ],
+            ],
+            'webhook_setup' => [
+                'label' => 'Webhook setup',
+                'type' => 'info',
+                'instructions' => [
+                    'Open the webhook settings.',
+                    'Add the webhook URL shown below.',
+                ],
+                'link' => [
+                    'label' => 'Open webhook settings',
+                    'url' => 'https://example.test/webhooks',
+                ],
+                'url' => '/api/webhooks/test',
+            ],
+            'secret_key' => [
+                'label' => 'Secret key',
+                'type' => 'password',
+                'required' => true,
+                'description' => 'Keep this value secret.',
+                'visible_when' => [
+                    'field' => 'environment',
+                    'value' => 'sandbox',
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/Support/Fakes/MismatchedManagerTestPaymentGateway.php
+++ b/tests/Support/Fakes/MismatchedManagerTestPaymentGateway.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tests\Support\Fakes;
+
+class MismatchedManagerTestPaymentGateway extends ManagerTestPaymentGateway
+{
+    public function key(): string
+    {
+        return 'provider/gateway';
+    }
+}

--- a/tests/Support/Fakes/TestWhatsAppDriver.php
+++ b/tests/Support/Fakes/TestWhatsAppDriver.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Support\Fakes;
+
+use OpenKOS\Core\Contracts\WhatsAppDriver;
+use OpenKOS\Core\Data\WhatsApp\DriverHealthResult;
+use OpenKOS\Core\Data\WhatsApp\WhatsAppMessage;
+
+class TestWhatsAppDriver implements WhatsAppDriver
+{
+    public static array $sentMessages = [];
+
+    public function __construct(private array $config = []) {}
+
+    public function send(WhatsAppMessage $message): void
+    {
+        self::$sentMessages[] = $message->phone;
+    }
+
+    public function supportsAttachments(): bool
+    {
+        return true;
+    }
+
+    public function health(): DriverHealthResult
+    {
+        return new DriverHealthResult(true);
+    }
+
+    public function supportsPairing(): bool
+    {
+        return false;
+    }
+
+    public function configurationSchema(): array
+    {
+        return [];
+    }
+
+    public function getPairingQrCode(): ?string
+    {
+        return null;
+    }
+
+    public function pair(): void {}
+
+    public function disconnect(): void {}
+}

--- a/tests/Support/Fakes/UnitTestFailingWhatsAppDriver.php
+++ b/tests/Support/Fakes/UnitTestFailingWhatsAppDriver.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Support\Fakes;
+
+use OpenKOS\Core\Contracts\WhatsAppDriver;
+use OpenKOS\Core\Data\WhatsApp\DriverHealthResult;
+use OpenKOS\Core\Data\WhatsApp\WhatsAppMessage;
+use RuntimeException;
+
+class UnitTestFailingWhatsAppDriver implements WhatsAppDriver
+{
+    public function __construct(public array $config = []) {}
+
+    public function send(WhatsAppMessage $message): void
+    {
+        throw new RuntimeException('Network connection failed');
+    }
+
+    public function supportsAttachments(): bool
+    {
+        return true;
+    }
+
+    public function health(): DriverHealthResult
+    {
+        return new DriverHealthResult(false, 'Unhealthy');
+    }
+
+    public function supportsPairing(): bool
+    {
+        return false;
+    }
+
+    public function configurationSchema(): array
+    {
+        return [];
+    }
+
+    public function getPairingQrCode(): ?string
+    {
+        return null;
+    }
+
+    public function pair(): void {}
+
+    public function disconnect(): void {}
+}

--- a/tests/Support/Fakes/UnitTestUnsupportedWhatsAppDriver.php
+++ b/tests/Support/Fakes/UnitTestUnsupportedWhatsAppDriver.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Support\Fakes;
+
+use OpenKOS\Core\Contracts\WhatsAppDriver;
+use OpenKOS\Core\Data\WhatsApp\DriverHealthResult;
+use OpenKOS\Core\Data\WhatsApp\WhatsAppMessage;
+
+class UnitTestUnsupportedWhatsAppDriver implements WhatsAppDriver
+{
+    public function __construct(public array $config = []) {}
+
+    public function send(WhatsAppMessage $message): void {}
+
+    public function supportsAttachments(): bool
+    {
+        return false;
+    }
+
+    public function health(): DriverHealthResult
+    {
+        return new DriverHealthResult(true);
+    }
+
+    public function supportsPairing(): bool
+    {
+        return false;
+    }
+
+    public function configurationSchema(): array
+    {
+        return [];
+    }
+
+    public function getPairingQrCode(): ?string
+    {
+        return null;
+    }
+
+    public function pair(): void {}
+
+    public function disconnect(): void {}
+}

--- a/tests/Support/Fakes/UnitTestWhatsAppDriver.php
+++ b/tests/Support/Fakes/UnitTestWhatsAppDriver.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Support\Fakes;
+
+use OpenKOS\Core\Contracts\WhatsAppDriver;
+use OpenKOS\Core\Data\WhatsApp\DriverHealthResult;
+use OpenKOS\Core\Data\WhatsApp\WhatsAppMessage;
+
+class UnitTestWhatsAppDriver implements WhatsAppDriver
+{
+    public static ?WhatsAppMessage $lastMessage = null;
+
+    public function __construct(public array $config = []) {}
+
+    public function send(WhatsAppMessage $message): void
+    {
+        self::$lastMessage = $message;
+    }
+
+    public function supportsAttachments(): bool
+    {
+        return true;
+    }
+
+    public function health(): DriverHealthResult
+    {
+        return new DriverHealthResult(true, 'Healthy');
+    }
+
+    public function supportsPairing(): bool
+    {
+        return false;
+    }
+
+    public function configurationSchema(): array
+    {
+        return [];
+    }
+
+    public function getPairingQrCode(): ?string
+    {
+        return null;
+    }
+
+    public function pair(): void {}
+
+    public function disconnect(): void {}
+}

--- a/tests/Support/Fixtures/ComposerDiscoveryFixturePlugin.php
+++ b/tests/Support/Fixtures/ComposerDiscoveryFixturePlugin.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Support\Fixtures;
+
+use OpenKOS\Platform\OpenKOSManager;
+use OpenKOS\Platform\Plugin\Plugin;
+use OpenKOS\Platform\Plugin\PluginManifest;
+
+class ComposerDiscoveryFixturePlugin extends Plugin
+{
+    public static int $registerCalls = 0;
+
+    public function manifest(): PluginManifest
+    {
+        return new PluginManifest(
+            id: 'fixture/composer-plugin',
+            name: 'Composer Fixture',
+            version: '1.0.0',
+        );
+    }
+
+    public function register(OpenKOSManager $platform): void
+    {
+        self::$registerCalls++;
+    }
+}

--- a/tests/Support/Fixtures/ComposerDiscoverySecondFixturePlugin.php
+++ b/tests/Support/Fixtures/ComposerDiscoverySecondFixturePlugin.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Support\Fixtures;
+
+use OpenKOS\Platform\OpenKOSManager;
+use OpenKOS\Platform\Plugin\Plugin;
+use OpenKOS\Platform\Plugin\PluginManifest;
+
+class ComposerDiscoverySecondFixturePlugin extends Plugin
+{
+    public function manifest(): PluginManifest
+    {
+        return new PluginManifest(
+            id: 'fixture/composer-plugin-second',
+            name: 'Composer Second Fixture',
+            version: '1.0.0',
+        );
+    }
+
+    public function register(OpenKOSManager $platform): void {}
+}

--- a/tests/Support/Fixtures/EventProbePlugin.php
+++ b/tests/Support/Fixtures/EventProbePlugin.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Support\Fixtures;
+
+use OpenKOS\Core\Events\PaymentRecorded;
+use OpenKOS\Platform\OpenKOSManager;
+use OpenKOS\Platform\Plugin\Plugin;
+use OpenKOS\Platform\Plugin\PluginManifest;
+
+class EventProbePlugin extends Plugin
+{
+    public static bool $fired = false;
+
+    public function manifest(): PluginManifest
+    {
+        return new PluginManifest(id: 'test/event', name: 'Event', version: '1.0.0');
+    }
+
+    public function register(OpenKOSManager $platform): void {}
+
+    public function listens(): array
+    {
+        return [
+            PaymentRecorded::class => fn (PaymentRecorded $event) => static::$fired = true,
+        ];
+    }
+}

--- a/tests/Support/Fixtures/OrderProbePluginA.php
+++ b/tests/Support/Fixtures/OrderProbePluginA.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Support\Fixtures;
+
+use OpenKOS\Platform\OpenKOSManager;
+use OpenKOS\Platform\Plugin\Plugin;
+use OpenKOS\Platform\Plugin\PluginManifest;
+
+class OrderProbePluginA extends Plugin
+{
+    public static array $calls = [];
+
+    public function manifest(): PluginManifest
+    {
+        return new PluginManifest(id: 'test/a', name: 'A', version: '1.0.0');
+    }
+
+    public function register(OpenKOSManager $platform): void
+    {
+        static::$calls[] = 'register:a';
+    }
+
+    public function boot(OpenKOSManager $platform): void
+    {
+        static::$calls[] = 'boot:a';
+    }
+}

--- a/tests/Support/Fixtures/OrderProbePluginB.php
+++ b/tests/Support/Fixtures/OrderProbePluginB.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Support\Fixtures;
+
+use OpenKOS\Platform\OpenKOSManager;
+use OpenKOS\Platform\Plugin\Plugin;
+use OpenKOS\Platform\Plugin\PluginManifest;
+
+class OrderProbePluginB extends Plugin
+{
+    public function manifest(): PluginManifest
+    {
+        return new PluginManifest(id: 'test/b', name: 'B', version: '1.0.0');
+    }
+
+    public function register(OpenKOSManager $platform): void
+    {
+        OrderProbePluginA::$calls[] = 'register:b';
+    }
+
+    public function boot(OpenKOSManager $platform): void
+    {
+        OrderProbePluginA::$calls[] = 'boot:b';
+    }
+}

--- a/tests/Support/Fixtures/PackageUninstallEvent.php
+++ b/tests/Support/Fixtures/PackageUninstallEvent.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Support\Fixtures;
+
+final class PackageUninstallEvent
+{
+    public function __construct(private readonly array $extra = []) {}
+
+    public function getOperation(): object
+    {
+        return new class($this->extra)
+        {
+            public function __construct(private readonly array $extra) {}
+
+            public function getPackage(): object
+            {
+                return new class($this->extra)
+                {
+                    public function __construct(private readonly array $extra) {}
+
+                    public function getName(): string
+                    {
+                        return 'vendor/payment-package';
+                    }
+
+                    public function getExtra(): array
+                    {
+                        return $this->extra;
+                    }
+                };
+            }
+        };
+    }
+}

--- a/tests/Unit/Services/MailManagerTest.php
+++ b/tests/Unit/Services/MailManagerTest.php
@@ -9,36 +9,14 @@ use App\Notifications\Drivers\SmtpMailDriver;
 use App\Services\MailManager;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
-use OpenKOS\Core\Contracts\MailDriver;
-use OpenKOS\Core\Data\Mail\DriverHealthResult;
 use OpenKOS\Core\Data\Mail\MailAddress;
 use OpenKOS\Core\Data\Mail\MailMessage;
-use OpenKOS\Core\Data\Mail\MailSendResult;
 use OpenKOS\Platform\Notification\NotificationDriverRegistration;
 use OpenKOS\Platform\Notification\NotificationRegistry;
+use Tests\Support\Fakes\MailManagerConfigProbeDriver;
 use Tests\TestCase;
 
 uses(TestCase::class, RefreshDatabase::class);
-
-class MailManagerConfigProbeDriver implements MailDriver
-{
-    public static array $configs = [];
-
-    public function __construct(private array $config = [])
-    {
-        self::$configs[] = $config;
-    }
-
-    public function send(MailMessage $message): MailSendResult
-    {
-        return new MailSendResult;
-    }
-
-    public function health(): DriverHealthResult
-    {
-        return new DriverHealthResult(true);
-    }
-}
 
 function registerMailManagerConfigProbe(array $config = []): void
 {

--- a/tests/Unit/Services/PaymentGatewayManagerTest.php
+++ b/tests/Unit/Services/PaymentGatewayManagerTest.php
@@ -2,15 +2,11 @@
 
 use App\Services\Payments\PaymentGatewayManager;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use OpenKOS\Core\Contracts\PaymentGateway;
-use OpenKOS\Core\Data\Payment\CheckoutInstructions;
-use OpenKOS\Core\Data\Payment\PaymentCreationResult;
-use OpenKOS\Core\Data\Payment\PaymentRequest;
-use OpenKOS\Core\Data\Payment\PaymentWebhookRequest;
-use OpenKOS\Core\Data\Payment\PaymentWebhookResult;
-use OpenKOS\Core\Enums\PaymentStatus;
 use OpenKOS\Platform\Payment\PaymentRegistry;
 use OpenKOS\Platform\Settings\SettingsManager;
+use Tests\Support\Fakes\BrokenManagerTestPaymentGateway;
+use Tests\Support\Fakes\ManagerTestPaymentGateway;
+use Tests\Support\Fakes\MismatchedManagerTestPaymentGateway;
 use Tests\TestCase;
 
 uses(TestCase::class, RefreshDatabase::class);
@@ -97,118 +93,3 @@ it('rejects gateways whose contract key differs from the registry key', function
     expect($gateway->find('registry/gateway'))->toBeNull()
         ->and($gateway->all()[0]['status'])->toBe('unavailable');
 });
-
-class ManagerTestPaymentGateway implements PaymentGateway
-{
-    public function __construct(public array $config = []) {}
-
-    public function key(): string
-    {
-        return 'test/gateway';
-    }
-
-    public function displayName(): string
-    {
-        return 'Test Gateway';
-    }
-
-    public function createPayment(PaymentRequest $request): PaymentCreationResult
-    {
-        return new PaymentCreationResult(
-            providerReference: 'provider-reference',
-            status: PaymentStatus::Pending,
-            amount: $request->amount,
-            instructions: new CheckoutInstructions,
-        );
-    }
-
-    public function handleCallback(PaymentWebhookRequest $request): PaymentWebhookResult
-    {
-        return new PaymentWebhookResult(
-            eventReference: 'event-reference',
-            providerReference: 'provider-reference',
-            status: PaymentStatus::Pending,
-        );
-    }
-
-    public function configurationSchema(): array
-    {
-        return [
-            'environment' => [
-                'label' => 'Environment',
-                'type' => 'select',
-                'required' => true,
-                'presentation' => 'segmented',
-                'default' => 'sandbox',
-                'options' => [
-                    ['value' => 'sandbox', 'label' => 'Sandbox'],
-                    ['value' => 'production', 'label' => 'Production'],
-                ],
-            ],
-            'webhook_setup' => [
-                'label' => 'Webhook setup',
-                'type' => 'info',
-                'instructions' => [
-                    'Open the webhook settings.',
-                    'Add the webhook URL shown below.',
-                ],
-                'link' => [
-                    'label' => 'Open webhook settings',
-                    'url' => 'https://example.test/webhooks',
-                ],
-                'url' => '/api/webhooks/test',
-            ],
-            'secret_key' => [
-                'label' => 'Secret key',
-                'type' => 'password',
-                'required' => true,
-                'description' => 'Keep this value secret.',
-                'visible_when' => [
-                    'field' => 'environment',
-                    'value' => 'sandbox',
-                ],
-            ],
-        ];
-    }
-}
-
-class BrokenManagerTestPaymentGateway implements PaymentGateway
-{
-    public function __construct()
-    {
-        throw new RuntimeException('broken gateway');
-    }
-
-    public function key(): string
-    {
-        return 'broken/gateway';
-    }
-
-    public function displayName(): string
-    {
-        return 'Broken Gateway';
-    }
-
-    public function createPayment(PaymentRequest $request): PaymentCreationResult
-    {
-        throw new RuntimeException('broken gateway');
-    }
-
-    public function handleCallback(PaymentWebhookRequest $request): PaymentWebhookResult
-    {
-        throw new RuntimeException('broken gateway');
-    }
-
-    public function configurationSchema(): array
-    {
-        return [];
-    }
-}
-
-class MismatchedManagerTestPaymentGateway extends ManagerTestPaymentGateway
-{
-    public function key(): string
-    {
-        return 'provider/gateway';
-    }
-}

--- a/tests/Unit/Services/WhatsAppManagerTest.php
+++ b/tests/Unit/Services/WhatsAppManagerTest.php
@@ -8,13 +8,13 @@ use App\Models\Setting;
 use App\Services\WhatsAppManager;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
-use OpenKOS\Core\Contracts\WhatsAppDriver;
-use OpenKOS\Core\Data\WhatsApp\DriverHealthResult;
 use OpenKOS\Core\Data\WhatsApp\WhatsAppAttachment;
 use OpenKOS\Core\Data\WhatsApp\WhatsAppContent;
-use OpenKOS\Core\Data\WhatsApp\WhatsAppMessage;
 use OpenKOS\Platform\Notification\NotificationDriverRegistration;
 use OpenKOS\Platform\Notification\NotificationRegistry;
+use Tests\Support\Fakes\UnitTestFailingWhatsAppDriver;
+use Tests\Support\Fakes\UnitTestUnsupportedWhatsAppDriver;
+use Tests\Support\Fakes\UnitTestWhatsAppDriver;
 use Tests\TestCase;
 
 uses(TestCase::class, RefreshDatabase::class);
@@ -120,119 +120,3 @@ describe('WhatsAppManager', function () {
         });
     });
 });
-
-class UnitTestWhatsAppDriver implements WhatsAppDriver
-{
-    public static ?WhatsAppMessage $lastMessage = null;
-
-    public function __construct(public array $config = []) {}
-
-    public function send(WhatsAppMessage $message): void
-    {
-        self::$lastMessage = $message;
-    }
-
-    public function supportsAttachments(): bool
-    {
-        return true;
-    }
-
-    public function health(): DriverHealthResult
-    {
-        return new DriverHealthResult(true, 'Healthy');
-    }
-
-    public function supportsPairing(): bool
-    {
-        return false;
-    }
-
-    public function configurationSchema(): array
-    {
-        return [];
-    }
-
-    public function getPairingQrCode(): ?string
-    {
-        return null;
-    }
-
-    public function pair(): void {}
-
-    public function disconnect(): void {}
-}
-
-class UnitTestFailingWhatsAppDriver implements WhatsAppDriver
-{
-    public function __construct(public array $config = []) {}
-
-    public function send(WhatsAppMessage $message): void
-    {
-        throw new RuntimeException('Network connection failed');
-    }
-
-    public function supportsAttachments(): bool
-    {
-        return true;
-    }
-
-    public function health(): DriverHealthResult
-    {
-        return new DriverHealthResult(false, 'Unhealthy');
-    }
-
-    public function supportsPairing(): bool
-    {
-        return false;
-    }
-
-    public function configurationSchema(): array
-    {
-        return [];
-    }
-
-    public function getPairingQrCode(): ?string
-    {
-        return null;
-    }
-
-    public function pair(): void {}
-
-    public function disconnect(): void {}
-}
-
-class UnitTestUnsupportedWhatsAppDriver implements WhatsAppDriver
-{
-    public function __construct(public array $config = []) {}
-
-    public function send(WhatsAppMessage $message): void {}
-
-    public function supportsAttachments(): bool
-    {
-        return false;
-    }
-
-    public function health(): DriverHealthResult
-    {
-        return new DriverHealthResult(true);
-    }
-
-    public function supportsPairing(): bool
-    {
-        return false;
-    }
-
-    public function configurationSchema(): array
-    {
-        return [];
-    }
-
-    public function getPairingQrCode(): ?string
-    {
-        return null;
-    }
-
-    public function pair(): void {}
-
-    public function disconnect(): void {}
-}


### PR DESCRIPTION
## Summary

- move 15 named test doubles and fixtures into PSR-4-compliant test support files
- update the nine affected Pest tests without changing production code or dependencies

## Verification

- `composer dump-autoload --optimize`
- focused OPE-141 suite: 49 tests, 126 assertions
- `vendor/bin/pint --dirty --format agent`
- PHP lint for all new support classes

Linear: OPE-141