### PR TITLE
feat(media): migrate legacy uploads

### DIFF
--- a/app/Actions/Payments/RecordPayment.php
+++ b/app/Actions/Payments/RecordPayment.php
@@ -9,14 +9,15 @@ use App\Exceptions\PaymentOverflowException;
 use App\Models\Invoice;
 use App\Models\User;
 use App\Results\Payment\RecordPaymentResult;
+use App\Services\Media\MediaManager;
 use Brick\Math\BigDecimal;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Str;
 
 class RecordPayment
 {
     public function __construct(
         private AllocatePayment $allocatePayment,
+        private MediaManager $mediaManager,
     ) {}
 
     public function execute(Invoice $invoice, RecordPaymentData $data, User $user, bool $forcePending = false): RecordPaymentResult
@@ -56,18 +57,16 @@ class RecordPayment
 
             if ($hasProof) {
                 $file = $data->proof;
-                $extension = $file->getClientOriginalExtension();
-                $path = $file->storeAs(
-                    'payment-proofs/'.$payment->id,
-                    (string) Str::uuid().'.'.$extension,
-                    'local',
-                );
+                $media = $this->mediaManager->store($payment, 'proofs', $file);
 
-                $payment->proofs()->create([
-                    'path' => $path,
-                    'original_name' => $file->getClientOriginalName(),
-                    'mime_type' => $file->getMimeType(),
+                $proof = $payment->proofs()->make([
+                    'media_id' => $media->id,
+                    'original_name' => $media->original_name,
+                    'mime_type' => $media->mime_type,
                 ]);
+
+                // Deprecated compatibility field; canonical storage is Media.
+                $proof->forceFill(['path' => $media->path])->saveOrFail();
             }
 
             if ($payment->status === PaymentStatus::Confirmed) {

--- a/app/Actions/Payments/RecordPayment.php
+++ b/app/Actions/Payments/RecordPayment.php
@@ -57,7 +57,8 @@ class RecordPayment
 
             if ($hasProof) {
                 $file = $data->proof;
-                $media = $this->mediaManager->store($payment, 'proofs', $file);
+                // Keep compatibility-phase uploads readable by released code, which assumes local.
+                $media = $this->mediaManager->store($payment, 'proofs', $file, disk: 'local');
 
                 $proof = $payment->proofs()->make([
                     'media_id' => $media->id,
@@ -76,7 +77,7 @@ class RecordPayment
             return $payment;
         });
 
-        $payment->load('confirmedBy:id,name', 'recordedBy:id,name', 'proofs');
+        $payment->load('confirmedBy:id,name', 'recordedBy:id,name', 'proofs.media');
 
         return RecordPaymentResult::success($payment);
 

--- a/app/Console/Commands/MigrateLegacyMedia.php
+++ b/app/Console/Commands/MigrateLegacyMedia.php
@@ -13,6 +13,7 @@ use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
@@ -150,13 +151,14 @@ final class MigrateLegacyMedia extends Command
             }
 
             $values = $attributes($record);
+            $this->lockOwner($ownerType, $values['owner_id']);
             $existing = $this->findExistingMedia(
                 $ownerType,
                 $values['owner_id'],
                 $collection,
                 $values['path'],
             );
-            $missing = false;
+            $missing = $existing !== null && ! $this->mediaFileExists($existing);
 
             if ($existing === null) {
                 [$existing, $missing] = $this->createMedia(
@@ -167,6 +169,8 @@ final class MigrateLegacyMedia extends Command
                     $legacyId,
                     $values,
                 );
+            } elseif ($missing) {
+                $this->markMissingMedia($existing, $table, $legacyId);
             }
 
             $link($record, $existing);
@@ -194,6 +198,43 @@ final class MigrateLegacyMedia extends Command
         }
 
         return $matches->first();
+    }
+
+    private function lockOwner(string $ownerType, int $ownerId): void
+    {
+        $owner = new $ownerType;
+        $query = $owner->newQuery();
+
+        if (in_array(SoftDeletes::class, class_uses_recursive($ownerType), true)) {
+            $query->withTrashed();
+        }
+
+        $query->lockForUpdate()->findOrFail($ownerId);
+    }
+
+    private function mediaFileExists(Media $media): bool
+    {
+        return $media->path !== '' && Storage::disk($media->disk)->exists($media->path);
+    }
+
+    private function markMissingMedia(Media $media, string $table, int $legacyId): void
+    {
+        $metadata = is_array($media->metadata) ? $media->metadata : [];
+        $legacyMetadata = is_array($metadata['legacy'] ?? null) ? $metadata['legacy'] : [];
+
+        $media->forceFill([
+            'metadata' => [
+                ...$metadata,
+                'legacy' => [
+                    ...$legacyMetadata,
+                    'table' => $table,
+                    'id' => $legacyId,
+                    'missing_file' => true,
+                ],
+            ],
+        ])->saveOrFail();
+
+        $this->warn("Missing legacy file: {$table}#{$legacyId} ({$media->path}).");
     }
 
     /**

--- a/app/Console/Commands/MigrateLegacyMedia.php
+++ b/app/Console/Commands/MigrateLegacyMedia.php
@@ -1,0 +1,276 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Media;
+use App\Models\Payment;
+use App\Models\PaymentProof;
+use App\Models\Tenant;
+use App\Models\TenantDocument;
+use Closure;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use RuntimeException;
+use Throwable;
+
+#[Signature('media:migrate-legacy {--chunk=500 : Number of legacy rows to process per chunk}')]
+#[Description('Backfill tenant documents and payment proofs into canonical media')]
+final class MigrateLegacyMedia extends Command
+{
+    private const DISK = 'local';
+
+    /**
+     * @var array<string, int>
+     */
+    private array $counts = [
+        'migrated' => 0,
+        'recovered' => 0,
+        'skipped' => 0,
+        'missing' => 0,
+        'failed' => 0,
+    ];
+
+    public function handle(): int
+    {
+        $chunk = (int) $this->option('chunk');
+
+        if ($chunk < 1) {
+            $this->error('The chunk size must be at least 1.');
+
+            return self::INVALID;
+        }
+
+        TenantDocument::query()
+            ->orderBy('id')
+            ->chunkById($chunk, function (Collection $documents): void {
+                foreach ($documents as $document) {
+                    $this->processTenantDocument($document);
+                }
+            });
+
+        PaymentProof::query()
+            ->orderBy('id')
+            ->chunkById($chunk, function (Collection $proofs): void {
+                foreach ($proofs as $proof) {
+                    $this->processPaymentProof($proof);
+                }
+            });
+
+        $this->info(sprintf(
+            'Legacy media migration: migrated=%d, recovered=%d, skipped=%d, missing=%d, failed=%d.',
+            $this->counts['migrated'],
+            $this->counts['recovered'],
+            $this->counts['skipped'],
+            $this->counts['missing'],
+            $this->counts['failed'],
+        ));
+
+        return $this->counts['failed'] === 0 ? self::SUCCESS : self::FAILURE;
+    }
+
+    private function processTenantDocument(TenantDocument $document): void
+    {
+        try {
+            $status = $this->migrateLegacyRecord(
+                Tenant::class,
+                'documents',
+                'tenant_documents',
+                $document->id,
+                fn (): ?Model => TenantDocument::query()->lockForUpdate()->find($document->id),
+                fn (Model $record): array => [
+                    'owner_id' => (int) $record->tenant_id,
+                    'path' => (string) $record->file_path,
+                    'original_name' => (string) $record->original_name,
+                    'mime_type' => (string) $record->mime_type,
+                    'size' => (int) $record->size,
+                ],
+                function (Model $record, Media $media): void {
+                    $record->forceFill(['media_id' => $media->id])->saveOrFail();
+                },
+            );
+
+            $this->counts[$status]++;
+        } catch (Throwable $exception) {
+            $this->recordFailure('tenant document', $document->id, $exception);
+        }
+    }
+
+    private function processPaymentProof(PaymentProof $proof): void
+    {
+        try {
+            $status = $this->migrateLegacyRecord(
+                Payment::class,
+                'proofs',
+                'payment_proofs',
+                $proof->id,
+                fn (): ?Model => PaymentProof::query()->lockForUpdate()->find($proof->id),
+                fn (Model $record): array => [
+                    'owner_id' => (int) $record->payment_id,
+                    'path' => (string) $record->path,
+                    'original_name' => (string) $record->original_name,
+                    'mime_type' => (string) $record->mime_type,
+                    'size' => null,
+                ],
+                function (Model $record, Media $media): void {
+                    $record->forceFill(['media_id' => $media->id])->saveOrFail();
+                },
+            );
+
+            $this->counts[$status]++;
+        } catch (Throwable $exception) {
+            $this->recordFailure('payment proof', $proof->id, $exception);
+        }
+    }
+
+    /**
+     * @param  Closure(): ?Model  $load
+     * @param  Closure(Model): array{owner_id: int, path: string, original_name: string, mime_type: string, size: ?int}  $attributes
+     * @param  Closure(Model, Media): void  $link
+     */
+    private function migrateLegacyRecord(
+        string $ownerType,
+        string $collection,
+        string $table,
+        int $legacyId,
+        Closure $load,
+        Closure $attributes,
+        Closure $link,
+    ): string {
+        return DB::transaction(function () use ($ownerType, $collection, $table, $legacyId, $load, $attributes, $link): string {
+            $record = $load();
+
+            if ($record === null || $record->media_id !== null) {
+                return 'skipped';
+            }
+
+            $values = $attributes($record);
+            $existing = $this->findExistingMedia(
+                $ownerType,
+                $values['owner_id'],
+                $collection,
+                $values['path'],
+            );
+            $missing = false;
+
+            if ($existing === null) {
+                [$existing, $missing] = $this->createMedia(
+                    $ownerType,
+                    $values['owner_id'],
+                    $collection,
+                    $table,
+                    $legacyId,
+                    $values,
+                );
+            }
+
+            $link($record, $existing);
+
+            return $missing ? 'missing' : ($existing->wasRecentlyCreated ? 'migrated' : 'recovered');
+        });
+    }
+
+    private function findExistingMedia(
+        string $ownerType,
+        int $ownerId,
+        string $collection,
+        string $path,
+    ): ?Media {
+        $matches = Media::query()
+            ->where('mediable_type', (new $ownerType)->getMorphClass())
+            ->where('mediable_id', $ownerId)
+            ->where('collection', $collection)
+            ->where('disk', self::DISK)
+            ->where('path', $path)
+            ->get();
+
+        if ($matches->count() > 1) {
+            throw new RuntimeException('Multiple canonical media rows match the legacy record.');
+        }
+
+        return $matches->first();
+    }
+
+    /**
+     * @param  array{owner_id: int, path: string, original_name: string, mime_type: string, size: ?int}  $values
+     * @return array{0: Media, 1: bool}
+     */
+    private function createMedia(
+        string $ownerType,
+        int $ownerId,
+        string $collection,
+        string $table,
+        int $legacyId,
+        array $values,
+    ): array {
+        $storage = Storage::disk(self::DISK);
+        $path = $values['path'];
+        $missing = $path === '' || ! $storage->exists($path);
+        $size = max(0, $values['size'] ?? 0);
+        $mimeType = $values['mime_type'] ?: 'application/octet-stream';
+
+        if (! $missing) {
+            try {
+                $size = (int) $storage->size($path);
+            } catch (Throwable) {
+                // Keep the legacy size when the backend cannot report it.
+            }
+
+            try {
+                $detectedMimeType = $storage->mimeType($path);
+
+                if (is_string($detectedMimeType) && $detectedMimeType !== '') {
+                    $mimeType = $detectedMimeType;
+                }
+            } catch (Throwable) {
+                // Keep the legacy MIME type when the backend cannot report it.
+            }
+        }
+
+        $metadata = [
+            'legacy' => [
+                'table' => $table,
+                'id' => $legacyId,
+                'missing_file' => $missing,
+            ],
+        ];
+
+        $media = Media::create([
+            'mediable_type' => (new $ownerType)->getMorphClass(),
+            'mediable_id' => $ownerId,
+            'collection' => $collection,
+            'disk' => self::DISK,
+            'path' => $path,
+            'mime_type' => $mimeType,
+            'size' => $size,
+            'original_name' => $this->originalName($values['original_name']),
+            'position' => 0,
+            'metadata' => $metadata,
+        ]);
+
+        if ($missing) {
+            $this->warn("Missing legacy file: {$table}#{$legacyId} ({$path}).");
+        }
+
+        return [$media, $missing];
+    }
+
+    private function originalName(string $originalName): string
+    {
+        $name = basename($originalName);
+
+        return Str::substr($name !== '' ? $name : 'file', 0, 255);
+    }
+
+    private function recordFailure(string $type, int $id, Throwable $exception): void
+    {
+        $this->counts['failed']++;
+        $this->error("Failed to migrate {$type}#{$id}: {$exception->getMessage()}");
+        report($exception);
+    }
+}

--- a/app/Http/Controllers/Dashboard/RentController.php
+++ b/app/Http/Controllers/Dashboard/RentController.php
@@ -166,7 +166,7 @@ class RentController extends Controller
                 'lease.unit.property',
                 'lineItems',
                 'payments' => fn ($q) => $q
-                    ->with(['confirmedBy:id,name', 'proofs'])
+                    ->with(['confirmedBy:id,name', 'proofs.media'])
                     ->latest('payment_date')
                     ->latest('id'),
             ]);

--- a/app/Http/Controllers/Dashboard/RentController.php
+++ b/app/Http/Controllers/Dashboard/RentController.php
@@ -382,7 +382,6 @@ class RentController extends Controller
                 'proofs' => $payment->proofs->map(fn (PaymentProof $proof) => [
                     'id' => $proof->id,
                     'payment_id' => $proof->payment_id,
-                    'path' => $proof->path,
                     'original_name' => $proof->original_name,
                     'mime_type' => $proof->mime_type,
                     'created_at' => DateTimeFormatter::iso($proof->created_at),

--- a/app/Http/Controllers/LeaseController.php
+++ b/app/Http/Controllers/LeaseController.php
@@ -57,7 +57,7 @@ class LeaseController extends Controller
             'primaryTenant:id,name,phone',
             'unit.property.city',
             'payments.confirmedBy:id,name',
-            'payments.proofs',
+            'payments.proofs.media',
             'payments.invoice:id,period_start,period_end,reference,status',
             'unitHistories.transferredBy:id,name',
         ]);
@@ -104,7 +104,7 @@ class LeaseController extends Controller
             ->defaultSort('-payment_date');
 
         $result = $table->paginate(
-            $lease->payments()->with(['confirmedBy:id,name', 'proofs', 'invoice:id,reference,period_start,period_end,status']),
+            $lease->payments()->with(['confirmedBy:id,name', 'proofs.media', 'invoice:id,reference,period_start,period_end,status']),
             $request,
             'payments',
         );
@@ -134,7 +134,7 @@ class LeaseController extends Controller
         $result = $table->paginate(
             PaymentProof::query()
                 ->whereHas('payment.invoice', fn ($q) => $q->where('lease_id', $lease->id))
-                ->with('payment:id,invoice_id,amount,status', 'payment.invoice:id,period_start'),
+                ->with('media', 'payment:id,invoice_id,amount,status', 'payment.invoice:id,period_start'),
             $request,
             'documents',
         );
@@ -153,7 +153,7 @@ class LeaseController extends Controller
         $unit->load('property.city');
 
         $leases = $unit->leases()
-            ->with(['tenants:id,name,phone', 'primaryTenant:id,name,phone', 'payments.confirmedBy:id,name', 'payments.proofs', 'payments.invoice:id,period_start,period_end,reference,status'])
+            ->with(['tenants:id,name,phone', 'primaryTenant:id,name,phone', 'payments.confirmedBy:id,name', 'payments.proofs.media', 'payments.invoice:id,period_start,period_end,reference,status'])
             ->withTrashed()
             ->orderBy('created_at', 'desc')
             ->get()
@@ -243,7 +243,7 @@ class LeaseController extends Controller
         $result = $table->paginate($query, $request, 'leases');
 
         $leases = $result['leases'];
-        $leases->loadMissing(['unit.property.city', 'payments.confirmedBy:id,name', 'payments.proofs', 'payments.invoice:id,period_start,period_end,reference,status']);
+        $leases->loadMissing(['unit.property.city', 'payments.confirmedBy:id,name', 'payments.proofs.media', 'payments.invoice:id,period_start,period_end,reference,status']);
 
         $availableUnits = Unit::query()
             ->with('property.city')

--- a/app/Http/Controllers/LeaseInvoiceController.php
+++ b/app/Http/Controllers/LeaseInvoiceController.php
@@ -72,7 +72,7 @@ class LeaseInvoiceController extends Controller
         $this->authorize('view', $lease);
 
         $invoice->loadMissing('lease.unit');
-        $invoice->load(['lineItems', 'payments.confirmedBy:id,name', 'payments.proofs']);
+        $invoice->load(['lineItems', 'payments.confirmedBy:id,name', 'payments.proofs.media']);
         $gatewayAttempts = $invoice->paymentAttempts()
             ->latest('id')
             ->get([

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -13,6 +13,7 @@ use App\Exceptions\PaymentOverflowException;
 use App\Http\Requests\Payment\StorePaymentRequest;
 use App\Models\Invoice;
 use App\Models\Lease;
+use App\Models\Media;
 use App\Models\Payment;
 use App\Models\PaymentProof;
 use App\Services\Payments\MoneyConverter;
@@ -77,13 +78,13 @@ class PaymentController extends Controller
         abort_if($proof->payment_id !== $payment->id, 404);
 
         if ($proof->media_id !== null) {
-            abort_if($proof->media === null, 404);
+            $media = $this->canonicalMedia($payment, $proof);
 
-            $storage = Storage::disk($proof->media->disk);
-            abort_unless($storage->exists($proof->media->path), 404);
+            $storage = Storage::disk($media->disk);
+            abort_unless($storage->exists($media->path), 404);
 
-            return $storage->response($proof->media->path, $proof->media->original_name, [
-                'Content-Type' => $proof->media->mime_type,
+            return $storage->response($media->path, $media->original_name, [
+                'Content-Type' => $media->mime_type,
             ]);
         }
 
@@ -93,6 +94,21 @@ class PaymentController extends Controller
         return $storage->response($proof->path, $proof->original_name, [
             'Content-Type' => $proof->mime_type,
         ]);
+    }
+
+    private function canonicalMedia(Payment $payment, PaymentProof $proof): Media
+    {
+        $media = $proof->media;
+
+        abort_if(
+            $media === null
+                || $media->mediable_type !== $payment->getMorphClass()
+                || (string) $media->mediable_id !== (string) $proof->payment_id
+                || $media->collection !== 'proofs',
+            404,
+        );
+
+        return $media;
     }
 
     public function __construct(

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -24,6 +24,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Inertia\Inertia;
 use OpenKOS\Core\Events\PaymentRecorded as PlatformPaymentRecorded;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class PaymentController extends Controller
 {
@@ -70,15 +71,28 @@ class PaymentController extends Controller
         return back();
     }
 
-    public function proof(Payment $payment, PaymentProof $proof)
+    public function proof(Payment $payment, PaymentProof $proof): StreamedResponse
     {
         $this->authorize('view', $payment);
+        abort_if($proof->payment_id !== $payment->id, 404);
 
-        if (! Storage::disk('local')->exists($proof->path)) {
-            abort(404);
+        if ($proof->media_id !== null) {
+            abort_if($proof->media === null, 404);
+
+            $storage = Storage::disk($proof->media->disk);
+            abort_unless($storage->exists($proof->media->path), 404);
+
+            return $storage->response($proof->media->path, $proof->media->original_name, [
+                'Content-Type' => $proof->media->mime_type,
+            ]);
         }
 
-        return Storage::disk('local')->response($proof->path);
+        $storage = Storage::disk('local');
+        abort_unless($storage->exists($proof->path), 404);
+
+        return $storage->response($proof->path, $proof->original_name, [
+            'Content-Type' => $proof->mime_type,
+        ]);
     }
 
     public function __construct(

--- a/app/Http/Controllers/TenantController.php
+++ b/app/Http/Controllers/TenantController.php
@@ -32,7 +32,7 @@ class TenantController extends Controller
 
         $tenant->load([
             'user:id,email,email_verified_at,last_login_at,is_active,invited_at',
-            'documents',
+            'documents.media',
             'leases' => fn ($q) => $q->where('status', 'active')
                 ->with(['unit.property', 'tenants:id,name,phone', 'primaryTenant:id,name,phone']),
         ])->loadCount(['leases as active_leases_count' => fn ($q) => $q->where('status', 'active')]);
@@ -92,7 +92,7 @@ class TenantController extends Controller
             ])
             ->defaultSort('-created_at');
 
-        $result = $table->paginate($tenant->documents(), $request, 'documents');
+        $result = $table->paginate($tenant->documents()->with('media'), $request, 'documents');
 
         return Inertia::render('tenants/documents', [
             ...$result,
@@ -159,7 +159,7 @@ class TenantController extends Controller
             : null;
 
         $query = Tenant::query()
-            ->with(['user:id,email,email_verified_at,last_login_at,is_active,invited_at', 'documents', 'leases' => fn ($q) => $q->where('status', 'active')->with(['unit.property', 'tenants:id,name,phone', 'primaryTenant:id,name,phone'])])
+            ->with(['user:id,email,email_verified_at,last_login_at,is_active,invited_at', 'documents.media', 'leases' => fn ($q) => $q->where('status', 'active')->with(['unit.property', 'tenants:id,name,phone', 'primaryTenant:id,name,phone'])])
             ->withCount(['leases as active_leases_count' => fn ($q) => $q->where('status', 'active')])
             ->when($assignedPropertyIds !== null, fn (Builder $q) => $q->whereHas(
                 'leases',

--- a/app/Http/Controllers/TenantDocumentController.php
+++ b/app/Http/Controllers/TenantDocumentController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\Tenant\StoreTenantDocumentRequest;
+use App\Models\Media;
 use App\Models\Tenant;
 use App\Models\TenantDocument;
 use App\Services\Media\MediaManager;
@@ -20,7 +21,8 @@ class TenantDocumentController extends Controller
         $file = $request->file('file');
 
         DB::transaction(function () use ($mediaManager, $tenant, $file, $request): void {
-            $media = $mediaManager->store($tenant, 'documents', $file);
+            // Keep compatibility-phase uploads readable by released code, which assumes local.
+            $media = $mediaManager->store($tenant, 'documents', $file, disk: 'local');
 
             $document = $tenant->documents()->make([
                 'media_id' => $media->id,
@@ -44,13 +46,13 @@ class TenantDocumentController extends Controller
         abort_if($document->tenant_id !== $tenant->id, 404);
 
         if ($document->media_id !== null) {
-            abort_if($document->media === null, 404);
+            $media = $this->canonicalMedia($tenant, $document);
 
-            $storage = Storage::disk($document->media->disk);
-            abort_unless($storage->exists($document->media->path), 404);
+            $storage = Storage::disk($media->disk);
+            abort_unless($storage->exists($media->path), 404);
 
-            return $storage->response($document->media->path, $document->media->original_name, [
-                'Content-Type' => $document->media->mime_type,
+            return $storage->response($media->path, $media->original_name, [
+                'Content-Type' => $media->mime_type,
             ]);
         }
 
@@ -68,15 +70,18 @@ class TenantDocumentController extends Controller
 
         abort_if($document->tenant_id !== $tenant->id, 404);
 
-        DB::transaction(function () use ($document, $mediaManager): void {
+        DB::transaction(function () use ($tenant, $document, $mediaManager): void {
             $media = $document->media;
             $legacyPath = $document->file_path;
             $hasCanonicalMedia = $document->media_id !== null;
 
+            if ($hasCanonicalMedia) {
+                $media = $this->canonicalMedia($tenant, $document);
+            }
+
             $document->deleteOrFail();
 
             if ($hasCanonicalMedia) {
-                abort_if($media === null, 404);
                 $mediaManager->remove($media);
 
                 return;
@@ -88,5 +93,20 @@ class TenantDocumentController extends Controller
         });
 
         return to_route('tenants.index');
+    }
+
+    private function canonicalMedia(Tenant $tenant, TenantDocument $document): Media
+    {
+        $media = $document->media;
+
+        abort_if(
+            $media === null
+                || $media->mediable_type !== $tenant->getMorphClass()
+                || (string) $media->mediable_id !== (string) $document->tenant_id
+                || $media->collection !== 'documents',
+            404,
+        );
+
+        return $media;
     }
 }

--- a/app/Http/Controllers/TenantDocumentController.php
+++ b/app/Http/Controllers/TenantDocumentController.php
@@ -5,33 +5,34 @@ namespace App\Http\Controllers;
 use App\Http\Requests\Tenant\StoreTenantDocumentRequest;
 use App\Models\Tenant;
 use App\Models\TenantDocument;
+use App\Services\Media\MediaManager;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
-use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class TenantDocumentController extends Controller
 {
-    public function store(StoreTenantDocumentRequest $request, Tenant $tenant): RedirectResponse
+    public function store(StoreTenantDocumentRequest $request, Tenant $tenant, MediaManager $mediaManager): RedirectResponse
     {
         $this->authorize('update', $tenant);
 
         $file = $request->file('file');
-        $extension = $file->getClientOriginalExtension();
-        $uuid = (string) Str::uuid();
-        $path = $file->storeAs(
-            'tenant-documents/'.$tenant->id,
-            $uuid.'.'.$extension,
-            'local'
-        );
 
-        $tenant->documents()->create([
-            'type' => $request->input('type'),
-            'original_name' => $file->getClientOriginalName(),
-            'file_path' => $path,
-            'mime_type' => $file->getMimeType(),
-            'size' => $file->getSize(),
-        ]);
+        DB::transaction(function () use ($mediaManager, $tenant, $file, $request): void {
+            $media = $mediaManager->store($tenant, 'documents', $file);
+
+            $document = $tenant->documents()->make([
+                'media_id' => $media->id,
+                'type' => $request->input('type'),
+                'original_name' => $media->original_name,
+                'mime_type' => $media->mime_type,
+                'size' => $media->size,
+            ]);
+
+            // Deprecated compatibility field; canonical storage is Media.
+            $document->forceFill(['file_path' => $media->path])->saveOrFail();
+        });
 
         return back();
     }
@@ -42,17 +43,49 @@ class TenantDocumentController extends Controller
 
         abort_if($document->tenant_id !== $tenant->id, 404);
 
-        return Storage::disk('local')->response($document->file_path, $document->original_name);
+        if ($document->media_id !== null) {
+            abort_if($document->media === null, 404);
+
+            $storage = Storage::disk($document->media->disk);
+            abort_unless($storage->exists($document->media->path), 404);
+
+            return $storage->response($document->media->path, $document->media->original_name, [
+                'Content-Type' => $document->media->mime_type,
+            ]);
+        }
+
+        $storage = Storage::disk('local');
+        abort_unless($storage->exists($document->file_path), 404);
+
+        return $storage->response($document->file_path, $document->original_name, [
+            'Content-Type' => $document->mime_type,
+        ]);
     }
 
-    public function destroy(Tenant $tenant, TenantDocument $document): RedirectResponse
+    public function destroy(Tenant $tenant, TenantDocument $document, MediaManager $mediaManager): RedirectResponse
     {
         $this->authorize('update', $tenant);
 
         abort_if($document->tenant_id !== $tenant->id, 404);
 
-        Storage::disk('local')->delete($document->file_path);
-        $document->delete();
+        DB::transaction(function () use ($document, $mediaManager): void {
+            $media = $document->media;
+            $legacyPath = $document->file_path;
+            $hasCanonicalMedia = $document->media_id !== null;
+
+            $document->deleteOrFail();
+
+            if ($hasCanonicalMedia) {
+                abort_if($media === null, 404);
+                $mediaManager->remove($media);
+
+                return;
+            }
+
+            DB::afterCommit(function () use ($legacyPath): void {
+                Storage::disk('local')->delete($legacyPath);
+            });
+        });
 
         return to_route('tenants.index');
     }

--- a/app/Models/Media.php
+++ b/app/Models/Media.php
@@ -23,6 +23,8 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 ])]
 class Media extends Model
 {
+    protected $hidden = ['disk', 'path'];
+
     /** @use HasFactory<MediaFactory> */
     use HasFactory, SerializesDatesWithTimezone;
 

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Concerns\Auditable;
+use App\Concerns\HasMedia;
 use App\Concerns\SerializesDatesWithTimezone;
 use App\Enums\PaymentStatus;
 use App\Services\Payments\MoneyConverter;
@@ -30,7 +31,7 @@ use LogicException;
 ])]
 class Payment extends Model
 {
-    use Auditable, HasFactory, SerializesDatesWithTimezone;
+    use Auditable, HasFactory, HasMedia, SerializesDatesWithTimezone;
 
     protected function casts(): array
     {

--- a/app/Models/PaymentProof.php
+++ b/app/Models/PaymentProof.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Concerns\SerializesDatesWithTimezone;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -15,7 +16,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 #[Fillable([
     'payment_id',
     'media_id',
-    'path',
     'original_name',
     'mime_type',
 ])]
@@ -33,5 +33,24 @@ class PaymentProof extends Model
     public function media(): BelongsTo
     {
         return $this->belongsTo(Media::class);
+    }
+
+    protected function originalName(): Attribute
+    {
+        return Attribute::get(fn (mixed $value): mixed => $this->canonicalValue('original_name', $value));
+    }
+
+    protected function mimeType(): Attribute
+    {
+        return Attribute::get(fn (mixed $value): mixed => $this->canonicalValue('mime_type', $value));
+    }
+
+    private function canonicalValue(string $attribute, mixed $legacyValue): mixed
+    {
+        if ($this->media_id === null) {
+            return $legacyValue;
+        }
+
+        return $this->relationLoaded('media') ? $this->media?->{$attribute} : null;
     }
 }

--- a/app/Models/PaymentProof.php
+++ b/app/Models/PaymentProof.php
@@ -8,8 +8,13 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+/**
+ * Legacy path is retained only for unmigrated rows and rollback.
+ * New code must use the linked Media record.
+ */
 #[Fillable([
     'payment_id',
+    'media_id',
     'path',
     'original_name',
     'mime_type',
@@ -18,8 +23,15 @@ class PaymentProof extends Model
 {
     use HasFactory, SerializesDatesWithTimezone;
 
+    protected $hidden = ['path', 'media_id'];
+
     public function payment(): BelongsTo
     {
         return $this->belongsTo(Payment::class);
+    }
+
+    public function media(): BelongsTo
+    {
+        return $this->belongsTo(Media::class);
     }
 }

--- a/app/Models/Tenant.php
+++ b/app/Models/Tenant.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Concerns\Auditable;
+use App\Concerns\HasMedia;
 use App\Concerns\SerializesDatesWithTimezone;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -26,7 +27,7 @@ use Illuminate\Notifications\Notification;
 ])]
 class Tenant extends Model
 {
-    use Auditable, HasFactory, Notifiable, SerializesDatesWithTimezone, SoftDeletes;
+    use Auditable, HasFactory, HasMedia, Notifiable, SerializesDatesWithTimezone, SoftDeletes;
 
     protected array $auditableMask = ['phone', 'id_card_number', 'emergency_contact_phone'];
 

--- a/app/Models/TenantDocument.php
+++ b/app/Models/TenantDocument.php
@@ -4,15 +4,28 @@ namespace App\Models;
 
 use App\Concerns\SerializesDatesWithTimezone;
 use App\Enums\TenantDocumentType;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+/**
+ * Legacy file_path is retained only for unmigrated rows and rollback.
+ * New code must use the linked Media record.
+ */
 class TenantDocument extends Model
 {
     use SerializesDatesWithTimezone;
 
+    protected $hidden = ['file_path', 'media_id'];
+
+    protected $appends = ['download_url'];
+
+    /**
+     * `file_path` remains fillable only for compatibility writes and rollback.
+     */
     protected $fillable = [
         'tenant_id',
+        'media_id',
         'type',
         'original_name',
         'file_path',
@@ -33,11 +46,16 @@ class TenantDocument extends Model
         return $this->belongsTo(Tenant::class);
     }
 
-    public function downloadUrl(): string
+    public function media(): BelongsTo
     {
-        return route('tenants.documents.show', [
+        return $this->belongsTo(Media::class);
+    }
+
+    protected function downloadUrl(): Attribute
+    {
+        return Attribute::get(fn (): string => route('tenants.documents.show', [
             'tenant' => $this->tenant_id,
             'document' => $this->id,
-        ]);
+        ]));
     }
 }

--- a/app/Models/TenantDocument.php
+++ b/app/Models/TenantDocument.php
@@ -21,14 +21,13 @@ class TenantDocument extends Model
     protected $appends = ['download_url'];
 
     /**
-     * `file_path` remains fillable only for compatibility writes and rollback.
+     * Legacy storage coordinates are written only through explicit compatibility paths.
      */
     protected $fillable = [
         'tenant_id',
         'media_id',
         'type',
         'original_name',
-        'file_path',
         'mime_type',
         'size',
     ];
@@ -57,5 +56,29 @@ class TenantDocument extends Model
             'tenant' => $this->tenant_id,
             'document' => $this->id,
         ]));
+    }
+
+    protected function originalName(): Attribute
+    {
+        return Attribute::get(fn (mixed $value): mixed => $this->canonicalValue('original_name', $value));
+    }
+
+    protected function mimeType(): Attribute
+    {
+        return Attribute::get(fn (mixed $value): mixed => $this->canonicalValue('mime_type', $value));
+    }
+
+    protected function size(): Attribute
+    {
+        return Attribute::get(fn (mixed $value): mixed => $this->canonicalValue('size', $value));
+    }
+
+    private function canonicalValue(string $attribute, mixed $legacyValue): mixed
+    {
+        if ($this->media_id === null) {
+            return $legacyValue;
+        }
+
+        return $this->relationLoaded('media') ? $this->media?->{$attribute} : null;
     }
 }

--- a/database/migrations/2026_08_23_120349_add_media_id_to_legacy_uploads_table.php
+++ b/database/migrations/2026_08_23_120349_add_media_id_to_legacy_uploads_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        foreach (['tenant_documents', 'payment_proofs'] as $tableName) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->foreignId('media_id')
+                    ->nullable()
+                    ->after('id')
+                    ->constrained('media')
+                    ->restrictOnDelete();
+                $table->index('media_id');
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        foreach (['tenant_documents', 'payment_proofs'] as $tableName) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->dropForeign(['media_id']);
+                $table->dropIndex(['media_id']);
+                $table->dropColumn('media_id');
+            });
+        }
+    }
+};

--- a/resources/js/pages/leases/documents.tsx
+++ b/resources/js/pages/leases/documents.tsx
@@ -2,6 +2,7 @@ import type { TableColumn } from '@/components/data-table';
 import { PluginRegion } from '@/components/shared/plugin-region';
 import { WorkspaceTable } from '@/components/shared/workspace-table';
 import { formatDate, formatPeriod } from '@/lib/formatters';
+import paymentRoutes from '@/routes/payments';
 import type {
     PaginatedData,
     ProofRow,
@@ -18,7 +19,10 @@ const columns: TableColumn<ProofRow>[] = [
         className: 'font-medium',
         render: (d) => (
             <a
-                href={`/payments/${d.payment_id}/proof/${d.id}`}
+                href={paymentRoutes.proof.url({
+                    payment: d.payment_id,
+                    proof: d.id,
+                })}
                 target="_blank"
                 rel="noreferrer"
                 onClick={(e) => e.stopPropagation()}

--- a/resources/js/types/models.ts
+++ b/resources/js/types/models.ts
@@ -229,7 +229,6 @@ export type LeaseData = {
 export type PaymentProof = {
     id: number;
     payment_id: number;
-    path: string;
     original_name: string;
     mime_type: string;
     created_at: string;

--- a/tests/Feature/LegacyMediaMigrationTest.php
+++ b/tests/Feature/LegacyMediaMigrationTest.php
@@ -1,0 +1,148 @@
+<?php
+
+use App\Models\Media;
+use App\Models\Payment;
+use App\Models\PaymentProof;
+use App\Models\Tenant;
+use App\Models\TenantDocument;
+use Illuminate\Support\Facades\Storage;
+
+beforeEach(function (): void {
+    Storage::fake('local');
+    config(['filesystems.default' => 'local']);
+});
+
+it('backfills tenant documents and payment proofs without copying bytes', function (): void {
+    $tenant = Tenant::factory()->create();
+    $tenantPath = 'tenant-documents/'.$tenant->id.'/legacy.pdf';
+    Storage::disk('local')->put($tenantPath, 'tenant document');
+    $document = TenantDocument::create([
+        'tenant_id' => $tenant->id,
+        'type' => 'ktp',
+        'original_name' => 'identity.pdf',
+        'file_path' => $tenantPath,
+        'mime_type' => 'application/pdf',
+        'size' => 15,
+    ]);
+
+    $payment = Payment::factory()->create();
+    $proofPath = 'payment-proofs/'.$payment->id.'/legacy.jpg';
+    Storage::disk('local')->put($proofPath, 'payment proof');
+    $proof = PaymentProof::create([
+        'payment_id' => $payment->id,
+        'path' => $proofPath,
+        'original_name' => 'receipt.jpg',
+        'mime_type' => 'image/jpeg',
+    ]);
+
+    $this->artisan('media:migrate-legacy')
+        ->assertExitCode(0);
+
+    $document->refresh();
+    $proof->refresh();
+
+    expect($document->media_id)->not->toBeNull()
+        ->and($document->media->mediable->is($tenant))->toBeTrue()
+        ->and($document->media->collection)->toBe('documents')
+        ->and($document->media->path)->toBe($tenantPath)
+        ->and($proof->media_id)->not->toBeNull()
+        ->and($proof->media->mediable->is($payment))->toBeTrue()
+        ->and($proof->media->collection)->toBe('proofs')
+        ->and($proof->media->path)->toBe($proofPath)
+        ->and(Media::query()->count())->toBe(2);
+
+    Storage::disk('local')->assertExists($tenantPath);
+    Storage::disk('local')->assertExists($proofPath);
+
+    $this->artisan('media:migrate-legacy')
+        ->assertExitCode(0);
+
+    expect(Media::query()->count())->toBe(2);
+});
+
+it('preserves a canonical row and reports a missing legacy file', function (): void {
+    $tenant = Tenant::factory()->create();
+    $document = TenantDocument::create([
+        'tenant_id' => $tenant->id,
+        'type' => 'passport',
+        'original_name' => 'missing.pdf',
+        'file_path' => 'tenant-documents/missing.pdf',
+        'mime_type' => 'application/pdf',
+        'size' => 42,
+    ]);
+
+    $this->artisan('media:migrate-legacy')
+        ->expectsOutputToContain('missing=1')
+        ->assertExitCode(0);
+
+    $document->refresh();
+
+    expect($document->media->metadata)->toMatchArray([
+        'legacy' => [
+            'table' => 'tenant_documents',
+            'id' => $document->id,
+            'missing_file' => true,
+        ],
+    ]);
+});
+
+it('uses a populated media pointer as the primary idempotency signal', function (): void {
+    $tenant = Tenant::factory()->create();
+    $media = Media::create([
+        'mediable_type' => $tenant->getMorphClass(),
+        'mediable_id' => $tenant->id,
+        'collection' => 'documents',
+        'disk' => 'local',
+        'path' => 'media/canonical.pdf',
+        'mime_type' => 'application/pdf',
+        'size' => 10,
+        'original_name' => 'canonical.pdf',
+        'position' => 0,
+    ]);
+    $document = TenantDocument::create([
+        'tenant_id' => $tenant->id,
+        'media_id' => $media->id,
+        'type' => 'other',
+        'original_name' => 'legacy.pdf',
+        'file_path' => 'tenant-documents/legacy.pdf',
+        'mime_type' => 'application/pdf',
+        'size' => 10,
+    ]);
+
+    $this->artisan('media:migrate-legacy')
+        ->assertExitCode(0);
+
+    expect(Media::query()->count())->toBe(1)
+        ->and($document->fresh()->media_id)->toBe($media->id);
+});
+
+it('fails instead of guessing when recovery finds multiple media rows', function (): void {
+    $tenant = Tenant::factory()->create();
+    $attributes = [
+        'mediable_type' => $tenant->getMorphClass(),
+        'mediable_id' => $tenant->id,
+        'collection' => 'documents',
+        'disk' => 'local',
+        'path' => 'tenant-documents/duplicate.pdf',
+        'mime_type' => 'application/pdf',
+        'size' => 10,
+        'original_name' => 'duplicate.pdf',
+        'position' => 0,
+    ];
+    Media::create($attributes);
+    Media::create($attributes);
+    $document = TenantDocument::create([
+        'tenant_id' => $tenant->id,
+        'type' => 'other',
+        'original_name' => 'duplicate.pdf',
+        'file_path' => $attributes['path'],
+        'mime_type' => 'application/pdf',
+        'size' => 10,
+    ]);
+
+    $this->artisan('media:migrate-legacy')
+        ->expectsOutputToContain('failed=1')
+        ->assertExitCode(1);
+
+    expect($document->fresh()->media_id)->toBeNull();
+});

--- a/tests/Feature/LegacyMediaMigrationTest.php
+++ b/tests/Feature/LegacyMediaMigrationTest.php
@@ -16,7 +16,7 @@ it('backfills tenant documents and payment proofs without copying bytes', functi
     $tenant = Tenant::factory()->create();
     $tenantPath = 'tenant-documents/'.$tenant->id.'/legacy.pdf';
     Storage::disk('local')->put($tenantPath, 'tenant document');
-    $document = TenantDocument::create([
+    $document = TenantDocument::forceCreate([
         'tenant_id' => $tenant->id,
         'type' => 'ktp',
         'original_name' => 'identity.pdf',
@@ -28,7 +28,7 @@ it('backfills tenant documents and payment proofs without copying bytes', functi
     $payment = Payment::factory()->create();
     $proofPath = 'payment-proofs/'.$payment->id.'/legacy.jpg';
     Storage::disk('local')->put($proofPath, 'payment proof');
-    $proof = PaymentProof::create([
+    $proof = PaymentProof::forceCreate([
         'payment_id' => $payment->id,
         'path' => $proofPath,
         'original_name' => 'receipt.jpg',
@@ -62,7 +62,7 @@ it('backfills tenant documents and payment proofs without copying bytes', functi
 
 it('preserves a canonical row and reports a missing legacy file', function (): void {
     $tenant = Tenant::factory()->create();
-    $document = TenantDocument::create([
+    $document = TenantDocument::forceCreate([
         'tenant_id' => $tenant->id,
         'type' => 'passport',
         'original_name' => 'missing.pdf',
@@ -86,6 +86,99 @@ it('preserves a canonical row and reports a missing legacy file', function (): v
     ]);
 });
 
+it('reports a missing file when recovering an existing canonical row', function (): void {
+    $tenant = Tenant::factory()->create();
+    $path = 'tenant-documents/recovered-missing.pdf';
+    $media = Media::create([
+        'mediable_type' => $tenant->getMorphClass(),
+        'mediable_id' => $tenant->id,
+        'collection' => 'documents',
+        'disk' => 'local',
+        'path' => $path,
+        'mime_type' => 'application/pdf',
+        'size' => 42,
+        'original_name' => 'canonical.pdf',
+        'position' => 0,
+    ]);
+    $document = TenantDocument::forceCreate([
+        'tenant_id' => $tenant->id,
+        'media_id' => $media->id,
+        'type' => 'passport',
+        'original_name' => 'legacy.pdf',
+        'file_path' => $path,
+        'mime_type' => 'application/pdf',
+        'size' => 42,
+    ]);
+
+    // Clear the pointer so the command exercises recovery rather than idempotency.
+    $document->forceFill(['media_id' => null])->saveOrFail();
+
+    $this->artisan('media:migrate-legacy')
+        ->expectsOutputToContain('missing=1')
+        ->assertExitCode(0);
+
+    expect($media->fresh()->metadata)->toMatchArray([
+        'legacy' => [
+            'table' => 'tenant_documents',
+            'id' => $document->id,
+            'missing_file' => true,
+        ],
+    ]);
+});
+
+it('uses canonical metadata after migration', function (): void {
+    $tenant = Tenant::factory()->create();
+    $path = 'tenant-documents/canonical.pdf';
+    Storage::disk('local')->put($path, 'canonical file');
+    $media = Media::create([
+        'mediable_type' => $tenant->getMorphClass(),
+        'mediable_id' => $tenant->id,
+        'collection' => 'documents',
+        'disk' => 'local',
+        'path' => $path,
+        'mime_type' => 'application/pdf',
+        'size' => 42,
+        'original_name' => 'canonical.pdf',
+        'position' => 0,
+    ]);
+    $document = TenantDocument::forceCreate([
+        'tenant_id' => $tenant->id,
+        'type' => 'passport',
+        'original_name' => 'legacy.txt',
+        'file_path' => $path,
+        'mime_type' => 'text/plain',
+        'size' => 1,
+    ]);
+
+    $this->artisan('media:migrate-legacy')->assertExitCode(0);
+
+    $document = $document->fresh()->load('media');
+
+    expect($document->media_id)->toBe($media->id)
+        ->and($document->original_name)->toBe('canonical.pdf')
+        ->and($document->mime_type)->toBe('application/pdf')
+        ->and($document->size)->toBe(42);
+});
+
+it('backfills documents for soft-deleted tenants', function (): void {
+    $tenant = Tenant::factory()->create();
+    $tenant->delete();
+    $path = 'tenant-documents/archived.pdf';
+    Storage::disk('local')->put($path, 'archived document');
+    $document = TenantDocument::forceCreate([
+        'tenant_id' => $tenant->id,
+        'type' => 'other',
+        'original_name' => 'archived.pdf',
+        'file_path' => $path,
+        'mime_type' => 'application/pdf',
+        'size' => 17,
+    ]);
+
+    $this->artisan('media:migrate-legacy')->assertExitCode(0);
+
+    expect($document->fresh()->media_id)->not->toBeNull();
+});
+
 it('uses a populated media pointer as the primary idempotency signal', function (): void {
     $tenant = Tenant::factory()->create();
     $media = Media::create([
@@ -99,7 +192,7 @@ it('uses a populated media pointer as the primary idempotency signal', function 
         'original_name' => 'canonical.pdf',
         'position' => 0,
     ]);
-    $document = TenantDocument::create([
+    $document = TenantDocument::forceCreate([
         'tenant_id' => $tenant->id,
         'media_id' => $media->id,
         'type' => 'other',
@@ -131,7 +224,7 @@ it('fails instead of guessing when recovery finds multiple media rows', function
     ];
     Media::create($attributes);
     Media::create($attributes);
-    $document = TenantDocument::create([
+    $document = TenantDocument::forceCreate([
         'tenant_id' => $tenant->id,
         'type' => 'other',
         'original_name' => 'duplicate.pdf',

--- a/tests/Feature/MediaTest.php
+++ b/tests/Feature/MediaTest.php
@@ -70,6 +70,17 @@ it('uses the configured default filesystem disk', function () {
     Storage::disk('public')->assertExists($media->path);
 });
 
+it('does not serialize storage coordinates', function () {
+    $property = Property::factory()->create();
+    $media = app(MediaManager::class)->store(
+        $property,
+        'photos',
+        UploadedFile::fake()->create('front-house.jpg', 1, 'image/jpeg'),
+    );
+
+    expect($media->toArray())->not->toHaveKeys(['disk', 'path']);
+});
+
 it('retrieves and reorders media within an owner collection', function () {
     $property = Property::factory()->create();
     $manager = app(MediaManager::class);

--- a/tests/Feature/PaymentTest.php
+++ b/tests/Feature/PaymentTest.php
@@ -5,6 +5,7 @@ use App\Enums\PaymentStatus;
 use App\Enums\Permission;
 use App\Models\Invoice;
 use App\Models\Lease;
+use App\Models\Media;
 use App\Models\Payment;
 use App\Models\PaymentAllocation;
 use App\Models\PaymentProof;
@@ -490,5 +491,38 @@ describe('proof download', function () {
         $this->actingAs($user)
             ->get(route('payments.proof', [$payment, $proof]))
             ->assertNotFound();
+    });
+
+    it('does not fall back to the legacy path after canonical migration', function () {
+        $user = User::factory()->owner()->create();
+        $lease = createLeaseForProperty();
+        $invoice = createInvoiceFor($lease);
+        $payment = Payment::factory()->create(['invoice_id' => $invoice->id]);
+        $canonicalPath = 'media/missing-proof.pdf';
+        $legacyPath = 'proofs/legacy-proof.pdf';
+        File::makeDirectory(dirname(storage_path('app/private/'.$legacyPath)), 0755, true, true);
+        File::put(storage_path('app/private/'.$legacyPath), 'legacy content');
+        $media = Media::create([
+            'mediable_type' => $payment->getMorphClass(),
+            'mediable_id' => $payment->id,
+            'collection' => 'proofs',
+            'disk' => 'local',
+            'path' => $canonicalPath,
+            'mime_type' => 'application/pdf',
+            'size' => 10,
+            'original_name' => 'proof.pdf',
+            'position' => 0,
+        ]);
+        $proof = PaymentProof::factory()->create([
+            'payment_id' => $payment->id,
+            'media_id' => $media->id,
+            'path' => $legacyPath,
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('payments.proof', [$payment, $proof]))
+            ->assertNotFound();
+
+        File::delete(storage_path('app/private/'.$legacyPath));
     });
 });

--- a/tests/Feature/PaymentTest.php
+++ b/tests/Feature/PaymentTest.php
@@ -16,8 +16,10 @@ use App\Models\User;
 use Database\Seeders\RegionAndCitySeeder;
 use Database\Seeders\RoleAndPermissionSeeder;
 use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
 
 uses()->beforeEach(function () {
     $this->seed(RoleAndPermissionSeeder::class);
@@ -265,6 +267,28 @@ describe('payment recording', function () {
         expect((int) $payment->verified_by)->toBe((int) $user->id);
         expect($payment->verified_at)->not->toBeNull();
         expect($payment->status)->toBe(PaymentStatus::Confirmed);
+    });
+
+    it('keeps compatibility-phase proof uploads on the local disk', function () {
+        Storage::fake('local');
+        Storage::fake('public');
+        config(['filesystems.default' => 'public']);
+        $user = User::factory()->owner()->create();
+        $lease = createLeaseForProperty();
+        $invoice = createInvoiceFor($lease);
+
+        $this->actingAs($user)
+            ->post(route('leases.payments.store', $lease), paymentPayload($invoice, [
+                'payment_method' => 'transfer',
+                'proof' => UploadedFile::fake()->image('receipt.jpg'),
+            ]))
+            ->assertRedirect();
+
+        $proof = $invoice->payments()->sole()->proofs()->sole();
+
+        expect($proof->media->disk)->toBe('local');
+        Storage::disk('local')->assertExists($proof->media->path);
+        expect(Storage::disk('public')->allFiles())->toBeEmpty();
     });
 });
 
@@ -524,5 +548,33 @@ describe('proof download', function () {
             ->assertNotFound();
 
         File::delete(storage_path('app/private/'.$legacyPath));
+    });
+
+    it('fails closed when canonical media belongs to another payment', function () {
+        $user = User::factory()->owner()->create();
+        $lease = createLeaseForProperty();
+        $invoice = createInvoiceFor($lease);
+        $payment = Payment::factory()->create(['invoice_id' => $invoice->id]);
+        $otherPayment = Payment::factory()->create(['invoice_id' => $invoice->id]);
+        $media = Media::create([
+            'mediable_type' => $otherPayment->getMorphClass(),
+            'mediable_id' => $otherPayment->id,
+            'collection' => 'proofs',
+            'disk' => 'local',
+            'path' => 'media/foreign-proof.pdf',
+            'mime_type' => 'application/pdf',
+            'size' => 10,
+            'original_name' => 'foreign-proof.pdf',
+            'position' => 0,
+        ]);
+        $proof = PaymentProof::factory()->create([
+            'payment_id' => $payment->id,
+            'media_id' => $media->id,
+            'path' => 'proofs/legacy-proof.pdf',
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('payments.proof', [$payment, $proof]))
+            ->assertNotFound();
     });
 });

--- a/tests/Feature/RentDashboardTest.php
+++ b/tests/Feature/RentDashboardTest.php
@@ -5,6 +5,7 @@ use App\Enums\PaymentStatus;
 use App\Models\Invoice;
 use App\Models\InvoiceLineItem;
 use App\Models\Lease;
+use App\Models\Media;
 use App\Models\Payment;
 use App\Models\PaymentProof;
 use App\Models\Property;
@@ -87,10 +88,23 @@ test('collection queue includes invoice detail payload', function () {
         'status' => PaymentStatus::Pending,
     ]);
 
-    PaymentProof::factory()->create([
+    $proof = PaymentProof::factory()->create([
         'payment_id' => $payment->id,
-        'original_name' => 'receipt.png',
+        'original_name' => 'legacy.txt',
+        'mime_type' => 'text/plain',
     ]);
+    $media = Media::create([
+        'mediable_type' => $payment->getMorphClass(),
+        'mediable_id' => $payment->id,
+        'collection' => 'proofs',
+        'disk' => 'local',
+        'path' => 'media/receipt.png',
+        'mime_type' => 'image/png',
+        'size' => 42,
+        'original_name' => 'receipt.png',
+        'position' => 0,
+    ]);
+    $proof->forceFill(['media_id' => $media->id])->saveOrFail();
 
     $this->actingAs($user)
         ->get(route('dashboard.rent'))
@@ -100,6 +114,7 @@ test('collection queue includes invoice detail payload', function () {
             ->where('entries.data.0.line_items.0.description', 'Monthly Rent')
             ->where('entries.data.0.payments.0.amount', '250000.000')
             ->where('entries.data.0.payments.0.proofs.0.original_name', 'receipt.png')
+            ->where('entries.data.0.payments.0.proofs.0.mime_type', 'image/png')
         );
 
     Carbon::setTestNow();

--- a/tests/Feature/Schema/ForeignKeyDeleteStrategyTest.php
+++ b/tests/Feature/Schema/ForeignKeyDeleteStrategyTest.php
@@ -25,7 +25,7 @@ $expected = [
         'transferred_by' => 'SET NULL',
     ],
     'reminder_logs' => ['lease_id' => 'RESTRICT'],
-    'tenant_documents' => ['tenant_id' => 'RESTRICT'],
+    'tenant_documents' => ['tenant_id' => 'RESTRICT', 'media_id' => 'RESTRICT'],
     'unit_rates' => ['unit_id' => 'RESTRICT'],
     'maintenance_tickets' => [
         'property_id' => 'RESTRICT',
@@ -50,7 +50,7 @@ $expected = [
     'model_has_roles' => ['role_id' => 'CASCADE'],
     'role_has_permissions' => ['permission_id' => 'CASCADE', 'role_id' => 'CASCADE'],
     'property_user' => ['user_id' => 'CASCADE', 'property_id' => 'CASCADE'],
-    'payment_proofs' => ['payment_id' => 'CASCADE'],
+    'payment_proofs' => ['payment_id' => 'CASCADE', 'media_id' => 'RESTRICT'],
 ];
 
 $appTables = array_keys($expected);

--- a/tests/Feature/TenantDocumentTest.php
+++ b/tests/Feature/TenantDocumentTest.php
@@ -52,6 +52,25 @@ it('stores new tenant documents through canonical media', function (): void {
     Storage::disk('local')->assertExists($document->media->path);
 });
 
+it('keeps compatibility-phase tenant uploads on the local disk', function (): void {
+    [$owner, $tenant] = tenantDocumentOwner();
+    Storage::fake('public');
+    config(['filesystems.default' => 'public']);
+
+    $this->actingAs($owner)
+        ->post(route('tenants.documents.store', $tenant), [
+            'type' => 'ktp',
+            'file' => UploadedFile::fake()->create('identity.pdf', 2, 'application/pdf'),
+        ])
+        ->assertRedirect();
+
+    $document = $tenant->documents()->sole();
+
+    expect($document->media->disk)->toBe('local');
+    Storage::disk('local')->assertExists($document->media->path);
+    expect(Storage::disk('public')->allFiles())->toBeEmpty();
+});
+
 it('never falls back to the legacy path after a canonical link exists', function (): void {
     [$owner, $tenant] = tenantDocumentOwner();
     $legacyPath = 'tenant-documents/legacy.pdf';
@@ -67,12 +86,41 @@ it('never falls back to the legacy path after a canonical link exists', function
         'original_name' => 'canonical.pdf',
         'position' => 0,
     ]);
-    $document = TenantDocument::create([
+    $document = TenantDocument::forceCreate([
         'tenant_id' => $tenant->id,
         'media_id' => $media->id,
         'type' => 'other',
         'original_name' => 'legacy.pdf',
         'file_path' => $legacyPath,
+        'mime_type' => 'application/pdf',
+        'size' => 10,
+    ]);
+
+    $this->actingAs($owner)
+        ->get(route('tenants.documents.show', [$tenant, $document]))
+        ->assertNotFound();
+});
+
+it('fails closed when canonical media belongs to another tenant', function (): void {
+    [$owner, $tenant] = tenantDocumentOwner();
+    $otherTenant = Tenant::factory()->create();
+    $media = Media::create([
+        'mediable_type' => $otherTenant->getMorphClass(),
+        'mediable_id' => $otherTenant->id,
+        'collection' => 'documents',
+        'disk' => 'local',
+        'path' => 'media/foreign.pdf',
+        'mime_type' => 'application/pdf',
+        'size' => 10,
+        'original_name' => 'foreign.pdf',
+        'position' => 0,
+    ]);
+    $document = TenantDocument::forceCreate([
+        'tenant_id' => $tenant->id,
+        'media_id' => $media->id,
+        'type' => 'other',
+        'original_name' => 'legacy.pdf',
+        'file_path' => 'tenant-documents/legacy.pdf',
         'mime_type' => 'application/pdf',
         'size' => 10,
     ]);

--- a/tests/Feature/TenantDocumentTest.php
+++ b/tests/Feature/TenantDocumentTest.php
@@ -1,0 +1,83 @@
+<?php
+
+use App\Models\Lease;
+use App\Models\Media;
+use App\Models\Property;
+use App\Models\Tenant;
+use App\Models\TenantDocument;
+use App\Models\Unit;
+use App\Models\User;
+use Database\Seeders\RoleAndPermissionSeeder;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+uses()->beforeEach(function (): void {
+    $this->seed(RoleAndPermissionSeeder::class);
+    Storage::fake('local');
+    config(['filesystems.default' => 'local']);
+});
+
+function tenantDocumentOwner(): array
+{
+    $owner = User::factory()->owner()->create();
+    $property = Property::factory()->create();
+    $owner->properties()->sync([$property->id]);
+    $unit = Unit::factory()->for($property)->create();
+    $tenant = Tenant::factory()->create();
+    Lease::factory()->create([
+        'unit_id' => $unit->id,
+        'primary_tenant_id' => $tenant->id,
+    ]);
+
+    return [$owner, $tenant];
+}
+
+it('stores new tenant documents through canonical media', function (): void {
+    [$owner, $tenant] = tenantDocumentOwner();
+
+    $this->actingAs($owner)
+        ->post(route('tenants.documents.store', $tenant), [
+            'type' => 'ktp',
+            'file' => UploadedFile::fake()->create('identity.pdf', 2, 'application/pdf'),
+        ])
+        ->assertRedirect();
+
+    $document = $tenant->documents()->sole();
+
+    expect($document->media_id)->not->toBeNull()
+        ->and($document->media->mediable->is($tenant))->toBeTrue()
+        ->and($document->media->collection)->toBe('documents')
+        ->and($document->file_path)->toBe($document->media->path);
+
+    Storage::disk('local')->assertExists($document->media->path);
+});
+
+it('never falls back to the legacy path after a canonical link exists', function (): void {
+    [$owner, $tenant] = tenantDocumentOwner();
+    $legacyPath = 'tenant-documents/legacy.pdf';
+    Storage::disk('local')->put($legacyPath, 'legacy file');
+    $media = Media::create([
+        'mediable_type' => $tenant->getMorphClass(),
+        'mediable_id' => $tenant->id,
+        'collection' => 'documents',
+        'disk' => 'local',
+        'path' => 'media/missing.pdf',
+        'mime_type' => 'application/pdf',
+        'size' => 10,
+        'original_name' => 'canonical.pdf',
+        'position' => 0,
+    ]);
+    $document = TenantDocument::create([
+        'tenant_id' => $tenant->id,
+        'media_id' => $media->id,
+        'type' => 'other',
+        'original_name' => 'legacy.pdf',
+        'file_path' => $legacyPath,
+        'mime_type' => 'application/pdf',
+        'size' => 10,
+    ]);
+
+    $this->actingAs($owner)
+        ->get(route('tenants.documents.show', [$tenant, $document]))
+        ->assertNotFound();
+});

--- a/tests/Feature/TenantPortalTest.php
+++ b/tests/Feature/TenantPortalTest.php
@@ -6,6 +6,7 @@ use App\Enums\PaymentStatus;
 use App\Models\Invoice;
 use App\Models\Lease;
 use App\Models\LeaseUnitHistory;
+use App\Models\Media;
 use App\Models\Payment;
 use App\Models\PaymentAttempt;
 use App\Models\Tenant;
@@ -670,14 +671,18 @@ test('tenant submits a pending invoice payment for verification', function () {
 
     $payment = $invoice->payments()->sole();
 
+    $proof = $payment->proofs->sole();
+
     expect($payment->status)->toBe(PaymentStatus::Pending)
         ->and($payment->recorded_by)->toBe($tenantUser->id)
         ->and($payment->confirmed_by)->toBeNull()
         ->and($payment->proofs)->toHaveCount(1)
+        ->and($proof->media_id)->not->toBeNull()
+        ->and($proof->media->is(Media::query()->find($proof->media_id)))->toBeTrue()
         ->and($invoice->fresh()->amount_paid)->toBe('0.000')
         ->and($invoice->fresh()->status)->toBe(InvoiceStatus::Pending);
 
-    Storage::disk('local')->assertExists($payment->proofs->sole()->path);
+    Storage::disk($proof->media->disk)->assertExists($proof->media->path);
 
     $this->actingAs($tenantUser)
         ->post(route('portal.billing.store'), [


### PR DESCRIPTION
## Summary

- Add canonical Media links for legacy tenant documents and payment proofs.
- Harden canonical ownership checks, migration recovery, and compatibility-disk behavior.
- Hide storage coordinates and prefer canonical metadata in serialized payloads.

## Tests

- `php artisan test --compact` — 939 passed, 1 skipped
- `vendor/bin/pint --dirty --format agent`

Refs OPE-165