### PR TITLE
fix(refs): retry allocation races

### DIFF
--- a/app/Actions/Leases/CreateLease.php
+++ b/app/Actions/Leases/CreateLease.php
@@ -13,7 +13,7 @@ use App\Models\Tenant;
 use App\Models\Unit;
 use App\Models\UnitRate;
 use App\Services\Payments\MoneyConverter;
-use Illuminate\Support\Facades\DB;
+use App\Services\ReferenceAllocationRetry;
 
 class CreateLease
 {
@@ -22,13 +22,14 @@ class CreateLease
         private LeaseStatusValidator $leaseStatusValidator,
         private GenerateInvoices $generateInvoices,
         private MoneyConverter $money,
+        private ReferenceAllocationRetry $referenceAllocationRetry,
     ) {}
 
     public function execute(Unit $unit, CreateLeaseData $data): mixed
     {
         $tenantIds = array_values(array_unique($data->tenantIds));
 
-        return DB::transaction(function () use ($unit, $data, $tenantIds) {
+        return $this->referenceAllocationRetry->run(function () use ($unit, $data, $tenantIds) {
             $unit = Unit::lockForUpdate()->findOrFail($unit->id);
             $unitRate = $data->unitRateId === null
                 ? null
@@ -121,7 +122,7 @@ class CreateLease
             $this->generateInvoices->execute($lease);
 
             return $lease;
-        });
+        }, 'leases');
     }
 
     private function ensureExistingLeaseTermsMatch(Lease $lease, ?UnitRate $unitRate, CreateLeaseData $data): void

--- a/app/Actions/Leases/MoveOutLease.php
+++ b/app/Actions/Leases/MoveOutLease.php
@@ -13,8 +13,8 @@ use App\Models\Lease;
 use App\Models\Unit;
 use App\Results\Lease\MoveOutLeaseResult;
 use App\Services\Payments\MoneyConverter;
+use App\Services\ReferenceAllocationRetry;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
 
 class MoveOutLease
 {
@@ -23,6 +23,7 @@ class MoveOutLease
         private LeaseStatusValidator $leaseStatusValidator,
         private GenerateInvoices $generateInvoices,
         private MoneyConverter $money,
+        private ReferenceAllocationRetry $referenceAllocationRetry,
     ) {}
 
     private function cancelFutureInvoices(Lease $lease): void
@@ -40,7 +41,7 @@ class MoveOutLease
 
     public function execute(Lease $lease, MoveOutLeaseData $data): MoveOutLeaseResult
     {
-        return DB::transaction(function () use ($lease, $data) {
+        return $this->referenceAllocationRetry->run(function () use ($lease, $data) {
             $unitIds = [$lease->unit_id];
             if ($data->moveToAnotherUnit) {
                 abort_unless($data->targetUnitId !== null, 422, __('Target unit is required.'));
@@ -61,7 +62,7 @@ class MoveOutLease
             }
 
             return $this->terminate($lockedLease, $sourceUnit, $data);
-        });
+        }, 'leases');
     }
 
     /**

--- a/app/Actions/Leases/RenewLease.php
+++ b/app/Actions/Leases/RenewLease.php
@@ -14,7 +14,7 @@ use App\Models\Lease;
 use App\Models\Unit;
 use App\Results\Lease\RenewLeaseResult;
 use App\Services\Payments\MoneyConverter;
-use Illuminate\Support\Facades\DB;
+use App\Services\ReferenceAllocationRetry;
 
 class RenewLease
 {
@@ -24,11 +24,12 @@ class RenewLease
         private readonly LeaseStatusValidator $leaseStatusValidator,
         private readonly GenerateInvoices $generateInvoices,
         private readonly MoneyConverter $money,
+        private readonly ReferenceAllocationRetry $referenceAllocationRetry,
     ) {}
 
     public function execute(Lease $lease, RenewLeaseData $data): RenewLeaseResult
     {
-        return DB::transaction(function () use ($lease, $data) {
+        return $this->referenceAllocationRetry->run(function () use ($lease, $data) {
             $unit = Unit::lockForUpdate()->findOrFail($lease->unit_id);
             $lockedLease = Lease::query()
                 ->whereKey($lease->getKey())
@@ -118,6 +119,6 @@ class RenewLease
             $this->generateInvoices->execute($newLease);
 
             return RenewLeaseResult::success($newLease);
-        });
+        }, 'leases');
     }
 }

--- a/app/Http/Controllers/MaintenanceTicketController.php
+++ b/app/Http/Controllers/MaintenanceTicketController.php
@@ -18,6 +18,7 @@ use App\Models\MaintenanceTicket;
 use App\Models\Property;
 use App\Models\Unit;
 use App\Models\User;
+use App\Services\ReferenceAllocationRetry;
 use App\Tables\Column;
 use App\Tables\Filter;
 use App\Tables\Table;
@@ -35,6 +36,7 @@ class MaintenanceTicketController extends Controller
         private TransitionValidator $transitionValidator,
         private BlockUnit $blockUnit,
         private ResolveTicket $resolveTicket,
+        private ReferenceAllocationRetry $referenceAllocationRetry,
     ) {}
 
     public function show(MaintenanceTicket $ticket): Response
@@ -163,22 +165,27 @@ class MaintenanceTicketController extends Controller
         $moveToUnitId = $data['move_tenant_to_unit_id'] ?? null;
         unset($data['block_unit'], $data['move_tenant_to_unit_id']);
 
-        DB::transaction(function () use ($data, $blockUnit, $moveToUnitId): void {
+        $result = $this->referenceAllocationRetry->run(function () use ($data, $blockUnit, $moveToUnitId): array {
             $ticket = MaintenanceTicket::create($data);
             $statusChanges = [];
-
-            MaintenanceTicketCreated::dispatch($ticket, actorId: Auth::id());
 
             if ($blockUnit && ! empty($data['unit_id'])) {
                 $statusChanges = $this->blockUnit->execute($data['unit_id'], $moveToUnitId);
             }
 
-            foreach ($statusChanges as $change) {
-                if ($change['from'] !== $change['unit']->status) {
-                    UnitStatusChanged::dispatch($change['unit'], $change['from'], $change['unit']->status, actorId: Auth::id());
-                }
+            return [
+                'ticket' => $ticket,
+                'status_changes' => $statusChanges,
+            ];
+        }, 'maintenance_tickets');
+
+        MaintenanceTicketCreated::dispatch($result['ticket'], actorId: Auth::id());
+
+        foreach ($result['status_changes'] as $change) {
+            if ($change['from'] !== $change['unit']->status) {
+                UnitStatusChanged::dispatch($change['unit'], $change['from'], $change['unit']->status, actorId: Auth::id());
             }
-        });
+        }
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Maintenance ticket created.')]);
 

--- a/app/Http/Controllers/TenantPortal/MaintenanceTicketController.php
+++ b/app/Http/Controllers/TenantPortal/MaintenanceTicketController.php
@@ -6,6 +6,7 @@ use App\Enums\MaintenancePriority;
 use App\Enums\MaintenanceStatus;
 use App\Events\Maintenance\MaintenanceTicketCreated;
 use App\Models\MaintenanceTicket;
+use App\Services\ReferenceAllocationRetry;
 use App\Support\DateTimeFormatter;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -15,6 +16,10 @@ use Inertia\Response;
 
 class MaintenanceTicketController extends TenantPortalController
 {
+    public function __construct(
+        private ReferenceAllocationRetry $referenceAllocationRetry,
+    ) {}
+
     public function index(Request $request): Response
     {
         $tenant = $this->tenant($request);
@@ -75,7 +80,7 @@ class MaintenanceTicketController extends TenantPortalController
 
         $isUnit = $validated['location_type'] === 'unit';
 
-        $ticket = MaintenanceTicket::create([
+        $ticket = $this->referenceAllocationRetry->run(fn (): MaintenanceTicket => MaintenanceTicket::create([
             'property_id' => $lease->unit->property_id,
             'unit_id' => $isUnit ? $lease->unit_id : null,
             'location' => $isUnit ? null : $validated['location'],
@@ -84,7 +89,7 @@ class MaintenanceTicketController extends TenantPortalController
             'priority' => MaintenancePriority::Medium->value,
             'status' => MaintenanceStatus::Reported->value,
             'created_by' => $request->user()->id,
-        ]);
+        ]), 'maintenance_tickets');
 
         MaintenanceTicketCreated::dispatch($ticket, actorId: $request->user()->id);
 

--- a/app/Models/Lease.php
+++ b/app/Models/Lease.php
@@ -60,13 +60,15 @@ class Lease extends Model
             if ($lease->reference === null) {
                 $prefix = Setting::get('lease_id_prefix') ?? 'LSX';
                 $year = now()->format('Y');
-                $pattern = $prefix.$year.'%';
+                $referencePrefix = $prefix.$year;
+                $pattern = $referencePrefix.'%';
 
-                $max = static::where('reference', 'like', $pattern)
-                    ->orderBy('reference', 'desc')
+                $max = static::withTrashed()
+                    ->where('reference', 'like', $pattern)
+                    ->orderByRaw('LENGTH(reference) DESC, reference DESC')
                     ->value('reference');
 
-                $seq = $max ? (int) substr($max, -4) + 1 : 1;
+                $seq = $max ? (int) substr($max, strlen($referencePrefix)) + 1 : 1;
 
                 $lease->reference = $prefix.$year.str_pad((string) $seq, 4, '0', STR_PAD_LEFT);
             }

--- a/app/Models/MaintenanceTicket.php
+++ b/app/Models/MaintenanceTicket.php
@@ -36,13 +36,14 @@ class MaintenanceTicket extends Model
         static::creating(function (MaintenanceTicket $ticket) {
             if ($ticket->reference === null) {
                 $year = now()->format('Y');
-                $pattern = 'TKT'.$year.'%';
+                $referencePrefix = 'TKT'.$year;
+                $pattern = $referencePrefix.'%';
 
                 $max = static::where('reference', 'like', $pattern)
-                    ->orderBy('reference', 'desc')
+                    ->orderByRaw('LENGTH(reference) DESC, reference DESC')
                     ->value('reference');
 
-                $seq = $max ? (int) substr($max, -4) + 1 : 1;
+                $seq = $max ? (int) substr($max, strlen($referencePrefix)) + 1 : 1;
 
                 $ticket->reference = 'TKT'.$year.str_pad((string) $seq, 4, '0', STR_PAD_LEFT);
             }

--- a/app/Services/ReferenceAllocationRetry.php
+++ b/app/Services/ReferenceAllocationRetry.php
@@ -53,6 +53,7 @@ class ReferenceAllocationRetry
         $isUniqueViolation = match (DB::getDriverName()) {
             'pgsql' => (string) ($errorInfo[0] ?? $exception->getCode()) === '23505',
             'mysql' => (int) ($errorInfo[1] ?? 0) === 1062,
+            'mariadb' => (int) ($errorInfo[1] ?? 0) === 1062,
             'sqlite' => (int) ($errorInfo[1] ?? 0) === 19,
             default => false,
         };

--- a/app/Services/ReferenceAllocationRetry.php
+++ b/app/Services/ReferenceAllocationRetry.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Services;
+
+use Closure;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use LogicException;
+
+class ReferenceAllocationRetry
+{
+    private const MAX_ATTEMPTS = 3;
+
+    /**
+     * @var array<string, list<string>>
+     */
+    private const REFERENCE_CONSTRAINTS = [
+        'leases' => [
+            'leases_reference_unique',
+            'leases.reference',
+        ],
+        'maintenance_tickets' => [
+            'maintenance_tickets_reference_unique',
+            'maintenance_tickets.reference',
+        ],
+    ];
+
+    /**
+     * @template TReturn
+     *
+     * @param  Closure(): TReturn  $callback
+     * @return TReturn
+     */
+    public function run(Closure $callback, string $table): mixed
+    {
+        for ($attempt = 1; $attempt <= self::MAX_ATTEMPTS; $attempt++) {
+            try {
+                return DB::transaction($callback);
+            } catch (QueryException $exception) {
+                if ($attempt === self::MAX_ATTEMPTS || ! $this->isRetryable($exception, $table)) {
+                    throw $exception;
+                }
+            }
+        }
+
+        throw new LogicException('Reference allocation retry loop exited unexpectedly.');
+    }
+
+    private function isRetryable(QueryException $exception, string $table): bool
+    {
+        $errorInfo = $exception->errorInfo ?? [];
+        $isUniqueViolation = match (DB::getDriverName()) {
+            'pgsql' => (string) ($errorInfo[0] ?? $exception->getCode()) === '23505',
+            'mysql' => (int) ($errorInfo[1] ?? 0) === 1062,
+            'sqlite' => (int) ($errorInfo[1] ?? 0) === 19,
+            default => false,
+        };
+
+        if (! $isUniqueViolation) {
+            return false;
+        }
+
+        $message = Str::lower($exception->getMessage());
+
+        foreach (self::REFERENCE_CONSTRAINTS[$table] ?? [] as $constraint) {
+            if (str_contains($message, $constraint)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Feature/ReferenceAllocationTest.php
+++ b/tests/Feature/ReferenceAllocationTest.php
@@ -1,0 +1,138 @@
+<?php
+
+use App\Models\Lease;
+use App\Models\MaintenanceTicket;
+use App\Models\Property;
+use App\Models\Tenant;
+use App\Models\Unit;
+use App\Services\ReferenceAllocationRetry;
+use Illuminate\Database\QueryException;
+
+it('retries lease allocation as a fresh transaction', function () {
+    $existingLease = Lease::factory()->create();
+    $attempts = 0;
+    $rolledBackPropertyName = 'rolled-back-lease-property';
+
+    $createdLease = app(ReferenceAllocationRetry::class)->run(function () use (&$attempts, $rolledBackPropertyName, $existingLease): Lease {
+        $attempts++;
+
+        if ($attempts === 1) {
+            $property = Property::factory()->create(['name' => $rolledBackPropertyName]);
+            $unit = Unit::factory()->for($property)->create();
+            $tenant = Tenant::factory()->create();
+
+            Lease::factory()->create([
+                'reference' => $existingLease->reference,
+                'unit_id' => $unit->id,
+                'primary_tenant_id' => $tenant->id,
+            ]);
+        }
+
+        return Lease::factory()->create();
+    }, 'leases');
+
+    expect($attempts)->toBe(2)
+        ->and($createdLease->reference)->not->toBe($existingLease->reference)
+        ->and(Property::query()->where('name', $rolledBackPropertyName)->exists())->toBeFalse()
+        ->and(Lease::query()->count())->toBe(2);
+});
+
+it('retries maintenance ticket allocation as a fresh transaction', function () {
+    $existingTicket = MaintenanceTicket::factory()->create();
+    $attempts = 0;
+    $rolledBackPropertyName = 'rolled-back-ticket-property';
+
+    $createdTicket = app(ReferenceAllocationRetry::class)->run(function () use (&$attempts, $rolledBackPropertyName, $existingTicket): MaintenanceTicket {
+        $attempts++;
+
+        if ($attempts === 1) {
+            $property = Property::factory()->create(['name' => $rolledBackPropertyName]);
+
+            MaintenanceTicket::factory()->create([
+                'property_id' => $property->id,
+                'unit_id' => null,
+                'reference' => $existingTicket->reference,
+            ]);
+        }
+
+        return MaintenanceTicket::factory()->create();
+    }, 'maintenance_tickets');
+
+    expect($attempts)->toBe(2)
+        ->and($createdTicket->reference)->not->toBe($existingTicket->reference)
+        ->and(Property::query()->where('name', $rolledBackPropertyName)->exists())->toBeFalse()
+        ->and(MaintenanceTicket::query()->count())->toBe(2);
+});
+
+it('does not retry unrelated unique constraint violations', function () {
+    $property = Property::factory()->create();
+    $unit = Unit::factory()->for($property)->create();
+    $tenant = Tenant::factory()->create();
+    $attempts = 0;
+    $createdLeaseId = null;
+    $exception = null;
+
+    try {
+        app(ReferenceAllocationRetry::class)->run(function () use (&$attempts, &$createdLeaseId, $unit, $tenant): void {
+            $attempts++;
+            $lease = Lease::factory()->create([
+                'unit_id' => $unit->id,
+                'primary_tenant_id' => $tenant->id,
+            ]);
+            $createdLeaseId = $lease->id;
+
+            $lease->tenants()->attach($tenant->id, ['is_primary' => true]);
+        }, 'leases');
+    } catch (QueryException $caught) {
+        $exception = $caught;
+    }
+
+    expect($exception)->toBeInstanceOf(QueryException::class)
+        ->and($attempts)->toBe(1)
+        ->and(Lease::query()->whereKey($createdLeaseId)->exists())->toBeFalse();
+});
+
+it('surfaces a reference collision after three attempts', function () {
+    $existingTicket = MaintenanceTicket::factory()->create();
+    $attempts = 0;
+    $exception = null;
+
+    try {
+        app(ReferenceAllocationRetry::class)->run(function () use (&$attempts, $existingTicket): void {
+            $attempts++;
+
+            MaintenanceTicket::factory()->create([
+                'reference' => $existingTicket->reference,
+            ]);
+        }, 'maintenance_tickets');
+    } catch (QueryException $caught) {
+        $exception = $caught;
+    }
+
+    expect($exception)->toBeInstanceOf(QueryException::class)
+        ->and($attempts)->toBe(3)
+        ->and(MaintenanceTicket::query()->count())->toBe(1);
+});
+
+it('keeps soft-deleted lease references reserved', function () {
+    $lease = Lease::factory()->create();
+    $reference = $lease->reference;
+
+    $lease->delete();
+
+    $nextLease = Lease::factory()->create();
+
+    expect($nextLease->reference)->not->toBe($reference)
+        ->and($nextLease->reference)->toEndWith('0002');
+});
+
+it('parses lease sequences beyond four digits numerically', function () {
+    $year = now()->format('Y');
+
+    Lease::factory()->create(['reference' => 'LSX'.$year.'9999']);
+    Lease::factory()->create(['reference' => 'LSX'.$year.'10000']);
+
+    $nextLease = Lease::factory()->create();
+
+    expect($nextLease->reference)->toBe('LSX'.$year.'10001');
+});


### PR DESCRIPTION
## Summary

- retry lease and maintenance-ticket reference allocation collisions
- rerun the complete creation transaction for each attempt
- preserve historical references and support MariaDB duplicate-key errors

## Validation

- focused reference, lease, and maintenance-ticket tests
- full test suite: 907 passed, 1 skipped