### PR TITLE
fix(reminders): add signed WhatsApp links

### DIFF
--- a/app/Notifications/RentReminder.php
+++ b/app/Notifications/RentReminder.php
@@ -12,6 +12,7 @@ use App\Notifications\Channels\MailChannel;
 use App\Notifications\Channels\WhatsAppChannel;
 use App\Services\Invoices\InvoicePdfArtifact;
 use App\Services\Payments\MoneyConverter;
+use App\Services\Payments\SignedInvoicePaymentLink;
 use Carbon\Carbon;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -125,7 +126,7 @@ class RentReminder extends Notification implements MailChannelNotification, Shou
         }
 
         return new WhatsAppContent(
-            message: $this->renderMessage($notifiable),
+            message: $this->renderMessage($notifiable, useSignedInvoiceLink: true),
             attachment: $attachment,
         );
     }
@@ -157,10 +158,10 @@ class RentReminder extends Notification implements MailChannelNotification, Shou
 
     public function toWhatsApp(object $notifiable): string
     {
-        return $this->renderMessage($notifiable);
+        return $this->renderMessage($notifiable, useSignedInvoiceLink: true);
     }
 
-    private function renderMessage(object $notifiable): string
+    private function renderMessage(object $notifiable, bool $useSignedInvoiceLink = false): string
     {
         $days = $this->event->overdueDays
             ?? (int) now()->startOfDay()->diffInDays(Carbon::parse($this->event->dueDate), false);
@@ -189,7 +190,7 @@ class RentReminder extends Notification implements MailChannelNotification, Shou
                 'amount' => $amount,
             ])
             : '';
-        $invoiceUrl = $this->invoiceUrl($notifiable);
+        $invoiceUrl = $this->invoiceUrl($notifiable, $useSignedInvoiceLink);
         $invoiceLink = $invoiceUrl
             ? __('notifications.rent.view_invoice').': '.$invoiceUrl
             : '';
@@ -218,9 +219,16 @@ class RentReminder extends Notification implements MailChannelNotification, Shou
         return isset($this->event->invoice) ? $this->event->invoice : null;
     }
 
-    private function invoiceUrl(object $notifiable): ?string
+    private function invoiceUrl(object $notifiable, bool $useSignedInvoiceLink = false): ?string
     {
-        return $this->portalUrl($notifiable, $this->invoice());
+        $invoice = $this->invoice();
+        $portalUrl = $this->portalUrl($notifiable, $invoice);
+
+        if ($portalUrl || ! $useSignedInvoiceLink || ! $invoice || ! ($notifiable instanceof Tenant)) {
+            return $portalUrl;
+        }
+
+        return app(SignedInvoicePaymentLink::class)->url($invoice);
     }
 
     private function portalUrl(object $notifiable, ?Invoice $invoice = null): ?string

--- a/tests/Feature/SendRentRemindersTest.php
+++ b/tests/Feature/SendRentRemindersTest.php
@@ -512,7 +512,7 @@ describe('SendRentRemindersAction', function () {
         Carbon::setTestNow();
     });
 
-    it('includes invoice context without a portal link for whatsapp-only tenants', function () {
+    it('includes a signed invoice link for whatsapp-only tenants', function () {
         Carbon::setTestNow(Carbon::parse('2026-07-01'));
         Notification::fake();
 
@@ -537,6 +537,7 @@ describe('SendRentRemindersAction', function () {
                     ->toContain($invoice->period_end->format('d M Y'))
                     ->toContain($invoice->due_date->format('d M Y'))
                     ->toContain('1.500.000')
+                    ->toMatch('#/pay/invoices/[A-Za-z0-9_-]+\?signature=[a-f0-9]+#')
                     ->not->toContain(route('portal.billing.invoices.show', $invoice));
 
                 $attachment = $content->attachment;
@@ -639,7 +640,7 @@ describe('SendRentRemindersAction', function () {
         Carbon::setTestNow();
     });
 
-    it('omits portal links for users without portal access', function (array $userAttributes) {
+    it('uses signed links for users without portal access', function (array $userAttributes) {
         Carbon::setTestNow(Carbon::parse('2026-07-01'));
         Notification::fake();
 
@@ -657,6 +658,7 @@ describe('SendRentRemindersAction', function () {
             RentReminder::class,
             function (RentReminder $notification) use ($invoice, $tenant): bool {
                 expect($notification->toWhatsAppChannel($tenant)->message)
+                    ->toMatch('#/pay/invoices/[A-Za-z0-9_-]+\?signature=[a-f0-9]+#')
                     ->not->toContain(route('portal.billing.invoices.show', $invoice));
                 expect($notification->toArray($tenant)['url'])->toBeNull();
 


### PR DESCRIPTION
## Summary

- Use signed invoice URLs for WhatsApp reminders when portal access is unavailable.
- Preserve portal URLs for active, verified tenants.
- Cover WhatsApp-only, unverified, and inactive users.

## Tests

- `php artisan test --compact tests/Feature/SendRentRemindersTest.php tests/Feature/SignedPaymentLinkTest.php`
- `vendor/bin/pint --dirty --format agent`
- `npm run build`