### PR TITLE
test(platform): isolate plugin discovery

### DIFF
--- a/tests/Feature/Platform/ComposerPluginDiscoveryTest.php
+++ b/tests/Feature/Platform/ComposerPluginDiscoveryTest.php
@@ -3,7 +3,6 @@
 use App\Services\Platform\ComposerPluginDiscovery;
 use Composer\InstalledVersions;
 use OpenKOS\Core\Contracts\PluginDiscovery;
-use OpenKOS\Platform\PlatformServiceProvider;
 use Tests\Support\Fixtures\ComposerDiscoveryFixturePlugin;
 use Tests\Support\Fixtures\ComposerDiscoverySecondFixturePlugin;
 
@@ -13,6 +12,10 @@ use Tests\Support\Fixtures\ComposerDiscoverySecondFixturePlugin;
 function withComposerDiscoveryFixtures(array $packages, Closure $callback): mixed
 {
     $original = require base_path('vendor/composer/installed.php');
+    $installedPackages = array_diff(
+        InstalledVersions::getInstalledPackages(),
+        array_keys($packages),
+    );
     $originalDisabledPackages = config('platform.discovery.disabled_packages', []);
     $versions = [];
     $directories = [];
@@ -37,6 +40,11 @@ function withComposerDiscoveryFixtures(array $packages, Closure $callback): mixe
                 'dev_requirement' => false,
             ];
         }
+
+        config(['platform.discovery.disabled_packages' => array_values(array_unique([
+            ...$originalDisabledPackages,
+            ...$installedPackages,
+        ]))]);
 
         InstalledVersions::reload([
             'root' => [
@@ -73,7 +81,7 @@ it('discovers a plugin declared by Composer metadata', function () {
         ],
     ], fn (): array => app(ComposerPluginDiscovery::class)->discover());
 
-    expect($plugins)->toContain(ComposerDiscoveryFixturePlugin::class);
+    expect($plugins)->toBe([ComposerDiscoveryFixturePlugin::class]);
 });
 
 it('ignores packages without OpenKOS plugin metadata', function () {
@@ -131,7 +139,7 @@ it('boots a Composer-discovered plugin through the normal lifecycle', function (
         ],
     ], function (): null {
         config(['platform.plugins' => []]);
-        (new PlatformServiceProvider(app()))->boot();
+        $this->bootPlatformWithIsolatedRegistries();
 
         return null;
     });
@@ -151,7 +159,7 @@ it('does not run any plugin lifecycle when discovery finds an invalid class', fu
 
     config(['platform.plugins' => []]);
 
-    expect(fn () => (new PlatformServiceProvider(app()))->boot())
+    expect(fn () => $this->bootPlatformWithIsolatedRegistries())
         ->toThrow(InvalidArgumentException::class, 'Plugin class [Acme\\MissingPlugin] does not exist.');
 
     expect(ComposerDiscoveryFixturePlugin::$registerCalls)->toBe(0);

--- a/tests/Feature/Platform/PluginBootTest.php
+++ b/tests/Feature/Platform/PluginBootTest.php
@@ -1,16 +1,17 @@
 <?php
 
+use Composer\InstalledVersions;
 use OpenKOS\Platform\Facades\OpenKOS;
-use OpenKOS\Platform\PlatformServiceProvider;
+use OpenKOS\Platform\Payment\PaymentRegistry;
 use OpenKOS\Plugins\Example\ExamplePlugin;
 use Tests\Support\Fixtures\OrderProbePluginA;
 use Tests\Support\Fixtures\OrderProbePluginB;
 
 // ExamplePlugin is disabled by default, so enable it explicitly to prove the
-// registration path. Registries are singletons, so assert "contains".
+// registration path.
 it('applies a plugins registrations across every registry on boot', function () {
     config(['platform.plugins' => [ExamplePlugin::class]]);
-    (new PlatformServiceProvider(app()))->boot();
+    $this->bootPlatformWithIsolatedRegistries();
 
     $navTitles = array_map(fn ($item) => $item->title, OpenKOS::navigation()->items('main'));
 
@@ -23,7 +24,15 @@ it('runs every register() before any boot()', function () {
     OrderProbePluginA::$calls = [];
     config(['platform.plugins' => [OrderProbePluginA::class, OrderProbePluginB::class]]);
 
-    (new PlatformServiceProvider(app()))->boot();
+    $this->bootPlatformWithIsolatedRegistries();
 
     expect(OrderProbePluginA::$calls)->toBe(['register:a', 'register:b', 'boot:a', 'boot:b']);
+});
+
+it('registers an installed Xendit plugin once during application boot', function () {
+    if (! in_array('openkos/payment-xendit', InstalledVersions::getInstalledPackages(), true)) {
+        $this->markTestSkipped('The openkos/payment-xendit package is not installed.');
+    }
+
+    expect(app(PaymentRegistry::class)->gateways())->toHaveKey('xendit');
 });

--- a/tests/Feature/Platform/PluginEventTest.php
+++ b/tests/Feature/Platform/PluginEventTest.php
@@ -10,13 +10,12 @@ use Database\Seeders\RegionAndCitySeeder;
 use Database\Seeders\RoleAndPermissionSeeder;
 use Illuminate\Support\Facades\Event;
 use OpenKOS\Core\Events\PaymentRecorded;
-use OpenKOS\Platform\PlatformServiceProvider;
 use Tests\Support\Fixtures\EventProbePlugin;
 
 it('wires a plugins event listeners at boot', function () {
     EventProbePlugin::$fired = false;
     config(['platform.plugins' => [EventProbePlugin::class]]);
-    (new PlatformServiceProvider(app()))->boot();
+    $this->bootPlatformWithIsolatedRegistries();
 
     event(new PaymentRecorded(paymentId: 1));
 

--- a/tests/Feature/Platform/PluginResourcesTest.php
+++ b/tests/Feature/Platform/PluginResourcesTest.php
@@ -2,7 +2,6 @@
 
 use App\Models\User;
 use Database\Seeders\RoleAndPermissionSeeder;
-use OpenKOS\Platform\PlatformServiceProvider;
 use OpenKOS\Plugins\Example\ExamplePlugin;
 use Spatie\Permission\Models\Permission;
 
@@ -11,7 +10,7 @@ use Spatie\Permission\Models\Permission;
 beforeEach(function () {
     $this->seed(RoleAndPermissionSeeder::class);
     config(['platform.plugins' => [ExamplePlugin::class]]);
-    (new PlatformServiceProvider(app()))->boot();
+    $this->bootPlatformWithIsolatedRegistries();
 });
 
 it('loads routes shipped by an enabled plugin', function () {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,9 +4,38 @@ namespace Tests;
 
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 use Laravel\Fortify\Features;
+use OpenKOS\Platform\Dashboard\DashboardRegistry;
+use OpenKOS\Platform\Navigation\NavigationRegistry;
+use OpenKOS\Platform\Notification\NotificationRegistry;
+use OpenKOS\Platform\OpenKOSManager;
+use OpenKOS\Platform\Payment\PaymentRegistry;
+use OpenKOS\Platform\Permission\PermissionRegistry;
+use OpenKOS\Platform\PlatformServiceProvider;
+use OpenKOS\Platform\Settings\SettingsManager;
+use OpenKOS\Platform\Settings\SettingsRegistry;
+use OpenKOS\Platform\Workspace\WorkspaceRegistry;
 
 abstract class TestCase extends BaseTestCase
 {
+    protected function bootPlatformWithIsolatedRegistries(): void
+    {
+        foreach ([
+            DashboardRegistry::class,
+            NavigationRegistry::class,
+            WorkspaceRegistry::class,
+            SettingsRegistry::class,
+            SettingsManager::class,
+            NotificationRegistry::class,
+            PaymentRegistry::class,
+            PermissionRegistry::class,
+            OpenKOSManager::class,
+        ] as $singleton) {
+            app()->forgetInstance($singleton);
+        }
+
+        (new PlatformServiceProvider(app()))->boot();
+    }
+
     protected function skipUnlessFortifyHas(string $feature, ?string $message = null): void
     {
         if (! Features::enabled($feature)) {


### PR DESCRIPTION
## Summary

- isolate Composer discovery fixtures from real installed plugins
- reset all platform registry singletons before manual provider boots
- cover normal application boot with the optional Xendit plugin

## Validation

- `vendor/bin/pint --dirty --format agent`
- targeted platform tests: 27 passed, 1 skipped
- full suite: 885 passed, 1 skipped
- simulated Xendit install: normal and fresh manual boots register `xendit` once

Refs OPE-162