### PR TITLE
fix(inertia): sync initial page props

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
             "dependencies": {
                 "@base-ui/react": "^1.5.0",
                 "@headlessui/react": "^2.2.0",
-                "@inertiajs/react": "^3.0.0",
-                "@inertiajs/vite": "^3.0.0",
+                "@inertiajs/react": "^3.7.0",
+                "@inertiajs/vite": "^3.7.0",
                 "@laravel/passkeys": "^0.2.0",
                 "@radix-ui/react-avatar": "^1.1.3",
                 "@radix-ui/react-checkbox": "^1.1.4",
@@ -733,9 +733,9 @@
             }
         },
         "node_modules/@inertiajs/core": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/@inertiajs/core/-/core-3.2.0.tgz",
-            "integrity": "sha512-9HXCyI8GjwN/KK3KSYZifuncZPc3jioDe/jDQVFZEJJEn89lhaE5+ope3l6sI+GaLLTs0MSZcOhyizlA5L7lig==",
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/@inertiajs/core/-/core-3.7.0.tgz",
+            "integrity": "sha512-JzysXTPsOpKcnR7ohwpgKE+UWBrKwW7z23DydWHSxjfQ02tJAKmNnZJAxnX7zH3zUSTqbtPge6QC8XhvfjNXmw==",
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.31",
@@ -752,12 +752,12 @@
             }
         },
         "node_modules/@inertiajs/react": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/@inertiajs/react/-/react-3.2.0.tgz",
-            "integrity": "sha512-Mg2d3Rw0/Cdmc94ZUS2ivWY0k0Jyjtci5g0em2F0N6treV5kLK15PgH1OYlDx8Xgin0mG3uchh+tQuv/Hh95uQ==",
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/@inertiajs/react/-/react-3.7.0.tgz",
+            "integrity": "sha512-rc/TsVT7ihDk+cMeCuU3BjdUfTq6HJwXqGy7oPaysLQCeyfhIaP2QgExo5R1QSCFIwl9un0MeZnzTOG+i38jLw==",
             "license": "MIT",
             "dependencies": {
-                "@inertiajs/core": "3.2.0",
+                "@inertiajs/core": "3.7.0",
                 "es-toolkit": "^1.33.0",
                 "laravel-precognition": "^2.0.0"
             },
@@ -767,12 +767,12 @@
             }
         },
         "node_modules/@inertiajs/vite": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/@inertiajs/vite/-/vite-3.2.0.tgz",
-            "integrity": "sha512-J8mVzsZj3igxpQ9ZF7z5aw29uRJ3XrmpuJuYDZ8CzOBgC5k93AY4x0qk1q+CPLWBSlXD6jf1qfFHn9LWwGgawA==",
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/@inertiajs/vite/-/vite-3.7.0.tgz",
+            "integrity": "sha512-eoOqvIEgmsktC/b5NuZjsj3VvCJ7GsbvHFN2IgT/7DXjLVdXGygWeyYHmS57AGSbb6yOyebeBR6cYkk6YyHOmg==",
             "license": "MIT",
             "dependencies": {
-                "@inertiajs/core": "3.2.0",
+                "@inertiajs/core": "3.7.0",
                 "tinyglobby": "^0.2.15"
             },
             "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "dependencies": {
         "@base-ui/react": "^1.5.0",
         "@headlessui/react": "^2.2.0",
-        "@inertiajs/react": "^3.0.0",
-        "@inertiajs/vite": "^3.0.0",
+        "@inertiajs/react": "^3.7.0",
+        "@inertiajs/vite": "^3.7.0",
         "@laravel/passkeys": "^0.2.0",
         "@radix-ui/react-avatar": "^1.1.3",
         "@radix-ui/react-checkbox": "^1.1.4",

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -87,10 +87,8 @@ createInertiaApp({
         }
     },
     strictMode: true,
-    withApp(app, { ssr }) {
-        syncDisplaySettings(
-            (app.props as { initialPage?: PageWithTimezone }).initialPage ?? {},
-        );
+    withApp(app, { ssr, page }) {
+        syncDisplaySettings(page as PageWithTimezone);
 
         if (!ssr) {
             router.on('navigate', ({ detail }) => {


### PR DESCRIPTION
## Summary

- bump `@inertiajs/react` and `@inertiajs/vite` to `3.7.0`
- use Inertia's `withApp` page argument for initial display settings
- prevent supported currencies from being reset to the IDR-only fallback during boot

## Verification

- `npm run build`
- `npm run types:check`
- `php artisan test --compact tests/Feature/DashboardTest.php` (16 passed)

Full-repo lint and format checks still report pre-existing issues outside this change.