### PR TITLE
fix(dashboard): align multi-currency cards

### DIFF
--- a/app/Business/Dashboard/OverviewStatsCalculator.php
+++ b/app/Business/Dashboard/OverviewStatsCalculator.php
@@ -45,11 +45,22 @@ class OverviewStatsCalculator
             fn ($row): string => BigDecimal::of((string) $row->total)->minus((string) $row->amount_paid)->toString(),
         );
 
+        $currencies = collect([
+            ...$monthlyPotential,
+            ...$revenueThisMonth,
+            ...$outstanding,
+        ])->pluck('currency')->unique()->values();
+
+        $monthlyPotential = $this->completeAmountGroups($monthlyPotential, $currencies);
+        $revenueThisMonth = $this->completeAmountGroups($revenueThisMonth, $currencies);
+        $outstanding = $this->completeAmountGroups($outstanding, $currencies);
+
         $potentialByCurrency = collect($monthlyPotential)->keyBy('currency');
         $revenueByCurrency = collect($revenueThisMonth)->keyBy('currency');
-        $collectionRate = $potentialByCurrency->map(function (array $potential) use ($revenueByCurrency): array {
-            $revenue = $revenueByCurrency->get($potential['currency']);
-            $rate = $revenue && BigDecimal::of($potential['amount'])->isPositive()
+        $collectionRate = $currencies->map(function (string $currency) use ($potentialByCurrency, $revenueByCurrency): array {
+            $potential = $potentialByCurrency->get($currency);
+            $revenue = $revenueByCurrency->get($currency);
+            $rate = $revenue && $potential && BigDecimal::of($potential['amount'])->isPositive()
                 ? BigDecimal::of($revenue['amount'])
                     ->dividedBy($potential['amount'], 4, RoundingMode::HalfUp)
                     ->multipliedBy(100)
@@ -57,8 +68,8 @@ class OverviewStatsCalculator
                     ->toInt()
                 : 0;
 
-            return ['currency' => $potential['currency'], 'rate' => $rate];
-        })->values()->all();
+            return ['currency' => $currency, 'rate' => $rate];
+        })->all();
 
         return [
             'revenue_this_month' => $revenueThisMonth,
@@ -86,5 +97,20 @@ class OverviewStatsCalculator
             })
             ->values()
             ->all();
+    }
+
+    /**
+     * @param  array<int, array{currency: string, amount: string}>  $groups
+     * @param  Collection<int, string>  $currencies
+     * @return array<int, array{currency: string, amount: string}>
+     */
+    private function completeAmountGroups(array $groups, Collection $currencies): array
+    {
+        $groupsByCurrency = collect($groups)->keyBy('currency');
+
+        return $currencies->map(fn (string $currency): array => [
+            'currency' => $currency,
+            'amount' => $groupsByCurrency->get($currency)['amount'] ?? BigDecimal::zero()->toString(),
+        ])->all();
     }
 }

--- a/app/Business/Dashboard/OverviewStatsCalculator.php
+++ b/app/Business/Dashboard/OverviewStatsCalculator.php
@@ -110,7 +110,7 @@ class OverviewStatsCalculator
 
         return $currencies->map(fn (string $currency): array => [
             'currency' => $currency,
-            'amount' => $groupsByCurrency->get($currency)['amount'] ?? BigDecimal::zero()->toString(),
+            'amount' => ($groupsByCurrency->get($currency) ?? ['amount' => BigDecimal::zero()->toString()])['amount'],
         ])->all();
     }
 }

--- a/app/Http/Controllers/Dashboard/RentController.php
+++ b/app/Http/Controllers/Dashboard/RentController.php
@@ -424,7 +424,7 @@ class RentController extends Controller
 
         return $currencies->map(fn (string $currency): array => [
             'currency' => $currency,
-            'amount' => $groupsByCurrency->get($currency)['amount'] ?? BigDecimal::zero()->toString(),
+            'amount' => ($groupsByCurrency->get($currency) ?? ['amount' => BigDecimal::zero()->toString()])['amount'],
         ])->all();
     }
 }

--- a/app/Http/Controllers/Dashboard/RentController.php
+++ b/app/Http/Controllers/Dashboard/RentController.php
@@ -147,6 +147,11 @@ class RentController extends Controller
             ])
             ->values()
             ->all();
+        $currencies = collect([
+            ...$outstandingAmounts,
+            ...$collectedAmounts,
+        ])->pluck('currency')->unique()->values();
+        $outstandingAmounts = $this->completeMoneyGroups($outstandingAmounts, $currencies);
         $lastPaymentDate = $paymentStats->pluck('last_payment_at')->filter()->max();
         $lastPaymentAt = $lastPaymentDate ? Carbon::parse($lastPaymentDate)->toDateString() : null;
 
@@ -406,5 +411,20 @@ class RentController extends Controller
             })
             ->values()
             ->all();
+    }
+
+    /**
+     * @param  array<int, array{currency: string, amount: string}>  $groups
+     * @param  Collection<int, string>  $currencies
+     * @return array<int, array{currency: string, amount: string}>
+     */
+    private function completeMoneyGroups(array $groups, Collection $currencies): array
+    {
+        $groupsByCurrency = collect($groups)->keyBy('currency');
+
+        return $currencies->map(fn (string $currency): array => [
+            'currency' => $currency,
+            'amount' => $groupsByCurrency->get($currency)['amount'] ?? BigDecimal::zero()->toString(),
+        ])->all();
     }
 }

--- a/database/migrations/2026_08_21_092958_backfill_legacy_currency_snapshots.php
+++ b/database/migrations/2026_08_21_092958_backfill_legacy_currency_snapshots.php
@@ -1,0 +1,27 @@
+<?php
+
+use App\Services\Payments\MoneyConverter;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $configuredCurrency = DB::table('settings')
+            ->where('key', 'currency')
+            ->value('value');
+        $currency = app(MoneyConverter::class)->normalizeCurrency($configuredCurrency);
+
+        foreach (['unit_rates', 'leases', 'invoices', 'payments'] as $table) {
+            DB::table($table)
+                ->whereNull('currency')
+                ->update(['currency' => $currency]);
+        }
+    }
+
+    public function down(): void
+    {
+        throw new RuntimeException('Irreversible migration: legacy currency snapshots cannot be safely restored.');
+    }
+};

--- a/resources/js/components/features/dashboard/business-health-panel.tsx
+++ b/resources/js/components/features/dashboard/business-health-panel.tsx
@@ -1,64 +1,157 @@
 import { AlertCircle, Building2, TrendingUp } from 'lucide-react';
 import { formatPrice } from '@/lib/formatters';
+import { cn } from '@/lib/utils';
 import type { Finance } from '@/types';
+import { CurrencyAmountList } from './currency-amount-list';
 
-export function BusinessHealthPanel({ finance }: { finance: Finance }) {
-    const formatGroups = (groups: Finance['revenue_this_month']) =>
-        groups.map((group) => formatPrice(group.amount, group.currency)).join(' · ') || '—';
+function amountSize(formattedAmount: string): string {
+    if (formattedAmount.length > 20) {
+        return 'text-lg sm:text-xl';
+    }
 
-    const formatRates = finance.collection_rate
-        .map((rate) => `${rate.currency} ${rate.rate}%`)
-        .join(' · ') || '—';
+    if (formattedAmount.length > 14) {
+        return 'text-xl sm:text-2xl';
+    }
+
+    return 'text-2xl sm:text-3xl';
+}
+
+function moneyAmountClass(
+    groups: Finance['revenue_this_month'],
+    colorClassName: string,
+): string {
+    const size =
+        groups.length === 1
+            ? amountSize(formatPrice(groups[0].amount, groups[0].currency))
+            : 'text-sm sm:text-base';
+
+    return cn(colorClassName, 'font-bold tabular-nums', size);
+}
+
+function RateProgress({ rate }: { rate: number }) {
+    return (
+        <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+            <div
+                className="h-full rounded-full bg-primary transition-all duration-300"
+                style={{
+                    width: `${Math.min(100, Math.max(0, rate))}%`,
+                }}
+            />
+        </div>
+    );
+}
+
+function CollectionRateValue({ rates }: { rates: Finance['collection_rate'] }) {
+    if (rates.length === 0) {
+        return (
+            <p className="text-2xl font-bold text-primary tabular-nums sm:text-3xl">
+                —
+            </p>
+        );
+    }
+
+    if (rates.length === 1) {
+        return (
+            <>
+                <p className="text-2xl font-bold text-primary tabular-nums sm:text-3xl">
+                    {rates[0].currency} {rates[0].rate}%
+                </p>
+                <div className="mt-2.5">
+                    <RateProgress rate={rates[0].rate} />
+                </div>
+            </>
+        );
+    }
 
     return (
+        <div className="mt-2 flex flex-col gap-2">
+            {rates.map((rate) => (
+                <div
+                    key={rate.currency}
+                    className="flex items-center gap-2 text-sm font-bold tabular-nums"
+                >
+                    <span className="w-8 shrink-0 text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+                        {rate.currency}
+                    </span>
+                    <span className="w-8 shrink-0 text-right text-primary">
+                        {rate.rate}%
+                    </span>
+                    <div className="min-w-0 flex-1">
+                        <RateProgress rate={rate.rate} />
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+}
+
+export function BusinessHealthPanel({ finance }: { finance: Finance }) {
+    return (
         <section className="mb-10 flex flex-col gap-3">
+            <h2 className="text-xs font-semibold tracking-wider text-muted-foreground uppercase">
+                Business Health
+            </h2>
             <div className="rounded-xl border border-border bg-card p-6 shadow-xs">
-                <h2 className="mb-4 text-xs font-semibold tracking-wider text-muted-foreground uppercase">
-                    Business Health
-                </h2>
-                <div className="grid gap-6 divide-y divide-border sm:grid-cols-2 sm:divide-x sm:divide-y-0 lg:grid-cols-4">
-                    <div className="pt-2 first:pl-0 sm:px-4 sm:pt-0">
+                <div className="grid gap-3 divide-y divide-border sm:grid-cols-2 sm:gap-4 sm:divide-x sm:divide-y-0 xl:grid-cols-4">
+                    <div className="pt-2 pb-2 first:pl-0 sm:px-4 sm:pt-0 sm:pb-0 sm:pl-0">
                         <div className="mb-1.5 flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
                             <TrendingUp className="size-3.5 text-surface-green-foreground" />
                             <span>Revenue This Month</span>
                         </div>
-                        <p className="text-2xl font-bold text-surface-green-foreground tabular-nums sm:text-3xl">
-                            {formatGroups(finance.revenue_this_month)}
-                        </p>
+                        <CurrencyAmountList
+                            groups={finance.revenue_this_month}
+                            amountClassName={moneyAmountClass(
+                                finance.revenue_this_month,
+                                'text-surface-green-foreground',
+                            )}
+                            className={
+                                finance.revenue_this_month.length > 1
+                                    ? 'mt-1'
+                                    : undefined
+                            }
+                        />
                     </div>
-                    <div className="pt-4 sm:px-4 sm:pt-0">
+                    <div className="pt-3 pb-2 sm:px-4 sm:pt-0 sm:pb-0">
                         <div className="mb-1.5 flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
                             <Building2 className="size-3.5 text-muted-foreground" />
                             <span>Monthly Potential</span>
                         </div>
-                        <p className="text-2xl font-bold text-foreground tabular-nums sm:text-3xl">
-                            {formatGroups(finance.monthly_potential)}
-                        </p>
+                        <CurrencyAmountList
+                            groups={finance.monthly_potential}
+                            amountClassName={moneyAmountClass(
+                                finance.monthly_potential,
+                                'text-foreground',
+                            )}
+                            className={
+                                finance.monthly_potential.length > 1
+                                    ? 'mt-1'
+                                    : undefined
+                            }
+                        />
                     </div>
-                    <div className="pt-4 sm:px-4 sm:pt-0">
+                    <div className="pt-3 pb-2 sm:px-4 sm:pt-0 sm:pb-0 sm:pl-0 xl:pl-4">
                         <div className="mb-1.5 flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
                             <AlertCircle className="size-3.5 text-surface-red-foreground" />
                             <span>Outstanding</span>
                         </div>
-                        <p className="text-2xl font-bold text-surface-red-foreground tabular-nums sm:text-3xl">
-                            {formatGroups(finance.outstanding)}
-                        </p>
+                        <CurrencyAmountList
+                            groups={finance.outstanding}
+                            amountClassName={moneyAmountClass(
+                                finance.outstanding,
+                                'text-surface-red-foreground',
+                            )}
+                            className={
+                                finance.outstanding.length > 1
+                                    ? 'mt-1'
+                                    : undefined
+                            }
+                        />
                     </div>
-                    <div className="pt-4 sm:px-4 sm:pt-0">
+                    <div className="pt-3 sm:px-4 sm:pt-0">
                         <div className="mb-1.5 flex items-center justify-between text-xs font-medium text-muted-foreground">
                             <span>Collection Rate</span>
                         </div>
-                        <p className="text-2xl font-bold text-primary tabular-nums sm:text-3xl">
-                            {formatRates}
-                        </p>
-                        <div className="mt-2.5 h-1.5 w-full overflow-hidden rounded-full bg-muted">
-                            <div
-                                className="h-full rounded-full bg-primary transition-all duration-300"
-                                style={{
-                                    width: `${Math.max(...finance.collection_rate.map((rate) => rate.rate), 0)}%`,
-                                }}
-                            />
-                        </div>
+                        <CollectionRateValue rates={finance.collection_rate} />
                     </div>
                 </div>
             </div>

--- a/resources/js/components/features/dashboard/currency-amount-list.tsx
+++ b/resources/js/components/features/dashboard/currency-amount-list.tsx
@@ -26,9 +26,9 @@ export function CurrencyAmountList({
     }
 
     return (
-        <div className={cn('flex flex-col gap-0.5', className)}>
+        <span className={cn('flex flex-col gap-0.5', className)}>
             {groups.map((group) => (
-                <div
+                <span
                     key={group.currency}
                     className="flex min-w-0 items-baseline gap-3 leading-none"
                 >
@@ -43,8 +43,8 @@ export function CurrencyAmountList({
                     >
                         {formatPrice(group.amount, group.currency)}
                     </span>
-                </div>
+                </span>
             ))}
-        </div>
+        </span>
     );
 }

--- a/resources/js/components/features/dashboard/currency-amount-list.tsx
+++ b/resources/js/components/features/dashboard/currency-amount-list.tsx
@@ -1,0 +1,50 @@
+import { formatPrice } from '@/lib/formatters';
+import { cn } from '@/lib/utils';
+import type { MoneyAggregate } from '@/types';
+
+type CurrencyAmountListProps = {
+    groups: MoneyAggregate[];
+    amountClassName?: string;
+    className?: string;
+};
+
+export function CurrencyAmountList({
+    groups,
+    amountClassName,
+    className,
+}: CurrencyAmountListProps) {
+    if (groups.length === 0) {
+        return <span className={cn(className, amountClassName)}>—</span>;
+    }
+
+    if (groups.length === 1) {
+        return (
+            <span className={cn(className, amountClassName)}>
+                {formatPrice(groups[0].amount, groups[0].currency)}
+            </span>
+        );
+    }
+
+    return (
+        <div className={cn('flex flex-col gap-0.5', className)}>
+            {groups.map((group) => (
+                <div
+                    key={group.currency}
+                    className="flex min-w-0 items-baseline gap-3 leading-none"
+                >
+                    <span className="w-9 shrink-0 text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+                        {group.currency}
+                    </span>
+                    <span
+                        className={cn(
+                            'min-w-0 text-right text-sm leading-tight font-bold break-words tabular-nums sm:text-base',
+                            amountClassName,
+                        )}
+                    >
+                        {formatPrice(group.amount, group.currency)}
+                    </span>
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/resources/js/components/features/dashboard/index.ts
+++ b/resources/js/components/features/dashboard/index.ts
@@ -1,4 +1,5 @@
 export * from './activity-feed-item';
 export * from './business-health-panel';
+export * from './currency-amount-list';
 export * from './operational-briefing-card';
 export * from './property-overview-card';

--- a/resources/js/components/features/dashboard/property-overview-card.tsx
+++ b/resources/js/components/features/dashboard/property-overview-card.tsx
@@ -9,10 +9,10 @@ export function PropertyOverviewCard({
     return (
         <Link
             href={`/properties/${property.slug}`}
-            className="block rounded-xl border border-border bg-card p-5 shadow-2xs transition-all duration-150 hover:-translate-y-0.5 hover:border-primary/50 hover:shadow-xs"
+            className="block min-w-0 rounded-xl border border-border bg-card p-5 shadow-2xs transition-all duration-150 hover:-translate-y-0.5 hover:border-primary/50 hover:shadow-xs"
         >
             <div className="mb-3 flex items-baseline justify-between gap-2">
-                <h3 className="truncate text-base font-semibold text-foreground">
+                <h3 className="min-w-0 truncate text-base font-semibold text-foreground">
                     {property.name}
                 </h3>
                 <span className="shrink-0 text-xs font-medium text-muted-foreground">
@@ -21,11 +21,11 @@ export function PropertyOverviewCard({
             </div>
 
             <div className="my-3 space-y-1.5">
-                <div className="flex items-center justify-between text-xs font-medium">
-                    <span className="text-muted-foreground">
+                <div className="flex min-w-0 items-center justify-between gap-2 text-xs font-medium">
+                    <span className="min-w-0 truncate text-muted-foreground">
                         Occupancy Rate
                     </span>
-                    <span className="font-bold text-primary tabular-nums">
+                    <span className="shrink-0 font-bold text-primary tabular-nums">
                         {property.occupancy_percentage}% Occupied
                     </span>
                 </div>
@@ -37,26 +37,26 @@ export function PropertyOverviewCard({
                 </div>
             </div>
 
-            <div className="mt-4 flex items-center justify-between border-t border-border/60 pt-3 text-xs font-medium text-muted-foreground">
-                <span className="flex items-center gap-1.5">
+            <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2 border-t border-border/60 pt-3 text-xs font-medium text-muted-foreground">
+                <span className="flex shrink-0 items-center gap-1.5 whitespace-nowrap">
                     <span className="size-2 shrink-0 rounded-full bg-surface-blue-foreground" />
                     <strong className="font-bold text-foreground tabular-nums">
                         {property.occupied_units}
-                    </strong>{' '}
+                    </strong>
                     Occupied
                 </span>
-                <span className="flex items-center gap-1.5">
+                <span className="flex shrink-0 items-center gap-1.5 whitespace-nowrap">
                     <span className="size-2 shrink-0 rounded-full bg-surface-green-foreground" />
                     <strong className="font-bold text-foreground tabular-nums">
                         {property.available_units}
-                    </strong>{' '}
+                    </strong>
                     Vacant
                 </span>
-                <span className="flex items-center gap-1.5">
+                <span className="flex shrink-0 items-center gap-1.5 whitespace-nowrap">
                     <span className="size-2 shrink-0 rounded-full bg-surface-amber-foreground" />
                     <strong className="font-bold text-foreground tabular-nums">
                         {property.maintenance_units}
-                    </strong>{' '}
+                    </strong>
                     Maintenance
                 </span>
             </div>

--- a/resources/js/components/shared/metric-card.tsx
+++ b/resources/js/components/shared/metric-card.tsx
@@ -14,7 +14,7 @@ export type MetricEmphasis = 'neutral' | 'subtle' | 'attention';
 export interface MetricCardProps {
     label: string;
     value: string | number;
-    subtext?: string;
+    subtext?: React.ReactNode;
     variant?: MetricVariant;
     emphasis?: MetricEmphasis;
     icon?: React.ComponentType<{ className?: string }>;
@@ -252,9 +252,9 @@ export function MetricCard({
                         {value}
                     </p>
                     {subtext && (
-                        <p className="mt-1 text-xs font-medium text-muted-foreground">
+                        <div className="mt-1 text-xs font-medium text-muted-foreground">
                             {subtext}
-                        </p>
+                        </div>
                     )}
                 </div>
 

--- a/resources/js/components/shared/metric-card.tsx
+++ b/resources/js/components/shared/metric-card.tsx
@@ -13,7 +13,7 @@ export type MetricEmphasis = 'neutral' | 'subtle' | 'attention';
 
 export interface MetricCardProps {
     label: string;
-    value: string | number;
+    value: React.ReactNode;
     subtext?: React.ReactNode;
     variant?: MetricVariant;
     emphasis?: MetricEmphasis;
@@ -245,7 +245,7 @@ export function MetricCard({
                     </p>
                     <p
                         className={cn(
-                            'mt-1.5 text-2xl font-bold tracking-tight tabular-nums sm:text-3xl',
+                            'mt-1.5 text-2xl font-bold tabular-nums sm:text-3xl',
                             styles.value,
                         )}
                     >

--- a/resources/js/pages/dashboard/overview.tsx
+++ b/resources/js/pages/dashboard/overview.tsx
@@ -196,9 +196,9 @@ export default function Overview({
                 <BusinessHealthPanel finance={finance} />
 
                 {/* 5. Lower Dashboard: Operational Workspace (Two-Column Layout) */}
-                <div className="grid gap-8 lg:grid-cols-12">
+                <div className="grid min-w-0 gap-8 lg:grid-cols-12">
                     {/* Left Column: Property Overview (~65% / lg:col-span-7) */}
-                    <section className="flex flex-col gap-3 lg:col-span-7">
+                    <section className="flex min-w-0 flex-col gap-3 lg:col-span-7">
                         <div className="flex items-center justify-between">
                             <h2 className="text-xs font-semibold tracking-wider text-muted-foreground uppercase">
                                 Property Overview
@@ -213,7 +213,7 @@ export default function Overview({
                                 </Link>
                             )}
                         </div>
-                        <div className="grid gap-4 sm:grid-cols-2">
+                        <div className="grid min-w-0 gap-4 sm:grid-cols-2">
                             {stats.properties
                                 .slice(0, 6)
                                 .map((property: PropertyStats) => (
@@ -226,7 +226,7 @@ export default function Overview({
                     </section>
 
                     {/* Right Column: Recent Activity Timeline (~35% / lg:col-span-5) */}
-                    <section className="flex flex-col gap-3 lg:col-span-5">
+                    <section className="flex min-w-0 flex-col gap-3 lg:col-span-5">
                         <div className="flex items-center justify-between">
                             <h2 className="text-xs font-semibold tracking-wider text-muted-foreground uppercase">
                                 Recent Activity

--- a/resources/js/pages/dashboard/overview.tsx
+++ b/resources/js/pages/dashboard/overview.tsx
@@ -15,6 +15,7 @@ import { useState } from 'react';
 import {
     ActivityFeedItem,
     BusinessHealthPanel,
+    CurrencyAmountList,
     getActivitySummaryChips,
     OperationalBriefingCard,
     PropertyFormSheet,
@@ -30,7 +31,6 @@ import {
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { formatPrice } from '@/lib/formatters';
 import { dashboard } from '@/routes';
 import type {
     AttentionData,
@@ -147,16 +147,15 @@ export default function Overview({
                             label="Overdue Invoices"
                             value={attention.overdue_invoices.count}
                             subtext={
-                                attention.overdue_invoices.amounts.length > 0
-                                    ? attention.overdue_invoices.amounts
-                                          .map((amount) =>
-                                              formatPrice(
-                                                  amount.amount,
-                                                  amount.currency,
-                                              ),
-                                          )
-                                          .join(' · ')
-                                    : undefined
+                                attention.overdue_invoices.amounts.length >
+                                0 ? (
+                                    <CurrencyAmountList
+                                        groups={
+                                            attention.overdue_invoices.amounts
+                                        }
+                                        amountClassName="text-surface-red-foreground"
+                                    />
+                                ) : undefined
                             }
                             variant="red"
                             emphasis="attention"

--- a/resources/js/pages/dashboard/rent.tsx
+++ b/resources/js/pages/dashboard/rent.tsx
@@ -17,6 +17,7 @@ import { useState } from 'react';
 import { DataTable } from '@/components/data-table';
 import type { TableColumn } from '@/components/data-table';
 import { SearchInput } from '@/components/data-table/search-input';
+import { CurrencyAmountList } from '@/components/features/dashboard/currency-amount-list';
 import InvoiceDetailSheet from '@/components/features/payments/invoice-detail-sheet';
 import QueuePaymentSheet from '@/components/features/payments/queue-payment-sheet';
 import { MetricCard } from '@/components/shared/metric-card';
@@ -148,7 +149,11 @@ function pendingReviewLabel(count: number | undefined): string {
 }
 
 function formatMoneyGroups(groups: MoneyAggregate[]): string {
-    return groups.map((group) => formatPrice(group.amount, group.currency)).join(' · ') || '—';
+    return (
+        groups
+            .map((group) => formatPrice(group.amount, group.currency))
+            .join(' · ') || '—'
+    );
 }
 
 export default function CollectionQueue({
@@ -449,7 +454,12 @@ export default function CollectionQueue({
                 <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                     <MetricCard
                         label="Outstanding Balance"
-                        value={formatMoneyGroups(outstanding.amounts)}
+                        value={
+                            <CurrencyAmountList
+                                groups={outstanding.amounts}
+                                amountClassName="text-surface-amber-foreground"
+                            />
+                        }
                         subtext={`${outstanding.count} invoice${outstanding.count !== 1 ? 's' : ''} unpaid`}
                         variant="amber"
                         emphasis="subtle"

--- a/tests/Feature/BackfillLegacyCurrencySnapshotsTest.php
+++ b/tests/Feature/BackfillLegacyCurrencySnapshotsTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use App\Models\Invoice;
+use App\Models\Lease;
+use App\Models\Payment;
+use App\Models\Setting;
+use App\Models\Unit;
+use Illuminate\Support\Facades\DB;
+
+it('backfills null currency snapshots from the current setting', function () {
+    Setting::set('currency', 'IDR');
+
+    $legacyUnit = Unit::factory()->create();
+    $legacyRate = $legacyUnit->rates()->firstOrFail();
+    $legacyLease = Lease::factory()->create([
+        'unit_id' => $legacyUnit->id,
+        'unit_rate_id' => $legacyRate->id,
+        'rent_amount' => 1_500_000,
+        'currency' => 'USD',
+    ]);
+    $legacyInvoice = Invoice::factory()->create([
+        'lease_id' => $legacyLease->id,
+        'currency' => 'USD',
+    ]);
+    $legacyPayment = Payment::factory()->create([
+        'invoice_id' => $legacyInvoice->id,
+        'currency' => 'USD',
+    ]);
+
+    $explicitUnit = Unit::factory()->create();
+    $explicitRate = $explicitUnit->rates()->firstOrFail();
+    DB::table('unit_rates')->where('id', $explicitRate->id)->update(['currency' => 'USD']);
+    $explicitLease = Lease::factory()->create([
+        'unit_id' => $explicitUnit->id,
+        'unit_rate_id' => $explicitRate->id,
+        'rent_amount' => 1_500_000,
+        'currency' => 'USD',
+    ]);
+    $explicitInvoice = Invoice::factory()->create([
+        'lease_id' => $explicitLease->id,
+        'currency' => 'USD',
+    ]);
+    $explicitPayment = Payment::factory()->create([
+        'invoice_id' => $explicitInvoice->id,
+        'currency' => 'USD',
+    ]);
+
+    DB::table('unit_rates')->where('id', $legacyRate->id)->update(['currency' => null]);
+    DB::table('leases')->where('id', $legacyLease->id)->update(['currency' => null]);
+    DB::table('invoices')->where('id', $legacyInvoice->id)->update(['currency' => null]);
+    DB::table('payments')->where('id', $legacyPayment->id)->update(['currency' => null]);
+
+    $migration = require database_path('migrations/2026_08_21_092958_backfill_legacy_currency_snapshots.php');
+    $migration->up();
+
+    expect(DB::table('unit_rates')->where('id', $legacyRate->id)->value('currency'))->toBe('IDR')
+        ->and(DB::table('leases')->where('id', $legacyLease->id)->value('currency'))->toBe('IDR')
+        ->and(DB::table('invoices')->where('id', $legacyInvoice->id)->value('currency'))->toBe('IDR')
+        ->and(DB::table('payments')->where('id', $legacyPayment->id)->value('currency'))->toBe('IDR')
+        ->and(DB::table('unit_rates')->where('id', $explicitRate->id)->value('currency'))->toBe('USD')
+        ->and(DB::table('leases')->where('id', $explicitLease->id)->value('currency'))->toBe('USD')
+        ->and(DB::table('invoices')->where('id', $explicitInvoice->id)->value('currency'))->toBe('USD')
+        ->and(DB::table('payments')->where('id', $explicitPayment->id)->value('currency'))->toBe('USD');
+});

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -222,6 +222,78 @@ test('dashboard shows overdue invoice count and amount in attention', function (
     Carbon::setTestNow();
 });
 
+test('dashboard keeps every finance metric aligned to the same currencies', function () {
+    Carbon::setTestNow(Carbon::parse('2026-07-10'));
+
+    $user = User::factory()->owner()->create();
+
+    $idrLease = Lease::factory()->create([
+        'currency' => 'IDR',
+        'rent_amount' => 1_000_000,
+        'start_date' => now()->subMonths(2),
+        'status' => LeaseStatus::Active->value,
+    ]);
+    $usdLease = Lease::factory()->create([
+        'currency' => 'USD',
+        'rent_amount' => 2_000_000,
+        'start_date' => now()->subMonths(2),
+        'status' => LeaseStatus::Active->value,
+    ]);
+
+    $idrInvoice = Invoice::factory()->create([
+        'lease_id' => $idrLease->id,
+        'currency' => 'IDR',
+        'period_start' => '2026-07-02',
+        'period_end' => '2026-07-31',
+        'due_date' => '2026-07-05',
+        'status' => InvoiceStatus::Paid,
+        'total' => 1_000_000,
+        'amount_paid' => 1_000_000,
+    ]);
+    Payment::factory()->create([
+        'invoice_id' => $idrInvoice->id,
+        'amount' => 1_000_000,
+        'currency' => 'IDR',
+        'payment_date' => '2026-07-05',
+        'status' => PaymentStatus::Confirmed,
+    ]);
+
+    Invoice::factory()->create([
+        'lease_id' => $usdLease->id,
+        'currency' => 'USD',
+        'period_start' => '2026-07-02',
+        'period_end' => '2026-07-31',
+        'due_date' => '2026-07-05',
+        'status' => InvoiceStatus::Pending,
+        'total' => 2_000_000,
+        'amount_paid' => 0,
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('finance.revenue_this_month', [
+                ['currency' => 'IDR', 'amount' => '1000000.000'],
+                ['currency' => 'USD', 'amount' => '0'],
+            ])
+            ->where('finance.monthly_potential', [
+                ['currency' => 'IDR', 'amount' => '1000000.000'],
+                ['currency' => 'USD', 'amount' => '2000000.000'],
+            ])
+            ->where('finance.outstanding', [
+                ['currency' => 'IDR', 'amount' => '0'],
+                ['currency' => 'USD', 'amount' => '2000000.000'],
+            ])
+            ->where('finance.collection_rate', [
+                ['currency' => 'IDR', 'rate' => 100],
+                ['currency' => 'USD', 'rate' => 0],
+            ])
+        );
+
+    Carbon::setTestNow();
+});
+
 test('dashboard shows due today count in attention', function () {
     Carbon::setTestNow(Carbon::parse('2026-07-10'));
 

--- a/tests/Feature/RentDashboardTest.php
+++ b/tests/Feature/RentDashboardTest.php
@@ -141,6 +141,57 @@ test('collection queue shows correct outstanding count', function () {
     Carbon::setTestNow();
 });
 
+test('outstanding amounts include currencies represented by collected payments', function () {
+    Carbon::setTestNow(Carbon::parse('2026-07-10'));
+
+    $user = User::factory()->owner()->create();
+
+    $idrLease = Lease::factory()->create([
+        'currency' => 'IDR',
+        'status' => 'active',
+        'start_date' => now()->subMonths(2),
+    ]);
+    Invoice::factory()->create([
+        'lease_id' => $idrLease->id,
+        'due_date' => '2026-07-05',
+        'total' => 106_951_000,
+        'amount_paid' => 0,
+        'status' => InvoiceStatus::Pending,
+    ]);
+
+    $usdLease = Lease::factory()->create([
+        'currency' => 'USD',
+        'status' => 'active',
+        'start_date' => now()->subMonths(2),
+    ]);
+    $usdInvoice = Invoice::factory()->create([
+        'lease_id' => $usdLease->id,
+        'currency' => 'USD',
+        'due_date' => '2026-07-05',
+        'total' => 1_200_000,
+        'amount_paid' => 1_200_000,
+        'status' => InvoiceStatus::Paid,
+    ]);
+    Payment::factory()->create([
+        'invoice_id' => $usdInvoice->id,
+        'amount' => 1_200_000,
+        'currency' => 'USD',
+        'payment_date' => '2026-07-09',
+        'status' => PaymentStatus::Confirmed,
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('dashboard.rent'))
+        ->assertInertia(fn ($page) => $page
+            ->where('outstanding.amounts', [
+                ['currency' => 'IDR', 'amount' => '106951000.000'],
+                ['currency' => 'USD', 'amount' => '0'],
+            ])
+        );
+
+    Carbon::setTestNow();
+});
+
 test('collection queue tab counts are correct', function () {
     Carbon::setTestNow(Carbon::parse('2026-07-10'));
 


### PR DESCRIPTION
## Summary

- Show grouped outstanding balances for every represented currency, including zero balances.
- Keep property overview legends readable on narrow cards.
- Use normal letter spacing for metric values.

## Validation

- `php artisan test --compact tests/Feature/RentDashboardTest.php`
- `npm run lint:check`
- `npm run types:check`
- `npm run build`