### PR TITLE
fix(billing): remove IDR display assumptions

### DIFF
--- a/app/Http/Controllers/Settings/ReminderController.php
+++ b/app/Http/Controllers/Settings/ReminderController.php
@@ -40,11 +40,14 @@ class ReminderController extends Controller
             ])
             ->all();
         $settings['reminder_channels'] ??= ['log'];
-        $previewAmount = $this->money->format(
-            '1500000',
-            (string) Setting::get('currency'),
-            (string) (Setting::get('locale') ?? 'id'),
-        );
+        $previewCurrency = Setting::get('currency');
+        $previewAmount = blank($previewCurrency)
+            ? ''
+            : $this->money->format(
+                '1500000',
+                (string) $previewCurrency,
+                (string) (Setting::get('locale') ?? 'id'),
+            );
 
         return Inertia::render('settings/reminders', [
             'settings' => $settings,

--- a/app/Http/Controllers/Settings/ReminderController.php
+++ b/app/Http/Controllers/Settings/ReminderController.php
@@ -6,6 +6,7 @@ use App\Actions\Settings\UpdateSettings;
 use App\Enums\ReminderType;
 use App\Http\Controllers\Controller;
 use App\Models\Setting;
+use App\Services\Payments\MoneyConverter;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
@@ -15,6 +16,7 @@ class ReminderController extends Controller
 {
     public function __construct(
         private UpdateSettings $updateSettings,
+        private MoneyConverter $money,
     ) {}
 
     public function edit(): Response
@@ -38,6 +40,11 @@ class ReminderController extends Controller
             ])
             ->all();
         $settings['reminder_channels'] ??= ['log'];
+        $previewAmount = $this->money->format(
+            '1500000',
+            (string) Setting::get('currency'),
+            (string) (Setting::get('locale') ?? 'id'),
+        );
 
         return Inertia::render('settings/reminders', [
             'settings' => $settings,
@@ -50,8 +57,9 @@ class ReminderController extends Controller
                 'reference' => 'INV-2026-07',
                 'period' => '01 Jul 2026 – 31 Jul 2026',
                 'date' => '01 Jul 2026',
-                'amount' => '1,500,000',
+                'amount' => $previewAmount,
             ]),
+            'previewAmount' => $previewAmount,
             'previewInvoiceLink' => __('notifications.rent.view_invoice').': https://example.test/portal/billing/invoices/1',
         ]);
     }

--- a/resources/js/components/features/tenants/assign-unit-sheet.tsx
+++ b/resources/js/components/features/tenants/assign-unit-sheet.tsx
@@ -111,14 +111,11 @@ export default function AssignUnitSheet({
         }
     }
 
-    const monthlyEquivalent = useMemo(
-        () =>
-            computeMonthlyEquivalent(
-                data.rent_amount,
-                Number.parseInt(data.billing_interval) || 1,
-                data.billing_unit,
-            ),
-        [data.rent_amount, data.billing_interval, data.billing_unit],
+    const monthlyEquivalent = computeMonthlyEquivalent(
+        data.rent_amount,
+        Number.parseInt(data.billing_interval) || 1,
+        data.billing_unit,
+        currency,
     );
 
     function handleOpenChange(next: boolean) {

--- a/resources/js/components/features/tenants/assign-unit-sheet.tsx
+++ b/resources/js/components/features/tenants/assign-unit-sheet.tsx
@@ -100,6 +100,7 @@ export default function AssignUnitSheet({
 
     const selectedRate = rates.find((r) => r.id === data.unit_rate_id) ?? null;
     const currency = selectedRate?.currency ?? setting.currency;
+    const monthlyCurrency = String(currency);
     const hasRates = rates.length > 0;
 
     function handleOverrideToggle(checked: boolean) {
@@ -111,11 +112,20 @@ export default function AssignUnitSheet({
         }
     }
 
-    const monthlyEquivalent = computeMonthlyEquivalent(
-        data.rent_amount,
-        Number.parseInt(data.billing_interval) || 1,
-        data.billing_unit,
-        currency,
+    const monthlyEquivalent = useMemo(
+        () =>
+            computeMonthlyEquivalent(
+                data.rent_amount,
+                Number.parseInt(data.billing_interval) || 1,
+                data.billing_unit,
+                monthlyCurrency,
+            ),
+        [
+            data.rent_amount,
+            data.billing_interval,
+            data.billing_unit,
+            monthlyCurrency,
+        ],
     );
 
     function handleOpenChange(next: boolean) {

--- a/resources/js/components/features/units/assign-tenant-sheet.tsx
+++ b/resources/js/components/features/units/assign-tenant-sheet.tsx
@@ -102,8 +102,9 @@ export default function AssignTenantSheet({
             data.rent_amount,
             Number.parseInt(data.billing_interval) || 1,
             data.billing_unit,
+            currency,
         );
-    }, [data.rent_amount, data.billing_interval, data.billing_unit]);
+    }, [data.rent_amount, data.billing_interval, data.billing_unit, currency]);
 
     function handleSubmit(e: React.FormEvent) {
         e.preventDefault();

--- a/resources/js/components/features/units/unit-form-sheet.tsx
+++ b/resources/js/components/features/units/unit-form-sheet.tsx
@@ -187,7 +187,7 @@ export default function UnitFormSheet({
                                     >
                                         <div className="grid flex-1 gap-1">
                                             <Label className="text-xs">
-                                                Amount ({setting.currency})
+                                                Amount ({rate.currency ?? setting.currency})
                                             </Label>
                                             <Input
                                                 type="number"

--- a/resources/js/lib/formatters.ts
+++ b/resources/js/lib/formatters.ts
@@ -1,14 +1,14 @@
 let displayTimezone = 'UTC';
-let displayCurrency = 'IDR';
+let displayCurrency: string | null = null;
 let displayLocale = 'id-ID';
-let currencyScales: Record<string, number> = { IDR: 0 };
+let currencyScales: Record<string, number> = {};
 
 export function setDisplayTimezone(timezone: string | null | undefined): void {
     displayTimezone = timezone || 'UTC';
 }
 
 export function setDisplayCurrency(currency: string | null | undefined): void {
-    displayCurrency = currency?.toUpperCase() || 'IDR';
+    displayCurrency = currency?.trim().toUpperCase() || null;
 }
 
 export function setDisplayLocale(locale: string | null | undefined): void {
@@ -17,7 +17,7 @@ export function setDisplayLocale(locale: string | null | undefined): void {
 
 export function setCurrencyScales(scales: Record<string, number> | null | undefined): void {
     currencyScales = Object.fromEntries(
-        Object.entries(scales || { IDR: 0 }).map(([currency, scale]) => [
+        Object.entries(scales || {}).map(([currency, scale]) => [
             currency.toUpperCase(),
             scale,
         ]),
@@ -107,7 +107,12 @@ export function formatPrice(
         return '—';
     }
 
-    const resolvedCurrency = currency?.toUpperCase() || displayCurrency;
+    const resolvedCurrency = currency?.trim().toUpperCase() || displayCurrency;
+
+    if (!resolvedCurrency) {
+        return '';
+    }
+
     const scale = scaleForCurrency(resolvedCurrency);
     const minor = decimalToMinorRounded(String(amount), scale);
 
@@ -164,16 +169,13 @@ export function formatSize(bytes: number): string {
     return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
 }
 
-export function formatRupiah(value: number | string | null): string {
-    return formatPrice(value, displayCurrency);
-}
-
 function decimalToMinor(amount: string, scale: number): bigint | null {
     if (!/^\d+(?:\.\d+)?$/.test(amount)) {
         return null;
     }
 
     const [whole, fraction = ''] = amount.split('.');
+
     if (fraction.length > scale && /[1-9]/.test(fraction.slice(scale))) {
         return null;
     }
@@ -233,13 +235,19 @@ export function computeMonthlyEquivalent(
     amount: string | null,
     interval: number | null,
     unit: string | null,
-    currency = displayCurrency,
+    currency?: string,
 ): string {
     if (!amount || !interval || !unit) {
         return '';
     }
 
-    const scale = scaleForCurrency(currency);
+    const resolvedCurrency = currency?.trim().toUpperCase() || displayCurrency;
+
+    if (!resolvedCurrency) {
+        return '';
+    }
+
+    const scale = scaleForCurrency(resolvedCurrency);
     const minor = decimalToMinor(amount, scale);
 
     if (minor === null) {
@@ -273,7 +281,7 @@ export function computeMonthlyEquivalent(
 
     const monthlyMinor = divideRounded(minor * numerator, denominator);
 
-    return `≈ ${formatPrice(minorToMajor(monthlyMinor, scale), currency)}/month`;
+    return `≈ ${formatPrice(minorToMajor(monthlyMinor, scale), resolvedCurrency)}/month`;
 }
 
 export function formatRelativeTime(iso: string): string {

--- a/resources/js/pages/maintenance-tickets/show.tsx
+++ b/resources/js/pages/maintenance-tickets/show.tsx
@@ -3,7 +3,7 @@ import { EntityWorkspaceLayout } from '@/components/shared/entity-workspace-layo
 import { StatusBadge } from '@/components/shared/status-badge';
 import { WorkspaceTabs } from '@/components/shared/workspace-tabs';
 import { Badge } from '@/components/ui/badge';
-import { formatDate } from '@/lib/formatters';
+import { formatDate, formatPrice } from '@/lib/formatters';
 import type { MaintenanceTicket } from '@/types';
 
 function Field({ label, value }: { label: string; value: React.ReactNode }) {
@@ -56,7 +56,7 @@ export default function MaintenanceTicketWorkspace({
                     />
                     <Field label="Assigned to" value={ticket.assignee?.name} />
                     <Field label="Reported by" value={ticket.creator?.name} />
-                    <Field label="Cost" value={ticket.cost} />
+                    <Field label="Cost" value={formatPrice(ticket.cost)} />
                     <Field
                         label="Created"
                         value={formatDate(ticket.created_at)}

--- a/resources/js/pages/settings/general.tsx
+++ b/resources/js/pages/settings/general.tsx
@@ -196,7 +196,7 @@ export default function General({
                                         }
                                         maxLength={3}
                                         className="font-mono uppercase"
-                                        placeholder="IDR"
+                                        placeholder="ISO 4217"
                                         required
                                     />
                                     {localizationForm.errors.currency && (

--- a/resources/js/pages/settings/reminders.tsx
+++ b/resources/js/pages/settings/reminders.tsx
@@ -47,6 +47,7 @@ export default function Reminders({
     settings,
     defaultTemplates,
     previewInvoiceContext,
+    previewAmount,
     previewInvoiceLink,
 }: {
     settings: {
@@ -58,6 +59,7 @@ export default function Reminders({
     };
     defaultTemplates: Record<string, string>;
     previewInvoiceContext: string;
+    previewAmount: string;
     previewInvoiceLink: string;
 }) {
     const {
@@ -97,7 +99,7 @@ export default function Reminders({
         name: 'John',
         unit: 'Unit A-02',
         days: settings.reminder_days_before,
-        amount: '1,500,000',
+        amount: previewAmount,
         date: '01 Jul 2026',
         overdueDays: 3,
     };

--- a/tests/Feature/Settings/ReminderSettingsTest.php
+++ b/tests/Feature/Settings/ReminderSettingsTest.php
@@ -70,6 +70,16 @@ describe('Reminder settings page', function () {
             );
     });
 
+    it('renders an empty preview amount when currency is unconfigured', function () {
+        $owner = User::factory()->owner()->create();
+        Setting::set('currency', '');
+
+        $this->actingAs($owner)
+            ->get(route('settings.reminders.edit'))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page->where('previewAmount', ''));
+    });
+
     it('updates reminder settings', function () {
         $owner = User::factory()->owner()->create();
 

--- a/tests/Feature/Settings/ReminderSettingsTest.php
+++ b/tests/Feature/Settings/ReminderSettingsTest.php
@@ -3,6 +3,7 @@
 use App\Models\Setting;
 use App\Models\Tenant;
 use App\Models\User;
+use App\Services\Payments\MoneyConverter;
 
 uses()->beforeEach(function () {
     $this->seed(RoleAndPermissionSeeder::class);
@@ -52,6 +53,20 @@ describe('Reminder settings page', function () {
                 ->has('defaultTemplates.overdue')
                 ->has('previewInvoiceContext')
                 ->has('previewInvoiceLink')
+            );
+    });
+
+    it('uses the configured currency for the preview amount', function () {
+        $owner = User::factory()->owner()->create();
+        Setting::set('currency', 'USD');
+        Setting::set('locale', 'en');
+        $expectedAmount = app(MoneyConverter::class)->format('1500000', 'USD', 'en');
+
+        $this->actingAs($owner)
+            ->get(route('settings.reminders.edit'))
+            ->assertInertia(fn ($page) => $page
+                ->where('previewAmount', $expectedAmount)
+                ->where('previewInvoiceContext', fn (string $context): bool => str_contains($context, $expectedAmount))
             );
     });
 


### PR DESCRIPTION
## Summary
- remove implicit IDR presentation fallbacks
- preserve selected rate currencies in assignment previews
- use server-formatted currency in reminder previews
- add USD reminder regression coverage

## Tests
- `php artisan test --compact`
- `npm run lint:check`
- `npm run types:check`
- `npm run build`

Refs OPE-159