### PR TITLE
fix(dashboard): preserve terminated lease finances

### DIFF
--- a/app/Business/Dashboard/OverviewStatsCalculator.php
+++ b/app/Business/Dashboard/OverviewStatsCalculator.php
@@ -3,6 +3,7 @@
 namespace App\Business\Dashboard;
 
 use App\Enums\InvoiceStatus;
+use App\Enums\LeaseStatus;
 use App\Models\Invoice;
 use App\Models\Payment;
 use Brick\Math\BigDecimal;
@@ -13,8 +14,11 @@ use Illuminate\Support\Collection;
 
 class OverviewStatsCalculator
 {
-    public function computeFinance(Builder $activeLeasesQuery): array
+    public function computeFinance(Builder $accessibleLeasesQuery): array
     {
+        $activeLeasesQuery = (clone $accessibleLeasesQuery)
+            ->where('status', LeaseStatus::Active->value);
+
         $monthlyPotential = $this->aggregate(
             (clone $activeLeasesQuery)->get(['rent_amount', 'currency']),
             fn ($row): string => (string) $row->rent_amount,
@@ -24,7 +28,7 @@ class OverviewStatsCalculator
         $currentMonth = (int) $now->month;
         $currentYear = (int) $now->year;
 
-        $leaseIds = (clone $activeLeasesQuery)->pluck('id');
+        $leaseIds = (clone $accessibleLeasesQuery)->pluck('id');
 
         $periodStart = Carbon::create($currentYear, $currentMonth, 1)->startOfDay();
         $periodEnd = Carbon::create($currentYear, $currentMonth, 1)->endOfMonth()->endOfDay();

--- a/app/Business/Dashboard/OverviewStatsCalculator.php
+++ b/app/Business/Dashboard/OverviewStatsCalculator.php
@@ -28,18 +28,18 @@ class OverviewStatsCalculator
         $currentMonth = (int) $now->month;
         $currentYear = (int) $now->year;
 
-        $leaseIds = (clone $accessibleLeasesQuery)->pluck('id');
+        $authorizedLeaseIds = (clone $accessibleLeasesQuery)->select('leases.id');
 
-        $periodStart = Carbon::create($currentYear, $currentMonth, 1)->startOfDay();
-        $periodEnd = Carbon::create($currentYear, $currentMonth, 1)->endOfMonth()->endOfDay();
+        $periodStart = Carbon::create($currentYear, $currentMonth, 1)->toDateString();
+        $periodEnd = Carbon::create($currentYear, $currentMonth, 1)->endOfMonth()->toDateString();
 
         $revenueThisMonth = Payment::where('status', 'confirmed')
             ->whereHas('invoice', fn (Builder $q) => $q
                 ->whereBetween('period_start', [$periodStart, $periodEnd])
-                ->whereIn('lease_id', $leaseIds))
+                ->whereIn('lease_id', clone $authorizedLeaseIds))
             ->get(['amount', 'currency']);
 
-        $outstanding = Invoice::whereIn('lease_id', $leaseIds)
+        $outstanding = Invoice::whereIn('lease_id', clone $authorizedLeaseIds)
             ->whereBetween('period_start', [$periodStart, $periodEnd])
             ->whereIn('status', [InvoiceStatus::Pending->value, InvoiceStatus::Partial->value])
             ->get(['total', 'amount_paid', 'currency']);

--- a/app/Http/Controllers/Dashboard/OverviewController.php
+++ b/app/Http/Controllers/Dashboard/OverviewController.php
@@ -66,12 +66,14 @@ class OverviewController extends Controller
             ))
             ->pluck('id');
 
-        $activeLeases = Lease::where('status', LeaseStatus::Active->value)
+        $accessibleLeases = Lease::query()
             ->whereHas('unit.property', fn (Builder $q) => $q->whereIn('id', $accessibleProperties));
 
-        $invoiceScope = Invoice::whereHas('lease', fn (Builder $q) => $q
-            ->where('status', LeaseStatus::Active->value)
-            ->whereHas('unit.property', fn (Builder $q) => $q->whereIn('id', $accessibleProperties)));
+        $activeLeases = (clone $accessibleLeases)
+            ->where('status', LeaseStatus::Active->value);
+
+        $invoiceScope = Invoice::query()
+            ->whereIn('lease_id', (clone $accessibleLeases)->select('id'));
 
         $overdueInvoices = (clone $invoiceScope)
             ->payable()
@@ -178,7 +180,7 @@ class OverviewController extends Controller
 
         $propertyTypes = PropertyType::active()->ordered()->get(['slug', 'label']);
 
-        $financeResult = $finance->computeFinance($activeLeases);
+        $financeResult = $finance->computeFinance($accessibleLeases);
 
         return Inertia::render('dashboard/overview', [
             'attention' => $attention,

--- a/app/Http/Controllers/Dashboard/RentController.php
+++ b/app/Http/Controllers/Dashboard/RentController.php
@@ -47,7 +47,6 @@ class RentController extends Controller
         ];
 
         $invoiceScope = Invoice::query()
-            ->whereHas('lease', fn (Builder $q) => $q->where('status', 'active'))
             ->whereHas('lease.unit', fn (Builder $q) => $q->whereIn('property_id', $accessiblePropertyIds));
 
         $invoiceTable = DB::getQueryGrammar()->wrap((new Invoice)->getTable());
@@ -131,7 +130,6 @@ class RentController extends Controller
         $paymentStats = Payment::query()
             ->where('status', PaymentStatus::Confirmed->value)
             ->whereHas('invoice', fn (Builder $q) => $q
-                ->whereHas('lease', fn (Builder $q) => $q->where('status', 'active'))
                 ->whereHas('lease.unit', fn (Builder $q) => $q->whereIn('property_id', $accessiblePropertyIds)))
             ->selectRaw(
                 'COALESCE(currency, ?) as currency, COALESCE(SUM(amount), 0) as amount, MAX(payment_date) as last_payment_at',

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Actions\Leases\MoveOutLease;
+use App\Data\Lease\MoveOutLeaseData;
 use App\Enums\InvoiceStatus;
 use App\Enums\LeaseStatus;
 use App\Enums\PaymentStatus;
@@ -289,6 +291,211 @@ test('dashboard keeps every finance metric aligned to the same currencies', func
                 ['currency' => 'IDR', 'rate' => 100],
                 ['currency' => 'USD', 'rate' => 0],
             ])
+        );
+
+    Carbon::setTestNow();
+});
+
+test('dashboard preserves historical financial activity after lease termination', function () {
+    Carbon::setTestNow(Carbon::parse('2026-07-10'));
+
+    $user = User::factory()->owner()->create();
+    $activeLease = Lease::factory()->create([
+        'currency' => 'IDR',
+        'rent_amount' => '1000000',
+        'start_date' => now()->subMonths(2),
+        'status' => LeaseStatus::Active,
+    ]);
+    $terminatedLease = Lease::factory()->create([
+        'currency' => 'USD',
+        'rent_amount' => '500',
+        'start_date' => now()->subMonths(2),
+        'status' => LeaseStatus::Active,
+    ]);
+    $invoice = Invoice::factory()->create([
+        'lease_id' => $terminatedLease->id,
+        'currency' => 'USD',
+        'period_start' => '2026-07-02',
+        'period_end' => '2026-07-31',
+        'due_date' => '2026-07-05',
+        'total' => 500,
+        'amount_paid' => 500,
+        'status' => InvoiceStatus::Paid,
+    ]);
+    Payment::factory()->create([
+        'invoice_id' => $invoice->id,
+        'amount' => 500,
+        'currency' => 'USD',
+        'payment_date' => '2026-07-05',
+        'status' => PaymentStatus::Confirmed,
+    ]);
+
+    app(MoveOutLease::class)->execute($terminatedLease, new MoveOutLeaseData(
+        terminationDate: '2026-07-10',
+        endDate: '2026-07-10',
+        reason: 'Historical dashboard test',
+    ));
+
+    expect($activeLease->fresh()->status)->toBe(LeaseStatus::Active)
+        ->and($terminatedLease->fresh()->status)->toBe(LeaseStatus::Terminated);
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('finance.revenue_this_month', [
+                ['currency' => 'IDR', 'amount' => '0'],
+                ['currency' => 'USD', 'amount' => '500.000'],
+            ])
+            ->where('finance.monthly_potential', [
+                ['currency' => 'IDR', 'amount' => '1000000.000'],
+                ['currency' => 'USD', 'amount' => '0'],
+            ])
+            ->where('finance.outstanding', [
+                ['currency' => 'IDR', 'amount' => '0'],
+                ['currency' => 'USD', 'amount' => '0'],
+            ])
+            ->where('finance.collection_rate', [
+                ['currency' => 'IDR', 'rate' => 0],
+                ['currency' => 'USD', 'rate' => 0],
+            ])
+        );
+
+    Carbon::setTestNow();
+});
+
+test('dashboard includes collectible invoices from terminated leases only', function () {
+    Carbon::setTestNow(Carbon::parse('2026-07-10'));
+
+    $user = User::factory()->owner()->create();
+    $lease = Lease::factory()->create([
+        'currency' => 'IDR',
+        'status' => LeaseStatus::Active,
+        'start_date' => now()->subMonths(2),
+    ]);
+
+    Invoice::factory()->create([
+        'lease_id' => $lease->id,
+        'currency' => 'IDR',
+        'period_start' => '2026-07-02',
+        'period_end' => '2026-07-31',
+        'due_date' => '2026-07-05',
+        'total' => 800,
+        'amount_paid' => 0,
+        'status' => InvoiceStatus::Pending,
+    ]);
+    Invoice::factory()->create([
+        'lease_id' => $lease->id,
+        'currency' => 'IDR',
+        'period_start' => '2026-07-03',
+        'period_end' => '2026-07-31',
+        'due_date' => '2026-07-10',
+        'total' => 500,
+        'amount_paid' => 100,
+        'status' => InvoiceStatus::Partial,
+    ]);
+    Invoice::factory()->create([
+        'lease_id' => $lease->id,
+        'currency' => 'IDR',
+        'period_start' => '2026-07-04',
+        'period_end' => '2026-07-31',
+        'due_date' => '2026-07-05',
+        'total' => 900,
+        'amount_paid' => 0,
+        'status' => InvoiceStatus::Cancelled,
+    ]);
+    Invoice::factory()->create([
+        'lease_id' => $lease->id,
+        'currency' => 'IDR',
+        'period_start' => '2026-07-01',
+        'period_end' => '2026-07-31',
+        'due_date' => '2026-07-05',
+        'total' => 1000,
+        'amount_paid' => 0,
+        'status' => InvoiceStatus::Void,
+    ]);
+
+    app(MoveOutLease::class)->execute($lease, new MoveOutLeaseData(
+        terminationDate: '2026-07-10',
+        endDate: '2026-07-10',
+        reason: 'Collectible invoice test',
+    ));
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('finance.outstanding', [[
+                'currency' => 'IDR',
+                'amount' => '1200.000',
+            ]])
+            ->where('attention.overdue_invoices.count', 1)
+            ->where('attention.overdue_invoices.amounts', [[
+                'currency' => 'IDR',
+                'amount' => '800.000',
+            ]])
+            ->where('attention.due_today', 1)
+        );
+
+    Carbon::setTestNow();
+});
+
+test('dashboard financial metrics remain scoped to accessible properties', function () {
+    Carbon::setTestNow(Carbon::parse('2026-07-10'));
+
+    $user = User::factory()->admin()->create();
+    $accessibleProperty = Property::factory()->create();
+    $user->properties()->sync([$accessibleProperty->id]);
+
+    $accessibleLease = Lease::factory()->create([
+        'unit_id' => Unit::factory()->for($accessibleProperty)->create()->id,
+        'currency' => 'USD',
+        'status' => LeaseStatus::Terminated,
+    ]);
+    $accessibleInvoice = Invoice::factory()->create([
+        'lease_id' => $accessibleLease->id,
+        'currency' => 'USD',
+        'period_start' => '2026-07-02',
+        'period_end' => '2026-07-31',
+        'status' => InvoiceStatus::Paid,
+        'total' => 100,
+        'amount_paid' => 100,
+    ]);
+    Payment::factory()->create([
+        'invoice_id' => $accessibleInvoice->id,
+        'amount' => 100,
+        'currency' => 'USD',
+        'status' => PaymentStatus::Confirmed,
+    ]);
+
+    $hiddenLease = Lease::factory()->create([
+        'currency' => 'USD',
+        'status' => LeaseStatus::Terminated,
+    ]);
+    $hiddenInvoice = Invoice::factory()->create([
+        'lease_id' => $hiddenLease->id,
+        'currency' => 'USD',
+        'period_start' => '2026-07-02',
+        'period_end' => '2026-07-31',
+        'status' => InvoiceStatus::Paid,
+        'total' => 900,
+        'amount_paid' => 900,
+    ]);
+    Payment::factory()->create([
+        'invoice_id' => $hiddenInvoice->id,
+        'amount' => 900,
+        'currency' => 'USD',
+        'status' => PaymentStatus::Confirmed,
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('finance.revenue_this_month', [[
+                'currency' => 'USD',
+                'amount' => '100.000',
+            ]])
         );
 
     Carbon::setTestNow();

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -315,7 +315,7 @@ test('dashboard preserves historical financial activity after lease termination'
     $invoice = Invoice::factory()->create([
         'lease_id' => $terminatedLease->id,
         'currency' => 'USD',
-        'period_start' => '2026-07-02',
+        'period_start' => '2026-07-01',
         'period_end' => '2026-07-31',
         'due_date' => '2026-07-05',
         'total' => 500,

--- a/tests/Feature/RentDashboardTest.php
+++ b/tests/Feature/RentDashboardTest.php
@@ -192,6 +192,87 @@ test('outstanding amounts include currencies represented by collected payments',
     Carbon::setTestNow();
 });
 
+test('collection queue preserves financial activity from terminated leases', function () {
+    Carbon::setTestNow(Carbon::parse('2026-07-10'));
+
+    $user = User::factory()->owner()->create();
+    $lease = Lease::factory()->terminated()->create([
+        'currency' => 'USD',
+        'end_date' => '2026-07-10',
+    ]);
+    Invoice::factory()->create([
+        'lease_id' => $lease->id,
+        'reference' => 'INV-TERMINATED-PENDING',
+        'currency' => 'USD',
+        'period_start' => '2026-07-01',
+        'due_date' => '2026-07-05',
+        'total' => 400,
+        'amount_paid' => 0,
+        'status' => InvoiceStatus::Pending,
+    ]);
+    $paidInvoice = Invoice::factory()->create([
+        'lease_id' => $lease->id,
+        'reference' => 'INV-TERMINATED-PAID',
+        'currency' => 'USD',
+        'period_start' => '2026-07-02',
+        'due_date' => '2026-07-05',
+        'total' => 600,
+        'amount_paid' => 600,
+        'status' => InvoiceStatus::Paid,
+    ]);
+    Invoice::factory()->create([
+        'lease_id' => $lease->id,
+        'currency' => 'USD',
+        'period_start' => '2026-07-03',
+        'total' => 700,
+        'amount_paid' => 0,
+        'status' => InvoiceStatus::Cancelled,
+    ]);
+    Invoice::factory()->create([
+        'lease_id' => $lease->id,
+        'currency' => 'USD',
+        'period_start' => '2026-07-04',
+        'total' => 800,
+        'amount_paid' => 0,
+        'status' => InvoiceStatus::Void,
+    ]);
+    Payment::factory()->create([
+        'invoice_id' => $paidInvoice->id,
+        'amount' => 600,
+        'currency' => 'USD',
+        'payment_date' => '2026-07-08',
+        'status' => PaymentStatus::Confirmed,
+    ]);
+
+    $this->actingAs($user)
+        ->get(route('dashboard.rent'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('tab_counts.all', 1)
+            ->where('tab_counts.paid', 1)
+            ->where('outstanding.count', 1)
+            ->where('outstanding.amounts', [[
+                'currency' => 'USD',
+                'amount' => '400.000',
+            ]])
+            ->where('progress.processed', 1)
+            ->where('progress.total', 2)
+            ->where('progress.amount_collected', [[
+                'currency' => 'USD',
+                'amount' => '600',
+            ]])
+        );
+
+    $this->actingAs($user)
+        ->get(route('dashboard.rent', ['urgency' => 'paid']))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('entries.data.0.reference', 'INV-TERMINATED-PAID')
+        );
+
+    Carbon::setTestNow();
+});
+
 test('collection queue tab counts are correct', function () {
     Carbon::setTestNow(Carbon::parse('2026-07-10'));
 


### PR DESCRIPTION
## Summary

- Preserve authorized terminated-lease financial history across overview and collection metrics.
- Keep active-only scoping for operational metrics.
- Use database subqueries for authorized lease filtering.
- Normalize reporting boundaries to date strings and cover the first day of the month.

## Validation

- `vendor/bin/pint --dirty --format agent`
- `php artisan test --compact` (890 passed, 1 skipped)

Refs OPE-161