### PR TITLE
fix(leases): scope rates to unit

### DIFF
--- a/app/Actions/Leases/CreateLease.php
+++ b/app/Actions/Leases/CreateLease.php
@@ -11,7 +11,6 @@ use App\Enums\UnitStatus;
 use App\Models\Lease;
 use App\Models\Tenant;
 use App\Models\Unit;
-use App\Models\UnitRate;
 use Illuminate\Support\Facades\DB;
 
 class CreateLease
@@ -28,6 +27,16 @@ class CreateLease
 
         return DB::transaction(function () use ($unit, $data, $tenantIds) {
             $unit = Unit::lockForUpdate()->findOrFail($unit->id);
+            $unitRate = $data->unitRateId === null
+                ? null
+                : $unit->rates()->find($data->unitRateId);
+
+            abort_if(
+                $data->unitRateId !== null && $unitRate === null,
+                422,
+                __('The selected rate does not belong to this unit.'),
+            );
+
             Tenant::query()->whereKey($tenantIds)->lockForUpdate()->get();
 
             abort_if(in_array($unit->status, [UnitStatus::Maintenance, UnitStatus::Unavailable], true), 422, __('This unit is not available for lease.'));
@@ -56,7 +65,6 @@ class CreateLease
 
             $this->ensureTenantsDoNotHaveActiveLease($tenantIds);
 
-            $unitRate = $data->unitRateId ? UnitRate::find($data->unitRateId) : null;
             $rentAmount = $data->rentAmount ?? $unitRate?->amount ?? $unit->rates()->where('billing_unit', 'month')->where('billing_interval', 1)->value('amount');
             $isCustomPrice = $data->rentAmount !== null && $unitRate && (float) $data->rentAmount !== (float) $unitRate->amount;
 

--- a/app/Http/Requests/Lease/StoreLeaseRequest.php
+++ b/app/Http/Requests/Lease/StoreLeaseRequest.php
@@ -24,7 +24,11 @@ class StoreLeaseRequest extends FormRequest
             'billing_interval' => ['nullable', 'integer', 'min:1', 'max:255'],
             'billing_unit' => ['nullable', 'string', Rule::in(BillingUnit::values())],
             'billing_strategy' => ['nullable', 'string', Rule::in(BillingStrategy::values())],
-            'unit_rate_id' => ['nullable', 'integer', 'exists:unit_rates,id'],
+            'unit_rate_id' => [
+                'nullable',
+                'integer',
+                Rule::exists('unit_rates', 'id')->where('unit_id', $this->route('unit')->id),
+            ],
             'deposit_amount' => ['nullable', 'numeric', 'min:0'],
             'deposit_paid_at' => ['nullable', 'date'],
             'deposit_refund_amount' => ['nullable', 'numeric', 'min:0'],

--- a/app/Http/Requests/Tenant/AssignUnitRequest.php
+++ b/app/Http/Requests/Tenant/AssignUnitRequest.php
@@ -25,7 +25,11 @@ class AssignUnitRequest extends FormRequest
             'billing_interval' => ['nullable', 'integer', 'min:1', 'max:255'],
             'billing_unit' => ['nullable', 'string', Rule::in(BillingUnit::values())],
             'billing_strategy' => ['nullable', 'string', Rule::in(BillingStrategy::values())],
-            'unit_rate_id' => ['nullable', 'integer', 'exists:unit_rates,id'],
+            'unit_rate_id' => [
+                'nullable',
+                'integer',
+                Rule::exists('unit_rates', 'id')->where('unit_id', $this->input('unit_id')),
+            ],
             'deposit_amount' => ['nullable', 'numeric', 'min:0'],
             'deposit_paid_at' => ['nullable', 'date'],
             'rent_due_day' => ['nullable', 'integer', 'between:1,31'],

--- a/tests/Feature/LeaseTest.php
+++ b/tests/Feature/LeaseTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Actions\Leases\CreateLease;
+use App\Data\Lease\CreateLeaseData;
 use App\Enums\LeaseStatus;
 use App\Models\Lease;
 use App\Models\Property;
@@ -8,6 +10,7 @@ use App\Models\Unit;
 use App\Models\User;
 use Database\Seeders\RegionAndCitySeeder;
 use Database\Seeders\RoleAndPermissionSeeder;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 uses()->beforeEach(function () {
     $this->seed(RoleAndPermissionSeeder::class);
@@ -135,6 +138,93 @@ describe('CRUD', function () {
         $lease = Lease::first();
 
         expect($lease->rent_amount)->toBe($unit->rates()->where('billing_unit', 'month')->where('billing_interval', 1)->value('amount'));
+    });
+
+    it('uses the selected unit rate when creating a lease', function () {
+        [$property, $unit] = createPropertyWithUnit();
+        $user = User::factory()->owner()->create();
+        $tenant = Tenant::factory()->create();
+        $rate = $unit->rates()->firstOrFail();
+
+        $this->actingAs($user)
+            ->post(route('properties.units.leases.store', [$property, $unit]), [
+                'tenant_ids' => [$tenant->id],
+                'start_date' => '2026-06-01',
+                'unit_rate_id' => $rate->id,
+            ])
+            ->assertRedirect();
+
+        $lease = Lease::firstOrFail();
+
+        expect($lease->unit_rate_id)->toBe($rate->id)
+            ->and($lease->rent_amount)->toBe($rate->amount);
+    });
+
+    it('rejects a rate from another unit when creating a lease', function () {
+        [$property, $unit] = createPropertyWithUnit();
+        $otherUnit = Unit::factory()->withRate(1_250_000)->create([
+            'property_id' => $property->id,
+        ]);
+        $user = User::factory()->owner()->create();
+        $tenant = Tenant::factory()->create();
+
+        $this->actingAs($user)
+            ->post(route('properties.units.leases.store', [$property, $unit]), [
+                'tenant_ids' => [$tenant->id],
+                'start_date' => '2026-06-01',
+                'unit_rate_id' => $otherUnit->rates()->firstOrFail()->id,
+            ])
+            ->assertSessionHasErrors('unit_rate_id');
+
+        expect(Lease::query()->exists())->toBeFalse();
+    });
+
+    it('rejects a stale rate when creating a lease', function () {
+        [$property, $unit] = createPropertyWithUnit();
+        $user = User::factory()->owner()->create();
+        $tenant = Tenant::factory()->create();
+
+        $this->actingAs($user)
+            ->post(route('properties.units.leases.store', [$property, $unit]), [
+                'tenant_ids' => [$tenant->id],
+                'start_date' => '2026-06-01',
+                'unit_rate_id' => $unit->rates()->max('id') + 1,
+            ])
+            ->assertSessionHasErrors('unit_rate_id');
+
+        expect(Lease::query()->exists())->toBeFalse();
+    });
+
+    it('rejects invalid rates in the lease creation action', function () {
+        [, $unit] = createPropertyWithUnit();
+        $otherUnit = Unit::factory()->withRate(1_250_000)->create();
+        $tenant = Tenant::factory()->create();
+
+        foreach ([$otherUnit->rates()->firstOrFail()->id, $unit->rates()->max('id') + 1] as $unitRateId) {
+            $data = new CreateLeaseData(
+                tenantIds: [$tenant->id],
+                startDate: '2026-06-01',
+                endDate: null,
+                rentAmount: null,
+                billingInterval: null,
+                billingUnit: null,
+                billingStrategy: null,
+                unitRateId: $unitRateId,
+                depositAmount: null,
+                depositPaidAt: null,
+                depositRefundAmount: null,
+                depositRefundedAt: null,
+                rentDueDay: null,
+                notes: null,
+            );
+
+            $this->assertThrows(
+                fn () => app(CreateLease::class)->execute($unit, $data),
+                fn (HttpException $exception): bool => $exception->getStatusCode() === 422,
+            );
+        }
+
+        expect(Lease::query()->exists())->toBeFalse();
     });
 
     it('validates required fields on create', function () {

--- a/tests/Feature/TenantTest.php
+++ b/tests/Feature/TenantTest.php
@@ -326,4 +326,37 @@ describe('unit assignment pricing', function () {
             ->and((float) $lease->rent_amount)->toBe(1_750_000.0)
             ->and($lease->is_custom_price)->toBeFalse();
     });
+
+    it('rejects a rate from another unit during assignment', function () {
+        $user = User::factory()->owner()->create();
+        $tenant = Tenant::factory()->create();
+        $unit = Unit::factory()->create();
+        $otherUnit = Unit::factory()->withRate(1_750_000)->create();
+
+        $this->actingAs($user)
+            ->post(route('tenants.assign-unit', $tenant), [
+                'unit_id' => $unit->id,
+                'unit_rate_id' => $otherUnit->rates()->firstOrFail()->id,
+                'start_date' => '2026-06-01',
+            ])
+            ->assertSessionHasErrors('unit_rate_id');
+
+        expect(Lease::query()->exists())->toBeFalse();
+    });
+
+    it('rejects a stale rate during assignment', function () {
+        $user = User::factory()->owner()->create();
+        $tenant = Tenant::factory()->create();
+        $unit = Unit::factory()->create();
+
+        $this->actingAs($user)
+            ->post(route('tenants.assign-unit', $tenant), [
+                'unit_id' => $unit->id,
+                'unit_rate_id' => $unit->rates()->max('id') + 1,
+                'start_date' => '2026-06-01',
+            ])
+            ->assertSessionHasErrors('unit_rate_id');
+
+        expect(Lease::query()->exists())->toBeFalse();
+    });
 });


### PR DESCRIPTION
## Summary

- scope lease-create and tenant-assignment rate validation to the selected unit
- enforce the same invariant through the locked unit in `CreateLease`
- reject cross-unit and stale rate IDs with validation-style 422 responses
- add valid, invalid, and direct-action regression coverage

## Verification

- `php artisan test --compact tests/Feature/LeaseTest.php`
- `php artisan test --compact tests/Feature/TenantTest.php`
- `vendor/bin/pint --dirty --format agent`
- `git diff --check`

Related: OPE-144