### PR TITLE
perf(reminders): batch daily reminder processing

### DIFF
--- a/app/Actions/Reminders/SendRentReminders.php
+++ b/app/Actions/Reminders/SendRentReminders.php
@@ -6,20 +6,20 @@ use App\Business\Reminders\PaymentReminderScheduler;
 use App\Data\Reminder\ReminderSettings;
 use App\Events\Reminder\InvoiceReminderDispatched;
 use App\Models\Lease;
-use App\Models\ReminderLog;
 use App\Models\Setting;
 use App\Repositories\ReminderRepository;
-use Illuminate\Support\Collection;
+use Illuminate\Database\Eloquent\Collection;
 
 class SendRentReminders
 {
+    private const CHUNK_SIZE = 100;
+
     public function __construct(
         private PaymentReminderScheduler $scheduler,
         private ReminderRepository $repository,
     ) {}
 
-    /** @return Collection<int, ReminderLog> */
-    public function execute(?Lease $lease = null): Collection
+    public function execute(?Lease $lease = null): int
     {
         $settings = new ReminderSettings(
             enabled: Setting::get('reminder_enabled') ?? true,
@@ -28,33 +28,81 @@ class SendRentReminders
         );
 
         if (! $settings->enabled) {
-            return collect();
+            return 0;
         }
-
-        $leases = $lease
-            ? [$lease->load(['primaryTenant.user'])]
-            : Lease::active()->with(['primaryTenant.user'])->get();
-
-        $sent = collect();
 
         $channels = Setting::get('reminder_channels') ?? ['log'];
 
-        foreach ($leases as $lease) {
-            $tenant = $lease->primaryTenant;
-            if (! $tenant?->hasReminderRoute($channels)) {
+        if ($lease) {
+            $lease->load(['primaryTenant.user', 'unit']);
+
+            return $this->processLease($lease, $settings, $channels);
+        }
+
+        $sent = 0;
+
+        Lease::active()
+            ->with(['primaryTenant.user', 'unit'])
+            ->chunkById(
+                self::CHUNK_SIZE,
+                function (Collection $leases) use (&$sent, $settings, $channels): void {
+                    $sent += $this->processLeaseChunk($leases, $settings, $channels);
+                },
+                'id',
+            );
+
+        return $sent;
+    }
+
+    private function processLease(Lease $lease, ReminderSettings $settings, array $channels): int
+    {
+        if (! $lease->primaryTenant?->hasReminderRoute($channels)) {
+            return 0;
+        }
+
+        return $this->recordEvents(
+            $this->scheduler->pendingFor($lease, $settings),
+            $channels,
+        );
+    }
+
+    /** @param  Collection<int, Lease>  $leases */
+    private function processLeaseChunk(Collection $leases, ReminderSettings $settings, array $channels): int
+    {
+        $eligibleLeases = $leases
+            ->filter(fn (Lease $lease): bool => $lease->primaryTenant?->hasReminderRoute($channels))
+            ->values();
+
+        if ($eligibleLeases->isEmpty()) {
+            return 0;
+        }
+
+        $eventsByLease = $this->scheduler->pendingForMany($eligibleLeases, $settings);
+        $sent = 0;
+
+        foreach ($eligibleLeases as $lease) {
+            $sent += $this->recordEvents(
+                $eventsByLease[$lease->getKey()] ?? [],
+                $channels,
+            );
+        }
+
+        return $sent;
+    }
+
+    private function recordEvents(iterable $events, array $channels): int
+    {
+        $sent = 0;
+
+        foreach ($events as $event) {
+            $log = $this->repository->recordIfAbsent($event, $channels);
+
+            if (! $log) {
                 continue;
             }
 
-            foreach ($this->scheduler->pendingFor($lease, $settings) as $event) {
-                $log = $this->repository->recordIfAbsent($event, $channels);
-
-                if (! $log) {
-                    continue;
-                }
-
-                InvoiceReminderDispatched::dispatch($event);
-                $sent->push($log);
-            }
+            InvoiceReminderDispatched::dispatch($event);
+            $sent++;
         }
 
         return $sent;

--- a/app/Business/Reminders/PaymentReminderScheduler.php
+++ b/app/Business/Reminders/PaymentReminderScheduler.php
@@ -9,13 +9,79 @@ use App\Models\Invoice;
 use App\Models\Lease;
 use Carbon\Carbon;
 use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Collection;
 
 class PaymentReminderScheduler
 {
     /** @return array<ReminderEvent> */
     public function pendingFor(Lease $lease, ReminderSettings $settings): array
     {
-        $invoices = $lease->invoices()->payable()->orderBy('period_start')->get();
+        $invoices = $lease->invoices()
+            ->payable()
+            ->orderBy('period_start')
+            ->get([
+                'id',
+                'lease_id',
+                'reference',
+                'period_start',
+                'period_end',
+                'due_date',
+                'status',
+                'total',
+                'amount_paid',
+                'currency',
+            ]);
+
+        return $this->eventsFor($lease, $invoices, $settings);
+    }
+
+    /**
+     * @param  Collection<int, Lease>  $leases
+     * @return array<int, array<int, ReminderEvent>>
+     */
+    public function pendingForMany(Collection $leases, ReminderSettings $settings): array
+    {
+        if ($leases->isEmpty()) {
+            return [];
+        }
+
+        $invoicesByLease = Invoice::query()
+            ->whereIn('lease_id', $leases->modelKeys())
+            ->payable()
+            ->orderBy('period_start')
+            ->get([
+                'id',
+                'lease_id',
+                'reference',
+                'period_start',
+                'period_end',
+                'due_date',
+                'status',
+                'total',
+                'amount_paid',
+                'currency',
+            ])
+            ->groupBy('lease_id');
+
+        $eventsByLease = [];
+
+        foreach ($leases as $lease) {
+            $eventsByLease[$lease->getKey()] = $this->eventsFor(
+                $lease,
+                $invoicesByLease->get($lease->getKey(), []),
+                $settings,
+            );
+        }
+
+        return $eventsByLease;
+    }
+
+    /**
+     * @param  iterable<Invoice>  $invoices
+     * @return array<int, ReminderEvent>
+     */
+    private function eventsFor(Lease $lease, iterable $invoices, ReminderSettings $settings): array
+    {
         $today = now()->startOfDay();
         $events = [];
 

--- a/app/Business/Reminders/PaymentReminderScheduler.php
+++ b/app/Business/Reminders/PaymentReminderScheduler.php
@@ -19,18 +19,7 @@ class PaymentReminderScheduler
         $invoices = $lease->invoices()
             ->payable()
             ->orderBy('period_start')
-            ->get([
-                'id',
-                'lease_id',
-                'reference',
-                'period_start',
-                'period_end',
-                'due_date',
-                'status',
-                'total',
-                'amount_paid',
-                'currency',
-            ]);
+            ->get();
 
         return $this->eventsFor($lease, $invoices, $settings);
     }
@@ -49,18 +38,7 @@ class PaymentReminderScheduler
             ->whereIn('lease_id', $leases->modelKeys())
             ->payable()
             ->orderBy('period_start')
-            ->get([
-                'id',
-                'lease_id',
-                'reference',
-                'period_start',
-                'period_end',
-                'due_date',
-                'status',
-                'total',
-                'amount_paid',
-                'currency',
-            ])
+            ->get()
             ->groupBy('lease_id');
 
         $eventsByLease = [];

--- a/app/Console/Commands/SendRentRemindersCommand.php
+++ b/app/Console/Commands/SendRentRemindersCommand.php
@@ -17,7 +17,7 @@ class SendRentRemindersCommand extends Command
         $leaseId = $this->argument('lease');
         $lease = $leaseId ? Lease::findOrFail($leaseId) : null;
 
-        $count = $action->execute($lease)->count();
+        $count = $action->execute($lease);
 
         $this->info("Sent {$count} reminder(s).");
     }

--- a/tests/Feature/SendRentRemindersTest.php
+++ b/tests/Feature/SendRentRemindersTest.php
@@ -313,8 +313,8 @@ describe('SendRentRemindersAction', function () {
         $first = $action->execute($lease);
         $second = $action->execute($lease);
 
-        expect($first)->toHaveCount(1);
-        expect($second)->toBeEmpty();
+        expect($first)->toBe(1);
+        expect($second)->toBe(0);
         expect(ReminderLog::count())->toBe(1);
 
         Notification::assertSentToTimes($lease->primaryTenant, RentReminder::class, 1);
@@ -334,7 +334,7 @@ describe('SendRentRemindersAction', function () {
         $action = app(SendRentReminders::class);
         $sent = $action->execute($lease);
 
-        expect($sent)->toBeEmpty();
+        expect($sent)->toBe(0);
         Notification::assertNothingSent();
 
         Carbon::setTestNow();
@@ -363,7 +363,7 @@ describe('SendRentRemindersAction', function () {
         $action = app(SendRentReminders::class);
         $sent = $action->execute($lease);
 
-        expect($sent)->toBeEmpty();
+        expect($sent)->toBe(0);
         Notification::assertNothingSent();
 
         Carbon::setTestNow();
@@ -379,9 +379,51 @@ describe('SendRentRemindersAction', function () {
 
         $sent = app(SendRentReminders::class)->execute($lease);
 
-        expect($sent)->toBeEmpty();
+        expect($sent)->toBe(0);
         expect(ReminderLog::count())->toBe(0);
         Notification::assertNothingSent();
+
+        Carbon::setTestNow();
+    });
+
+    it('processes large batches in chunks and batches invoice queries', function () {
+        Carbon::setTestNow(Carbon::parse('2026-07-01'));
+        Notification::fake();
+
+        $leases = Lease::factory()->count(101)->create([
+            'start_date' => '2026-06-01',
+            'rent_amount' => 1500000.00,
+            'rent_due_day' => 1,
+            'billing_interval' => 1,
+            'billing_unit' => 'month',
+            'status' => 'active',
+        ]);
+
+        foreach ($leases as $lease) {
+            Invoice::factory()->for($lease)->create([
+                'period_start' => '2026-06-01',
+                'period_end' => '2026-06-30',
+                'due_date' => '2026-07-01',
+                'total' => 1500000,
+                'amount_paid' => 0,
+            ]);
+        }
+
+        $invoiceQueries = [];
+        DB::listen(function (QueryExecuted $query) use (&$invoiceQueries): void {
+            if (str_contains(strtolower($query->sql), 'where "lease_id" in')) {
+                $invoiceQueries[] = $query->sql;
+            }
+        });
+
+        $sent = app(SendRentReminders::class)->execute();
+
+        expect($sent)->toBe($leases->count())
+            ->and(count($invoiceQueries))->toBeGreaterThan(0)
+            ->and(count($invoiceQueries))->toBeLessThan($leases->count())
+            ->and(ReminderLog::count())->toBe($leases->count());
+
+        expect(app(SendRentReminders::class)->execute())->toBe(0);
 
         Carbon::setTestNow();
     });

--- a/tests/Feature/SendRentRemindersTest.php
+++ b/tests/Feature/SendRentRemindersTest.php
@@ -411,7 +411,10 @@ describe('SendRentRemindersAction', function () {
 
         $invoiceQueries = [];
         DB::listen(function (QueryExecuted $query) use (&$invoiceQueries): void {
-            if (str_contains(strtolower($query->sql), 'where "lease_id" in')) {
+            $sql = strtolower($query->sql);
+
+            if (str_contains($sql, ' from "invoices"')
+                && ! str_contains($sql, 'select exists')) {
                 $invoiceQueries[] = $query->sql;
             }
         });


### PR DESCRIPTION
## Summary

- process scheduled reminders with stable lease ID chunks
- batch payable invoice loading per lease chunk
- keep complete Invoice hydration for reminder event compatibility
- return a bounded sent count while preserving manual sends and deduplication

## Validation

- focused reminder tests: 36 passed
- full suite: 925 passed, 1 skipped
- Pint and diff checks passed

Refs OPE-149