### PR TITLE
fix(units): refresh rate status

### DIFF
--- a/resources/js/pages/properties/units/rates.tsx
+++ b/resources/js/pages/properties/units/rates.tsx
@@ -133,6 +133,10 @@ export default function UnitRates({
     }
 
     function submitRates(rates: UnitRate[], onSuccess?: () => void) {
+        if (processing) {
+            return;
+        }
+
         transform((formData) => ({ ...formData, rates }));
         submit(
             properties.units.update({
@@ -146,10 +150,12 @@ export default function UnitRates({
 
                     const updatedUnit = page.props.unit as Unit | undefined;
 
-                    setData({
-                        rates: updatedUnit?.rates ?? rates,
-                        updated_at: updatedUnit?.updated_at ?? data.updated_at,
-                    });
+                    setData((current) => ({
+                        ...current,
+                        rates: updatedUnit?.rates ?? current.rates,
+                        updated_at:
+                            updatedUnit?.updated_at ?? current.updated_at,
+                    }));
 
                     onSuccess?.();
                 },
@@ -260,6 +266,7 @@ export default function UnitRates({
                                     type="button"
                                     variant="ghost"
                                     size="icon-sm"
+                                    disabled={processing}
                                     aria-label={`Actions for ${currency} rate`}
                                 >
                                     <Ellipsis />

--- a/tests/Feature/UnitTest.php
+++ b/tests/Feature/UnitTest.php
@@ -294,6 +294,56 @@ describe('CRUD', function () {
             ->assertSessionHasNoErrors();
 
         expect($rate->fresh()->is_active)->toBeTrue();
+
+        $this->actingAs($user)
+            ->get(route('properties.units.rates', [$property, $unit]))
+            ->assertInertia(fn ($page) => $page
+                ->component('properties/units/rates')
+                ->where('unit.rates', function ($rates) use ($rate): bool {
+                    $updatedRate = collect($rates)->firstWhere('id', $rate->id);
+
+                    return $updatedRate !== null
+                        && $updatedRate['is_active'] === true;
+                })
+            );
+    });
+
+    it('deactivates a persisted active rate and refreshes the workspace state', function () {
+        $user = User::factory()->owner()->create();
+        $property = Property::factory()->create();
+        $unit = Unit::factory()->for($property)->create();
+        $rate = $unit->activeRates()->firstOrFail();
+
+        $this->actingAs($user)
+            ->put(route('properties.units.update', [$property, $unit]), [
+                'name' => $unit->name,
+                'capacity' => $unit->capacity,
+                'updated_at' => $unit->updated_at->toISOString(),
+                'rates' => [[
+                    'id' => $rate->id,
+                    'billing_interval' => $rate->billing_interval,
+                    'billing_unit' => $rate->billing_unit->value,
+                    'amount' => $rate->amount,
+                    'currency' => $rate->currency,
+                    'is_active' => false,
+                ]],
+            ])
+            ->assertRedirect()
+            ->assertSessionHasNoErrors();
+
+        expect($rate->fresh()->is_active)->toBeFalse();
+
+        $this->actingAs($user)
+            ->get(route('properties.units.rates', [$property, $unit]))
+            ->assertInertia(fn ($page) => $page
+                ->component('properties/units/rates')
+                ->where('unit.rates', function ($rates) use ($rate): bool {
+                    $updatedRate = collect($rates)->firstWhere('id', $rate->id);
+
+                    return $updatedRate !== null
+                        && $updatedRate['is_active'] === false;
+                })
+            );
     });
 
     it('deletes a unit via soft delete', function () {


### PR DESCRIPTION
## Summary
- merge refreshed rate props without clearing the unit form
- prevent duplicate rate status mutations while processing
- cover deactivate/reactivate workspace state refreshes

## Verification
- php artisan test --compact
- npm run types:check
- npm run lint:check
- npm run build

Linear: OPE-163