### PR TITLE
fix(reminders): normalize reminder deduplication

### DIFF
--- a/app/Models/ReminderLog.php
+++ b/app/Models/ReminderLog.php
@@ -10,6 +10,12 @@ class ReminderLog extends Model
 {
     use HasFactory;
 
+    public const NON_OVERDUE_DAYS = -1;
+
+    protected $attributes = [
+        'overdue_days' => self::NON_OVERDUE_DAYS,
+    ];
+
     protected $fillable = [
         'lease_id',
         'period_start',

--- a/app/Repositories/ReminderRepository.php
+++ b/app/Repositories/ReminderRepository.php
@@ -4,40 +4,28 @@ namespace App\Repositories;
 
 use App\Data\Reminder\ReminderEvent;
 use App\Models\ReminderLog;
-use Illuminate\Database\QueryException;
+use Illuminate\Database\UniqueConstraintViolationException;
 
 class ReminderRepository
 {
-    public function alreadySent(ReminderEvent $event): bool
-    {
-        return ReminderLog::where('lease_id', $event->lease->id)
-            ->where('period_start', $event->periodStart)
-            ->where('reminder_type', $event->type->value)
-            ->where('overdue_days', $event->overdueDays)
-            ->exists();
-    }
-
     public function recordIfAbsent(ReminderEvent $event, array $channels = ['whatsapp']): ?ReminderLog
     {
-        if ($this->alreadySent($event)) {
-            return null;
-        }
-
         try {
             return ReminderLog::create([
                 'lease_id' => $event->lease->id,
                 'period_start' => $event->periodStart,
                 'period_end' => $event->periodEnd,
                 'reminder_type' => $event->type->value,
-                'overdue_days' => $event->overdueDays,
+                'overdue_days' => $event->overdueDays ?? ReminderLog::NON_OVERDUE_DAYS,
                 'notification_class' => 'App\Notifications\RentReminder',
                 'channel' => implode(',', $channels),
                 'scheduled_for' => today(),
                 'sent_at' => now(),
             ]);
-        } catch (QueryException $e) {
-            if (! str_starts_with((string) $e->getCode(), '23')) {
-                throw $e;
+        } catch (UniqueConstraintViolationException $exception) {
+            if ($exception->index !== 'reminder_logs_unique'
+                && $exception->columns !== ['lease_id', 'period_start', 'reminder_type', 'overdue_days']) {
+                throw $exception;
             }
 
             return null;

--- a/database/factories/ReminderLogFactory.php
+++ b/database/factories/ReminderLogFactory.php
@@ -20,7 +20,7 @@ class ReminderLogFactory extends Factory
             'period_start' => now()->startOfMonth()->toDateString(),
             'period_end' => now()->endOfMonth()->toDateString(),
             'reminder_type' => fake()->randomElement(['upcoming', 'due_today', 'overdue']),
-            'overdue_days' => null,
+            'overdue_days' => ReminderLog::NON_OVERDUE_DAYS,
             'notification_class' => 'App\Notifications\RentReminder',
             'channel' => 'whatsapp',
             'scheduled_for' => now()->toDateString(),

--- a/database/migrations/2026_08_20_093028_normalize_reminder_log_deduplication_key.php
+++ b/database/migrations/2026_08_20_093028_normalize_reminder_log_deduplication_key.php
@@ -1,0 +1,96 @@
+<?php
+
+use App\Models\ReminderLog;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $this->ensureNormalizedKeysAreUnique();
+
+        Schema::table('reminder_logs', function (Blueprint $table) {
+            $table->dropUnique('reminder_logs_unique');
+        });
+
+        Schema::table('reminder_logs', function (Blueprint $table) {
+            $table->smallInteger('overdue_days')
+                ->nullable()
+                ->default(null)
+                ->change();
+        });
+
+        DB::table('reminder_logs')
+            ->whereNull('overdue_days')
+            ->update(['overdue_days' => ReminderLog::NON_OVERDUE_DAYS]);
+
+        Schema::table('reminder_logs', function (Blueprint $table) {
+            $table->smallInteger('overdue_days')
+                ->default(ReminderLog::NON_OVERDUE_DAYS)
+                ->nullable(false)
+                ->change();
+            $table->unique(
+                ['lease_id', 'period_start', 'reminder_type', 'overdue_days'],
+                'reminder_logs_unique',
+            );
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('reminder_logs', function (Blueprint $table) {
+            $table->dropUnique('reminder_logs_unique');
+        });
+
+        Schema::table('reminder_logs', function (Blueprint $table) {
+            $table->smallInteger('overdue_days')
+                ->nullable()
+                ->default(null)
+                ->change();
+        });
+
+        DB::table('reminder_logs')
+            ->where('overdue_days', ReminderLog::NON_OVERDUE_DAYS)
+            ->update(['overdue_days' => null]);
+
+        Schema::table('reminder_logs', function (Blueprint $table) {
+            $table->unsignedTinyInteger('overdue_days')
+                ->nullable()
+                ->default(null)
+                ->change();
+        });
+
+        Schema::table('reminder_logs', function (Blueprint $table) {
+            $table->unique(
+                ['lease_id', 'period_start', 'reminder_type', 'overdue_days'],
+                'reminder_logs_unique',
+            );
+        });
+    }
+
+    private function ensureNormalizedKeysAreUnique(): void
+    {
+        $hasDuplicates = DB::table('reminder_logs')
+            ->select('lease_id', 'period_start', 'reminder_type')
+            ->selectRaw(
+                'COALESCE(overdue_days, ?) AS normalized_overdue_days',
+                [ReminderLog::NON_OVERDUE_DAYS],
+            )
+            ->groupBy('lease_id', 'period_start', 'reminder_type')
+            ->groupByRaw(
+                'COALESCE(overdue_days, ?)',
+                [ReminderLog::NON_OVERDUE_DAYS],
+            )
+            ->havingRaw('COUNT(*) > 1')
+            ->exists();
+
+        if ($hasDuplicates) {
+            throw new RuntimeException(
+                'Cannot normalize reminder_logs.overdue_days because duplicate reminder keys exist.',
+            );
+        }
+    }
+};

--- a/tests/Feature/SendRentRemindersTest.php
+++ b/tests/Feature/SendRentRemindersTest.php
@@ -3,8 +3,10 @@
 use App\Actions\Invoices\GenerateInvoices;
 use App\Actions\Reminders\SendRentReminders;
 use App\Business\Reminders\PaymentReminderScheduler;
+use App\Data\Reminder\ReminderEvent;
 use App\Data\Reminder\ReminderSettings;
 use App\Enums\InvoiceStatus;
+use App\Enums\ReminderType;
 use App\Jobs\GenerateInvoicePdfArtifact;
 use App\Models\Invoice;
 use App\Models\Lease;
@@ -15,9 +17,16 @@ use App\Models\Tenant;
 use App\Models\Unit;
 use App\Models\User;
 use App\Notifications\RentReminder;
+use App\Repositories\ReminderRepository;
 use App\Services\Invoices\InvoicePdfArtifact;
 use Carbon\Carbon;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Database\QueryException;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\UniqueConstraintViolationException;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Storage;
 
 uses()->beforeEach(function () {
@@ -56,6 +65,19 @@ function createLeaseWithTenant(array $overrides = []): Lease
     app(GenerateInvoices::class)->execute($lease);
 
     return $lease;
+}
+
+function reminderEventFor(Lease $lease, ReminderType $type, ?int $overdueDays = null): ReminderEvent
+{
+    return new ReminderEvent(
+        lease: $lease,
+        type: $type,
+        periodStart: '2026-07-01',
+        periodEnd: '2026-07-31',
+        dueDate: '2026-07-01',
+        amount: 1_500_000,
+        overdueDays: $overdueDays,
+    );
 }
 
 describe('PaymentReminderScheduler', function () {
@@ -165,6 +187,96 @@ describe('PaymentReminderScheduler', function () {
         expect($queuedReminder->shouldSend($lease->primaryTenant, 'mail'))->toBeFalse();
 
         Carbon::setTestNow();
+    });
+});
+
+describe('ReminderRepository', function () {
+    it('records a new reminder with one insert attempt', function () {
+        $lease = createLeaseWithTenant();
+        $queries = [];
+
+        DB::listen(function (QueryExecuted $query) use (&$queries): void {
+            if (str_contains(strtolower($query->sql), 'reminder_logs')) {
+                $queries[] = $query->sql;
+            }
+        });
+
+        $log = app(ReminderRepository::class)->recordIfAbsent(
+            reminderEventFor($lease, ReminderType::Upcoming),
+        );
+
+        expect($log)->toBeInstanceOf(ReminderLog::class)
+            ->and($log?->overdue_days)->toBe(ReminderLog::NON_OVERDUE_DAYS)
+            ->and($queries)->toHaveCount(1)
+            ->and(strtolower($queries[0]))->toContain('insert');
+    });
+
+    it('ignores duplicate reminder keys', function (ReminderType $type, ?int $overdueDays) {
+        $lease = createLeaseWithTenant();
+        $repository = app(ReminderRepository::class);
+        $event = reminderEventFor($lease, $type, $overdueDays);
+
+        expect($repository->recordIfAbsent($event))->toBeInstanceOf(ReminderLog::class)
+            ->and($repository->recordIfAbsent($event))->toBeNull()
+            ->and(ReminderLog::count())->toBe(1);
+    })->with([
+        'upcoming' => [ReminderType::Upcoming, null],
+        'due today' => [ReminderType::DueToday, null],
+        'overdue' => [ReminderType::Overdue, 1],
+    ]);
+
+    it('keeps upcoming and due-today reminder keys distinct', function () {
+        $lease = createLeaseWithTenant();
+        $repository = app(ReminderRepository::class);
+
+        $upcoming = $repository->recordIfAbsent(
+            reminderEventFor($lease, ReminderType::Upcoming),
+        );
+        $dueToday = $repository->recordIfAbsent(
+            reminderEventFor($lease, ReminderType::DueToday),
+        );
+
+        expect($upcoming)->toBeInstanceOf(ReminderLog::class)
+            ->and($dueToday)->toBeInstanceOf(ReminderLog::class)
+            ->and(ReminderLog::count())->toBe(2);
+    });
+
+    it('preserves zero overdue days', function () {
+        $lease = createLeaseWithTenant();
+
+        $log = app(ReminderRepository::class)->recordIfAbsent(
+            reminderEventFor($lease, ReminderType::Overdue, 0),
+        );
+
+        expect($log?->overdue_days)->toBe(0);
+    });
+
+    it('rethrows foreign-key violations', function () {
+        $lease = createLeaseWithTenant();
+        $lease->id = PHP_INT_MAX;
+
+        expect(fn () => app(ReminderRepository::class)->recordIfAbsent(
+            reminderEventFor($lease, ReminderType::Upcoming),
+        ))->toThrow(QueryException::class);
+    });
+
+    it('rethrows unrelated unique constraint violations', function () {
+        Schema::table('reminder_logs', function (Blueprint $table): void {
+            $table->unique('channel', 'reminder_logs_channel_unique');
+        });
+
+        try {
+            ReminderLog::factory()->create(['channel' => 'whatsapp']);
+            $lease = createLeaseWithTenant();
+
+            expect(fn () => app(ReminderRepository::class)->recordIfAbsent(
+                reminderEventFor($lease, ReminderType::Upcoming),
+            ))->toThrow(UniqueConstraintViolationException::class);
+        } finally {
+            Schema::table('reminder_logs', function (Blueprint $table): void {
+                $table->dropUnique('reminder_logs_channel_unique');
+            });
+        }
     });
 });
 

--- a/tests/Unit/Database/NormalizeReminderLogDeduplicationKeyTest.php
+++ b/tests/Unit/Database/NormalizeReminderLogDeduplicationKeyTest.php
@@ -1,0 +1,81 @@
+<?php
+
+use App\Models\ReminderLog;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+beforeEach(function (): void {
+    $this->originalDatabaseConnection = DB::getDefaultConnection();
+
+    config([
+        'database.connections.ope_migration' => [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+            'foreign_key_constraints' => true,
+        ],
+    ]);
+
+    DB::purge('ope_migration');
+    DB::setDefaultConnection('ope_migration');
+
+    Schema::create('reminder_logs', function (Blueprint $table): void {
+        $table->id();
+        $table->unsignedBigInteger('lease_id');
+        $table->date('period_start');
+        $table->string('reminder_type');
+        $table->unsignedTinyInteger('overdue_days')->nullable();
+        $table->unique(
+            ['lease_id', 'period_start', 'reminder_type', 'overdue_days'],
+            'reminder_logs_unique',
+        );
+    });
+});
+
+afterEach(function (): void {
+    DB::disconnect('ope_migration');
+    DB::purge('ope_migration');
+    DB::setDefaultConnection($this->originalDatabaseConnection);
+});
+
+it('round-trips null and zero overdue days through the migration', function (): void {
+    DB::table('reminder_logs')->insert([
+        [
+            'lease_id' => 1,
+            'period_start' => '2026-07-01',
+            'reminder_type' => 'upcoming',
+            'overdue_days' => null,
+        ],
+        [
+            'lease_id' => 1,
+            'period_start' => '2026-07-01',
+            'reminder_type' => 'overdue',
+            'overdue_days' => 0,
+        ],
+    ]);
+
+    $migration = require database_path(
+        'migrations/2026_08_20_093028_normalize_reminder_log_deduplication_key.php',
+    );
+
+    $migration->up();
+
+    expect(normalizedOverdueDays())->toBe([ReminderLog::NON_OVERDUE_DAYS, 0]);
+
+    $migration->down();
+
+    expect(normalizedOverdueDays())->toBe([null, 0]);
+});
+
+function normalizedOverdueDays(): array
+{
+    return DB::table('reminder_logs')
+        ->orderBy('id')
+        ->pluck('overdue_days')
+        ->map(fn ($days) => $days === null ? null : (int) $days)
+        ->all();
+}


### PR DESCRIPTION
## Summary

- normalize nullable overdue reminder keys to a non-null signed sentinel
- enforce idempotency with direct inserts and narrowly handle duplicate keys
- preserve overdue day zero and add migration round-trip coverage

## Tests

- 36 tests, 140 assertions
- Pint and diff checks
- SQLite migration fresh/rollback smoke test

Refs OPE-146