### PR TITLE
feat(settings): add customizable branding

### DIFF
--- a/app/Actions/Settings/UpdateBranding.php
+++ b/app/Actions/Settings/UpdateBranding.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Actions\Settings;
+
+use App\Models\Setting;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use InvalidArgumentException;
+use RuntimeException;
+use Throwable;
+
+class UpdateBranding
+{
+    private const SETTING_KEYS = [
+        'logo' => 'branding_logo_path',
+        'favicon' => 'branding_favicon_path',
+    ];
+
+    public function __construct(
+        private UpdateSettings $updateSettings,
+    ) {}
+
+    public function execute(string $asset, UploadedFile $file, Authenticatable $actor): void
+    {
+        $key = $this->settingKey($asset);
+        $disk = $this->disk();
+        $previousPath = (string) Setting::get($key);
+        $newPath = null;
+
+        try {
+            $newPath = $file->store('branding', $disk);
+
+            if ($newPath === false) {
+                throw new RuntimeException('Branding file could not be stored.');
+            }
+
+            $this->updateSettings->execute([$key => $newPath], $actor);
+        } catch (Throwable $exception) {
+            $settingsState = is_string($newPath)
+                ? $this->settingMatches($key, $newPath)
+                : false;
+
+            if ($settingsState === true && $previousPath !== $newPath) {
+                $this->delete($disk, $previousPath);
+            } elseif ($settingsState === false && is_string($newPath)) {
+                $this->delete($disk, $newPath);
+            }
+
+            throw $exception;
+        }
+
+        if ($previousPath !== $newPath) {
+            $this->delete($disk, $previousPath);
+        }
+    }
+
+    public function remove(string $asset, Authenticatable $actor): void
+    {
+        $key = $this->settingKey($asset);
+        $disk = $this->disk();
+        $previousPath = (string) Setting::get($key);
+
+        try {
+            $this->updateSettings->execute([$key => ''], $actor);
+        } catch (Throwable $exception) {
+            if ($this->settingMatches($key, '') === true) {
+                $this->delete($disk, $previousPath);
+            }
+
+            throw $exception;
+        }
+
+        $this->delete($disk, $previousPath);
+    }
+
+    private function settingKey(string $asset): string
+    {
+        return self::SETTING_KEYS[$asset]
+            ?? throw new InvalidArgumentException("Unsupported branding asset [{$asset}].");
+    }
+
+    private function disk(): string
+    {
+        return (string) config('filesystems.default', 'local');
+    }
+
+    private function delete(string $disk, string $path): void
+    {
+        if (filled($path)) {
+            Storage::disk($disk)->delete($path);
+        }
+    }
+
+    private function settingMatches(string $key, string $value): ?bool
+    {
+        try {
+            return Setting::get($key) === $value;
+        } catch (Throwable) {
+            return null;
+        }
+    }
+}

--- a/app/Http/Controllers/BrandingAssetController.php
+++ b/app/Http/Controllers/BrandingAssetController.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Setting;
+use Illuminate\Filesystem\FilesystemAdapter;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Throwable;
+
+class BrandingAssetController extends Controller
+{
+    private const ASSETS = [
+        'logo' => [
+            'setting' => 'branding_logo_path',
+            'fallback' => 'assets/brand/openkos-logo.svg',
+            'fallback_mime' => 'image/svg+xml',
+            'mimes' => ['image/jpeg', 'image/png', 'image/webp'],
+        ],
+        'favicon' => [
+            'setting' => 'branding_favicon_path',
+            'fallback' => 'favicon.ico',
+            'fallback_mime' => 'image/x-icon',
+            'mimes' => ['image/png', 'image/x-icon', 'image/vnd.microsoft.icon'],
+        ],
+    ];
+
+    public function __invoke(string $asset): BinaryFileResponse|StreamedResponse
+    {
+        $definition = self::ASSETS[$asset] ?? abort(404);
+        $fallback = public_path($definition['fallback']);
+
+        try {
+            $disk = Storage::disk((string) config('filesystems.default', 'local'));
+            $path = Setting::get($definition['setting']);
+
+            if (is_string($path) && filled($path) && $disk->exists($path)) {
+                $mimeType = $disk->mimeType($path);
+
+                if (is_string($mimeType) && in_array($mimeType, $definition['mimes'], true)) {
+                    return $this->storedResponse($disk, $path, $mimeType);
+                }
+            }
+        } catch (Throwable) {
+            // Fall through to the bundled asset when custom storage is unavailable.
+        }
+
+        abort_unless(is_file($fallback), 404);
+
+        return response()->file($fallback, [
+            'Content-Type' => $definition['fallback_mime'],
+            'Cache-Control' => 'public, max-age=31536000, immutable',
+            'X-Content-Type-Options' => 'nosniff',
+        ]);
+    }
+
+    private function storedResponse(FilesystemAdapter $disk, string $path, string $mimeType): StreamedResponse
+    {
+        return $disk->response($path, null, [
+            'Content-Type' => $mimeType,
+            'Cache-Control' => 'public, max-age=31536000, immutable',
+            'X-Content-Type-Options' => 'nosniff',
+        ]);
+    }
+}

--- a/app/Http/Controllers/Settings/GeneralController.php
+++ b/app/Http/Controllers/Settings/GeneralController.php
@@ -2,8 +2,10 @@
 
 namespace App\Http\Controllers\Settings;
 
+use App\Actions\Settings\UpdateBranding;
 use App\Actions\Settings\UpdateSettings;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Settings\UpdateBrandingRequest;
 use App\Models\Setting;
 use App\Services\Payments\MoneyConverter;
 use Illuminate\Http\RedirectResponse;
@@ -16,6 +18,7 @@ class GeneralController extends Controller
 {
     public function __construct(
         private UpdateSettings $updateSettings,
+        private UpdateBranding $updateBranding,
     ) {}
 
     public function edit(): Response
@@ -64,6 +67,26 @@ class GeneralController extends Controller
         $this->updateSettings->execute($validated, $request->user());
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('General settings updated.')]);
+
+        return back();
+    }
+
+    public function updateBranding(UpdateBrandingRequest $request, string $asset): RedirectResponse
+    {
+        $this->updateBranding->execute($asset, $request->file('file'), $request->user());
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __(':asset updated.', ['asset' => ucfirst($asset)])]);
+
+        return back();
+    }
+
+    public function removeBranding(Request $request, string $asset): RedirectResponse
+    {
+        abort_unless($request->user()?->isOwner(), 403);
+
+        $this->updateBranding->remove($asset, $request->user());
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Default :asset restored.', ['asset' => ucfirst($asset)])]);
 
         return back();
     }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -5,13 +5,20 @@ namespace App\Http\Middleware;
 use App\Models\Setting;
 use App\Services\Payments\MoneyConverter;
 use Closure;
+use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
 use Inertia\Middleware;
 use OpenKOS\Platform\Facades\OpenKOS;
 use Symfony\Component\HttpFoundation\Response;
 
 class HandleInertiaRequests extends Middleware
 {
+    private const BRANDING_MIMES = [
+        'logo' => ['image/jpeg', 'image/png', 'image/webp'],
+        'favicon' => ['image/png', 'image/x-icon', 'image/vnd.microsoft.icon'],
+    ];
+
     protected $rootView = 'app';
 
     public function handle(Request $request, Closure $next): Response
@@ -47,8 +54,15 @@ class HandleInertiaRequests extends Middleware
             // password, API tokens — so they never go into the app-wide share. Their
             // own settings pages load them (masked) separately.
             'setting' => fn () => collect(Setting::get())
-                ->except(['mail_config', 'whatsapp_config', 'payment_gateway_config'])
+                ->except([
+                    'mail_config',
+                    'whatsapp_config',
+                    'payment_gateway_config',
+                    'branding_logo_path',
+                    'branding_favicon_path',
+                ])
                 ->all(),
+            'branding' => fn () => $this->branding(),
             'notificationChannels' => fn () => [
                 'mail' => filled(data_get(Setting::effectiveMailConfig(), 'host')),
                 'whatsapp' => filled(Setting::get('whatsapp_driver')),
@@ -90,5 +104,71 @@ class HandleInertiaRequests extends Middleware
         $permission = $page['permission'] ?? null;
 
         return $permission === null || $user->isOwner() || $user->can($permission);
+    }
+
+    /**
+     * @return array{logoUrl: string, faviconUrl: string, hasCustomLogo: bool, hasCustomFavicon: bool, hasConfiguredLogo: bool, hasConfiguredFavicon: bool}
+     */
+    private function branding(): array
+    {
+        $logoPath = Setting::get('branding_logo_path');
+        $faviconPath = Setting::get('branding_favicon_path');
+        $hasConfiguredLogo = $this->isConfigured($logoPath);
+        $hasConfiguredFavicon = $this->isConfigured($faviconPath);
+        $disk = null;
+
+        if ($hasConfiguredLogo || $hasConfiguredFavicon) {
+            try {
+                $disk = Storage::disk((string) config('filesystems.default', 'local'));
+            } catch (\Throwable) {
+                // Use bundled branding when the configured disk is unavailable.
+            }
+        }
+
+        $logoVersion = $this->storedAssetVersion('logo', $logoPath, $disk);
+        $faviconVersion = $this->storedAssetVersion('favicon', $faviconPath, $disk);
+
+        return [
+            'logoUrl' => $this->brandingUrl('logo', $logoVersion),
+            'faviconUrl' => $this->brandingUrl('favicon', $faviconVersion),
+            'hasCustomLogo' => $logoVersion !== null,
+            'hasCustomFavicon' => $faviconVersion !== null,
+            'hasConfiguredLogo' => $hasConfiguredLogo,
+            'hasConfiguredFavicon' => $hasConfiguredFavicon,
+        ];
+    }
+
+    private function brandingUrl(string $asset, ?string $version): string
+    {
+        return route('branding.asset', [
+            'asset' => $asset,
+            'v' => $version ?? 'default',
+        ]);
+    }
+
+    private function storedAssetVersion(string $asset, mixed $path, ?FilesystemAdapter $disk): ?string
+    {
+        if ($disk === null || ! $this->isConfigured($path)) {
+            return null;
+        }
+
+        try {
+            if (! $disk->exists($path)) {
+                return null;
+            }
+
+            $mimeType = $disk->mimeType($path);
+
+            return is_string($mimeType) && in_array($mimeType, self::BRANDING_MIMES[$asset], true)
+                ? sha1((string) $path)
+                : null;
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    private function isConfigured(mixed $path): bool
+    {
+        return is_string($path) && filled($path);
     }
 }

--- a/app/Http/Requests/Settings/UpdateBrandingRequest.php
+++ b/app/Http/Requests/Settings/UpdateBrandingRequest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Requests\Settings;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateBrandingRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->isOwner() ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'file' => [
+                'required',
+                'file',
+                'max:'.$this->maxSize(),
+                'mimes:'.$this->extensions(),
+                'mimetypes:'.$this->mimeTypes(),
+            ],
+        ];
+    }
+
+    private function maxSize(): int
+    {
+        return $this->asset() === 'favicon' ? 512 : 2048;
+    }
+
+    private function extensions(): string
+    {
+        return $this->asset() === 'favicon'
+            ? 'png,ico'
+            : 'jpg,jpeg,png,webp';
+    }
+
+    private function mimeTypes(): string
+    {
+        return $this->asset() === 'favicon'
+            ? 'image/png,image/x-icon,image/vnd.microsoft.icon'
+            : 'image/jpeg,image/png,image/webp';
+    }
+
+    private function asset(): string
+    {
+        return (string) $this->route('asset');
+    }
+}

--- a/config/settings.php
+++ b/config/settings.php
@@ -3,6 +3,8 @@
 return [
 
     'site_name' => ['default' => 'OpenKOS', 'cast' => 'string'],
+    'branding_logo_path' => ['default' => '', 'cast' => 'string'],
+    'branding_favicon_path' => ['default' => '', 'cast' => 'string'],
     'country_code' => ['default' => 'ID', 'cast' => 'string'],
     'locale' => ['default' => 'id', 'cast' => 'string'],
     'currency' => ['default' => 'IDR', 'cast' => 'string'],

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -30,6 +30,16 @@ including:
   same-host uploads
 - `TRUSTED_PROXIES` containing the reverse-proxy addresses or networks
 
+## Branding storage verification
+
+Logo and favicon files use `FILESYSTEM_DISK` and are streamed through the
+application's branding routes, including when the disk is private. Automated
+coverage uses Laravel's local fake disk; there is no remote-storage test
+harness. Before enabling a remote or private production disk, manually verify
+upload, replacement, removal, and the `Content-Type` returned by both branding
+routes. Also verify that an Inertia navigation after a favicon change updates
+the browser tab; this remains an integration check rather than a browser test.
+
 The application is HTTP-only inside the Compose network. Terminate TLS in
 Traefik, Caddy, Cloudflare Tunnel, or another external load balancer and
 forward `X-Forwarded-For`, `X-Forwarded-Host`, `X-Forwarded-Port`, and

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -22,6 +22,7 @@ type PageWithTimezone = {
             currency_scales?: Record<string, number>;
         };
         setting?: { currency?: string; locale?: string };
+        branding?: { faviconUrl?: string };
     };
 };
 
@@ -30,6 +31,18 @@ function syncDisplaySettings(page: PageWithTimezone): void {
     setCurrencyScales(page.props?.app?.currency_scales);
     setDisplayCurrency(page.props?.setting?.currency);
     setDisplayLocale(page.props?.setting?.locale);
+}
+
+function syncBrandingFavicon(page: PageWithTimezone): void {
+    const faviconUrl = page.props?.branding?.faviconUrl;
+
+    if (!faviconUrl || typeof document === 'undefined') {
+        return;
+    }
+
+    document
+        .querySelector<HTMLLinkElement>('link[data-branding-favicon]')
+        ?.setAttribute('href', faviconUrl);
 }
 
 // The server drives the display name from the settings table (site_name),
@@ -89,10 +102,12 @@ createInertiaApp({
     strictMode: true,
     withApp(app, { ssr, page }) {
         syncDisplaySettings(page as PageWithTimezone);
+        syncBrandingFavicon(page as PageWithTimezone);
 
         if (!ssr) {
             router.on('navigate', ({ detail }) => {
                 syncDisplaySettings(detail.page);
+                syncBrandingFavicon(detail.page);
             });
         }
 

--- a/resources/js/components/features/app/app-header.tsx
+++ b/resources/js/components/features/app/app-header.tsx
@@ -47,9 +47,8 @@ const activeItemStyles =
     'text-neutral-900 dark:bg-neutral-800 dark:text-neutral-100';
 
 export function AppHeader({ breadcrumbs = [] }: Props) {
-    const { auth, setting } = usePage<{
+    const { auth } = usePage<{
         auth: Auth;
-        setting: { site_name: string };
     }>().props;
     const getInitials = useInitials();
     const { isCurrentUrl, whenCurrentUrl } = useCurrentUrl();
@@ -78,9 +77,7 @@ export function AppHeader({ breadcrumbs = [] }: Props) {
                                     Navigation menu
                                 </SheetTitle>
                                 <SheetHeader className="flex justify-start text-left">
-                                    <span className="text-base font-semibold">
-                                        {setting.site_name}
-                                    </span>
+                                    <AppLogo />
                                 </SheetHeader>
                                 <div className="flex h-full flex-1 flex-col space-y-4 p-4">
                                     <div className="flex h-full flex-col justify-between text-sm">

--- a/resources/js/components/features/app/app-logo.tsx
+++ b/resources/js/components/features/app/app-logo.tsx
@@ -1,11 +1,20 @@
 import { usePage } from '@inertiajs/react';
 
 export default function AppLogo() {
-    const { setting } = usePage<{ setting: { site_name: string } }>().props;
+    const { setting, branding } = usePage<{
+        setting: { site_name: string };
+        branding: { logoUrl: string };
+    }>().props;
 
     return (
-        <span className="truncate text-sm font-semibold">
-            {setting.site_name}
+        <span className="flex min-w-0 items-center gap-2 truncate text-sm font-semibold">
+            <img
+                src={branding.logoUrl}
+                alt=""
+                aria-hidden="true"
+                className="size-6 shrink-0 object-contain"
+            />
+            <span className="truncate">{setting.site_name}</span>
         </span>
     );
 }

--- a/resources/js/layouts/auth/auth-card-layout.tsx
+++ b/resources/js/layouts/auth/auth-card-layout.tsx
@@ -1,5 +1,6 @@
-import { Link, usePage } from '@inertiajs/react';
+import { Link } from '@inertiajs/react';
 import type { PropsWithChildren } from 'react';
+import AppLogo from '@/components/features/app/app-logo';
 import {
     Card,
     CardContent,
@@ -18,8 +19,6 @@ export default function AuthCardLayout({
     title?: string;
     description?: string;
 }>) {
-    const { setting } = usePage<{ setting: { site_name: string } }>().props;
-
     return (
         <div className="flex min-h-svh flex-col items-center justify-center gap-6 bg-muted p-6 md:p-10">
             <div className="flex w-full max-w-md flex-col gap-6">
@@ -27,9 +26,7 @@ export default function AuthCardLayout({
                     href={login()}
                     className="flex items-center gap-2 self-center font-medium"
                 >
-                    <span className="text-sm font-semibold">
-                        {setting.site_name}
-                    </span>
+                    <AppLogo />
                 </Link>
 
                 <div className="flex flex-col gap-6">

--- a/resources/js/layouts/auth/auth-simple-layout.tsx
+++ b/resources/js/layouts/auth/auth-simple-layout.tsx
@@ -1,4 +1,5 @@
-import { Link, usePage } from '@inertiajs/react';
+import { Link } from '@inertiajs/react';
+import AppLogo from '@/components/features/app/app-logo';
 import { login } from '@/routes';
 import type { AuthLayoutProps } from '@/types';
 
@@ -7,8 +8,6 @@ export default function AuthSimpleLayout({
     title,
     description,
 }: AuthLayoutProps) {
-    const { setting } = usePage<{ setting: { site_name: string } }>().props;
-
     return (
         <div className="flex min-h-svh flex-col items-center justify-center gap-6 bg-background p-6 md:p-10">
             <div className="w-full max-w-sm">
@@ -18,9 +17,7 @@ export default function AuthSimpleLayout({
                             href={login()}
                             className="flex flex-col items-center gap-2 font-medium"
                         >
-                            <span className="text-sm font-semibold">
-                                {setting.site_name}
-                            </span>
+                            <AppLogo />
                         </Link>
 
                         <div className="space-y-2 text-center">

--- a/resources/js/layouts/auth/auth-split-layout.tsx
+++ b/resources/js/layouts/auth/auth-split-layout.tsx
@@ -1,4 +1,5 @@
-import { Link, usePage } from '@inertiajs/react';
+import { Link } from '@inertiajs/react';
+import AppLogo from '@/components/features/app/app-logo';
 import { login } from '@/routes';
 import type { AuthLayoutProps } from '@/types';
 
@@ -7,8 +8,6 @@ export default function AuthSplitLayout({
     title,
     description,
 }: AuthLayoutProps) {
-    const { setting } = usePage<{ setting: { site_name: string } }>().props;
-
     return (
         <div className="relative grid h-dvh flex-col items-center justify-center px-8 sm:px-0 lg:max-w-none lg:grid-cols-2 lg:px-0">
             <div className="relative hidden h-full flex-col bg-muted p-10 text-white lg:flex dark:border-r">
@@ -17,7 +16,7 @@ export default function AuthSplitLayout({
                     href={login()}
                     className="relative z-20 flex items-center text-lg font-medium"
                 >
-                    {setting.site_name}
+                    <AppLogo />
                 </Link>
             </div>
             <div className="w-full lg:p-8">
@@ -26,7 +25,7 @@ export default function AuthSplitLayout({
                         href={login()}
                         className="relative z-20 flex items-center justify-center lg:hidden"
                     >
-                        {setting.site_name}
+                        <AppLogo />
                     </Link>
                     <div className="flex flex-col items-start gap-2 text-left sm:items-center sm:text-center">
                         <h1 className="text-xl font-medium">{title}</h1>

--- a/resources/js/pages/settings/general.tsx
+++ b/resources/js/pages/settings/general.tsx
@@ -1,5 +1,8 @@
-import { useForm } from '@inertiajs/react';
+import { router, useForm, usePage } from '@inertiajs/react';
+import type { FormEvent } from 'react';
+import { useState } from 'react';
 import { AppearanceTabs } from '@/components/features';
+import { InputError } from '@/components/shared';
 import { Button } from '@/components/ui/button';
 import {
     Card,
@@ -22,6 +25,12 @@ import {
     edit as editGeneral,
     update as updateGeneral,
 } from '@/routes/settings/general';
+import {
+    destroy as destroyBranding,
+    update as updateBranding,
+} from '@/routes/settings/general/branding';
+
+type BrandingAsset = 'logo' | 'favicon';
 
 export default function General({
     settings,
@@ -39,6 +48,22 @@ export default function General({
     };
     timezone_list: string[];
 }) {
+    const { branding } = usePage<{
+        branding: {
+            logoUrl: string;
+            faviconUrl: string;
+            hasCustomLogo: boolean;
+            hasCustomFavicon: boolean;
+            hasConfiguredLogo: boolean;
+            hasConfiguredFavicon: boolean;
+        };
+    }>().props;
+    const [uploadingBranding, setUploadingBranding] =
+        useState<BrandingAsset | null>(null);
+    const [brandingErrors, setBrandingErrors] = useState<
+        Record<string, string>
+    >({});
+
     const siteForm = useForm({
         site_name: settings.site_name,
     });
@@ -59,6 +84,38 @@ export default function General({
         invoice_pdf_enabled: settings.invoice_pdf_enabled,
     });
 
+    function uploadBranding(
+        event: FormEvent<HTMLFormElement>,
+        asset: BrandingAsset,
+    ): void {
+        event.preventDefault();
+
+        const form = event.currentTarget;
+
+        setUploadingBranding(asset);
+        setBrandingErrors({});
+
+        router.post(updateBranding.url({ asset }), new FormData(form), {
+            preserveScroll: true,
+            onError: (errors) => setBrandingErrors(errors),
+            onFinish: () => {
+                setUploadingBranding(null);
+                form.reset();
+            },
+        });
+    }
+
+    function removeBranding(asset: BrandingAsset): void {
+        setUploadingBranding(asset);
+        setBrandingErrors({});
+
+        router.delete(destroyBranding.url({ asset }), {
+            preserveScroll: true,
+            onError: (errors) => setBrandingErrors(errors),
+            onFinish: () => setUploadingBranding(null),
+        });
+    }
+
     return (
         <div className="space-y-6">
             <div>
@@ -67,6 +124,119 @@ export default function General({
                     Manage application-wide settings.
                 </p>
             </div>
+
+            <Card>
+                <CardHeader>
+                    <CardTitle>Branding</CardTitle>
+                    <CardDescription>
+                        Customize the logo and favicon used by this
+                        installation.
+                    </CardDescription>
+                </CardHeader>
+                <CardContent className="grid gap-6 lg:grid-cols-2">
+                    {(
+                        [
+                            {
+                                asset: 'logo',
+                                title: 'Website logo',
+                                description:
+                                    'Shown in application navigation and authentication pages.',
+                                url: branding.logoUrl,
+                                hasCustom: branding.hasCustomLogo,
+                                hasConfigured: branding.hasConfiguredLogo,
+                                accept: '.jpg,.jpeg,.png,.webp',
+                                formats: 'JPG, PNG, or WebP · 2 MB maximum',
+                            },
+                            {
+                                asset: 'favicon',
+                                title: 'Browser favicon',
+                                description:
+                                    'Shown in browser tabs and bookmarks.',
+                                url: branding.faviconUrl,
+                                hasCustom: branding.hasCustomFavicon,
+                                hasConfigured: branding.hasConfiguredFavicon,
+                                accept: '.png,.ico',
+                                formats: 'PNG or ICO · 512 KB maximum',
+                            },
+                        ] as const
+                    ).map((item) => (
+                        <div key={item.asset} className="space-y-4 rounded-lg border p-4">
+                            <div className="flex items-center gap-4">
+                                <div className="flex size-20 items-center justify-center rounded-md border bg-muted/30 p-2">
+                                    <img
+                                        src={item.url}
+                                        alt={`${item.title} preview`}
+                                        className="size-full object-contain"
+                                    />
+                                </div>
+                                <div>
+                                    <h3 className="font-medium">{item.title}</h3>
+                                    <p className="text-sm text-muted-foreground">
+                                        {item.description}
+                                    </p>
+                                    <p className="mt-1 text-xs text-muted-foreground">
+                                        {item.hasCustom
+                                            ? 'Using custom asset'
+                                            : 'Using bundled default'}
+                                    </p>
+                                </div>
+                            </div>
+
+                            <form
+                                onSubmit={(event) =>
+                                    uploadBranding(event, item.asset)
+                                }
+                                className="space-y-3"
+                            >
+                                <div className="grid gap-2">
+                                    <Label htmlFor={`${item.asset}-file`}>
+                                        Upload replacement
+                                    </Label>
+                                    <Input
+                                        id={`${item.asset}-file`}
+                                        name="file"
+                                        type="file"
+                                        accept={item.accept}
+                                        required
+                                        aria-describedby={`${item.asset}-formats`}
+                                    />
+                                    <p
+                                        id={`${item.asset}-formats`}
+                                        className="text-xs text-muted-foreground"
+                                    >
+                                        {item.formats}
+                                    </p>
+                                    <InputError message={brandingErrors.file} />
+                                </div>
+
+                                <div className="flex flex-wrap gap-2">
+                                    <Button
+                                        type="submit"
+                                        disabled={uploadingBranding !== null}
+                                    >
+                                        {uploadingBranding === item.asset
+                                            ? 'Uploading...'
+                                            : 'Upload'}
+                                    </Button>
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        disabled={
+                                            !item.hasConfigured ||
+                                            uploadingBranding !== null
+                                        }
+                                        onClick={() =>
+                                            removeBranding(item.asset)
+                                        }
+                                    >
+                                        Restore default
+                                    </Button>
+                                </div>
+                            </form>
+                        </div>
+                    ))}
+                </CardContent>
+            </Card>
 
             <div className="grid gap-6 lg:grid-cols-2 lg:items-start">
                 <div className="space-y-6">

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -25,6 +25,14 @@ declare module '@inertiajs/core' {
                 currency: string;
                 timezone: string;
             };
+            branding: {
+                logoUrl: string;
+                faviconUrl: string;
+                hasCustomLogo: boolean;
+                hasCustomFavicon: boolean;
+                hasConfiguredLogo: boolean;
+                hasConfiguredFavicon: boolean;
+            };
             notificationChannels: { mail: boolean; whatsapp: boolean };
             sidebarOpen: boolean;
             platform: Platform;

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -30,8 +30,7 @@
             }
         </style>
 
-        <link rel="icon" href="/favicon.ico" sizes="any">
-        <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+        <link data-branding-favicon rel="icon" href="{{ data_get($page, 'props.branding.faviconUrl', route('branding.asset', ['asset' => 'favicon', 'v' => 'default'])) }}">
         <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 
         @fonts

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\BrandingAssetController;
 use App\Http\Controllers\Settings\AboutController;
 use App\Http\Controllers\Settings\GeneralController;
 use App\Http\Controllers\Settings\MailController;
@@ -12,6 +13,10 @@ use App\Http\Controllers\Settings\SettingValuesController;
 use App\Http\Controllers\Settings\WhatsAppController;
 use Illuminate\Auth\Middleware\RequirePassword;
 use Illuminate\Support\Facades\Route;
+
+Route::get('branding/{asset}', BrandingAssetController::class)
+    ->whereIn('asset', ['logo', 'favicon'])
+    ->name('branding.asset');
 
 Route::middleware(['auth'])->group(function () {
     Route::redirect('settings', '/settings/profile');
@@ -37,6 +42,12 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::middleware('role:owner')->group(function () {
         Route::get('settings/general', [GeneralController::class, 'edit'])->name('settings.general.edit');
         Route::patch('settings/general', [GeneralController::class, 'update'])->name('settings.general.update');
+        Route::post('settings/general/branding/{asset}', [GeneralController::class, 'updateBranding'])
+            ->whereIn('asset', ['logo', 'favicon'])
+            ->name('settings.general.branding.update');
+        Route::delete('settings/general/branding/{asset}', [GeneralController::class, 'removeBranding'])
+            ->whereIn('asset', ['logo', 'favicon'])
+            ->name('settings.general.branding.destroy');
 
         Route::get('settings/payment-gateway', [PaymentGatewayController::class, 'edit'])->name('settings.payment-gateway.edit');
         Route::patch('settings/payment-gateway', [PaymentGatewayController::class, 'update'])->name('settings.payment-gateway.update');

--- a/tests/Feature/Settings/BrandingSettingsTest.php
+++ b/tests/Feature/Settings/BrandingSettingsTest.php
@@ -1,0 +1,247 @@
+<?php
+
+use App\Actions\Settings\UpdateBranding;
+use App\Actions\Settings\UpdateSettings;
+use App\Models\Setting;
+use App\Models\User;
+use Database\Seeders\RoleAndPermissionSeeder;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Storage;
+use Inertia\Testing\AssertableInertia as Assert;
+use OpenKOS\Core\Events\SettingsUpdated as PlatformSettingsUpdated;
+
+use function Pest\Laravel\mock;
+
+uses()->beforeEach(function () {
+    $this->seed(RoleAndPermissionSeeder::class);
+    config(['filesystems.default' => 'local']);
+    Storage::fake('local');
+});
+
+test('bundled branding is served and raw paths stay out of shared settings', function () {
+    $this->get(route('branding.asset', ['asset' => 'logo']))
+        ->assertSuccessful()
+        ->assertHeader('Content-Type', 'image/svg+xml');
+
+    $this->get(route('branding.asset', ['asset' => 'favicon']))
+        ->assertSuccessful()
+        ->assertHeader('Content-Type', 'image/x-icon');
+
+    $this->get(route('login'))
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('branding.hasCustomLogo', false)
+            ->where('branding.hasCustomFavicon', false)
+            ->missing('setting.branding_logo_path')
+            ->missing('setting.branding_favicon_path'));
+});
+
+test('owners can upload and replace branding assets', function () {
+    $owner = User::factory()->owner()->create();
+
+    $this->actingAs($owner)
+        ->post(route('settings.general.branding.update', ['asset' => 'logo']), [
+            'file' => UploadedFile::fake()->image('logo.png'),
+        ])
+        ->assertRedirect();
+
+    $firstPath = Setting::get('branding_logo_path');
+
+    expect($firstPath)->toStartWith('branding/');
+    Storage::disk('local')->assertExists($firstPath);
+
+    $this->get(route('branding.asset', ['asset' => 'logo']))
+        ->assertSuccessful()
+        ->assertHeader('Content-Type', 'image/png');
+
+    $this->actingAs($owner)
+        ->post(route('settings.general.branding.update', ['asset' => 'logo']), [
+            'file' => UploadedFile::fake()->image('replacement.png'),
+        ])
+        ->assertRedirect();
+
+    $secondPath = Setting::get('branding_logo_path');
+
+    expect($secondPath)->not->toBe($firstPath);
+    Storage::disk('local')->assertMissing($firstPath);
+    Storage::disk('local')->assertExists($secondPath);
+});
+
+test('replacement keeps the new file when settings commit before a later failure', function () {
+    $owner = User::factory()->owner()->create();
+    $oldPath = 'branding/old-logo.png';
+
+    Storage::disk('local')->put($oldPath, 'old');
+    Setting::set('branding_logo_path', $oldPath);
+
+    Event::listen(PlatformSettingsUpdated::class, function (): void {
+        throw new RuntimeException('Listener failed after settings commit.');
+    });
+
+    expect(fn () => app(UpdateBranding::class)->execute(
+        'logo',
+        UploadedFile::fake()->image('replacement.png'),
+        $owner,
+    ))->toThrow(RuntimeException::class);
+
+    $newPath = Setting::get('branding_logo_path');
+
+    expect($newPath)->toBeString()
+        ->and(Setting::get('branding_logo_path'))->toBe($newPath);
+    Storage::disk('local')->assertExists($newPath);
+    Storage::disk('local')->assertMissing($oldPath);
+});
+
+test('replacement removes the new file when settings fail before commit', function () {
+    $owner = User::factory()->owner()->create();
+    $oldPath = 'branding/old-logo.png';
+
+    Storage::disk('local')->put($oldPath, 'old');
+    Setting::set('branding_logo_path', $oldPath);
+
+    $newPath = null;
+    $updateSettings = mock(UpdateSettings::class);
+    $updateSettings->shouldReceive('execute')->once()->andReturnUsing(function (array $data) use (&$newPath): void {
+        $newPath = $data['branding_logo_path'];
+
+        throw new RuntimeException('Settings write failed before commit.');
+    });
+
+    expect(fn () => (new UpdateBranding($updateSettings))->execute(
+        'logo',
+        UploadedFile::fake()->image('replacement.png'),
+        $owner,
+    ))->toThrow(RuntimeException::class);
+
+    expect($newPath)->toBeString()
+        ->and(Setting::get('branding_logo_path'))->toBe($oldPath);
+    Storage::disk('local')->assertMissing($newPath);
+    Storage::disk('local')->assertExists($oldPath);
+});
+
+test('removal deletes the old file when settings commit before a later failure', function () {
+    $owner = User::factory()->owner()->create();
+    $oldPath = 'branding/old-logo.png';
+
+    Storage::disk('local')->put($oldPath, 'old');
+    Setting::set('branding_logo_path', $oldPath);
+
+    $updateSettings = mock(UpdateSettings::class);
+    $updateSettings->shouldReceive('execute')->once()->andReturnUsing(function (): void {
+        Setting::set('branding_logo_path', '');
+
+        throw new RuntimeException('Listener failed after settings commit.');
+    });
+
+    expect(fn () => (new UpdateBranding($updateSettings))->remove('logo', $owner))
+        ->toThrow(RuntimeException::class);
+
+    expect(Setting::get('branding_logo_path'))->toBe('');
+    Storage::disk('local')->assertMissing($oldPath);
+});
+
+test('owners can upload and remove a favicon', function () {
+    $owner = User::factory()->owner()->create();
+
+    $this->actingAs($owner)
+        ->post(route('settings.general.branding.update', ['asset' => 'favicon']), [
+            'file' => UploadedFile::fake()->image('favicon.png', 32, 32),
+        ])
+        ->assertRedirect();
+
+    $path = Setting::get('branding_favicon_path');
+
+    Storage::disk('local')->assertExists($path);
+
+    $this->actingAs($owner)
+        ->delete(route('settings.general.branding.destroy', ['asset' => 'favicon']))
+        ->assertRedirect();
+
+    expect(Setting::get('branding_favicon_path'))->toBe('');
+    Storage::disk('local')->assertMissing($path);
+
+    $this->get(route('branding.asset', ['asset' => 'favicon']))
+        ->assertSuccessful()
+        ->assertHeader('Content-Type', 'image/x-icon');
+});
+
+test('missing stored files fall back to bundled branding', function () {
+    $owner = User::factory()->owner()->create();
+    Setting::set('branding_logo_path', 'branding/missing.png');
+
+    $this->get(route('branding.asset', ['asset' => 'logo']))
+        ->assertSuccessful()
+        ->assertHeader('Content-Type', 'image/svg+xml');
+
+    $this->get(route('login'))
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('branding.hasCustomLogo', false)
+            ->where('branding.hasConfiguredLogo', true));
+
+    $this->actingAs($owner)
+        ->delete(route('settings.general.branding.destroy', ['asset' => 'logo']))
+        ->assertRedirect();
+
+    expect(Setting::get('branding_logo_path'))->toBe('');
+});
+
+test('branding props fall back when the configured disk cannot be resolved', function () {
+    Setting::set('branding_logo_path', 'branding/logo.png');
+    config(['filesystems.default' => 'missing']);
+
+    $this->get(route('login'))
+        ->assertSuccessful()
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('branding.hasCustomLogo', false)
+            ->where('branding.hasConfiguredLogo', true)
+            ->where('branding.logoUrl', route('branding.asset', ['asset' => 'logo', 'v' => 'default'])));
+});
+
+test('stored files with unsupported MIME types are treated as bundled branding', function () {
+    $path = 'branding/not-a-logo.txt';
+
+    Storage::disk('local')->put($path, 'not an image');
+    Setting::set('branding_logo_path', $path);
+
+    $this->get(route('branding.asset', ['asset' => 'logo']))
+        ->assertSuccessful()
+        ->assertHeader('Content-Type', 'image/svg+xml');
+
+    $this->get(route('login'))
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('branding.hasCustomLogo', false)
+            ->where('branding.hasConfiguredLogo', true));
+});
+
+test('branding uploads reject unsupported and oversized files', function () {
+    $owner = User::factory()->owner()->create();
+
+    $this->actingAs($owner)
+        ->post(route('settings.general.branding.update', ['asset' => 'logo']), [
+            'file' => UploadedFile::fake()->create('logo.svg', 10, 'image/svg+xml'),
+        ])
+        ->assertSessionHasErrors('file');
+
+    $this->actingAs($owner)
+        ->post(route('settings.general.branding.update', ['asset' => 'favicon']), [
+            'file' => UploadedFile::fake()->create('favicon.png', 513, 'image/png'),
+        ])
+        ->assertSessionHasErrors('file');
+
+    expect(Setting::get('branding_logo_path'))->toBe('')
+        ->and(Setting::get('branding_favicon_path'))->toBe('');
+});
+
+test('non-owners cannot modify branding', function () {
+    $admin = User::factory()->admin()->create();
+
+    $this->actingAs($admin)
+        ->post(route('settings.general.branding.update', ['asset' => 'logo']), [
+            'file' => UploadedFile::fake()->image('logo.png'),
+        ])
+        ->assertForbidden();
+
+    $this->actingAs($admin)
+        ->delete(route('settings.general.branding.destroy', ['asset' => 'logo']))
+        ->assertForbidden();
+});


### PR DESCRIPTION
## Summary
- Add owner-only logo and favicon upload, replacement, removal, validation, and bundled fallbacks.
- Stream private-disk assets through fixed branding routes with stable cache busting.
- Harden commit/fallback behavior and stale-setting cleanup.
- Document remote/private storage and browser favicon manual verification for OPE-150.

## Verification
- php artisan test --compact — 897 passed, 1 skipped
- php artisan test --compact tests/Feature/Settings/BrandingSettingsTest.php — 11 passed
- vendor/bin/pint --dirty --format agent
- npm run types:check
- npm run lint:check
- npm run build