### PR TITLE
fix(occupancy): serialize unit transitions

### DIFF
--- a/app/Actions/Leases/MoveOutLease.php
+++ b/app/Actions/Leases/MoveOutLease.php
@@ -12,6 +12,7 @@ use App\Enums\UnitStatus;
 use App\Models\Lease;
 use App\Models\Unit;
 use App\Results\Lease\MoveOutLeaseResult;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 
 class MoveOutLease
@@ -38,25 +39,60 @@ class MoveOutLease
     public function execute(Lease $lease, MoveOutLeaseData $data): MoveOutLeaseResult
     {
         return DB::transaction(function () use ($lease, $data) {
+            $unitIds = [$lease->unit_id];
             if ($data->moveToAnotherUnit) {
-                return $this->transfer($lease, $data);
+                abort_unless($data->targetUnitId !== null, 422, __('Target unit is required.'));
+                $unitIds[] = $data->targetUnitId;
             }
 
-            return $this->terminate($lease, $data);
+            $lockedUnits = $this->lockUnits($unitIds);
+            $sourceUnit = $lockedUnits->get($lease->unit_id);
+            $lockedLease = Lease::query()->lockForUpdate()->findOrFail($lease->id);
+
+            abort_unless($sourceUnit && (int) $lockedLease->unit_id === $sourceUnit->id, 422, __('Lease is no longer assigned to this unit.'));
+
+            if ($data->moveToAnotherUnit) {
+                $targetUnit = $lockedUnits->get($data->targetUnitId);
+                abort_unless($targetUnit, 404);
+
+                return $this->transfer($lockedLease, $sourceUnit, $targetUnit, $data);
+            }
+
+            return $this->terminate($lockedLease, $sourceUnit, $data);
         });
     }
 
-    private function terminate(Lease $lease, MoveOutLeaseData $data): MoveOutLeaseResult
+    /**
+     * @param  array<int, int|null>  $unitIds
+     * @return Collection<int, Unit>
+     */
+    private function lockUnits(array $unitIds): Collection
     {
-        $oldStatus = $lease->status;
+        $unitIds = array_values(array_unique(array_filter($unitIds, fn (?int $unitId): bool => $unitId !== null)));
+        sort($unitIds);
 
-        $this->leaseStatusValidator->validate($oldStatus, LeaseStatus::Terminated);
+        $units = Unit::query()
+            ->whereKey($unitIds)
+            ->orderBy('id')
+            ->lockForUpdate()
+            ->get()
+            ->keyBy('id');
+
+        abort_unless($units->count() === count($unitIds), 404);
+
+        return $units;
+    }
+
+    private function terminate(Lease $lease, Unit $oldUnit, MoveOutLeaseData $data): MoveOutLeaseResult
+    {
+        $oldLeaseStatus = $lease->status;
+        $oldSourceStatus = $oldUnit->status;
+
+        $this->leaseStatusValidator->validate($oldLeaseStatus, LeaseStatus::Terminated);
 
         $depositRefundAmount = $data->depositReturned
             ? ($data->depositRefundAmount ?? $lease->deposit_amount)
             : null;
-
-        $oldUnit = $lease->unit;
 
         $lease->update([
             'end_date' => $data->endDate,
@@ -74,17 +110,24 @@ class MoveOutLease
             $oldUnit->update(['status' => UnitStatus::Available]);
         }
 
-        return MoveOutLeaseResult::success($lease);
+        return MoveOutLeaseResult::success(
+            oldLease: $lease,
+            sourceUnit: $oldUnit,
+            oldLeaseStatus: $oldLeaseStatus,
+            oldSourceStatus: $oldSourceStatus,
+            newSourceStatus: $oldUnit->status,
+        );
     }
 
-    private function transfer(Lease $lease, MoveOutLeaseData $data): MoveOutLeaseResult
+    private function transfer(Lease $lease, Unit $oldUnit, Unit $targetUnit, MoveOutLeaseData $data): MoveOutLeaseResult
     {
-        $oldStatus = $lease->status; // ponytail: captured before validator call
+        $oldLeaseStatus = $lease->status;
+        $oldSourceStatus = $oldUnit->status;
+        $oldTargetStatus = $targetUnit->status;
 
-        $this->leaseStatusValidator->validate($oldStatus, LeaseStatus::Terminated);
+        $this->leaseStatusValidator->validate($oldLeaseStatus, LeaseStatus::Terminated);
 
-        $targetUnit = Unit::lockForUpdate()->findOrFail($data->targetUnitId);
-
+        abort_if($targetUnit->id === $oldUnit->id, 422, __('Cannot move to the same unit.'));
         abort_if(in_array($targetUnit->status, [UnitStatus::Maintenance, UnitStatus::Unavailable], true), 422, __('Target unit is not available for lease.'));
 
         $lease->load('tenants');
@@ -103,8 +146,6 @@ class MoveOutLease
         $depositRefundAmount = $data->depositReturned
             ? ($data->depositRefundAmount ?? $lease->deposit_amount)
             : null;
-
-        $oldUnit = $lease->unit;
 
         $lease->update([
             'end_date' => $data->endDate,
@@ -127,6 +168,7 @@ class MoveOutLease
         $lease->load('tenants');
         $existingLease = $targetUnit->leases()->where('status', LeaseStatus::Active->value)->first();
 
+        $newLease = null;
         if ($existingLease) {
             $existingTenantIds = $existingLease->tenants()->pluck('tenants.id');
 
@@ -172,6 +214,16 @@ class MoveOutLease
 
         $targetUnit->update(['status' => UnitStatus::Occupied]);
 
-        return MoveOutLeaseResult::success($lease, $newLease ?? null);
+        return MoveOutLeaseResult::success(
+            oldLease: $lease,
+            newLease: $newLease,
+            sourceUnit: $oldUnit,
+            targetUnit: $targetUnit,
+            oldLeaseStatus: $oldLeaseStatus,
+            oldSourceStatus: $oldSourceStatus,
+            newSourceStatus: $oldUnit->status,
+            oldTargetStatus: $oldTargetStatus,
+            newTargetStatus: $targetUnit->status,
+        );
     }
 }

--- a/app/Actions/Maintenance/BlockUnit.php
+++ b/app/Actions/Maintenance/BlockUnit.php
@@ -4,28 +4,51 @@ namespace App\Actions\Maintenance;
 
 use App\Enums\LeaseStatus;
 use App\Enums\UnitStatus;
+use App\Models\Lease;
 use App\Models\LeaseUnitHistory;
 use App\Models\Unit;
 use Illuminate\Support\Facades\DB;
 
 class BlockUnit
 {
-    public function execute(int $unitId, ?int $moveToUnitId): void
+    /**
+     * @return array<int, array{unit: Unit, from: UnitStatus}>
+     */
+    public function execute(int $unitId, ?int $moveToUnitId): array
     {
-        $unit = Unit::lockForUpdate()->findOrFail($unitId);
-        $activeLease = $unit->leases()->where('status', LeaseStatus::Active->value)->first();
+        return DB::transaction(function () use ($unitId, $moveToUnitId): array {
+            $unitIds = array_values(array_unique(array_filter([$unitId, $moveToUnitId])));
+            sort($unitIds);
 
-        if ($activeLease && $moveToUnitId) {
-            $this->transferOccupants($unit, $activeLease, $moveToUnitId);
-        } else {
-            $unit->update(['status' => UnitStatus::Maintenance]);
-        }
+            $lockedUnits = Unit::query()
+                ->whereKey($unitIds)
+                ->orderBy('id')
+                ->lockForUpdate()
+                ->get()
+                ->keyBy('id');
+
+            abort_unless($lockedUnits->has($unitId), 404);
+
+            $changes = $lockedUnits
+                ->map(fn (Unit $unit): array => ['unit' => $unit, 'from' => $unit->status])
+                ->all();
+
+            $unit = $lockedUnits->get($unitId);
+            $activeLease = $unit->leases()->where('status', LeaseStatus::Active->value)->first();
+
+            if ($activeLease && $moveToUnitId) {
+                abort_unless($lockedUnits->has($moveToUnitId), 404);
+                $this->transferOccupants($unit, $activeLease, $lockedUnits->get($moveToUnitId));
+            } else {
+                $unit->update(['status' => UnitStatus::Maintenance]);
+            }
+
+            return $changes;
+        });
     }
 
-    private function transferOccupants(Unit $unit, mixed $activeLease, int $targetUnitId): void
+    private function transferOccupants(Unit $unit, Lease $activeLease, Unit $targetUnit): void
     {
-        $targetUnit = Unit::lockForUpdate()->findOrFail($targetUnitId);
-
         abort_if(in_array($targetUnit->status, [UnitStatus::Maintenance, UnitStatus::Unavailable], true), 422, __('Target unit is not available for lease.'));
         abort_if($targetUnit->id === $unit->id, 422, __('Cannot move to the same unit.'));
 

--- a/app/Actions/Maintenance/ResolveTicket.php
+++ b/app/Actions/Maintenance/ResolveTicket.php
@@ -8,47 +8,76 @@ use App\Models\Lease;
 use App\Models\LeaseUnitHistory;
 use App\Models\MaintenanceTicket;
 use App\Models\Unit;
+use Illuminate\Support\Facades\DB;
 
 class ResolveTicket
 {
-    public function execute(MaintenanceTicket $ticket, bool $moveBack): void
+    /**
+     * @return array<int, array{unit: Unit, from: UnitStatus}>
+     */
+    public function execute(MaintenanceTicket $ticket, bool $moveBack): array
     {
-        if (! $ticket->unit_id) {
-            return;
-        }
+        return DB::transaction(function () use ($ticket, $moveBack): array {
+            $ticket = MaintenanceTicket::query()->lockForUpdate()->findOrFail($ticket->id);
 
-        $staysMaintenance = MaintenanceTicket::query()
-            ->where('unit_id', $ticket->unit_id)
-            ->whereKeyNot($ticket->id)
-            ->whereNotIn('status', ['resolved', 'cancelled'])
-            ->exists();
+            if (! $ticket->unit_id) {
+                return [];
+            }
 
-        if ($staysMaintenance) {
-            return;
-        }
+            $transfer = $moveBack
+                ? LeaseUnitHistory::query()
+                    ->where('from_unit_id', $ticket->unit_id)
+                    ->where('reason', 'maintenance')
+                    ->orderBy('effective_date', 'desc')
+                    ->orderBy('id', 'desc')
+                    ->lockForUpdate()
+                    ->first()
+                : null;
 
-        $unit = Unit::lockForUpdate()->findOrFail($ticket->unit_id);
+            $unitIds = array_values(array_unique(array_filter([
+                $ticket->unit_id,
+                $transfer?->to_unit_id,
+            ])));
+            sort($unitIds);
 
-        if ($moveBack) {
-            $this->moveOccupantsBack($ticket, $unit);
-        }
+            $lockedUnits = Unit::query()
+                ->whereKey($unitIds)
+                ->orderBy('id')
+                ->lockForUpdate()
+                ->get()
+                ->keyBy('id');
 
-        $hasActiveLease = $unit->leases()->where('status', LeaseStatus::Active->value)->exists();
-        $unit->update(['status' => $hasActiveLease ? UnitStatus::Occupied : UnitStatus::Available]);
+            abort_unless($lockedUnits->has($ticket->unit_id), 404);
+
+            $changes = $lockedUnits
+                ->map(fn (Unit $unit): array => ['unit' => $unit, 'from' => $unit->status])
+                ->all();
+
+            $unit = $lockedUnits->get($ticket->unit_id);
+            $staysMaintenance = MaintenanceTicket::query()
+                ->where('unit_id', $ticket->unit_id)
+                ->whereKeyNot($ticket->id)
+                ->whereNotIn('status', ['resolved', 'cancelled'])
+                ->exists();
+
+            if ($staysMaintenance) {
+                return $changes;
+            }
+
+            if ($moveBack && $transfer) {
+                abort_unless($lockedUnits->has($transfer->to_unit_id), 404);
+                $this->moveOccupantsBack($ticket, $unit, $lockedUnits->get($transfer->to_unit_id), $transfer);
+            }
+
+            $hasActiveLease = $unit->leases()->where('status', LeaseStatus::Active->value)->exists();
+            $unit->update(['status' => $hasActiveLease ? UnitStatus::Occupied : UnitStatus::Available]);
+
+            return $changes;
+        });
     }
 
-    private function moveOccupantsBack(MaintenanceTicket $ticket, Unit $unit): void
+    private function moveOccupantsBack(MaintenanceTicket $ticket, Unit $unit, Unit $targetUnit, LeaseUnitHistory $transfer): void
     {
-        $transfer = LeaseUnitHistory::query()
-            ->where('from_unit_id', $ticket->unit_id)
-            ->where('reason', 'maintenance')
-            ->orderBy('effective_date', 'desc')
-            ->first();
-
-        if (! $transfer) {
-            return;
-        }
-
         $movedLease = Lease::where('status', LeaseStatus::Active->value)
             ->where('unit_id', $transfer->to_unit_id)
             ->first();
@@ -85,7 +114,6 @@ class ResolveTicket
             'notes' => $notes,
         ]);
 
-        $targetUnit = Unit::lockForUpdate()->findOrFail($transfer->to_unit_id);
         $targetUnitStillOccupied = $targetUnit->leases()->where('status', LeaseStatus::Active->value)->exists();
         $targetUnit->update(['status' => $targetUnitStillOccupied ? UnitStatus::Occupied : UnitStatus::Available]);
     }

--- a/app/Events/Lease/LeaseStatusChanged.php
+++ b/app/Events/Lease/LeaseStatusChanged.php
@@ -4,9 +4,10 @@ namespace App\Events\Lease;
 
 use App\Enums\LeaseStatus;
 use App\Models\Lease;
+use Illuminate\Contracts\Events\ShouldDispatchAfterCommit;
 use Illuminate\Foundation\Events\Dispatchable;
 
-class LeaseStatusChanged
+class LeaseStatusChanged implements ShouldDispatchAfterCommit
 {
     use Dispatchable;
 

--- a/app/Events/Maintenance/MaintenanceResolved.php
+++ b/app/Events/Maintenance/MaintenanceResolved.php
@@ -3,9 +3,10 @@
 namespace App\Events\Maintenance;
 
 use App\Models\MaintenanceTicket;
+use Illuminate\Contracts\Events\ShouldDispatchAfterCommit;
 use Illuminate\Foundation\Events\Dispatchable;
 
-class MaintenanceResolved
+class MaintenanceResolved implements ShouldDispatchAfterCommit
 {
     use Dispatchable;
 

--- a/app/Events/Maintenance/MaintenanceTicketCreated.php
+++ b/app/Events/Maintenance/MaintenanceTicketCreated.php
@@ -3,9 +3,10 @@
 namespace App\Events\Maintenance;
 
 use App\Models\MaintenanceTicket;
+use Illuminate\Contracts\Events\ShouldDispatchAfterCommit;
 use Illuminate\Foundation\Events\Dispatchable;
 
-class MaintenanceTicketCreated
+class MaintenanceTicketCreated implements ShouldDispatchAfterCommit
 {
     use Dispatchable;
 

--- a/app/Events/Maintenance/MaintenanceTicketUpdated.php
+++ b/app/Events/Maintenance/MaintenanceTicketUpdated.php
@@ -3,9 +3,10 @@
 namespace App\Events\Maintenance;
 
 use App\Models\MaintenanceTicket;
+use Illuminate\Contracts\Events\ShouldDispatchAfterCommit;
 use Illuminate\Foundation\Events\Dispatchable;
 
-class MaintenanceTicketUpdated
+class MaintenanceTicketUpdated implements ShouldDispatchAfterCommit
 {
     use Dispatchable;
 

--- a/app/Events/Unit/UnitStatusChanged.php
+++ b/app/Events/Unit/UnitStatusChanged.php
@@ -4,9 +4,10 @@ namespace App\Events\Unit;
 
 use App\Enums\UnitStatus;
 use App\Models\Unit;
+use Illuminate\Contracts\Events\ShouldDispatchAfterCommit;
 use Illuminate\Foundation\Events\Dispatchable;
 
-class UnitStatusChanged
+class UnitStatusChanged implements ShouldDispatchAfterCommit
 {
     use Dispatchable;
 

--- a/app/Http/Controllers/LeaseController.php
+++ b/app/Http/Controllers/LeaseController.php
@@ -361,31 +361,39 @@ class LeaseController extends Controller
     {
         $this->authorize('delete', $lease);
 
-        $oldStatus = $lease->status;
+        $result = DB::transaction(function () use ($lease, $unit): array {
+            $lockedUnit = Unit::query()->lockForUpdate()->findOrFail($unit->id);
+            $lockedLease = Lease::query()->lockForUpdate()->findOrFail($lease->id);
+            $oldStatus = $lockedLease->status;
 
-        $this->leaseStatusValidator->validate($oldStatus, LeaseStatus::Terminated);
+            abort_unless((int) $lockedLease->unit_id === $lockedUnit->id, 422, __('Lease is no longer assigned to this unit.'));
+            $this->leaseStatusValidator->validate($oldStatus, LeaseStatus::Terminated);
 
-        DB::transaction(function () use ($lease, $unit) {
-            $lease->update([
+            $lockedLease->update([
                 'end_date' => now(),
                 'status' => LeaseStatus::Terminated,
                 'termination_date' => now(),
                 'termination_reason' => request('reason'),
             ]);
 
-            $unit->unsetRelation('leases');
+            $lockedUnit->unsetRelation('leases');
 
-            if ($unit->leases()->where('status', LeaseStatus::Active->value)->doesntExist() && $unit->status !== UnitStatus::Maintenance) {
-                $oldUnitStatus = $unit->status;
-                $unit->update(['status' => UnitStatus::Available]);
+            if ($lockedUnit->leases()->where('status', LeaseStatus::Active->value)->doesntExist() && $lockedUnit->status !== UnitStatus::Maintenance) {
+                $oldUnitStatus = $lockedUnit->status;
+                $lockedUnit->update(['status' => UnitStatus::Available]);
 
-                if ($oldUnitStatus !== $unit->status) {
-                    UnitStatusChanged::dispatch($unit, $oldUnitStatus, $unit->status, actorId: Auth::id());
+                if ($oldUnitStatus !== $lockedUnit->status) {
+                    UnitStatusChanged::dispatch($lockedUnit, $oldUnitStatus, $lockedUnit->status, actorId: Auth::id());
                 }
             }
+
+            return [
+                'lease' => $lockedLease,
+                'old_status' => $oldStatus,
+            ];
         });
 
-        LeaseStatusChanged::dispatch($lease, $oldStatus, LeaseStatus::Terminated, actorId: Auth::id());
+        LeaseStatusChanged::dispatch($result['lease'], $result['old_status'], LeaseStatus::Terminated, actorId: Auth::id());
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Lease terminated.')]);
 
@@ -413,33 +421,22 @@ class LeaseController extends Controller
             targetUnitId: $validated['target_unit_id'] ?? null,
         );
 
-        $oldLeaseStatus = $lease->status;
-        $sourceUnit = $lease->unit;
-        $oldSourceStatus = $sourceUnit->status;
-
-        $oldTargetStatus = $targetUnit?->status;
-
         $result = $action->execute($lease, $data);
 
         if ($result->failed()) {
             abort(422, $result->error);
         }
 
-        $lease->refresh();
-        if ($oldLeaseStatus !== $lease->status) {
-            LeaseStatusChanged::dispatch($lease, $oldLeaseStatus, $lease->status, actorId: Auth::id());
+        if ($result->oldLeaseStatus !== $result->oldLease?->status) {
+            LeaseStatusChanged::dispatch($result->oldLease, $result->oldLeaseStatus, $result->oldLease->status, actorId: Auth::id());
         }
 
-        $sourceUnit->refresh();
-        if ($oldSourceStatus !== $sourceUnit->status) {
-            UnitStatusChanged::dispatch($sourceUnit, $oldSourceStatus, $sourceUnit->status, actorId: Auth::id());
+        if ($result->oldSourceStatus !== $result->newSourceStatus) {
+            UnitStatusChanged::dispatch($result->sourceUnit, $result->oldSourceStatus, $result->newSourceStatus, actorId: Auth::id());
         }
 
-        if ($targetUnit) {
-            $targetUnit->refresh();
-            if ($oldTargetStatus !== $targetUnit->status) {
-                UnitStatusChanged::dispatch($targetUnit, $oldTargetStatus, $targetUnit->status, actorId: Auth::id());
-            }
+        if ($result->oldTargetStatus !== $result->newTargetStatus) {
+            UnitStatusChanged::dispatch($result->targetUnit, $result->oldTargetStatus, $result->newTargetStatus, actorId: Auth::id());
         }
 
         Inertia::flash('toast', [
@@ -518,29 +515,22 @@ class LeaseController extends Controller
             carryDepositRefund: true,
         );
 
-        $oldLeaseStatus = $lease->status;
-        $oldSourceStatus = $unit->status;
-        $oldTargetStatus = $targetUnit->status;
-
         $result = $action->execute($lease, $data);
 
         if ($result->failed()) {
             abort(422, $result->error);
         }
 
-        $lease->refresh();
-        if ($oldLeaseStatus !== $lease->status) {
-            LeaseStatusChanged::dispatch($lease, $oldLeaseStatus, $lease->status, actorId: Auth::id());
+        if ($result->oldLeaseStatus !== $result->oldLease?->status) {
+            LeaseStatusChanged::dispatch($result->oldLease, $result->oldLeaseStatus, $result->oldLease->status, actorId: Auth::id());
         }
 
-        $unit->refresh();
-        if ($oldSourceStatus !== $unit->status) {
-            UnitStatusChanged::dispatch($unit, $oldSourceStatus, $unit->status, actorId: Auth::id());
+        if ($result->oldSourceStatus !== $result->newSourceStatus) {
+            UnitStatusChanged::dispatch($result->sourceUnit, $result->oldSourceStatus, $result->newSourceStatus, actorId: Auth::id());
         }
 
-        $targetUnit->refresh();
-        if ($oldTargetStatus !== $targetUnit->status) {
-            UnitStatusChanged::dispatch($targetUnit, $oldTargetStatus, $targetUnit->status, actorId: Auth::id());
+        if ($result->oldTargetStatus !== $result->newTargetStatus) {
+            UnitStatusChanged::dispatch($result->targetUnit, $result->oldTargetStatus, $result->newTargetStatus, actorId: Auth::id());
         }
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Tenant moved to new unit.')]);

--- a/app/Http/Controllers/MaintenanceTicketController.php
+++ b/app/Http/Controllers/MaintenanceTicketController.php
@@ -25,6 +25,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -162,31 +163,22 @@ class MaintenanceTicketController extends Controller
         $moveToUnitId = $data['move_tenant_to_unit_id'] ?? null;
         unset($data['block_unit'], $data['move_tenant_to_unit_id']);
 
-        $ticket = MaintenanceTicket::create($data);
+        DB::transaction(function () use ($data, $blockUnit, $moveToUnitId): void {
+            $ticket = MaintenanceTicket::create($data);
+            $statusChanges = [];
 
-        MaintenanceTicketCreated::dispatch($ticket, actorId: Auth::id());
+            MaintenanceTicketCreated::dispatch($ticket, actorId: Auth::id());
 
-        if ($blockUnit && ! empty($data['unit_id'])) {
-            $unit = Unit::findOrFail($data['unit_id']);
-            $oldStatus = $unit->status;
-
-            $targetUnit = $moveToUnitId ? Unit::find($moveToUnitId) : null;
-            $oldTargetStatus = $targetUnit?->status;
-
-            $this->blockUnit->execute($data['unit_id'], $moveToUnitId);
-
-            $unit->refresh();
-            if ($oldStatus !== $unit->status) {
-                UnitStatusChanged::dispatch($unit, $oldStatus, $unit->status, actorId: Auth::id());
+            if ($blockUnit && ! empty($data['unit_id'])) {
+                $statusChanges = $this->blockUnit->execute($data['unit_id'], $moveToUnitId);
             }
 
-            if ($targetUnit) {
-                $targetUnit->refresh();
-                if ($oldTargetStatus !== $targetUnit->status) {
-                    UnitStatusChanged::dispatch($targetUnit, $oldTargetStatus, $targetUnit->status, actorId: Auth::id());
+            foreach ($statusChanges as $change) {
+                if ($change['from'] !== $change['unit']->status) {
+                    UnitStatusChanged::dispatch($change['unit'], $change['from'], $change['unit']->status, actorId: Auth::id());
                 }
             }
-        }
+        });
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Maintenance ticket created.')]);
 
@@ -198,60 +190,54 @@ class MaintenanceTicketController extends Controller
         $this->authorize('update', $ticket);
 
         $validated = $request->validated();
-
-        if (isset($validated['status'])) {
-            $newStatus = MaintenanceStatus::from($validated['status']);
-            $this->transitionValidator->validate($ticket->status, $newStatus);
-
-            if ($newStatus === MaintenanceStatus::Resolved) {
-                $validated['resolved_at'] ??= now();
-            }
-
-            $statusChangedToResolved = $newStatus === MaintenanceStatus::Resolved;
-        }
-
         $restoreUnit = ! empty($validated['restore_unit']);
         $moveBack = ! empty($validated['move_back']);
         unset($validated['restore_unit'], $validated['move_back']);
 
-        $ticket->update($validated);
+        $restoreResult = DB::transaction(function () use ($ticket, $validated, $restoreUnit, $moveBack): array {
+            $ticket = MaintenanceTicket::query()->lockForUpdate()->findOrFail($ticket->id);
+            $statusChangedToResolved = false;
 
-        if ($ticket->wasChanged()) {
-            MaintenanceTicketUpdated::dispatch($ticket, actorId: Auth::id());
-        }
+            if (isset($validated['status'])) {
+                $newStatus = MaintenanceStatus::from($validated['status']);
+                $this->transitionValidator->validate($ticket->status, $newStatus);
 
-        if (($statusChangedToResolved ?? false)) {
-            MaintenanceResolved::dispatch($ticket, actorId: Auth::id());
-        }
-
-        if ($restoreUnit && $ticket->unit_id) {
-            $unit = Unit::findOrFail($ticket->unit_id);
-            $oldStatus = $unit->status;
-
-            $transfer = LeaseUnitHistory::query()
-                ->where('from_unit_id', $ticket->unit_id)
-                ->where('reason', 'maintenance')
-                ->orderBy('effective_date', 'desc')
-                ->first();
-            $targetUnit = $transfer ? Unit::find($transfer->to_unit_id) : null;
-            $oldTargetStatus = $targetUnit?->status;
-
-            $this->resolveTicket->execute($ticket, $moveBack);
-
-            $unit->refresh();
-            if ($oldStatus !== $unit->status) {
-                UnitStatusChanged::dispatch($unit, $oldStatus, $unit->status, actorId: Auth::id());
-            }
-
-            if ($targetUnit) {
-                $targetUnit->refresh();
-                if ($oldTargetStatus !== $targetUnit->status) {
-                    UnitStatusChanged::dispatch($targetUnit, $oldTargetStatus, $targetUnit->status, actorId: Auth::id());
+                if ($newStatus === MaintenanceStatus::Resolved) {
+                    $validated['resolved_at'] ??= now();
+                    $statusChangedToResolved = true;
                 }
             }
 
-            $unitName = $unit->name ?? '';
-            Inertia::flash('toast', ['type' => 'success', 'message' => __('Ticket updated. Unit :name restored.', ['name' => $unitName])]);
+            $ticket->update($validated);
+
+            if ($ticket->wasChanged()) {
+                MaintenanceTicketUpdated::dispatch($ticket, actorId: Auth::id());
+            }
+
+            if ($statusChangedToResolved) {
+                MaintenanceResolved::dispatch($ticket, actorId: Auth::id());
+            }
+
+            $statusChanges = [];
+            $didRestore = $restoreUnit && $ticket->unit_id;
+            if ($didRestore) {
+                $statusChanges = $this->resolveTicket->execute($ticket, $moveBack);
+
+                foreach ($statusChanges as $change) {
+                    if ($change['from'] !== $change['unit']->status) {
+                        UnitStatusChanged::dispatch($change['unit'], $change['from'], $change['unit']->status, actorId: Auth::id());
+                    }
+                }
+            }
+
+            return [
+                'did_restore' => (bool) $didRestore,
+                'unit_name' => $didRestore ? ($statusChanges[$ticket->unit_id]['unit']->name ?? '') : '',
+            ];
+        });
+
+        if ($restoreResult['did_restore']) {
+            Inertia::flash('toast', ['type' => 'success', 'message' => __('Ticket updated. Unit :name restored.', ['name' => $restoreResult['unit_name']])]);
 
             return back();
         }

--- a/app/Http/Requests/Lease/MoveLeaseRequest.php
+++ b/app/Http/Requests/Lease/MoveLeaseRequest.php
@@ -2,8 +2,10 @@
 
 namespace App\Http\Requests\Lease;
 
+use App\Models\Unit;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class MoveLeaseRequest extends FormRequest
 {
@@ -12,8 +14,11 @@ class MoveLeaseRequest extends FormRequest
      */
     public function rules(): array
     {
+        $unit = $this->route('unit');
+        $sourceUnitId = $unit instanceof Unit ? $unit->id : null;
+
         return [
-            'target_unit_id' => ['required', 'integer', 'exists:units,id'],
+            'target_unit_id' => ['required', 'integer', Rule::notIn([$sourceUnitId]), 'exists:units,id'],
         ];
     }
 }

--- a/app/Http/Requests/Lease/MoveOutRequest.php
+++ b/app/Http/Requests/Lease/MoveOutRequest.php
@@ -2,8 +2,10 @@
 
 namespace App\Http\Requests\Lease;
 
+use App\Models\Lease;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class MoveOutRequest extends FormRequest
 {
@@ -12,6 +14,9 @@ class MoveOutRequest extends FormRequest
      */
     public function rules(): array
     {
+        $lease = $this->route('lease');
+        $sourceUnitId = $lease instanceof Lease ? $lease->unit_id : null;
+
         return [
             'move_out_date' => ['required', 'date'],
             'reason' => ['nullable', 'string', 'max:255'],
@@ -19,7 +24,7 @@ class MoveOutRequest extends FormRequest
             'deposit_refund_amount' => ['nullable', 'numeric', 'min:0'],
             'notes' => ['nullable', 'string', 'max:65535'],
             'move_to_another_unit' => ['nullable', 'boolean'],
-            'target_unit_id' => ['nullable', 'integer', 'exists:units,id'],
+            'target_unit_id' => ['nullable', 'integer', Rule::notIn([$sourceUnitId]), 'exists:units,id'],
         ];
     }
 }

--- a/app/Results/Lease/MoveOutLeaseResult.php
+++ b/app/Results/Lease/MoveOutLeaseResult.php
@@ -2,13 +2,23 @@
 
 namespace App\Results\Lease;
 
+use App\Enums\LeaseStatus;
+use App\Enums\UnitStatus;
 use App\Models\Lease;
+use App\Models\Unit;
 
 final readonly class MoveOutLeaseResult
 {
     public function __construct(
         public ?Lease $oldLease = null,
         public ?Lease $newLease = null,
+        public ?Unit $sourceUnit = null,
+        public ?Unit $targetUnit = null,
+        public ?LeaseStatus $oldLeaseStatus = null,
+        public ?UnitStatus $oldSourceStatus = null,
+        public ?UnitStatus $newSourceStatus = null,
+        public ?UnitStatus $oldTargetStatus = null,
+        public ?UnitStatus $newTargetStatus = null,
         public ?string $error = null,
     ) {}
 
@@ -22,9 +32,28 @@ final readonly class MoveOutLeaseResult
         return $this->error !== null;
     }
 
-    public static function success(Lease $oldLease, ?Lease $newLease = null): self
-    {
-        return new self(oldLease: $oldLease, newLease: $newLease);
+    public static function success(
+        Lease $oldLease,
+        ?Lease $newLease = null,
+        ?Unit $sourceUnit = null,
+        ?Unit $targetUnit = null,
+        ?LeaseStatus $oldLeaseStatus = null,
+        ?UnitStatus $oldSourceStatus = null,
+        ?UnitStatus $newSourceStatus = null,
+        ?UnitStatus $oldTargetStatus = null,
+        ?UnitStatus $newTargetStatus = null,
+    ): self {
+        return new self(
+            oldLease: $oldLease,
+            newLease: $newLease,
+            sourceUnit: $sourceUnit,
+            targetUnit: $targetUnit,
+            oldLeaseStatus: $oldLeaseStatus,
+            oldSourceStatus: $oldSourceStatus,
+            newSourceStatus: $newSourceStatus,
+            oldTargetStatus: $oldTargetStatus,
+            newTargetStatus: $newTargetStatus,
+        );
     }
 
     public static function error(string $error): self

--- a/tests/Feature/Domain/DomainEventTest.php
+++ b/tests/Feature/Domain/DomainEventTest.php
@@ -5,6 +5,7 @@ use App\Enums\MaintenancePriority;
 use App\Enums\MaintenanceStatus;
 use App\Enums\UnitStatus;
 use App\Events\Lease\LeaseCreated;
+use App\Events\Lease\LeaseStatusChanged;
 use App\Events\Maintenance\MaintenanceResolved;
 use App\Events\Maintenance\MaintenanceTicketCreated;
 use App\Events\Payment\PaymentRecorded;
@@ -48,7 +49,7 @@ describe('lease events', function () {
     });
 
     it('dispatches UnitStatusChanged when lease termination frees a unit', function () {
-        Event::fake([UnitStatusChanged::class]);
+        Event::fake([LeaseStatusChanged::class, UnitStatusChanged::class]);
 
         $property = Property::factory()->create();
         $unit = Unit::factory()->withRate(1_000_000)->occupied()->create(['property_id' => $property->id]);
@@ -66,6 +67,7 @@ describe('lease events', function () {
 
         // ponytail: UnitStatusChanged only fires when the status actually changes.
         // The unit starts occupied and termination flips it to available.
+        Event::assertDispatched(LeaseStatusChanged::class);
         Event::assertDispatched(UnitStatusChanged::class);
     });
 });

--- a/tests/Feature/LeaseTest.php
+++ b/tests/Feature/LeaseTest.php
@@ -1,6 +1,9 @@
 <?php
 
+use App\Actions\Leases\MoveOutLease;
+use App\Data\Lease\MoveOutLeaseData;
 use App\Enums\LeaseStatus;
+use App\Enums\UnitStatus;
 use App\Models\Lease;
 use App\Models\Property;
 use App\Models\Tenant;
@@ -8,6 +11,7 @@ use App\Models\Unit;
 use App\Models\User;
 use Database\Seeders\RegionAndCitySeeder;
 use Database\Seeders\RoleAndPermissionSeeder;
+use Illuminate\Support\Facades\DB;
 
 uses()->beforeEach(function () {
     $this->seed(RoleAndPermissionSeeder::class);
@@ -268,6 +272,51 @@ describe('move unit', function () {
         expect($newLease->deposit_amount)->toBe('500000.00');
     });
 
+    it('returns authoritative transition state from a move', function () {
+        $property = Property::factory()->create();
+        $targetUnit = Unit::factory()->withRate(1_200_000)->for($property)->create();
+        $sourceUnit = Unit::factory()->withRate(1_000_000)->for($property)->occupied()->create();
+        $tenant = Tenant::factory()->create();
+        $lease = Lease::factory()->create([
+            'primary_tenant_id' => $tenant->id,
+            'unit_id' => $sourceUnit->id,
+            'status' => LeaseStatus::Active,
+        ]);
+
+        $result = app(MoveOutLease::class)->execute($lease, new MoveOutLeaseData(
+            terminationDate: now()->toDateString(),
+            endDate: now()->toDateString(),
+            reason: 'Moved to target unit',
+            moveToAnotherUnit: true,
+            targetUnitId: $targetUnit->id,
+        ));
+
+        expect($result->oldLeaseStatus)->toBe(LeaseStatus::Active)
+            ->and($result->oldSourceStatus)->toBe(UnitStatus::Occupied)
+            ->and($result->newSourceStatus)->toBe(UnitStatus::Available)
+            ->and($result->oldTargetStatus)->toBe(UnitStatus::Available)
+            ->and($result->newTargetStatus)->toBe(UnitStatus::Occupied);
+    });
+
+    it('rejects moving a lease to its current unit', function () {
+        [$property, $unit] = createPropertyWithUnit();
+        $user = User::factory()->owner()->create();
+        $tenant = Tenant::factory()->create();
+        $lease = Lease::factory()->create([
+            'primary_tenant_id' => $tenant->id,
+            'unit_id' => $unit->id,
+            'status' => LeaseStatus::Active,
+        ]);
+
+        $this->actingAs($user)
+            ->post(route('properties.units.leases.move', [$property, $unit, $lease]), [
+                'target_unit_id' => $unit->id,
+            ])
+            ->assertSessionHasErrors('target_unit_id');
+
+        expect($lease->fresh()->status)->toBe(LeaseStatus::Active);
+    });
+
     it('denies admin from accessing leases of a property they are not assigned to', function () {
         $admin = User::factory()->admin()->create();
         [$propertyA] = createPropertyWithUnit();
@@ -395,6 +444,42 @@ describe('move unit', function () {
                 'target_unit_id' => $unitB->id,
             ])
             ->assertStatus(422);
+    });
+
+    it('locks reverse-direction move units in ascending id order', function () {
+        $property = Property::factory()->create();
+        $targetUnit = Unit::factory()->withRate(1_200_000)->for($property)->create();
+        $sourceUnit = Unit::factory()->withRate(1_000_000)->for($property)->create();
+        $tenant = Tenant::factory()->create();
+        $lease = Lease::factory()->create([
+            'primary_tenant_id' => $tenant->id,
+            'unit_id' => $sourceUnit->id,
+            'status' => LeaseStatus::Active,
+        ]);
+
+        DB::connection()->flushQueryLog();
+        DB::connection()->enableQueryLog();
+
+        app(MoveOutLease::class)->execute($lease, new MoveOutLeaseData(
+            terminationDate: now()->toDateString(),
+            endDate: now()->toDateString(),
+            reason: 'Moved to target unit',
+            moveToAnotherUnit: true,
+            targetUnitId: $targetUnit->id,
+        ));
+
+        $lockQueries = collect(DB::connection()->getQueryLog())
+            ->filter(fn (array $query): bool => str_contains($query['query'], 'from "units"') && str_contains($query['query'], 'order by "id" asc'));
+
+        expect($lockQueries)->not->toBeEmpty();
+
+        $lockQuery = $lockQueries->last();
+
+        if ($lockQuery['bindings'] !== []) {
+            expect(array_map('intval', $lockQuery['bindings']))->toBe([$targetUnit->id, $sourceUnit->id]);
+        } else {
+            expect($lockQuery['query'])->toContain(sprintf('in (%d, %d)', $targetUnit->id, $sourceUnit->id));
+        }
     });
 });
 

--- a/tests/Feature/MaintenanceTicketCrudTest.php
+++ b/tests/Feature/MaintenanceTicketCrudTest.php
@@ -4,6 +4,9 @@ use App\Enums\LeaseStatus;
 use App\Enums\MaintenancePriority;
 use App\Enums\MaintenanceStatus;
 use App\Enums\UnitStatus;
+use App\Events\Maintenance\MaintenanceTicketCreated;
+use App\Events\Unit\UnitStatusChanged;
+use App\Models\Lease;
 use App\Models\LeaseUnitHistory;
 use App\Models\MaintenanceTicket;
 use App\Models\Property;
@@ -11,6 +14,8 @@ use App\Models\Tenant;
 use App\Models\Unit;
 use App\Models\User;
 use Database\Seeders\RoleAndPermissionSeeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
 use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Models\Role as SpatieRole;
 
@@ -221,6 +226,129 @@ it('moves tenant and blocks unit when move_tenant_to_unit_id provided', function
     expect($targetUnit->fresh()->status)->toBe(UnitStatus::Occupied);
     expect($targetUnit->leases()->where('status', LeaseStatus::Active->value)->count())->toBe(1);
     expect($lease->fresh()->unitHistories()->count())->toBe(1);
+});
+
+it('rolls back maintenance ticket and occupancy changes when a transfer fails', function () {
+    $owner = User::factory()->owner()->create();
+    $property = Property::factory()->create();
+    $sourceUnit = Unit::factory()->for($property)->occupied()->create();
+    $targetUnit = Unit::factory()->for($property)->occupied()->create();
+    $sourceLease = Lease::factory()->create([
+        'unit_id' => $sourceUnit->id,
+        'status' => LeaseStatus::Active,
+    ]);
+    Lease::factory()->create([
+        'unit_id' => $targetUnit->id,
+        'status' => LeaseStatus::Active,
+    ]);
+
+    Event::fake([MaintenanceTicketCreated::class, UnitStatusChanged::class]);
+
+    $this->actingAs($owner)
+        ->post(route('maintenance-tickets.store'), [
+            'property_id' => $property->id,
+            'unit_id' => $sourceUnit->id,
+            'title' => 'Broken ceiling',
+            'priority' => MaintenancePriority::Urgent->value,
+            'block_unit' => true,
+            'move_tenant_to_unit_id' => $targetUnit->id,
+        ])
+        ->assertUnprocessable();
+
+    expect(MaintenanceTicket::query()->count())->toBe(0)
+        ->and(LeaseUnitHistory::query()->count())->toBe(0)
+        ->and($sourceLease->fresh()->unit_id)->toBe($sourceUnit->id)
+        ->and($sourceUnit->fresh()->status)->toBe(UnitStatus::Occupied)
+        ->and($targetUnit->fresh()->status)->toBe(UnitStatus::Occupied);
+
+    Event::assertNotDispatched(MaintenanceTicketCreated::class);
+    Event::assertNotDispatched(UnitStatusChanged::class);
+});
+
+it('locks reverse-direction maintenance transfer units in ascending id order', function () {
+    $owner = User::factory()->owner()->create();
+    $property = Property::factory()->create();
+    $targetUnit = Unit::factory()->for($property)->create();
+    $sourceUnit = Unit::factory()->for($property)->occupied()->create();
+    Lease::factory()->create([
+        'unit_id' => $sourceUnit->id,
+        'status' => LeaseStatus::Active,
+    ]);
+
+    DB::connection()->flushQueryLog();
+    DB::connection()->enableQueryLog();
+
+    $this->actingAs($owner)
+        ->post(route('maintenance-tickets.store'), [
+            'property_id' => $property->id,
+            'unit_id' => $sourceUnit->id,
+            'title' => 'Broken ceiling',
+            'priority' => MaintenancePriority::Urgent->value,
+            'block_unit' => true,
+            'move_tenant_to_unit_id' => $targetUnit->id,
+        ])
+        ->assertRedirect();
+
+    $lockQueries = collect(DB::connection()->getQueryLog())
+        ->filter(fn (array $query): bool => str_contains($query['query'], 'from "units"') && str_contains($query['query'], 'order by "id" asc'));
+
+    expect($lockQueries)->not->toBeEmpty();
+
+    $lockQuery = $lockQueries->last();
+
+    if ($lockQuery['bindings'] !== []) {
+        expect(array_map('intval', $lockQuery['bindings']))->toBe([$targetUnit->id, $sourceUnit->id]);
+    } else {
+        expect($lockQuery['query'])->toContain(sprintf('in (%d, %d)', $targetUnit->id, $sourceUnit->id));
+    }
+});
+
+it('locks reverse-direction maintenance restore units in ascending id order', function () {
+    $owner = User::factory()->owner()->create();
+    $property = Property::factory()->create();
+    $targetUnit = Unit::factory()->for($property)->occupied()->create();
+    $sourceUnit = Unit::factory()->for($property)->create(['status' => UnitStatus::Maintenance]);
+    $lease = Lease::factory()->create([
+        'unit_id' => $targetUnit->id,
+        'status' => LeaseStatus::Active,
+    ]);
+
+    LeaseUnitHistory::create([
+        'lease_id' => $lease->id,
+        'from_unit_id' => $sourceUnit->id,
+        'to_unit_id' => $targetUnit->id,
+        'reason' => 'maintenance',
+        'effective_date' => now(),
+    ]);
+
+    $ticket = MaintenanceTicket::factory()->create([
+        'unit_id' => $sourceUnit->id,
+        'status' => MaintenanceStatus::InProgress->value,
+    ]);
+
+    DB::connection()->flushQueryLog();
+    DB::connection()->enableQueryLog();
+
+    $this->actingAs($owner)
+        ->put(route('maintenance-tickets.update', $ticket), [
+            'status' => MaintenanceStatus::Resolved->value,
+            'restore_unit' => true,
+            'move_back' => true,
+        ])
+        ->assertRedirect();
+
+    $lockQueries = collect(DB::connection()->getQueryLog())
+        ->filter(fn (array $query): bool => str_contains($query['query'], 'from "units"') && str_contains($query['query'], 'order by "id" asc'));
+
+    expect($lockQueries)->not->toBeEmpty();
+
+    $lockQuery = $lockQueries->last();
+
+    if ($lockQuery['bindings'] !== []) {
+        expect(array_map('intval', $lockQuery['bindings']))->toBe([$targetUnit->id, $sourceUnit->id]);
+    } else {
+        expect($lockQuery['query'])->toContain(sprintf('in (%d, %d)', $targetUnit->id, $sourceUnit->id));
+    }
 });
 
 it('keeps the tenant on the same unit when blocking without a move target', function () {


### PR DESCRIPTION
## Summary
- Serialize occupancy mutations with deterministic unit locks and transaction-safe actions
- Emit lease, maintenance, and unit events after commit from authoritative transition state
- Reject same-unit moves and add rollback, lock-order, and transition-state coverage

## Verification
- `php artisan test --compact` — 803 tests, 3,714 assertions
- `vendor/bin/pint --dirty --format agent`
- `git diff --check`

Refs OPE-143