### PR TITLE
feat(dates): serialize model dates with timezone

### DIFF
--- a/app/Concerns/SerializesDatesWithTimezone.php
+++ b/app/Concerns/SerializesDatesWithTimezone.php
@@ -2,22 +2,13 @@
 
 namespace App\Concerns;
 
-use Carbon\Carbon;
+use App\Support\DateTimeFormatter;
 use DateTimeInterface;
-use Exception;
 
 trait SerializesDatesWithTimezone
 {
     protected function serializeDate(DateTimeInterface $date): string
     {
-        try {
-            return Carbon::instance($date)
-                ->setTimezone(config('app.display_timezone', 'UTC'))
-                ->toISOString(true);
-        } catch (Exception) {
-            return Carbon::instance($date)
-                ->setTimezone('UTC')
-                ->toISOString(true);
-        }
+        return DateTimeFormatter::iso($date);
     }
 }

--- a/app/Concerns/SerializesDatesWithTimezone.php
+++ b/app/Concerns/SerializesDatesWithTimezone.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Concerns;
+
+use Carbon\Carbon;
+use DateTimeInterface;
+use Exception;
+
+trait SerializesDatesWithTimezone
+{
+    protected function serializeDate(DateTimeInterface $date): string
+    {
+        try {
+            return Carbon::instance($date)
+                ->setTimezone(config('app.display_timezone', 'UTC'))
+                ->toISOString(true);
+        } catch (Exception) {
+            return Carbon::instance($date)
+                ->setTimezone('UTC')
+                ->toISOString(true);
+        }
+    }
+}

--- a/app/Http/Controllers/Dashboard/OverviewController.php
+++ b/app/Http/Controllers/Dashboard/OverviewController.php
@@ -19,6 +19,7 @@ use App\Models\PropertyType;
 use App\Models\Region;
 use App\Models\Setting;
 use App\Models\Unit;
+use App\Support\DateTimeFormatter;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
@@ -139,7 +140,7 @@ class OverviewController extends Controller
             ->map(fn (AuditLog $log) => [
                 'id' => $log->id,
                 'description' => $this->describeAudit($log),
-                'created_at' => $log->created_at->toISOString(),
+                'created_at' => DateTimeFormatter::iso($log->created_at),
                 'subject_type' => $log->auditable_type,
                 'subject_id' => $log->auditable_id,
                 'actor_name' => $log->actor?->name ?? 'System',

--- a/app/Http/Controllers/Dashboard/RentController.php
+++ b/app/Http/Controllers/Dashboard/RentController.php
@@ -10,10 +10,10 @@ use App\Models\Payment;
 use App\Models\PaymentProof;
 use App\Models\Property;
 use App\Models\ReminderLog;
+use App\Support\DateTimeFormatter;
 use App\Tables\Column;
 use App\Tables\Filter;
 use App\Tables\Table;
-use Carbon\Carbon;
 use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
@@ -132,9 +132,7 @@ class RentController extends Controller
 
         $collectedAmount = (int) ($paymentStats?->collected_amount ?? 0);
         $lastPaymentDate = $paymentStats?->last_payment_date;
-        $lastPaymentAt = $lastPaymentDate
-            ? Carbon::parse((string) $lastPaymentDate)->toDateTimeString()
-            : null;
+        $lastPaymentAt = $lastPaymentDate ? (string) $lastPaymentDate : null;
 
         // --- Queue table ---
 
@@ -271,7 +269,7 @@ class RentController extends Controller
                 'reminder_type' => $r->reminder_type,
                 'channel' => $r->channel,
                 'scheduled_for' => $r->scheduled_for?->toDateString(),
-                'sent_at' => $r->sent_at?->toDateTimeString() ?? null,
+                'sent_at' => DateTimeFormatter::nullableIso($r->sent_at),
                 'overdue_days' => $r->overdue_days,
             ]);
 
@@ -358,14 +356,14 @@ class RentController extends Controller
                 'recorded_by_user' => null,
                 'verified_by' => $payment->verified_by,
                 'verified_by_user' => null,
-                'verified_at' => $payment->verified_at?->toDateTimeString(),
+                'verified_at' => DateTimeFormatter::nullableIso($payment->verified_at),
                 'proofs' => $payment->proofs->map(fn (PaymentProof $proof) => [
                     'id' => $proof->id,
                     'payment_id' => $proof->payment_id,
                     'path' => $proof->path,
                     'original_name' => $proof->original_name,
                     'mime_type' => $proof->mime_type,
-                    'created_at' => $proof->created_at->toDateTimeString(),
+                    'created_at' => DateTimeFormatter::iso($proof->created_at),
                 ])->values()->all(),
             ])->values()->all(),
         ];

--- a/app/Http/Controllers/LeaseInvoiceController.php
+++ b/app/Http/Controllers/LeaseInvoiceController.php
@@ -10,6 +10,7 @@ use App\Models\PaymentAttempt;
 use App\Models\Setting;
 use App\Services\Invoices\InvoicePdfArtifact;
 use App\Services\Payments\SignedInvoicePaymentLink;
+use App\Support\DateTimeFormatter;
 use App\Tables\Column;
 use App\Tables\Filter;
 use App\Tables\Table;
@@ -97,10 +98,10 @@ class LeaseInvoiceController extends Controller
                 'amount' => $attempt->amount,
                 'currency' => $attempt->currency,
                 'status' => $attempt->status->value,
-                'expires_at' => $attempt->expires_at,
-                'initiated_at' => $attempt->initiated_at,
-                'created_at' => $attempt->created_at,
-                'updated_at' => $attempt->updated_at,
+                'expires_at' => DateTimeFormatter::nullableIso($attempt->expires_at),
+                'initiated_at' => DateTimeFormatter::iso($attempt->initiated_at),
+                'created_at' => DateTimeFormatter::iso($attempt->created_at),
+                'updated_at' => DateTimeFormatter::iso($attempt->updated_at),
                 'failure_code' => $this->failureCode($attempt),
                 'failure_message' => $this->failureMessage($attempt),
                 'recheckable' => $attempt->status === GatewayPaymentStatus::Pending

--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -8,6 +8,7 @@ use App\Http\Requests\Role\CloneRoleRequest;
 use App\Http\Requests\Role\StoreRoleRequest;
 use App\Http\Requests\Role\UpdateRoleRequest;
 use App\Models\Role;
+use App\Support\DateTimeFormatter;
 use App\Support\RecommendedRoles;
 use App\Tables\Column;
 use App\Tables\Filter;
@@ -36,7 +37,7 @@ class RoleController extends Controller
                 'is_active' => $role->is_active,
                 'users_count' => $role->users_count,
                 'permissions' => $role->permissions->pluck('name'),
-                'created_at' => $role->created_at?->toISOString(),
+                'created_at' => DateTimeFormatter::nullableIso($role->created_at),
             ],
         ]);
     }
@@ -79,7 +80,7 @@ class RoleController extends Controller
             'users_count' => $role->users_count,
             'permissions_count' => $role->permissions->count(),
             'permissions' => $role->permissions->pluck('name'),
-            'created_at' => $role->created_at?->toISOString(),
+            'created_at' => DateTimeFormatter::nullableIso($role->created_at),
         ]);
 
         return Inertia::render('roles/index', [

--- a/app/Http/Controllers/SignedPaymentController.php
+++ b/app/Http/Controllers/SignedPaymentController.php
@@ -11,6 +11,7 @@ use App\Models\Invoice;
 use App\Models\PaymentAttempt;
 use App\Services\Payments\PaymentGatewayManager;
 use App\Services\Payments\SignedInvoicePaymentLink;
+use App\Support\DateTimeFormatter;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
@@ -65,10 +66,10 @@ class SignedPaymentController extends Controller
                 'amount' => (string) $attempt->amount,
                 'currency' => $attempt->currency,
                 'status' => $attempt->status->value,
-                'expires_at' => $attempt->expires_at?->toISOString(),
+                'expires_at' => DateTimeFormatter::nullableIso($attempt->expires_at),
                 'resumable' => $attempt->resumable,
                 'checkout_instructions' => $attempt->checkout_instructions,
-                'initiated_at' => $attempt->initiated_at->toISOString(),
+                'initiated_at' => DateTimeFormatter::iso($attempt->initiated_at),
             ])->values()->all(),
             'onlinePaymentAvailable' => $this->isPayable($invoice)
                 && ($hasResumableAttempt || $gateways->active() !== null),

--- a/app/Http/Controllers/TenantPortal/DashboardController.php
+++ b/app/Http/Controllers/TenantPortal/DashboardController.php
@@ -6,6 +6,7 @@ use App\Enums\PaymentStatus;
 use App\Models\Invoice;
 use App\Models\Lease;
 use App\Models\Payment;
+use App\Support\DateTimeFormatter;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -183,9 +184,12 @@ class DashboardController extends TenantPortalController
                     PaymentStatus::Confirmed => 'payment_confirmed',
                     PaymentStatus::Cancelled => 'payment_cancelled',
                 },
-                'date' => ($payment->status === PaymentStatus::Pending
-                    ? $payment->payment_date
-                    : $payment->verified_at ?? $payment->updated_at)->toDateString(),
+                'date' => DateTimeFormatter::format(
+                    $payment->status === PaymentStatus::Pending
+                        ? $payment->payment_date
+                        : $payment->verified_at ?? $payment->updated_at,
+                    'Y-m-d',
+                ),
                 'amount' => (string) $payment->amount,
                 'reference' => $payment->invoice?->reference,
             ]);
@@ -195,7 +199,7 @@ class DashboardController extends TenantPortalController
             ->get(['id', 'reference', 'created_at'])
             ->map(fn (Invoice $invoice) => [
                 'type' => 'invoice_issued',
-                'date' => $invoice->created_at->toDateString(),
+                'date' => DateTimeFormatter::format($invoice->created_at, 'Y-m-d'),
                 'amount' => null,
                 'reference' => $invoice->reference,
             ]);

--- a/app/Http/Controllers/TenantPortal/MaintenanceTicketController.php
+++ b/app/Http/Controllers/TenantPortal/MaintenanceTicketController.php
@@ -6,6 +6,7 @@ use App\Enums\MaintenancePriority;
 use App\Enums\MaintenanceStatus;
 use App\Events\Maintenance\MaintenanceTicketCreated;
 use App\Models\MaintenanceTicket;
+use App\Support\DateTimeFormatter;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
@@ -32,7 +33,7 @@ class MaintenanceTicketController extends TenantPortalController
                 'title' => $ticket->title,
                 'status' => $ticket->status->value,
                 'priority' => $ticket->priority->value,
-                'created_at' => $ticket->created_at->toDateString(),
+                'created_at' => DateTimeFormatter::format($ticket->created_at, 'Y-m-d'),
                 'property_name' => $ticket->property?->name,
                 'unit_name' => $ticket->unit?->name,
                 'location' => $ticket->location,
@@ -110,7 +111,7 @@ class MaintenanceTicketController extends TenantPortalController
             'description' => $ticket->description,
             'status' => $ticket->status->value,
             'priority' => $ticket->priority->value,
-            'created_at' => $ticket->created_at->toDateString(),
+            'created_at' => DateTimeFormatter::format($ticket->created_at, 'Y-m-d'),
             'property_name' => $ticket->property?->name,
             'unit_name' => $ticket->unit?->name,
             'location' => $ticket->location,

--- a/app/Http/Controllers/TenantPortal/NotificationController.php
+++ b/app/Http/Controllers/TenantPortal/NotificationController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\TenantPortal;
 
+use App\Support\DateTimeFormatter;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Notifications\DatabaseNotification;
@@ -24,8 +25,8 @@ class NotificationController extends TenantPortalController
                     'title' => $notification->data['title'] ?? '',
                     'message' => $notification->data['message'] ?? '',
                     'url' => $notification->data['url'] ?? null,
-                    'created_at' => $notification->created_at->toIso8601String(),
-                    'read_at' => $notification->read_at?->toIso8601String(),
+                    'created_at' => DateTimeFormatter::iso($notification->created_at),
+                    'read_at' => DateTimeFormatter::nullableIso($notification->read_at),
                 ]),
             'unreadCount' => $tenant->unreadNotifications()->count(),
         ]);

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -11,6 +11,7 @@ use App\Models\Property;
 use App\Models\Role as RoleModel;
 use App\Models\User;
 use App\Notifications\UserInvitation;
+use App\Support\DateTimeFormatter;
 use App\Tables\Column;
 use App\Tables\Filter;
 use App\Tables\Table;
@@ -57,9 +58,9 @@ class UserController extends Controller
             ])->values(),
             'is_active' => $user->is_active,
             'status' => $user->invited_at ? 'invited' : ($user->is_active ? 'active' : 'disabled'),
-            'invited_at' => $user->invited_at?->toISOString(),
-            'email_verified_at' => $user->email_verified_at?->toISOString(),
-            'last_login_at' => $user->last_login_at?->toISOString(),
+            'invited_at' => DateTimeFormatter::nullableIso($user->invited_at),
+            'email_verified_at' => DateTimeFormatter::nullableIso($user->email_verified_at),
+            'last_login_at' => DateTimeFormatter::nullableIso($user->last_login_at),
         ];
     }
 

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -38,6 +38,9 @@ class HandleInertiaRequests extends Middleware
         return [
             ...parent::share($request),
             'name' => config('app.name'),
+            'app' => [
+                'timezone' => config('app.display_timezone', 'UTC'),
+            ],
             // Integration configs (mail_config, whatsapp_config, payment_gateway_config) hold secrets — SMTP
             // password, API tokens — so they never go into the app-wide share. Their
             // own settings pages load them (masked) separately.

--- a/app/Models/ActivityLog.php
+++ b/app/Models/ActivityLog.php
@@ -2,12 +2,15 @@
 
 namespace App\Models;
 
+use App\Concerns\SerializesDatesWithTimezone;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 class ActivityLog extends Model
 {
+    use SerializesDatesWithTimezone;
+
     const UPDATED_AT = null;
 
     protected $fillable = [

--- a/app/Models/AuditLog.php
+++ b/app/Models/AuditLog.php
@@ -2,11 +2,14 @@
 
 namespace App\Models;
 
+use App\Concerns\SerializesDatesWithTimezone;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 class AuditLog extends Model
 {
+    use SerializesDatesWithTimezone;
+
     const UPDATED_AT = null;
 
     protected $fillable = [

--- a/app/Models/City.php
+++ b/app/Models/City.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Concerns\SerializesDatesWithTimezone;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -15,7 +16,7 @@ use Illuminate\Support\Str;
 ])]
 class City extends Model
 {
-    use HasFactory;
+    use HasFactory, SerializesDatesWithTimezone;
 
     protected static function booted(): void
     {

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Concerns\Auditable;
+use App\Concerns\SerializesDatesWithTimezone;
 use App\Enums\InvoiceStatus;
 use App\Enums\PaymentStatus;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
@@ -26,7 +27,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 ])]
 class Invoice extends Model
 {
-    use Auditable, HasFactory;
+    use Auditable, HasFactory, SerializesDatesWithTimezone;
 
     protected static function boot(): void
     {
@@ -75,9 +76,9 @@ class Invoice extends Model
     protected function casts(): array
     {
         return [
-            'period_start' => 'date',
-            'period_end' => 'date',
-            'due_date' => 'date',
+            'period_start' => 'date:Y-m-d',
+            'period_end' => 'date:Y-m-d',
+            'due_date' => 'date:Y-m-d',
             'status' => InvoiceStatus::class,
             'total' => 'decimal:2',
             'amount_paid' => 'decimal:2',

--- a/app/Models/InvoiceLineItem.php
+++ b/app/Models/InvoiceLineItem.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Concerns\SerializesDatesWithTimezone;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -15,7 +16,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 ])]
 class InvoiceLineItem extends Model
 {
-    use HasFactory;
+    use HasFactory, SerializesDatesWithTimezone;
 
     protected function casts(): array
     {

--- a/app/Models/Lease.php
+++ b/app/Models/Lease.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Concerns\Auditable;
+use App\Concerns\SerializesDatesWithTimezone;
 use App\Enums\BillingStrategy;
 use App\Enums\BillingUnit;
 use App\Enums\LeaseStatus;
@@ -44,7 +45,7 @@ use Illuminate\Support\Collection;
 ])]
 class Lease extends Model
 {
-    use Auditable, HasFactory, SoftDeletes;
+    use Auditable, HasFactory, SerializesDatesWithTimezone, SoftDeletes;
 
     protected static function boot(): void
     {
@@ -72,8 +73,8 @@ class Lease extends Model
     protected function casts(): array
     {
         return [
-            'start_date' => 'date',
-            'end_date' => 'date',
+            'start_date' => 'date:Y-m-d',
+            'end_date' => 'date:Y-m-d',
             'rent_amount' => 'decimal:2',
             'billing_interval' => 'integer',
             'billing_unit' => BillingUnit::class,
@@ -85,7 +86,7 @@ class Lease extends Model
             'deposit_paid_at' => 'datetime',
             'deposit_refunded_at' => 'datetime',
             'rent_due_day' => 'integer',
-            'termination_date' => 'date',
+            'termination_date' => 'date:Y-m-d',
         ];
     }
 

--- a/app/Models/LeaseUnitHistory.php
+++ b/app/Models/LeaseUnitHistory.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Concerns\SerializesDatesWithTimezone;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -17,6 +18,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 ])]
 class LeaseUnitHistory extends Model
 {
+    use SerializesDatesWithTimezone;
+
     protected $table = 'lease_unit_histories';
 
     protected function casts(): array

--- a/app/Models/MaintenanceTicket.php
+++ b/app/Models/MaintenanceTicket.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Concerns\SerializesDatesWithTimezone;
 use App\Enums\MaintenancePriority;
 use App\Enums\MaintenanceStatus;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
@@ -26,7 +27,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 ])]
 class MaintenanceTicket extends Model
 {
-    use HasFactory;
+    use HasFactory, SerializesDatesWithTimezone;
 
     protected static function boot(): void
     {

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Concerns\Auditable;
+use App\Concerns\SerializesDatesWithTimezone;
 use App\Enums\PaymentStatus;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -26,13 +27,13 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 ])]
 class Payment extends Model
 {
-    use Auditable, HasFactory;
+    use Auditable, HasFactory, SerializesDatesWithTimezone;
 
     protected function casts(): array
     {
         return [
             'amount' => 'decimal:2',
-            'payment_date' => 'date',
+            'payment_date' => 'date:Y-m-d',
             'status' => PaymentStatus::class,
             'verified_at' => 'datetime',
         ];

--- a/app/Models/PaymentAllocation.php
+++ b/app/Models/PaymentAllocation.php
@@ -2,11 +2,14 @@
 
 namespace App\Models;
 
+use App\Concerns\SerializesDatesWithTimezone;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class PaymentAllocation extends Model
 {
+    use SerializesDatesWithTimezone;
+
     protected $fillable = [
         'payment_id',
         'invoice_id',

--- a/app/Models/PaymentAttempt.php
+++ b/app/Models/PaymentAttempt.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Concerns\Auditable;
+use App\Concerns\SerializesDatesWithTimezone;
 use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Builder;
@@ -33,7 +34,7 @@ use OpenKOS\Core\Enums\PaymentStatus;
 ])]
 class PaymentAttempt extends Model
 {
-    use Auditable, HasFactory;
+    use Auditable, HasFactory, SerializesDatesWithTimezone;
 
     protected static function booted(): void
     {

--- a/app/Models/PaymentProof.php
+++ b/app/Models/PaymentProof.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Concerns\SerializesDatesWithTimezone;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -15,7 +16,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 ])]
 class PaymentProof extends Model
 {
-    use HasFactory;
+    use HasFactory, SerializesDatesWithTimezone;
 
     public function payment(): BelongsTo
     {

--- a/app/Models/Permission.php
+++ b/app/Models/Permission.php
@@ -2,10 +2,13 @@
 
 namespace App\Models;
 
+use App\Concerns\SerializesDatesWithTimezone;
 use Spatie\Permission\Models\Permission as SpatiePermission;
 
 class Permission extends SpatiePermission
 {
+    use SerializesDatesWithTimezone;
+
     protected $fillable = [
         'name',
         'guard_name',

--- a/app/Models/Property.php
+++ b/app/Models/Property.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Concerns\Auditable;
+use App\Concerns\SerializesDatesWithTimezone;
 use App\Enums\UnitStatus;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Builder;
@@ -31,7 +32,7 @@ use Illuminate\Support\Str;
 ])]
 class Property extends Model
 {
-    use Auditable, HasFactory, SoftDeletes;
+    use Auditable, HasFactory, SerializesDatesWithTimezone, SoftDeletes;
 
     protected array $auditableMask = ['phone'];
 

--- a/app/Models/PropertyType.php
+++ b/app/Models/PropertyType.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Concerns\SerializesDatesWithTimezone;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -20,7 +21,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 ])]
 class PropertyType extends Model
 {
-    use HasFactory;
+    use HasFactory, SerializesDatesWithTimezone;
 
     protected function casts(): array
     {

--- a/app/Models/Region.php
+++ b/app/Models/Region.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Concerns\SerializesDatesWithTimezone;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -15,7 +16,7 @@ use Illuminate\Support\Str;
 ])]
 class Region extends Model
 {
-    use HasFactory;
+    use HasFactory, SerializesDatesWithTimezone;
 
     protected static function booted(): void
     {

--- a/app/Models/ReminderLog.php
+++ b/app/Models/ReminderLog.php
@@ -2,13 +2,14 @@
 
 namespace App\Models;
 
+use App\Concerns\SerializesDatesWithTimezone;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class ReminderLog extends Model
 {
-    use HasFactory;
+    use HasFactory, SerializesDatesWithTimezone;
 
     protected $fillable = [
         'lease_id',

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -2,11 +2,14 @@
 
 namespace App\Models;
 
+use App\Concerns\SerializesDatesWithTimezone;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Spatie\Permission\Models\Role as SpatieRole;
 
 class Role extends SpatieRole
 {
+    use SerializesDatesWithTimezone;
+
     protected $fillable = [
         'name',
         'guard_name',

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Concerns\SerializesDatesWithTimezone;
 use App\Services\Settings\SettingCaster;
 use App\Services\Settings\SettingManager;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -9,7 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class Setting extends Model
 {
-    use HasFactory;
+    use HasFactory, SerializesDatesWithTimezone;
 
     protected $fillable = ['key', 'value', 'type'];
 

--- a/app/Models/Tenant.php
+++ b/app/Models/Tenant.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Concerns\Auditable;
+use App\Concerns\SerializesDatesWithTimezone;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -25,7 +26,7 @@ use Illuminate\Notifications\Notification;
 ])]
 class Tenant extends Model
 {
-    use Auditable, HasFactory, Notifiable, SoftDeletes;
+    use Auditable, HasFactory, Notifiable, SerializesDatesWithTimezone, SoftDeletes;
 
     protected array $auditableMask = ['phone', 'id_card_number', 'emergency_contact_phone'];
 

--- a/app/Models/TenantDocument.php
+++ b/app/Models/TenantDocument.php
@@ -2,12 +2,15 @@
 
 namespace App\Models;
 
+use App\Concerns\SerializesDatesWithTimezone;
 use App\Enums\TenantDocumentType;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class TenantDocument extends Model
 {
+    use SerializesDatesWithTimezone;
+
     protected $fillable = [
         'tenant_id',
         'type',

--- a/app/Models/Unit.php
+++ b/app/Models/Unit.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Concerns\Auditable;
+use App\Concerns\SerializesDatesWithTimezone;
 use App\Enums\UnitStatus;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Builder;
@@ -27,7 +28,7 @@ use Illuminate\Support\Str;
 ])]
 class Unit extends Model
 {
-    use Auditable, HasFactory, SoftDeletes;
+    use Auditable, HasFactory, SerializesDatesWithTimezone, SoftDeletes;
 
     protected function casts(): array
     {

--- a/app/Models/UnitRate.php
+++ b/app/Models/UnitRate.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Concerns\SerializesDatesWithTimezone;
 use App\Enums\BillingUnit;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -19,7 +20,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 ])]
 class UnitRate extends Model
 {
-    use HasFactory;
+    use HasFactory, SerializesDatesWithTimezone;
 
     protected $table = 'unit_rates';
 
@@ -30,8 +31,8 @@ class UnitRate extends Model
             'billing_unit' => BillingUnit::class,
             'amount' => 'decimal:2',
             'is_active' => 'boolean',
-            'effective_from' => 'date',
-            'effective_until' => 'date',
+            'effective_from' => 'date:Y-m-d',
+            'effective_until' => 'date:Y-m-d',
         ];
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Concerns\SerializesDatesWithTimezone;
 use App\Enums\Role;
 use Database\Factories\UserFactory;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
@@ -23,7 +24,7 @@ use Spatie\Permission\Traits\HasRoles;
 class User extends Authenticatable implements MustVerifyEmail, PasskeyUser
 {
     /** @use HasFactory<UserFactory> */
-    use HasFactory, HasRoles, Notifiable, PasskeyAuthenticatable, TwoFactorAuthenticatable {
+    use HasFactory, HasRoles, Notifiable, PasskeyAuthenticatable, SerializesDatesWithTimezone, TwoFactorAuthenticatable {
         HasRoles::hasRole as protected traitHasRole;
     }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,8 +2,11 @@
 
 namespace App\Providers;
 
+use App\Models\Setting;
 use Carbon\CarbonImmutable;
+use DateTimeZone;
 use Illuminate\Auth\Events\Login;
+use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
@@ -15,7 +18,29 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->configureDefaults();
+        $this->configureDisplayTimezone();
         $this->configureAuthEvents();
+    }
+
+    protected function configureDisplayTimezone(): void
+    {
+        try {
+            $timezone = Setting::get('timezone');
+        } catch (QueryException) {
+            $timezone = null;
+        }
+
+        if (! is_string($timezone) || $timezone === '') {
+            $timezone = 'UTC';
+        }
+
+        try {
+            new DateTimeZone($timezone);
+        } catch (\Exception) {
+            $timezone = 'UTC';
+        }
+
+        config(['app.display_timezone' => $timezone]);
     }
 
     protected function configureDefaults(): void

--- a/app/Support/DateTimeFormatter.php
+++ b/app/Support/DateTimeFormatter.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Support;
+
+use Carbon\Carbon;
+use DateTimeInterface;
+use DateTimeZone;
+use Exception;
+
+final class DateTimeFormatter
+{
+    public static function inDisplayTimezone(?DateTimeInterface $date): ?Carbon
+    {
+        return $date === null ? null : self::convert($date);
+    }
+
+    public static function iso(DateTimeInterface $date): string
+    {
+        return self::convert($date)->toISOString(true);
+    }
+
+    public static function nullableIso(?DateTimeInterface $date): ?string
+    {
+        return $date === null ? null : self::iso($date);
+    }
+
+    public static function format(?DateTimeInterface $date, string $format): ?string
+    {
+        return self::inDisplayTimezone($date)?->format($format);
+    }
+
+    private static function convert(DateTimeInterface $date): Carbon
+    {
+        return Carbon::instance($date)->setTimezone(self::displayTimezone());
+    }
+
+    private static function displayTimezone(): DateTimeZone
+    {
+        $timezone = config('app.display_timezone', 'UTC');
+
+        try {
+            return new DateTimeZone(is_string($timezone) ? $timezone : 'UTC');
+        } catch (Exception) {
+            return new DateTimeZone('UTC');
+        }
+    }
+}

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -1,4 +1,4 @@
-import { createInertiaApp } from '@inertiajs/react';
+import { createInertiaApp, router } from '@inertiajs/react';
 import { Toaster } from '@/components/ui/sonner';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { initializeTheme } from '@/hooks/use-appearance';
@@ -7,7 +7,20 @@ import AuthLayout from '@/layouts/auth-layout';
 import PublicPaymentLayout from '@/layouts/public-payment-layout';
 import SettingsLayout from '@/layouts/settings/layout';
 import TenantPortalLayout from '@/layouts/tenant-portal-layout';
+import { setDisplayTimezone } from '@/lib/formatters';
 import '@/plugins';
+
+type PageWithTimezone = {
+    props?: {
+        app?: {
+            timezone?: string;
+        };
+    };
+};
+
+function syncDisplayTimezone(page: PageWithTimezone): void {
+    setDisplayTimezone(page.props?.app?.timezone);
+}
 
 // The server drives the display name from the settings table (site_name),
 // shared as the `name` prop on the initial page. Read it here so the title
@@ -64,7 +77,17 @@ createInertiaApp({
         }
     },
     strictMode: true,
-    withApp(app) {
+    withApp(app, { ssr }) {
+        syncDisplayTimezone(
+            (app.props as { initialPage?: PageWithTimezone }).initialPage ?? {},
+        );
+
+        if (!ssr) {
+            router.on('navigate', ({ detail }) => {
+                syncDisplayTimezone(detail.page);
+            });
+        }
+
         return (
             <TooltipProvider delayDuration={0}>
                 {app}

--- a/resources/js/lib/formatters.ts
+++ b/resources/js/lib/formatters.ts
@@ -1,7 +1,39 @@
-export function todayISO(): string {
-    const d = new Date();
+let displayTimezone = 'UTC';
 
-    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+export function setDisplayTimezone(timezone: string | null | undefined): void {
+    displayTimezone = timezone || 'UTC';
+}
+
+function dateTimeFormatter(
+    locale: string,
+    options: Intl.DateTimeFormatOptions,
+    timeZone = displayTimezone,
+): Intl.DateTimeFormat {
+    try {
+        return new Intl.DateTimeFormat(locale, { ...options, timeZone });
+    } catch {
+        return new Intl.DateTimeFormat(locale, { ...options, timeZone: 'UTC' });
+    }
+}
+
+function isDateOnly(value: string): boolean {
+    return /^\d{4}-\d{2}-\d{2}$/.test(value);
+}
+
+export function todayISO(): string {
+    const parts = dateTimeFormatter('en-CA', {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+    })
+        .formatToParts(new Date())
+        .reduce<Record<string, string>>((result, part) => {
+            result[part.type] = part.value;
+
+            return result;
+        }, {});
+
+    return `${parts.year}-${parts.month}-${parts.day}`;
 }
 
 export function formatDate(dateStr: string | null): string {
@@ -9,11 +41,32 @@ export function formatDate(dateStr: string | null): string {
         return '—';
     }
 
-    return new Date(dateStr).toLocaleDateString('id-ID', {
+    return dateTimeFormatter(
+        'id-ID',
+        {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+        },
+        isDateOnly(dateStr) ? 'UTC' : displayTimezone,
+    ).format(new Date(dateStr));
+}
+
+export function formatDateTime(
+    dateStr: string | null,
+    locale = 'id-ID',
+): string {
+    if (!dateStr) {
+        return '—';
+    }
+
+    return dateTimeFormatter(locale, {
         year: 'numeric',
         month: 'short',
         day: 'numeric',
-    });
+        hour: '2-digit',
+        minute: '2-digit',
+    }).format(new Date(dateStr));
 }
 
 export function formatPrice(cents: string | null): string {

--- a/resources/js/pages/dashboard/rent.tsx
+++ b/resources/js/pages/dashboard/rent.tsx
@@ -146,28 +146,6 @@ function pendingReviewLabel(count: number | undefined): string {
     return `Pending review · ${count}`;
 }
 
-function timeAgo(dateStr: string | null): string | null {
-    if (!dateStr) {
-        return null;
-    }
-
-    const diff = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
-
-    if (diff < 60) {
-        return 'just now';
-    }
-
-    if (diff < 3600) {
-        return `${Math.floor(diff / 60)}m ago`;
-    }
-
-    if (diff < 86400) {
-        return `${Math.floor(diff / 3600)}h ago`;
-    }
-
-    return `${Math.floor(diff / 86400)}d ago`;
-}
-
 export default function CollectionQueue({
     entries: data,
     sort: currentSort = 'due_date',
@@ -420,7 +398,7 @@ export default function CollectionQueue({
         progress.total > 0
             ? Math.round((progress.processed / progress.total) * 100)
             : 0;
-    const lastPaymentAgo = timeAgo(progress.last_payment_at);
+    const lastPaymentDate = formatDate(progress.last_payment_at);
 
     return (
         <>
@@ -474,7 +452,7 @@ export default function CollectionQueue({
                     />
                     <MetricCard
                         label="Last Payment Recorded"
-                        value={lastPaymentAgo ?? '—'}
+                        value={lastPaymentDate}
                         variant="neutral"
                         icon={Clock}
                     />

--- a/resources/js/pages/maintenance-tickets/show.tsx
+++ b/resources/js/pages/maintenance-tickets/show.tsx
@@ -3,6 +3,7 @@ import { EntityWorkspaceLayout } from '@/components/shared/entity-workspace-layo
 import { StatusBadge } from '@/components/shared/status-badge';
 import { WorkspaceTabs } from '@/components/shared/workspace-tabs';
 import { Badge } from '@/components/ui/badge';
+import { formatDate } from '@/lib/formatters';
 import type { MaintenanceTicket } from '@/types';
 
 function Field({ label, value }: { label: string; value: React.ReactNode }) {
@@ -58,15 +59,13 @@ export default function MaintenanceTicketWorkspace({
                     <Field label="Cost" value={ticket.cost} />
                     <Field
                         label="Created"
-                        value={new Date(ticket.created_at).toLocaleDateString()}
+                        value={formatDate(ticket.created_at)}
                     />
                     <Field
                         label="Resolved"
                         value={
                             ticket.resolved_at
-                                ? new Date(
-                                      ticket.resolved_at,
-                                  ).toLocaleDateString()
+                                ? formatDate(ticket.resolved_at)
                                 : '—'
                         }
                     />

--- a/resources/js/pages/users/index.tsx
+++ b/resources/js/pages/users/index.tsx
@@ -41,6 +41,7 @@ import {
     SheetTitle,
 } from '@/components/ui/sheet';
 import { useTable } from '@/hooks/use-table';
+import { formatDateTime } from '@/lib/formatters';
 import users, {
     destroy,
     resendInvitation,
@@ -83,15 +84,12 @@ function StatusBadge({ user }: { user: ManagedUser }) {
     return <SharedStatusBadge domain="user" value={user.status} />;
 }
 
-function formatDate(value: string | null) {
+function formatLastLogin(value: string | null) {
     if (!value) {
         return 'Never';
     }
 
-    return new Intl.DateTimeFormat('en', {
-        dateStyle: 'medium',
-        timeStyle: 'short',
-    }).format(new Date(value));
+    return formatDateTime(value, 'en');
 }
 
 export default function Index({
@@ -192,7 +190,7 @@ export default function Index({
             label: 'Last Login',
             sortable: true,
             className: 'text-muted-foreground',
-            render: (u) => formatDate(u.last_login_at),
+            render: (u) => formatLastLogin(u.last_login_at),
         },
         {
             key: '_roles',
@@ -697,7 +695,9 @@ function UserDetailSheet({
                                             Last login
                                         </span>
                                         <span className="text-sm tabular-nums">
-                                            {formatDate(user.last_login_at)}
+                                            {formatLastLogin(
+                                                user.last_login_at,
+                                            )}
                                         </span>
                                     </div>
                                 </div>

--- a/resources/js/pages/users/show.tsx
+++ b/resources/js/pages/users/show.tsx
@@ -3,6 +3,7 @@ import { EntityWorkspaceLayout } from '@/components/shared/entity-workspace-layo
 import { StatusBadge } from '@/components/shared/status-badge';
 import { WorkspaceTabs } from '@/components/shared/workspace-tabs';
 import { Badge } from '@/components/ui/badge';
+import { formatDate, formatDateTime } from '@/lib/formatters';
 
 import type { WorkspaceUser } from '@/types';
 
@@ -53,7 +54,7 @@ export default function UserWorkspace({ user }: { user: WorkspaceUser }) {
                         label="Last login"
                         value={
                             user.last_login_at
-                                ? new Date(user.last_login_at).toLocaleString()
+                                ? formatDateTime(user.last_login_at)
                                 : 'Never'
                         }
                     />
@@ -61,18 +62,14 @@ export default function UserWorkspace({ user }: { user: WorkspaceUser }) {
                         label="Email verified"
                         value={
                             user.email_verified_at
-                                ? new Date(
-                                      user.email_verified_at,
-                                  ).toLocaleDateString()
+                                ? formatDate(user.email_verified_at)
                                 : 'No'
                         }
                     />
                     <Field
                         label="Invited"
                         value={
-                            user.invited_at
-                                ? new Date(user.invited_at).toLocaleDateString()
-                                : '—'
+                            user.invited_at ? formatDate(user.invited_at) : '—'
                         }
                     />
                 </div>

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -12,6 +12,9 @@ declare module '@inertiajs/core' {
     export interface InertiaConfig {
         sharedPageProps: {
             name: string;
+            app: {
+                timezone: string;
+            };
             auth: Auth;
             setting: {
                 id: number;

--- a/resources/views/invoices/pdf.blade.php
+++ b/resources/views/invoices/pdf.blade.php
@@ -55,7 +55,7 @@
 <body>
 @php
     $formatDate = static fn ($date): string => $date?->copy()->locale($locale)->translatedFormat('d M Y') ?? '-';
-    $formatDateTime = static fn ($date): string => $date?->copy()->timezone('Asia/Jakarta')->locale($locale)->translatedFormat('d M Y, H:i') ?? '-';
+    $formatDateTime = static fn ($date, string $format = 'd M Y, H:i'): string => App\Support\DateTimeFormatter::inDisplayTimezone($date)?->locale($locale)->translatedFormat($format) ?? '-';
     $formatMoney = static fn (string $amount): string => (string) Illuminate\Support\Number::currency(
         (float) $amount,
         in: $currency,
@@ -77,7 +77,7 @@
     };
     $tenant = $invoice->lease?->primaryTenant;
     $payments = $invoice->payments ?? collect();
-    $generatedAt = now()->timezone('Asia/Jakarta')->locale($locale)->translatedFormat('d M Y, H:i');
+    $generatedAt = App\Support\DateTimeFormatter::inDisplayTimezone(now())->locale($locale)->translatedFormat('d M Y, H:i T');
 @endphp
 
 <table class="header">
@@ -98,7 +98,7 @@
     <tr>
         <td>
             <p class="label">Issue date</p>
-            <p class="value">{{ $formatDate($invoice->created_at) }}</p>
+            <p class="value">{{ $formatDateTime($invoice->created_at, 'd M Y') }}</p>
         </td>
         <td>
             <p class="label">Billing period</p>
@@ -199,7 +199,7 @@
     </section>
 @endif
 
-<p class="footer">Generated on {{ $generatedAt }} WIB. This document reflects the invoice status at the time it was generated.</p>
+<p class="footer">Generated on {{ $generatedAt }}. This document reflects the invoice status at the time it was generated.</p>
 @if ($autoPrint ?? false)
     <script>
         window.addEventListener('load', () => window.print());

--- a/tests/Feature/Providers/ServiceProviderTest.php
+++ b/tests/Feature/Providers/ServiceProviderTest.php
@@ -4,6 +4,7 @@ use App\Exceptions\MailDriverNotFoundException;
 use App\Models\Setting;
 use App\Notifications\Drivers\LogMailDriver;
 use App\Notifications\UserInvitation;
+use App\Providers\AppServiceProvider;
 use App\Providers\NotificationServiceProvider;
 use App\Services\MailManager;
 use App\Services\Platform\ComposerPluginDiscovery;
@@ -12,12 +13,41 @@ use App\Services\Settings\SettingManager;
 use App\Services\WhatsAppManager;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Schema;
 use OpenKOS\Core\Contracts\PluginDiscovery;
 use OpenKOS\Core\Contracts\SettingsStore;
 use OpenKOS\Core\Data\Mail\MailAddress;
 use OpenKOS\Core\Data\Mail\MailMessage;
 use OpenKOS\Platform\Notification\NotificationDriverRegistration;
 use OpenKOS\Platform\Notification\NotificationRegistry;
+
+it('configures a valid display timezone without changing the application timezone', function () {
+    Setting::set('timezone', 'America/New_York');
+    app()->forgetScopedInstances();
+
+    (new AppServiceProvider(app()))->boot();
+
+    expect(config('app.display_timezone'))->toBe('America/New_York')
+        ->and(config('app.timezone'))->toBe('UTC');
+});
+
+it('falls back to UTC for an invalid persisted display timezone', function () {
+    Setting::set('timezone', 'invalid/timezone');
+    app()->forgetScopedInstances();
+
+    (new AppServiceProvider(app()))->boot();
+
+    expect(config('app.display_timezone'))->toBe('UTC');
+});
+
+it('boots with UTC when the settings table is unavailable', function () {
+    Schema::dropIfExists('settings');
+    app()->forgetScopedInstances();
+
+    (new AppServiceProvider(app()))->boot();
+
+    expect(config('app.display_timezone'))->toBe('UTC');
+});
 
 it('registers application services through dedicated providers', function () {
     expect(app(SettingManager::class))

--- a/tests/Feature/RentDashboardTest.php
+++ b/tests/Feature/RentDashboardTest.php
@@ -241,7 +241,7 @@ test('collection queue tab counts are correct', function () {
             ->where('progress.processed', 1)
             ->where('progress.total', 5)
             ->where('progress.amount_collected', 600000)
-            ->where('progress.last_payment_at', '2026-07-09 00:00:00')
+            ->where('progress.last_payment_at', '2026-07-09')
         );
 
     expect($invoiceAggregateQueries)->toBe(1)

--- a/tests/Feature/SharedPropsTest.php
+++ b/tests/Feature/SharedPropsTest.php
@@ -22,6 +22,16 @@ it('does not leak mail or whatsapp secrets in shared props', function () {
     expect(json_encode($props))->not->toContain('wa-token-123');
 });
 
+it('shares the configured display timezone', function () {
+    config(['app.display_timezone' => 'Asia/Jakarta']);
+
+    $props = $this->actingAs(User::factory()->owner()->create())
+        ->get(route('dashboard'))
+        ->viewData('page')['props'];
+
+    expect($props['app']['timezone'])->toBe('Asia/Jakarta');
+});
+
 it('exposes notification channel readiness as booleans only', function () {
     config(['mail.mailers.smtp.host' => null]);
     putenv('MAIL_HOST=');

--- a/tests/Feature/TenantInvoicePdfTest.php
+++ b/tests/Feature/TenantInvoicePdfTest.php
@@ -278,7 +278,26 @@ test('invoice PDF renders confirmed payment details and history', function () {
         ->toContain('Total paid')
         ->toContain('Outstanding')
         ->toContain('Generated on')
-        ->toContain('WIB');
+        ->toContain('UTC');
+});
+
+test('invoice PDF formats verified timestamps in the configured timezone', function () {
+    config(['app.display_timezone' => 'Asia/Jakarta']);
+
+    $fixture = createTenantInvoicePdfFixture();
+    $invoice = $fixture['invoice'];
+    $invoice->payments()->create([
+        'amount' => '500000.00',
+        'payment_date' => '2026-07-29',
+        'payment_method' => 'bank_transfer',
+        'status' => 'confirmed',
+        'verified_at' => '2026-07-29 23:30:00',
+    ]);
+    $invoice->refresh()->load(['lease.unit.property', 'lineItems', 'payments']);
+    $invoice->append(['outstanding', 'display_status']);
+
+    expect(renderTenantInvoicePdfView($invoice))
+        ->toContain('30 Jul 2026, 06:30');
 });
 
 test('invoice PDF derives overdue status at the end-of-day boundary', function () {

--- a/tests/Unit/Models/SerializesDatesWithTimezoneTest.php
+++ b/tests/Unit/Models/SerializesDatesWithTimezoneTest.php
@@ -2,6 +2,8 @@
 
 use App\Models\Invoice;
 use App\Models\User;
+use App\Support\DateTimeFormatter;
+use Carbon\CarbonImmutable;
 use Tests\TestCase;
 
 uses(TestCase::class);
@@ -30,4 +32,14 @@ it('falls back to UTC when the display timezone is invalid', function () {
 
     expect($user->toArray()['created_at'])
         ->toBe('2026-08-20T23:30:00.000000+00:00');
+});
+
+it('uses the configured timezone for explicit date formatting', function () {
+    config(['app.display_timezone' => 'Asia/Jakarta']);
+    $date = CarbonImmutable::parse('2026-08-20T23:30:00Z');
+
+    expect(DateTimeFormatter::iso($date))
+        ->toBe('2026-08-21T06:30:00.000000+07:00')
+        ->and(DateTimeFormatter::format($date, 'Y-m-d'))
+        ->toBe('2026-08-21');
 });

--- a/tests/Unit/Models/SerializesDatesWithTimezoneTest.php
+++ b/tests/Unit/Models/SerializesDatesWithTimezoneTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Models\Invoice;
+use App\Models\User;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+it('serializes model datetimes in the configured display timezone', function () {
+    config(['app.display_timezone' => 'Asia/Jakarta']);
+
+    $user = User::make()->forceFill(['created_at' => '2026-08-20 23:30:00']);
+
+    expect($user->toArray()['created_at'])
+        ->toBe('2026-08-21T06:30:00.000000+07:00');
+});
+
+it('keeps calendar-only casts unchanged', function () {
+    config(['app.display_timezone' => 'Asia/Jakarta']);
+
+    $invoice = Invoice::make(['period_start' => '2026-08-20']);
+
+    expect($invoice->toArray()['period_start'])->toBe('2026-08-20');
+});
+
+it('falls back to UTC when the display timezone is invalid', function () {
+    config(['app.display_timezone' => 'invalid/timezone']);
+
+    $user = User::make()->forceFill(['created_at' => '2026-08-20 23:30:00']);
+
+    expect($user->toArray()['created_at'])
+        ->toBe('2026-08-20T23:30:00.000000+00:00');
+});


### PR DESCRIPTION
## Summary

- Serialize Eloquent datetime casts in the configured display timezone while keeping application and database timezone UTC.
- Normalize explicit backend and dashboard datetime payloads through a shared formatter.
- Share the configured IANA timezone with Inertia and use it for frontend date/time formatting.
- Preserve date-only values as `YYYY-MM-DD`.
- Use the configured timezone and abbreviation in invoice PDFs instead of hardcoded Asia/Jakarta/WIB output.
- Fall back to UTC when settings are unavailable or invalid.

Long-lived workers should be reloaded after changing the timezone setting so they pick up the boot-time configuration.

## Testing

- `php artisan test --compact` — 806 tests, 3,700 assertions
- `npm run types:check`
- `npm run lint:check`
- `npm run build`
- `vendor/bin/pint --dirty --format agent`

Refs OPE-94