### PR TITLE
feat(media): add reusable media foundation

### DIFF
--- a/app/Concerns/HasMedia.php
+++ b/app/Concerns/HasMedia.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Concerns;
+
+use App\Models\Media;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+
+trait HasMedia
+{
+    public function media(): MorphMany
+    {
+        return $this->morphMany(Media::class, 'mediable');
+    }
+}

--- a/app/Models/Media.php
+++ b/app/Models/Media.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\SerializesDatesWithTimezone;
+use Database\Factories\MediaFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+#[Fillable([
+    'mediable_type',
+    'mediable_id',
+    'collection',
+    'disk',
+    'path',
+    'mime_type',
+    'size',
+    'original_name',
+    'position',
+    'metadata',
+])]
+class Media extends Model
+{
+    /** @use HasFactory<MediaFactory> */
+    use HasFactory, SerializesDatesWithTimezone;
+
+    protected function casts(): array
+    {
+        return [
+            'mediable_id' => 'integer',
+            'size' => 'integer',
+            'position' => 'integer',
+            'metadata' => 'array',
+        ];
+    }
+
+    public function mediable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+}

--- a/app/Models/Property.php
+++ b/app/Models/Property.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Concerns\Auditable;
+use App\Concerns\HasMedia;
 use App\Concerns\SerializesDatesWithTimezone;
 use App\Enums\UnitStatus;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
@@ -32,7 +33,7 @@ use Illuminate\Support\Str;
 ])]
 class Property extends Model
 {
-    use Auditable, HasFactory, SerializesDatesWithTimezone, SoftDeletes;
+    use Auditable, HasFactory, HasMedia, SerializesDatesWithTimezone, SoftDeletes;
 
     protected array $auditableMask = ['phone'];
 

--- a/app/Services/Media/MediaManager.php
+++ b/app/Services/Media/MediaManager.php
@@ -26,7 +26,7 @@ class MediaManager
         int $position = 0,
         ?array $metadata = null,
     ): Media {
-        $this->validateOwner($owner);
+        $ownerId = $this->ownerId($owner);
         $collection = $this->validateCollection($collection);
         $this->validatePosition($position);
 
@@ -41,7 +41,7 @@ class MediaManager
             $path,
             fn (): Media => Media::create([
                 'mediable_type' => $owner->getMorphClass(),
-                'mediable_id' => $owner->getKey(),
+                'mediable_id' => $ownerId,
                 'collection' => $collection,
                 'disk' => $diskName,
                 'path' => $path,
@@ -51,6 +51,7 @@ class MediaManager
                 'position' => $position,
                 'metadata' => $metadata,
             ]),
+            fn (mixed $result): bool => $this->mediaHasExpectedPath($result, $diskName, $path),
         );
     }
 
@@ -60,46 +61,67 @@ class MediaManager
         ?string $disk = null,
         ?array $metadata = null,
     ): Media {
+        $metadataProvided = func_num_args() >= 4;
+        $mediaId = $this->persistedMediaId($media);
+
+        if ($mediaId === null) {
+            throw new InvalidArgumentException('Media must be persisted before it can be replaced.');
+        }
+
+        $persistedMedia = Media::query()->findOrFail($mediaId);
         [$mimeType, $size, $originalName] = $this->fileMetadata($file);
-        $diskName = $this->resolveDisk($disk ?? $media->disk);
+        $diskName = $this->resolveDisk($disk ?? (string) $persistedMedia->disk);
         $storage = Storage::disk($diskName);
         $path = $this->storeFile($storage, $file);
-
-        $oldDiskName = (string) $media->disk;
-        $oldPath = (string) $media->path;
-        $mediaId = $media->getKey();
 
         return $this->persistWithRollbackCleanup(
             $storage,
             $diskName,
             $path,
-            function () use ($media, $diskName, $path, $mimeType, $size, $originalName, $metadata, $oldDiskName, $oldPath, $mediaId): Media {
-                $media->forceFill([
+            function () use ($mediaId, $disk, $diskName, $path, $mimeType, $size, $originalName, $metadata, $metadataProvided): Media {
+                $lockedMedia = Media::query()->lockForUpdate()->findOrFail($mediaId);
+                $oldDiskName = (string) $lockedMedia->disk;
+                $oldPath = (string) $lockedMedia->path;
+
+                if ($disk === null && $oldDiskName !== $diskName) {
+                    throw new RuntimeException('Media changed during replacement; please retry.');
+                }
+
+                $lockedMedia->forceFill([
                     'disk' => $diskName,
                     'path' => $path,
                     'mime_type' => $mimeType,
                     'size' => $size,
                     'original_name' => $originalName,
-                    'metadata' => $metadata ?? $media->metadata,
+                    'metadata' => $metadataProvided ? $metadata : $lockedMedia->metadata,
                 ])->saveOrFail();
 
-                DB::afterCommit(function () use ($oldDiskName, $oldPath, $mediaId): void {
-                    $this->deleteFileByDiskName($oldDiskName, $oldPath, $mediaId);
-                });
+                if ($oldDiskName !== $diskName || $oldPath !== $path) {
+                    DB::afterCommit(function () use ($oldDiskName, $oldPath, $mediaId): void {
+                        $this->deleteFileByDiskName($oldDiskName, $oldPath, $mediaId);
+                    });
+                }
 
-                return $media;
+                return $lockedMedia;
             },
+            fn (mixed $result): bool => $this->mediaHasExpectedPath($result, $diskName, $path),
         );
     }
 
     public function remove(Media $media): void
     {
-        $diskName = (string) $media->disk;
-        $path = (string) $media->path;
-        $mediaId = $media->getKey();
+        $mediaId = $this->persistedMediaId($media);
 
-        DB::transaction(function () use ($media, $diskName, $path, $mediaId): void {
-            $media->deleteOrFail();
+        if ($mediaId === null) {
+            throw new InvalidArgumentException('Media must be persisted before it can be removed.');
+        }
+
+        DB::transaction(function () use ($mediaId): void {
+            $lockedMedia = Media::query()->lockForUpdate()->findOrFail($mediaId);
+            $diskName = (string) $lockedMedia->disk;
+            $path = (string) $lockedMedia->path;
+
+            $lockedMedia->deleteOrFail();
 
             DB::afterCommit(function () use ($diskName, $path, $mediaId): void {
                 $this->deleteFileByDiskName($diskName, $path, $mediaId);
@@ -109,54 +131,77 @@ class MediaManager
 
     public function removeForOwner(Model $owner, ?string $collection = null): void
     {
-        $this->validateOwner($owner);
+        $ownerId = $this->ownerId($owner);
+        $collection = $collection === null ? null : $this->validateCollection($collection);
 
-        $media = Media::query()
-            ->whereMorphedTo('mediable', $owner)
-            ->when(
-                $collection !== null,
-                fn (Builder $query) => $query->where('collection', $this->validateCollection($collection)),
-            )
-            ->get();
+        DB::transaction(function () use ($owner, $ownerId, $collection): void {
+            $media = Media::query()
+                ->where('mediable_type', $owner->getMorphClass())
+                ->where('mediable_id', $ownerId)
+                ->when($collection !== null, fn (Builder $query) => $query->where('collection', $collection))
+                ->orderBy('id')
+                ->lockForUpdate()
+                ->get();
+            $files = [];
 
-        foreach ($media as $item) {
-            $this->remove($item);
-        }
+            foreach ($media as $item) {
+                $files[] = [
+                    'disk' => (string) $item->disk,
+                    'path' => (string) $item->path,
+                    'id' => $item->getKey(),
+                ];
+                $item->deleteOrFail();
+            }
+
+            DB::afterCommit(function () use ($files): void {
+                foreach ($files as $file) {
+                    $this->deleteFileByDiskName($file['disk'], $file['path'], $file['id']);
+                }
+            });
+        });
     }
 
     public function reorder(Model $owner, string $collection, array $mediaIds): void
     {
-        $this->validateOwner($owner);
+        $this->ownerId($owner);
         $collection = $this->validateCollection($collection);
         $mediaIds = array_values($mediaIds);
+
+        foreach ($mediaIds as $mediaId) {
+            if (! is_int($mediaId) && ! is_string($mediaId)) {
+                throw new InvalidArgumentException('Media IDs must be integers or strings.');
+            }
+        }
+
         $normalizedIds = array_map(static fn (mixed $id): string => (string) $id, $mediaIds);
 
         if (count($normalizedIds) !== count(array_unique($normalizedIds))) {
             throw new InvalidArgumentException('Media IDs must be unique.');
         }
 
-        $media = $this->forCollection($owner, $collection)
-            ->get()
-            ->keyBy(fn (Media $item): string => (string) $item->getKey());
+        DB::transaction(function () use ($owner, $collection, $mediaIds, $normalizedIds): void {
+            $media = $this->forCollection($owner, $collection)
+                ->lockForUpdate()
+                ->get()
+                ->keyBy(fn (Media $item): string => (string) $item->getKey());
 
-        if ($media->count() !== count($mediaIds)) {
-            throw new InvalidArgumentException('Media IDs must belong to the owner and collection.');
-        }
+            if ($media->count() !== count($mediaIds)) {
+                throw new InvalidArgumentException('Media IDs must belong to the owner and collection.');
+            }
 
-        if ($mediaIds === []) {
-            return;
-        }
+            if ($mediaIds === []) {
+                return;
+            }
 
-        $ownerIds = array_map(static fn (mixed $id): string => (string) $id, $media->keys()->all());
-        $requestedIds = $normalizedIds;
-        sort($ownerIds);
-        sort($requestedIds);
+            $ownerIds = array_map(static fn (mixed $id): string => (string) $id, $media->keys()->all());
+            $requestedIds = $normalizedIds;
+            sort($ownerIds);
+            sort($requestedIds);
 
-        if ($ownerIds !== $requestedIds) {
-            throw new InvalidArgumentException('Media IDs must belong to the owner and collection.');
-        }
+            if ($ownerIds !== $requestedIds) {
+                throw new InvalidArgumentException('Media IDs must belong to the owner and collection.');
+            }
 
-        DB::transaction(function () use ($media, $normalizedIds): void {
             foreach ($normalizedIds as $position => $mediaId) {
                 $media->get($mediaId)->forceFill(['position' => $position])->saveOrFail();
             }
@@ -165,10 +210,11 @@ class MediaManager
 
     public function forCollection(Model $owner, string $collection): Builder
     {
-        $this->validateOwner($owner);
+        $ownerId = $this->ownerId($owner);
 
         return Media::query()
-            ->whereMorphedTo('mediable', $owner)
+            ->where('mediable_type', $owner->getMorphClass())
+            ->where('mediable_id', $ownerId)
             ->where('collection', $this->validateCollection($collection))
             ->orderBy('position')
             ->orderBy('id');
@@ -178,6 +224,7 @@ class MediaManager
      * @template TValue
      *
      * @param  Closure(): TValue  $persist
+     * @param  Closure(TValue): bool  $verify
      * @return TValue
      */
     private function persistWithRollbackCleanup(
@@ -185,36 +232,108 @@ class MediaManager
         string $diskName,
         string $path,
         Closure $persist,
+        Closure $verify,
     ): mixed {
         $connection = DB::connection();
         $initialLevel = $connection->transactionLevel();
         $transactionStarted = false;
         $cleanupRegistered = false;
+        $commitAttempted = false;
+        $rootCommitAttempted = false;
+        $result = null;
 
         try {
             $connection->beginTransaction();
             $transactionStarted = true;
-            $connection->afterRollBack(function () use ($storage, $diskName, $path): void {
-                $this->deleteFile($storage, $diskName, $path);
+            $connection->afterRollBack(function () use (&$rootCommitAttempted, $storage, $diskName, $path): void {
+                if (! $rootCommitAttempted) {
+                    $this->deleteFile($storage, $diskName, $path);
+                }
             });
             $cleanupRegistered = true;
 
             $result = $persist();
+            $commitAttempted = true;
+            $rootCommitAttempted = $initialLevel === 0;
             $connection->commit();
 
             return $result;
         } catch (Throwable $exception) {
             if (! $transactionStarted) {
                 $this->deleteFile($storage, $diskName, $path);
-            } elseif ($connection->transactionLevel() > $initialLevel) {
-                try {
-                    $connection->rollBack();
-                } catch (Throwable $rollbackException) {
-                    report($rollbackException);
+            } elseif (! $commitAttempted) {
+                if ($connection->transactionLevel() > $initialLevel) {
+                    try {
+                        $connection->rollBack();
+                    } catch (Throwable $rollbackException) {
+                        report($rollbackException);
+                    }
                 }
 
                 if (! $cleanupRegistered) {
                     $this->deleteFile($storage, $diskName, $path);
+                }
+            } elseif ($initialLevel > 0) {
+                if ($connection->transactionLevel() > $initialLevel) {
+                    try {
+                        $connection->rollBack();
+                    } catch (Throwable $rollbackException) {
+                        report($rollbackException);
+                    }
+                }
+            } else {
+                $rootCommitAttempted = true;
+                $rollbackSucceeded = true;
+
+                try {
+                    if ($connection->transactionLevel() > $initialLevel) {
+                        $connection->rollBack();
+                    }
+                } catch (Throwable $rollbackException) {
+                    $rollbackSucceeded = false;
+                    report($rollbackException);
+                }
+
+                try {
+                    $persisted = $verify($result);
+                } catch (Throwable $verificationException) {
+                    Log::error('Media persistence outcome requires reconciliation.', [
+                        'disk' => $diskName,
+                        'path' => $path,
+                        'exception' => $verificationException,
+                    ]);
+
+                    throw new RuntimeException(
+                        'Media persistence outcome requires reconciliation.',
+                        0,
+                        $exception,
+                    );
+                }
+
+                if (! $rollbackSucceeded) {
+                    Log::error('Media persistence outcome requires reconciliation.', [
+                        'disk' => $diskName,
+                        'path' => $path,
+                        'media_id' => $result instanceof Media ? $result->getKey() : null,
+                        'exception' => $exception,
+                    ]);
+
+                    throw new RuntimeException(
+                        'Media persistence outcome requires reconciliation.',
+                        0,
+                        $exception,
+                    );
+                }
+
+                if (! $persisted) {
+                    $this->deleteFile($storage, $diskName, $path);
+                } else {
+                    Log::warning('Media commit completed with an exception.', [
+                        'disk' => $diskName,
+                        'path' => $path,
+                        'media_id' => $result instanceof Media ? $result->getKey() : null,
+                        'exception' => $exception,
+                    ]);
                 }
             }
 
@@ -222,11 +341,13 @@ class MediaManager
         }
     }
 
-    private function validateOwner(Model $owner): void
+    private function ownerId(Model $owner): mixed
     {
-        if ($owner->getKey() === null) {
+        if (! $owner->exists || $owner->getKey() === null) {
             throw new InvalidArgumentException('Media owners must be persisted before attaching media.');
         }
+
+        return $owner->getRawOriginal($owner->getKeyName()) ?? $owner->getKey();
     }
 
     private function validateCollection(string $collection): string
@@ -243,6 +364,26 @@ class MediaManager
         if ($position < 0) {
             throw new InvalidArgumentException('Media positions cannot be negative.');
         }
+    }
+
+    private function persistedMediaId(Media $media): mixed
+    {
+        if (! $media->exists) {
+            return null;
+        }
+
+        return $media->getRawOriginal($media->getKeyName()) ?? $media->getKey();
+    }
+
+    private function mediaHasExpectedPath(mixed $media, string $diskName, string $path): bool
+    {
+        return $media instanceof Media
+            && $media->getKey() !== null
+            && Media::query()
+                ->whereKey($media->getKey())
+                ->where('disk', $diskName)
+                ->where('path', $path)
+                ->exists();
     }
 
     /**

--- a/app/Services/Media/MediaManager.php
+++ b/app/Services/Media/MediaManager.php
@@ -1,0 +1,324 @@
+<?php
+
+namespace App\Services\Media;
+
+use App\Models\Media;
+use Closure;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Filesystem\FilesystemAdapter;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+use RuntimeException;
+use Throwable;
+
+class MediaManager
+{
+    public function store(
+        Model $owner,
+        string $collection,
+        UploadedFile $file,
+        ?string $disk = null,
+        int $position = 0,
+        ?array $metadata = null,
+    ): Media {
+        $this->validateOwner($owner);
+        $collection = $this->validateCollection($collection);
+        $this->validatePosition($position);
+
+        [$mimeType, $size, $originalName] = $this->fileMetadata($file);
+        $diskName = $this->resolveDisk($disk);
+        $storage = Storage::disk($diskName);
+        $path = $this->storeFile($storage, $file);
+
+        return $this->persistWithRollbackCleanup(
+            $storage,
+            $diskName,
+            $path,
+            fn (): Media => Media::create([
+                'mediable_type' => $owner->getMorphClass(),
+                'mediable_id' => $owner->getKey(),
+                'collection' => $collection,
+                'disk' => $diskName,
+                'path' => $path,
+                'mime_type' => $mimeType,
+                'size' => $size,
+                'original_name' => $originalName,
+                'position' => $position,
+                'metadata' => $metadata,
+            ]),
+        );
+    }
+
+    public function replace(
+        Media $media,
+        UploadedFile $file,
+        ?string $disk = null,
+        ?array $metadata = null,
+    ): Media {
+        [$mimeType, $size, $originalName] = $this->fileMetadata($file);
+        $diskName = $this->resolveDisk($disk ?? $media->disk);
+        $storage = Storage::disk($diskName);
+        $path = $this->storeFile($storage, $file);
+
+        $oldDiskName = (string) $media->disk;
+        $oldPath = (string) $media->path;
+        $mediaId = $media->getKey();
+
+        return $this->persistWithRollbackCleanup(
+            $storage,
+            $diskName,
+            $path,
+            function () use ($media, $diskName, $path, $mimeType, $size, $originalName, $metadata, $oldDiskName, $oldPath, $mediaId): Media {
+                $media->forceFill([
+                    'disk' => $diskName,
+                    'path' => $path,
+                    'mime_type' => $mimeType,
+                    'size' => $size,
+                    'original_name' => $originalName,
+                    'metadata' => $metadata ?? $media->metadata,
+                ])->saveOrFail();
+
+                DB::afterCommit(function () use ($oldDiskName, $oldPath, $mediaId): void {
+                    $this->deleteFileByDiskName($oldDiskName, $oldPath, $mediaId);
+                });
+
+                return $media;
+            },
+        );
+    }
+
+    public function remove(Media $media): void
+    {
+        $diskName = (string) $media->disk;
+        $path = (string) $media->path;
+        $mediaId = $media->getKey();
+
+        DB::transaction(function () use ($media, $diskName, $path, $mediaId): void {
+            $media->deleteOrFail();
+
+            DB::afterCommit(function () use ($diskName, $path, $mediaId): void {
+                $this->deleteFileByDiskName($diskName, $path, $mediaId);
+            });
+        });
+    }
+
+    public function removeForOwner(Model $owner, ?string $collection = null): void
+    {
+        $this->validateOwner($owner);
+
+        $media = Media::query()
+            ->whereMorphedTo('mediable', $owner)
+            ->when(
+                $collection !== null,
+                fn (Builder $query) => $query->where('collection', $this->validateCollection($collection)),
+            )
+            ->get();
+
+        foreach ($media as $item) {
+            $this->remove($item);
+        }
+    }
+
+    public function reorder(Model $owner, string $collection, array $mediaIds): void
+    {
+        $this->validateOwner($owner);
+        $collection = $this->validateCollection($collection);
+        $mediaIds = array_values($mediaIds);
+        $normalizedIds = array_map(static fn (mixed $id): string => (string) $id, $mediaIds);
+
+        if (count($normalizedIds) !== count(array_unique($normalizedIds))) {
+            throw new InvalidArgumentException('Media IDs must be unique.');
+        }
+
+        $media = $this->forCollection($owner, $collection)
+            ->get()
+            ->keyBy(fn (Media $item): string => (string) $item->getKey());
+
+        if ($media->count() !== count($mediaIds)) {
+            throw new InvalidArgumentException('Media IDs must belong to the owner and collection.');
+        }
+
+        if ($mediaIds === []) {
+            return;
+        }
+
+        $ownerIds = array_map(static fn (mixed $id): string => (string) $id, $media->keys()->all());
+        $requestedIds = $normalizedIds;
+        sort($ownerIds);
+        sort($requestedIds);
+
+        if ($ownerIds !== $requestedIds) {
+            throw new InvalidArgumentException('Media IDs must belong to the owner and collection.');
+        }
+
+        DB::transaction(function () use ($media, $normalizedIds): void {
+            foreach ($normalizedIds as $position => $mediaId) {
+                $media->get($mediaId)->forceFill(['position' => $position])->saveOrFail();
+            }
+        });
+    }
+
+    public function forCollection(Model $owner, string $collection): Builder
+    {
+        $this->validateOwner($owner);
+
+        return Media::query()
+            ->whereMorphedTo('mediable', $owner)
+            ->where('collection', $this->validateCollection($collection))
+            ->orderBy('position')
+            ->orderBy('id');
+    }
+
+    /**
+     * @template TValue
+     *
+     * @param  Closure(): TValue  $persist
+     * @return TValue
+     */
+    private function persistWithRollbackCleanup(
+        FilesystemAdapter $storage,
+        string $diskName,
+        string $path,
+        Closure $persist,
+    ): mixed {
+        $connection = DB::connection();
+        $initialLevel = $connection->transactionLevel();
+        $transactionStarted = false;
+        $cleanupRegistered = false;
+
+        try {
+            $connection->beginTransaction();
+            $transactionStarted = true;
+            $connection->afterRollBack(function () use ($storage, $diskName, $path): void {
+                $this->deleteFile($storage, $diskName, $path);
+            });
+            $cleanupRegistered = true;
+
+            $result = $persist();
+            $connection->commit();
+
+            return $result;
+        } catch (Throwable $exception) {
+            if (! $transactionStarted) {
+                $this->deleteFile($storage, $diskName, $path);
+            } elseif ($connection->transactionLevel() > $initialLevel) {
+                try {
+                    $connection->rollBack();
+                } catch (Throwable $rollbackException) {
+                    report($rollbackException);
+                }
+
+                if (! $cleanupRegistered) {
+                    $this->deleteFile($storage, $diskName, $path);
+                }
+            }
+
+            throw $exception;
+        }
+    }
+
+    private function validateOwner(Model $owner): void
+    {
+        if ($owner->getKey() === null) {
+            throw new InvalidArgumentException('Media owners must be persisted before attaching media.');
+        }
+    }
+
+    private function validateCollection(string $collection): string
+    {
+        if (preg_match('/\A[a-zA-Z0-9_-]{1,64}\z/', $collection) !== 1) {
+            throw new InvalidArgumentException('Media collections must contain only letters, numbers, underscores, or hyphens.');
+        }
+
+        return $collection;
+    }
+
+    private function validatePosition(int $position): void
+    {
+        if ($position < 0) {
+            throw new InvalidArgumentException('Media positions cannot be negative.');
+        }
+    }
+
+    /**
+     * @return array{string, int, string}
+     */
+    private function fileMetadata(UploadedFile $file): array
+    {
+        $mimeType = $file->getMimeType();
+        $size = $file->getSize();
+
+        if (! is_string($mimeType) || $mimeType === '' || ! is_int($size)) {
+            throw new InvalidArgumentException('Media files must have detectable MIME type and size.');
+        }
+
+        $originalName = basename($file->getClientOriginalName());
+
+        return [$mimeType, $size, Str::substr($originalName !== '' ? $originalName : 'file', 0, 255)];
+    }
+
+    private function resolveDisk(?string $disk): string
+    {
+        $disk ??= (string) config('filesystems.default', 'local');
+
+        if ($disk === '') {
+            throw new InvalidArgumentException('A filesystem disk is required for media.');
+        }
+
+        return $disk;
+    }
+
+    private function storeFile(FilesystemAdapter $storage, UploadedFile $file): string
+    {
+        $path = $storage->putFile('media', $file);
+
+        if (! is_string($path) || $path === '') {
+            throw new RuntimeException('Unable to store media file.');
+        }
+
+        return $path;
+    }
+
+    private function deleteFile(
+        FilesystemAdapter $storage,
+        string $diskName,
+        string $path,
+        mixed $mediaId = null,
+    ): void {
+        try {
+            if (! $storage->delete($path)) {
+                Log::warning('Media file cleanup failed.', [
+                    'disk' => $diskName,
+                    'path' => $path,
+                    'media_id' => $mediaId,
+                ]);
+            }
+        } catch (Throwable $exception) {
+            Log::warning('Media file cleanup failed.', [
+                'disk' => $diskName,
+                'path' => $path,
+                'media_id' => $mediaId,
+                'exception' => $exception,
+            ]);
+        }
+    }
+
+    private function deleteFileByDiskName(string $diskName, string $path, mixed $mediaId = null): void
+    {
+        try {
+            $this->deleteFile(Storage::disk($diskName), $diskName, $path, $mediaId);
+        } catch (Throwable $exception) {
+            Log::warning('Media file cleanup failed.', [
+                'disk' => $diskName,
+                'path' => $path,
+                'media_id' => $mediaId,
+                'exception' => $exception,
+            ]);
+        }
+    }
+}

--- a/database/factories/MediaFactory.php
+++ b/database/factories/MediaFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Media;
+use App\Models\Property;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Media>
+ */
+class MediaFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'mediable_type' => Property::class,
+            'mediable_id' => Property::factory(),
+            'collection' => 'attachments',
+            'disk' => (string) config('filesystems.default', 'local'),
+            'path' => 'media/'.fake()->uuid().'.bin',
+            'mime_type' => 'application/octet-stream',
+            'size' => 1024,
+            'original_name' => 'attachment.bin',
+            'position' => 0,
+            'metadata' => null,
+        ];
+    }
+}

--- a/database/migrations/2026_08_22_202536_create_media_table.php
+++ b/database/migrations/2026_08_22_202536_create_media_table.php
@@ -13,7 +13,8 @@ return new class extends Migration
     {
         Schema::create('media', function (Blueprint $table) {
             $table->id();
-            $table->morphs('mediable');
+            $table->string('mediable_type');
+            $table->unsignedBigInteger('mediable_id');
             $table->string('collection', 64);
             $table->string('disk', 64);
             $table->string('path');

--- a/database/migrations/2026_08_22_202536_create_media_table.php
+++ b/database/migrations/2026_08_22_202536_create_media_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('media', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('mediable');
+            $table->string('collection', 64);
+            $table->string('disk', 64);
+            $table->string('path');
+            $table->string('mime_type');
+            $table->unsignedBigInteger('size');
+            $table->string('original_name');
+            $table->unsignedInteger('position')->default(0);
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+
+            $table->index(
+                ['mediable_type', 'mediable_id', 'collection', 'position'],
+                'idx_media_owner_collection_position',
+            );
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('media');
+    }
+};

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -314,6 +314,14 @@ Every foreign key intentionally chooses one of four strategies:
 
 The full FK inventory with per-constraint rationale is enforced by `tests/Feature/Schema/ForeignKeyDeleteStrategyTest.php`.
 
+### Polymorphic Media Owner IDs
+
+The reusable `media` foundation stores `mediable_id` as an unsigned BIGINT,
+matching the integer primary keys used by current OpenKOS domain models. A
+plugin owner must use a compatible integer key before opting into `HasMedia`.
+UUID or other custom owner keys require a deliberate schema extension rather
+than being silently coerced by the generic media layer.
+
 ### Composite Indexes
 
 Composite indexes are added to support production query patterns (filtering and sorting across multiple columns). The rationale for each:

--- a/tests/Feature/MediaTest.php
+++ b/tests/Feature/MediaTest.php
@@ -3,7 +3,10 @@
 use App\Models\Media;
 use App\Models\Property;
 use App\Services\Media\MediaManager;
+use Illuminate\Database\Events\TransactionCommitted;
+use Illuminate\Database\Events\TransactionCommitting;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Storage;
 
@@ -33,6 +36,23 @@ it('stores media metadata and bytes for a polymorphic owner', function () {
         ->and($media->path)->not->toContain('front-house.jpg');
 
     Storage::disk('local')->assertExists($media->path);
+});
+
+it('uses the persisted owner identity when the owner model is dirty', function () {
+    $property = Property::factory()->create();
+    $otherProperty = Property::factory()->create();
+    $manager = app(MediaManager::class);
+    $persistedOwnerId = $property->getRawOriginal('id');
+    $property->setAttribute('id', $otherProperty->id);
+
+    $media = $manager->store(
+        $property,
+        'photos',
+        UploadedFile::fake()->create('front-house.jpg', 1, 'image/jpeg'),
+    );
+
+    expect($media->mediable_id)->toBe($persistedOwnerId)
+        ->and($manager->forCollection($property, 'photos')->sole()->is($media))->toBeTrue();
 });
 
 it('uses the configured default filesystem disk', function () {
@@ -80,12 +100,16 @@ it('rejects duplicate or foreign media IDs during reorder', function () {
     expect(fn () => $manager->reorder($property, 'photos', [$foreign->id]))
         ->toThrow(InvalidArgumentException::class);
 
+    expect(fn () => $manager->reorder($property, 'photos', [null]))
+        ->toThrow(InvalidArgumentException::class);
+
     expect(fn () => $manager->reorder($property, 'photos', []))
         ->toThrow(InvalidArgumentException::class);
 });
 
 it('replaces a file while preserving media identity and ownership', function () {
     $property = Property::factory()->create();
+    $otherProperty = Property::factory()->create();
     $manager = app(MediaManager::class);
     $media = $manager->store(
         $property,
@@ -95,11 +119,16 @@ it('replaces a file while preserving media identity and ownership', function () 
         metadata: ['alt' => 'Old'],
     );
     $oldPath = $media->path;
+    $media->forceFill([
+        'mediable_id' => $otherProperty->id,
+        'collection' => 'mutated',
+        'position' => 99,
+        'metadata' => ['alt' => 'Dirty'],
+    ]);
 
     $replaced = $manager->replace(
         $media,
         UploadedFile::fake()->create('new.webp', 2, 'image/webp'),
-        metadata: ['alt' => 'New'],
     );
 
     expect($replaced->id)->toBe($media->id)
@@ -107,10 +136,18 @@ it('replaces a file while preserving media identity and ownership', function () 
         ->and($replaced->collection)->toBe('photos')
         ->and($replaced->position)->toBe(3)
         ->and($replaced->mime_type)->toBe('image/webp')
-        ->and($replaced->metadata)->toBe(['alt' => 'New']);
+        ->and($replaced->metadata)->toBe(['alt' => 'Old']);
 
     Storage::disk('local')->assertMissing($oldPath);
     Storage::disk('local')->assertExists($replaced->path);
+
+    $cleared = $manager->replace(
+        $replaced,
+        UploadedFile::fake()->create('cleared.webp', 2, 'image/webp'),
+        metadata: null,
+    );
+
+    expect($cleared->fresh()->metadata)->toBeNull();
 });
 
 it('cleans up the new file when initial persistence fails', function () {
@@ -160,6 +197,54 @@ it('keeps the old file when replacement persistence fails', function () {
     expect(Storage::disk('local')->allFiles('media'))->toHaveCount(1);
 });
 
+it('retains the file when a committed media transaction reports an exception', function () {
+    $property = Property::factory()->create();
+    $event = TransactionCommitted::class;
+
+    Event::listen($event, function (): void {
+        throw new RuntimeException('Simulated post-commit failure.');
+    });
+
+    try {
+        expect(fn () => app(MediaManager::class)->store(
+            $property,
+            'photos',
+            UploadedFile::fake()->create('committed.jpg', 1, 'image/jpeg'),
+        ))->toThrow(RuntimeException::class);
+    } finally {
+        Event::forget($event);
+    }
+
+    $media = Media::query()->sole();
+
+    expect($media->path)->not->toBeEmpty();
+    Storage::disk('local')->assertExists($media->path);
+});
+
+it('cleans the file when the root media transaction fails before commit', function () {
+    $property = Property::factory()->create();
+    DB::commit();
+    $event = TransactionCommitting::class;
+
+    Event::listen($event, function (): void {
+        throw new RuntimeException('Simulated pre-commit failure.');
+    });
+
+    try {
+        expect(fn () => app(MediaManager::class)->store(
+            $property,
+            'photos',
+            UploadedFile::fake()->create('rolled-back.jpg', 1, 'image/jpeg'),
+        ))->toThrow(RuntimeException::class);
+    } finally {
+        Event::forget($event);
+        $property->delete();
+    }
+
+    expect(Media::query()->count())->toBe(0);
+    Storage::disk('local')->assertDirectoryEmpty('media');
+});
+
 it('removes media rows and files, including when the file is already missing', function () {
     $property = Property::factory()->create();
     $manager = app(MediaManager::class);
@@ -196,6 +281,31 @@ it('preserves media through owner soft deletion until explicit cleanup', functio
 
     expect(Media::query()->find($media->id))->toBeNull();
     Storage::disk('local')->assertMissing($path);
+});
+
+it('rolls back all owner media rows when bulk cleanup fails', function () {
+    $property = Property::factory()->create();
+    $manager = app(MediaManager::class);
+    $first = $manager->store($property, 'photos', UploadedFile::fake()->create('first.jpg', 1, 'image/jpeg'));
+    $second = $manager->store($property, 'photos', UploadedFile::fake()->create('second.jpg', 1, 'image/jpeg'));
+    $event = 'eloquent.deleting: '.Media::class;
+    $deletions = 0;
+
+    Event::listen($event, function () use (&$deletions): void {
+        if (++$deletions === 2) {
+            throw new RuntimeException('Simulated bulk cleanup failure.');
+        }
+    });
+
+    try {
+        expect(fn () => $manager->removeForOwner($property))->toThrow(RuntimeException::class);
+    } finally {
+        Event::forget($event);
+    }
+
+    expect(Media::query()->whereKey([$first->id, $second->id])->count())->toBe(2);
+    Storage::disk('local')->assertExists($first->path);
+    Storage::disk('local')->assertExists($second->path);
 });
 
 it('rejects unsafe collection names', function (string $collection) {

--- a/tests/Feature/MediaTest.php
+++ b/tests/Feature/MediaTest.php
@@ -1,0 +1,209 @@
+<?php
+
+use App\Models\Media;
+use App\Models\Property;
+use App\Services\Media\MediaManager;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Storage;
+
+beforeEach(function () {
+    Storage::fake('local');
+    config(['filesystems.default' => 'local']);
+});
+
+it('stores media metadata and bytes for a polymorphic owner', function () {
+    $property = Property::factory()->create();
+
+    $media = app(MediaManager::class)->store(
+        $property,
+        'photos',
+        UploadedFile::fake()->create('front-house.jpg', 1, 'image/jpeg'),
+        position: 2,
+        metadata: ['alt' => 'Front of house'],
+    );
+
+    expect($property->media()->sole()->is($media))->toBeTrue()
+        ->and($media->mediable->is($property))->toBeTrue()
+        ->and($media->collection)->toBe('photos')
+        ->and($media->disk)->toBe('local')
+        ->and($media->mime_type)->toBe('image/jpeg')
+        ->and($media->size)->toBeGreaterThan(0)
+        ->and($media->original_name)->toBe('front-house.jpg')
+        ->and($media->path)->not->toContain('front-house.jpg');
+
+    Storage::disk('local')->assertExists($media->path);
+});
+
+it('uses the configured default filesystem disk', function () {
+    Storage::fake('public');
+    config(['filesystems.default' => 'public']);
+    $property = Property::factory()->create();
+
+    $media = app(MediaManager::class)->store(
+        $property,
+        'photos',
+        UploadedFile::fake()->create('front-house.jpg', 1, 'image/jpeg'),
+    );
+
+    expect($media->disk)->toBe('public');
+    Storage::disk('public')->assertExists($media->path);
+});
+
+it('retrieves and reorders media within an owner collection', function () {
+    $property = Property::factory()->create();
+    $manager = app(MediaManager::class);
+
+    $first = $manager->store($property, 'photos', UploadedFile::fake()->create('first.jpg', 1, 'image/jpeg'));
+    $second = $manager->store($property, 'photos', UploadedFile::fake()->create('second.jpg', 1, 'image/jpeg'));
+    $document = $manager->store($property, 'documents', UploadedFile::fake()->create('lease.pdf', 1, 'application/pdf'));
+
+    $manager->reorder($property, 'photos', [$second->id, $first->id]);
+
+    expect($manager->forCollection($property, 'photos')->pluck('id')->all())
+        ->toBe([$second->id, $first->id])
+        ->and($second->fresh()->position)->toBe(0)
+        ->and($first->fresh()->position)->toBe(1)
+        ->and($document->fresh()->position)->toBe(0);
+});
+
+it('rejects duplicate or foreign media IDs during reorder', function () {
+    $property = Property::factory()->create();
+    $otherProperty = Property::factory()->create();
+    $manager = app(MediaManager::class);
+    $media = $manager->store($property, 'photos', UploadedFile::fake()->create('photo.jpg', 1, 'image/jpeg'));
+    $foreign = $manager->store($otherProperty, 'photos', UploadedFile::fake()->create('foreign.jpg', 1, 'image/jpeg'));
+
+    expect(fn () => $manager->reorder($property, 'photos', [$media->id, $media->id]))
+        ->toThrow(InvalidArgumentException::class);
+
+    expect(fn () => $manager->reorder($property, 'photos', [$foreign->id]))
+        ->toThrow(InvalidArgumentException::class);
+
+    expect(fn () => $manager->reorder($property, 'photos', []))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+it('replaces a file while preserving media identity and ownership', function () {
+    $property = Property::factory()->create();
+    $manager = app(MediaManager::class);
+    $media = $manager->store(
+        $property,
+        'photos',
+        UploadedFile::fake()->create('old.jpg', 1, 'image/jpeg'),
+        position: 3,
+        metadata: ['alt' => 'Old'],
+    );
+    $oldPath = $media->path;
+
+    $replaced = $manager->replace(
+        $media,
+        UploadedFile::fake()->create('new.webp', 2, 'image/webp'),
+        metadata: ['alt' => 'New'],
+    );
+
+    expect($replaced->id)->toBe($media->id)
+        ->and($replaced->mediable_id)->toBe($property->id)
+        ->and($replaced->collection)->toBe('photos')
+        ->and($replaced->position)->toBe(3)
+        ->and($replaced->mime_type)->toBe('image/webp')
+        ->and($replaced->metadata)->toBe(['alt' => 'New']);
+
+    Storage::disk('local')->assertMissing($oldPath);
+    Storage::disk('local')->assertExists($replaced->path);
+});
+
+it('cleans up the new file when initial persistence fails', function () {
+    $property = Property::factory()->create();
+    $event = 'eloquent.creating: '.Media::class;
+
+    Event::listen($event, function (Media $media): void {
+        throw new RuntimeException('Simulated media persistence failure.');
+    });
+
+    try {
+        expect(fn () => app(MediaManager::class)->store(
+            $property,
+            'photos',
+            UploadedFile::fake()->create('failed.jpg', 1, 'image/jpeg'),
+        ))->toThrow(RuntimeException::class);
+    } finally {
+        Event::forget($event);
+    }
+
+    expect(Media::query()->count())->toBe(0);
+    Storage::disk('local')->assertDirectoryEmpty('media');
+});
+
+it('keeps the old file when replacement persistence fails', function () {
+    $property = Property::factory()->create();
+    $manager = app(MediaManager::class);
+    $media = $manager->store($property, 'photos', UploadedFile::fake()->create('old.jpg', 1, 'image/jpeg'));
+    $oldPath = $media->path;
+    $event = 'eloquent.updating: '.Media::class;
+
+    Event::listen($event, function (Media $media): void {
+        throw new RuntimeException('Simulated media replacement failure.');
+    });
+
+    try {
+        expect(fn () => $manager->replace(
+            $media,
+            UploadedFile::fake()->create('new.jpg', 1, 'image/jpeg'),
+        ))->toThrow(RuntimeException::class);
+    } finally {
+        Event::forget($event);
+    }
+
+    expect($media->fresh()->path)->toBe($oldPath);
+    Storage::disk('local')->assertExists($oldPath);
+    expect(Storage::disk('local')->allFiles('media'))->toHaveCount(1);
+});
+
+it('removes media rows and files, including when the file is already missing', function () {
+    $property = Property::factory()->create();
+    $manager = app(MediaManager::class);
+    $media = $manager->store($property, 'photos', UploadedFile::fake()->create('photo.jpg', 1, 'image/jpeg'));
+    $path = $media->path;
+
+    $manager->remove($media);
+
+    expect(Media::query()->find($media->id))->toBeNull();
+    Storage::disk('local')->assertMissing($path);
+
+    $missing = Media::factory()->for($property, 'mediable')->create([
+        'collection' => 'photos',
+        'path' => 'media/missing.jpg',
+    ]);
+
+    $manager->remove($missing);
+
+    expect(Media::query()->find($missing->id))->toBeNull();
+});
+
+it('preserves media through owner soft deletion until explicit cleanup', function () {
+    $property = Property::factory()->create();
+    $manager = app(MediaManager::class);
+    $media = $manager->store($property, 'photos', UploadedFile::fake()->create('photo.jpg', 1, 'image/jpeg'));
+    $path = $media->path;
+
+    $property->delete();
+
+    expect(Media::query()->find($media->id))->not->toBeNull();
+    Storage::disk('local')->assertExists($path);
+
+    $manager->removeForOwner($property);
+
+    expect(Media::query()->find($media->id))->toBeNull();
+    Storage::disk('local')->assertMissing($path);
+});
+
+it('rejects unsafe collection names', function (string $collection) {
+    $property = Property::factory()->create();
+
+    expect(fn () => app(MediaManager::class)->store(
+        $property,
+        $collection,
+        UploadedFile::fake()->create('file.bin', 1, 'application/octet-stream'),
+    ))->toThrow(InvalidArgumentException::class);
+})->with(['photo gallery', '../photos', 'photos/extra', '']);

--- a/tests/Feature/Schema/CompositeIndexTest.php
+++ b/tests/Feature/Schema/CompositeIndexTest.php
@@ -31,6 +31,9 @@ $expected = [
     'properties' => [
         'idx_properties_active_name' => ['is_active', 'name'],
     ],
+    'media' => [
+        'idx_media_owner_collection_position' => ['mediable_type', 'mediable_id', 'collection', 'position'],
+    ],
 ];
 
 $appTables = array_keys($expected);


### PR DESCRIPTION
## Summary

- add a polymorphic Media model, HasMedia trait, and reusable MediaManager foundation
- preserve database and filesystem consistency across store, replace, reorder, and removal flows
- harden rollback, concurrent replacement, dirty-model, and metadata edge cases
- document the integer owner-ID boundary and remove the redundant morph index

## Verification

- `php artisan test --compact` — 918 passed, 1 skipped
- `vendor/bin/pint --dirty --format agent`

Refs OPE-164