### PR TITLE
feat(payments): enforce gateway currencies

### DIFF
--- a/app/Actions/Payments/StartGatewayPayment.php
+++ b/app/Actions/Payments/StartGatewayPayment.php
@@ -6,6 +6,7 @@ use App\Business\Payments\PaymentAttemptStatusValidator;
 use App\Enums\InvoiceStatus;
 use App\Exceptions\InvoiceNotPayableException;
 use App\Exceptions\PaymentGatewayCreationException;
+use App\Exceptions\PaymentGatewayCurrencyUnsupportedException;
 use App\Exceptions\PaymentGatewayUnavailableException;
 use App\Models\Invoice;
 use App\Models\PaymentAttempt;
@@ -129,6 +130,10 @@ class StartGatewayPayment
             $gateway = $this->gateways->active();
             if ($gatewayKey === null || $gateway === null) {
                 throw new PaymentGatewayUnavailableException('No active payment gateway is configured.');
+            }
+
+            if ($this->gateways->supportsCurrency($gateway, $currency) === false) {
+                throw new PaymentGatewayCurrencyUnsupportedException($gatewayKey, $currency);
             }
 
             $attempt = $locked->paymentAttempts()->create([

--- a/app/Exceptions/PaymentGatewayCurrencyUnsupportedException.php
+++ b/app/Exceptions/PaymentGatewayCurrencyUnsupportedException.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Exceptions;
+
+use Illuminate\Support\Str;
+use RuntimeException;
+
+final class PaymentGatewayCurrencyUnsupportedException extends RuntimeException
+{
+    public function __construct(string $gatewayKey, public readonly string $currency)
+    {
+        parent::__construct(sprintf(
+            '%s is not available for %s payments.',
+            Str::headline($gatewayKey),
+            $currency,
+        ));
+    }
+}

--- a/app/Http/Controllers/SignedPaymentController.php
+++ b/app/Http/Controllers/SignedPaymentController.php
@@ -6,6 +6,7 @@ use App\Actions\Payments\StartGatewayPayment;
 use App\Enums\InvoiceStatus;
 use App\Exceptions\InvoiceNotPayableException;
 use App\Exceptions\PaymentGatewayCreationException;
+use App\Exceptions\PaymentGatewayCurrencyUnsupportedException;
 use App\Exceptions\PaymentGatewayUnavailableException;
 use App\Models\Invoice;
 use App\Models\PaymentAttempt;
@@ -36,6 +37,10 @@ class SignedPaymentController extends Controller
         $hasResumableAttempt = $gatewayAttempts->contains(
             fn (PaymentAttempt $attempt): bool => $attempt->resumable,
         );
+        $activeGateway = $hasResumableAttempt ? null : $gateways->active();
+        $currencySupported = $activeGateway === null
+            ? false
+            : $gateways->supportsCurrency($activeGateway, $invoice->currency) !== false;
 
         return Inertia::render('payments/signed-invoice', [
             'invoice' => [
@@ -73,7 +78,7 @@ class SignedPaymentController extends Controller
                 'initiated_at' => DateTimeFormatter::iso($attempt->initiated_at),
             ])->values()->all(),
             'onlinePaymentAvailable' => $this->isPayable($invoice)
-                && ($hasResumableAttempt || $gateways->active() !== null),
+                && ($hasResumableAttempt || $currencySupported),
             'paymentUrl' => $request->fullUrl(),
             'csrfToken' => csrf_token(),
         ]);
@@ -89,6 +94,8 @@ class SignedPaymentController extends Controller
 
         try {
             $result = $action->executeViaSignedLink($invoice);
+        } catch (PaymentGatewayCurrencyUnsupportedException) {
+            return $this->gatewayPaymentError($request, __('Online payment is not available for this invoice.'));
         } catch (InvoiceNotPayableException|PaymentGatewayUnavailableException) {
             return $this->gatewayPaymentError($request, __('Online payment is not available for this invoice.'));
         } catch (PaymentGatewayCreationException $exception) {

--- a/app/Http/Controllers/TenantPortal/PaymentController.php
+++ b/app/Http/Controllers/TenantPortal/PaymentController.php
@@ -10,6 +10,7 @@ use App\Enums\PaymentStatus;
 use App\Events\Payment\PaymentRecorded;
 use App\Exceptions\InvoiceNotPayableException;
 use App\Exceptions\PaymentGatewayCreationException;
+use App\Exceptions\PaymentGatewayCurrencyUnsupportedException;
 use App\Exceptions\PaymentGatewayUnavailableException;
 use App\Exceptions\PaymentOverflowException;
 use App\Http\Requests\Payment\StoreTenantPortalPaymentRequest;
@@ -26,6 +27,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Inertia\Response;
 use OpenKOS\Core\Enums\PaymentStatus as GatewayPaymentStatus;
@@ -217,12 +219,25 @@ class PaymentController extends TenantPortalController
         $hasResumableAttempt = $gatewayAttempts->contains(
             fn (PaymentAttempt $attempt): bool => $attempt->resumable,
         );
+        $activeGateway = $hasResumableAttempt ? null : $gateways->active();
+        $currencySupported = $activeGateway === null
+            ? false
+            : $gateways->supportsCurrency($activeGateway, $invoice->currency) !== false;
+        $onlinePaymentUnavailableReason = ! $hasResumableAttempt
+            && $activeGateway !== null
+            && ! $currencySupported
+            ? __(':gateway is not available for :currency payments.', [
+                'gateway' => Str::headline($gateways->activeKey() ?? 'The active gateway'),
+                'currency' => $invoice->currency,
+            ])
+            : null;
 
         return Inertia::render('tenant-portal/payments/invoice', [
             'invoice' => $invoice,
             'invoicePdf' => ['status' => $invoicePdfStatus],
             'gatewayAttempts' => $gatewayAttempts,
-            'onlinePaymentAvailable' => $hasResumableAttempt || $gateways->active() !== null,
+            'onlinePaymentAvailable' => $hasResumableAttempt || $currencySupported,
+            'onlinePaymentUnavailableReason' => $onlinePaymentUnavailableReason,
             'lease' => [
                 'reference' => $invoice->lease->reference,
                 'unit_name' => $invoice->lease->unit?->name,
@@ -237,6 +252,8 @@ class PaymentController extends TenantPortalController
 
         try {
             $result = $action->execute($invoice, $request->user());
+        } catch (PaymentGatewayCurrencyUnsupportedException $exception) {
+            return $this->gatewayPaymentError($exception->getMessage());
         } catch (InvoiceNotPayableException|PaymentGatewayUnavailableException) {
             return $this->gatewayPaymentError(__('Online payment is not available for this invoice.'));
         } catch (PaymentGatewayCreationException $exception) {

--- a/app/Services/Payments/PaymentGatewayManager.php
+++ b/app/Services/Payments/PaymentGatewayManager.php
@@ -58,6 +58,7 @@ class PaymentGatewayManager
                     'configuration_schema' => [],
                     'configuration' => [],
                     'secret_fields' => [],
+                    'supported_currencies' => null,
                     'status' => 'unavailable',
                     'missing_fields' => [],
                     'error' => 'This payment gateway is unavailable.',

--- a/app/Services/Payments/PaymentGatewayManager.php
+++ b/app/Services/Payments/PaymentGatewayManager.php
@@ -4,6 +4,7 @@ namespace App\Services\Payments;
 
 use Illuminate\Contracts\Container\Container;
 use OpenKOS\Core\Contracts\PaymentGateway;
+use OpenKOS\Core\Contracts\PaymentGatewayCurrencySupport;
 use OpenKOS\Core\Contracts\PaymentGatewayStatusLookup;
 use OpenKOS\Platform\Payment\PaymentRegistry;
 use OpenKOS\Platform\Settings\SettingsManager;
@@ -45,6 +46,7 @@ class PaymentGatewayManager
                     'configuration_schema' => $this->publicSchema($schema),
                     'configuration' => $this->publicConfiguration($schema, $configuration),
                     'secret_fields' => $this->configuredSecretFields($schema, $configuration),
+                    'supported_currencies' => $this->supportedCurrencies($gateway),
                     'status' => $missing === [] ? 'configured' : 'incomplete',
                     'missing_fields' => $missing,
                     'error' => null,
@@ -128,6 +130,54 @@ class PaymentGatewayManager
     public function supportsStatusLookup(string $key): bool
     {
         return $this->find($key) instanceof PaymentGatewayStatusLookup;
+    }
+
+    public function supportsCurrency(PaymentGateway $gateway, string $currency): ?bool
+    {
+        if (! interface_exists(PaymentGatewayCurrencySupport::class)
+            || ! $gateway instanceof PaymentGatewayCurrencySupport) {
+            return null;
+        }
+
+        try {
+            $declared = $this->supportedCurrencies($gateway);
+
+            return $gateway->supportsCurrency($currency)
+                && in_array(strtoupper(trim($currency)), $declared, true);
+        } catch (\Throwable $exception) {
+            report($exception);
+
+            return false;
+        }
+    }
+
+    /**
+     * @return list<string>|null
+     */
+    public function supportedCurrencies(PaymentGateway $gateway): ?array
+    {
+        if (! interface_exists(PaymentGatewayCurrencySupport::class)
+            || ! $gateway instanceof PaymentGatewayCurrencySupport) {
+            return null;
+        }
+
+        $currencies = $gateway->supportedCurrencies();
+
+        if (! array_is_list($currencies)) {
+            throw new \RuntimeException('Payment gateway supported currencies must be a list.');
+        }
+
+        $normalized = [];
+
+        foreach ($currencies as $currency) {
+            if (! is_string($currency) || ! preg_match('/\A[A-Z]{3}\z/D', strtoupper(trim($currency)))) {
+                throw new \RuntimeException('Payment gateway supported currencies must be ISO 4217 codes.');
+            }
+
+            $normalized[] = strtoupper(trim($currency));
+        }
+
+        return array_values(array_unique($normalized));
     }
 
     public function activeKey(): ?string

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "laravel/framework": "^13.7",
         "laravel/tinker": "^3.0",
         "laravel/wayfinder": "^0.1.14",
-        "openkos/platform": "^0.2.2",
+        "openkos/platform": "^0.2.3",
         "spatie/laravel-permission": "^7.4",
         "spatie/laravel-query-builder": "^7.3"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "884817dcf51c9ddd4d0e4f3b1b1b6157",
+    "content-hash": "46947d45ea007b765375f3d9a8ce0515",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -3317,16 +3317,16 @@
         },
         {
             "name": "openkos/platform",
-            "version": "0.2.2",
+            "version": "0.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/senatroxx/openkos-platform.git",
-                "reference": "3669d1d825c3c22b462088602b9a5ef2c15b42f0"
+                "reference": "e205d385b086a29db98441e961c271b54cd891fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/senatroxx/openkos-platform/zipball/3669d1d825c3c22b462088602b9a5ef2c15b42f0",
-                "reference": "3669d1d825c3c22b462088602b9a5ef2c15b42f0",
+                "url": "https://api.github.com/repos/senatroxx/openkos-platform/zipball/e205d385b086a29db98441e961c271b54cd891fe",
+                "reference": "e205d385b086a29db98441e961c271b54cd891fe",
                 "shasum": ""
             },
             "require": {
@@ -3364,9 +3364,9 @@
             "description": "The OpenKOS platform and plugin SDK.",
             "support": {
                 "issues": "https://github.com/senatroxx/openkos-platform/issues",
-                "source": "https://github.com/senatroxx/openkos-platform/tree/v0.2.2"
+                "source": "https://github.com/senatroxx/openkos-platform/tree/v0.2.3"
             },
-            "time": "2026-08-18T11:04:43+00:00"
+            "time": "2026-08-24T04:26:34+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",

--- a/resources/js/pages/settings/payment-gateway.tsx
+++ b/resources/js/pages/settings/payment-gateway.tsx
@@ -140,7 +140,9 @@ export default function PaymentGateway({
                             ? 'attempt is'
                             : 'attempts are'}{' '}
                         in progress. Wait until{' '}
-                        {activePaymentAttemptCount === 1 ? 'it completes' : 'they complete'}{' '}
+                        {activePaymentAttemptCount === 1
+                            ? 'it completes'
+                            : 'they complete'}{' '}
                         or expire before switching or deactivating the gateway.
                     </AlertDescription>
                 </Alert>
@@ -215,6 +217,16 @@ export default function PaymentGateway({
                                             {errors.gateway}
                                         </p>
                                     )}
+                                    {selectedGateway &&
+                                        selectedGateway.supported_currencies !==
+                                            null && (
+                                            <p className="text-xs text-muted-foreground">
+                                                Supported currencies:{' '}
+                                                {selectedGateway.supported_currencies.join(
+                                                    ', ',
+                                                ) || 'None'}
+                                            </p>
+                                        )}
                                 </div>
 
                                 {selectedGateway?.status === 'unavailable' && (

--- a/resources/js/pages/settings/payment-gateway.tsx
+++ b/resources/js/pages/settings/payment-gateway.tsx
@@ -218,8 +218,9 @@ export default function PaymentGateway({
                                         </p>
                                     )}
                                     {selectedGateway &&
-                                        selectedGateway.supported_currencies !==
-                                            null && (
+                                        Array.isArray(
+                                            selectedGateway.supported_currencies,
+                                        ) && (
                                             <p className="text-xs text-muted-foreground">
                                                 Supported currencies:{' '}
                                                 {selectedGateway.supported_currencies.join(

--- a/resources/js/pages/tenant-portal/payments/invoice.tsx
+++ b/resources/js/pages/tenant-portal/payments/invoice.tsx
@@ -23,6 +23,7 @@ export default function InvoiceDetail({
     invoicePdf,
     gatewayAttempts,
     onlinePaymentAvailable,
+    onlinePaymentUnavailableReason,
 }: {
     invoice: Invoice;
     lease: InvoiceLease;
@@ -31,6 +32,7 @@ export default function InvoiceDetail({
     };
     gatewayAttempts: GatewayPaymentAttempt[];
     onlinePaymentAvailable: boolean;
+    onlinePaymentUnavailableReason?: string | null;
 }) {
     const [paymentOpen, setPaymentOpen] = useState(false);
     const [gatewayProcessing, setGatewayProcessing] = useState(false);
@@ -114,7 +116,10 @@ export default function InvoiceDetail({
                                         >
                                             <span>{item.description}</span>
                                             <span className="tabular-nums">
-                                                {formatPrice(item.amount, invoice.currency)}
+                                                {formatPrice(
+                                                    item.amount,
+                                                    invoice.currency,
+                                                )}
                                             </span>
                                         </div>
                                     ))}
@@ -205,7 +210,10 @@ export default function InvoiceDetail({
                             Outstanding balance
                         </p>
                         <p className="mt-1 text-2xl font-semibold tabular-nums">
-                            {formatPrice(invoice.outstanding ?? '0', invoice.currency)}
+                            {formatPrice(
+                                invoice.outstanding ?? '0',
+                                invoice.currency,
+                            )}
                         </p>
                         <div className="mt-5 grid gap-4 text-sm">
                             <Detail
@@ -266,6 +274,11 @@ export default function InvoiceDetail({
                                           ? 'Continue online payment'
                                           : 'Pay online'}
                                 </Button>
+                            )}
+                            {isPayable && onlinePaymentUnavailableReason && (
+                                <p className="text-xs text-muted-foreground">
+                                    {onlinePaymentUnavailableReason}
+                                </p>
                             )}
                             {isPayable && (
                                 <Button

--- a/resources/js/types/settings.ts
+++ b/resources/js/types/settings.ts
@@ -67,6 +67,7 @@ export type PaymentGateway = {
     secret_fields: string[];
     status: 'configured' | 'incomplete' | 'unavailable';
     missing_fields: string[];
+    supported_currencies: string[] | null;
     error: string | null;
 };
 

--- a/tests/Feature/SignedPaymentLinkTest.php
+++ b/tests/Feature/SignedPaymentLinkTest.php
@@ -20,11 +20,12 @@ uses()->beforeEach(function () {
     $this->seed(RoleAndPermissionSeeder::class);
 });
 
-function bindSignedPaymentGateway(?PaymentGateway $gateway): void
+function bindSignedPaymentGateway(?PaymentGateway $gateway, ?bool $currencySupport = null): void
 {
     $manager = Mockery::mock(PaymentGatewayManager::class);
     $manager->shouldReceive('activeKey')->andReturn($gateway ? 'test-gateway' : null);
     $manager->shouldReceive('active')->andReturn($gateway);
+    $manager->shouldReceive('supportsCurrency')->zeroOrMoreTimes()->andReturn($currencySupport);
 
     app()->instance(PaymentGatewayManager::class, $manager);
 }
@@ -115,6 +116,29 @@ it('starts checkout from a signed link without authentication', function () {
 
     expect($invoice->fresh()->status)->toBe(InvoiceStatus::Pending)
         ->and($invoice->paymentAttempts()->sole()->status)->toBe(GatewayPaymentStatus::Pending);
+});
+
+it('hides signed checkout when the gateway rejects the invoice currency', function () {
+    $invoice = Invoice::factory()->create(['currency' => 'USD']);
+    bindSignedPaymentGateway(Mockery::mock(PaymentGateway::class), currencySupport: false);
+
+    $this->get(signedInvoiceUrl($invoice))
+        ->assertInertia(fn ($page) => $page
+            ->where('onlinePaymentAvailable', false));
+});
+
+it('rejects unsupported signed checkout without creating an attempt', function () {
+    $invoice = Invoice::factory()->create(['currency' => 'USD']);
+    bindSignedPaymentGateway(Mockery::mock(PaymentGateway::class), currencySupport: false);
+
+    $this->post(signedInvoiceUrl($invoice))
+        ->assertRedirect()
+        ->assertInertiaFlash('toast', [
+            'type' => 'error',
+            'message' => 'Online payment is not available for this invoice.',
+        ]);
+
+    expect($invoice->paymentAttempts()->count())->toBe(0);
 });
 
 it('reuses persisted checkout instructions when no gateway is active', function () {

--- a/tests/Feature/StartGatewayPaymentTest.php
+++ b/tests/Feature/StartGatewayPaymentTest.php
@@ -3,6 +3,7 @@
 use App\Actions\Payments\StartGatewayPayment;
 use App\Exceptions\InvoiceNotPayableException;
 use App\Exceptions\PaymentGatewayCreationException;
+use App\Exceptions\PaymentGatewayCurrencyUnsupportedException;
 use App\Models\Invoice;
 use App\Models\Lease;
 use App\Models\Payment;
@@ -28,6 +29,7 @@ function startGatewayPaymentAction(PaymentGateway $gateway): StartGatewayPayment
     $manager = Mockery::mock(PaymentGatewayManager::class);
     $manager->shouldReceive('active')->andReturn($gateway);
     $manager->shouldReceive('activeKey')->andReturn('test-gateway');
+    $manager->shouldReceive('supportsCurrency')->zeroOrMoreTimes()->andReturn(null);
 
     app()->instance(PaymentGatewayManager::class, $manager);
 
@@ -76,6 +78,29 @@ it('creates a provider attempt with exact currency-aware money and normalized in
         ->and($result->attempt->fresh()->status)->toBe(PaymentStatus::Pending)
         ->and($result->attempt->fresh()->checkout_instructions['entries'][0]['key'])->toBe('va_number')
         ->and($result->attempt->fresh()->metadata['channel'])->toBe('virtual_account');
+});
+
+it('rejects an unsupported invoice currency before creating an attempt', function () {
+    $invoice = Invoice::factory()->create();
+    $gateway = Mockery::mock(PaymentGateway::class);
+    $gateway->shouldReceive('key')->andReturn('test-gateway');
+    $gateway->shouldNotReceive('createPayment');
+
+    $manager = Mockery::mock(PaymentGatewayManager::class);
+    $manager->shouldReceive('active')->once()->andReturn($gateway);
+    $manager->shouldReceive('activeKey')->once()->andReturn('test-gateway');
+    $manager->shouldReceive('supportsCurrency')
+        ->once()
+        ->with($gateway, $invoice->currency)
+        ->andReturnFalse();
+    app()->instance(PaymentGatewayManager::class, $manager);
+
+    expect(fn () => app(StartGatewayPayment::class)->execute(
+        $invoice,
+        User::factory()->owner()->create(),
+    ))->toThrow(PaymentGatewayCurrencyUnsupportedException::class, 'not available');
+
+    expect($invoice->paymentAttempts()->count())->toBe(0);
 });
 
 it('reuses a valid pending attempt without creating another provider checkout', function () {

--- a/tests/Feature/TenantPortalTest.php
+++ b/tests/Feature/TenantPortalTest.php
@@ -27,11 +27,12 @@ uses()->beforeEach(function () {
     $this->seed(RoleAndPermissionSeeder::class);
 });
 
-function bindTenantPortalGateway(?PaymentGateway $gateway): void
+function bindTenantPortalGateway(?PaymentGateway $gateway, ?bool $currencySupport = null): void
 {
     $manager = Mockery::mock(PaymentGatewayManager::class);
     $manager->shouldReceive('activeKey')->andReturn($gateway ? 'test-gateway' : null);
     $manager->shouldReceive('active')->andReturn($gateway);
+    $manager->shouldReceive('supportsCurrency')->zeroOrMoreTimes()->andReturn($currencySupport);
 
     app()->instance(PaymentGatewayManager::class, $manager);
 }
@@ -470,6 +471,33 @@ test('tenant sees online payment unavailable without a gateway or resumable atte
             'type' => 'error',
             'message' => 'Online payment is not available for this invoice.',
         ]);
+});
+
+test('tenant sees online payment unavailable when the gateway rejects the invoice currency', function () {
+    $user = User::factory()->create();
+    $tenant = Tenant::factory()->withUser($user)->create();
+    $lease = Lease::factory()->create(['primary_tenant_id' => $tenant->id]);
+    $invoice = Invoice::factory()->create([
+        'lease_id' => $lease->id,
+        'currency' => 'USD',
+        'status' => InvoiceStatus::Pending,
+    ]);
+    bindTenantPortalGateway(Mockery::mock(PaymentGateway::class), currencySupport: false);
+
+    $this->actingAs($user)
+        ->get(route('portal.billing.invoices.show', $invoice))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('onlinePaymentAvailable', false)
+            ->where('onlinePaymentUnavailableReason', 'Test Gateway is not available for USD payments.'));
+
+    $this->post(route('portal.billing.invoices.pay', $invoice))
+        ->assertInertiaFlash('toast', [
+            'type' => 'error',
+            'message' => 'Test Gateway is not available for USD payments.',
+        ]);
+
+    expect($invoice->paymentAttempts()->count())->toBe(0);
 });
 
 test('tenant sees only their billing data', function () {

--- a/tests/Support/Fakes/CurrencyAwareManagerTestPaymentGateway.php
+++ b/tests/Support/Fakes/CurrencyAwareManagerTestPaymentGateway.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Support\Fakes;
+
+use OpenKOS\Core\Contracts\PaymentGatewayCurrencySupport;
+
+class CurrencyAwareManagerTestPaymentGateway extends ManagerTestPaymentGateway implements PaymentGatewayCurrencySupport
+{
+    public function key(): string
+    {
+        return 'currency-aware';
+    }
+
+    public function supportsCurrency(string $currency): bool
+    {
+        return in_array(strtoupper(trim($currency)), $this->supportedCurrencies(), true);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function supportedCurrencies(): array
+    {
+        return ['IDR'];
+    }
+}

--- a/tests/Support/Fakes/MalformedCurrencyManagerTestPaymentGateway.php
+++ b/tests/Support/Fakes/MalformedCurrencyManagerTestPaymentGateway.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Support\Fakes;
+
+class MalformedCurrencyManagerTestPaymentGateway extends CurrencyAwareManagerTestPaymentGateway
+{
+    public function key(): string
+    {
+        return 'malformed-currency';
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function supportedCurrencies(): array
+    {
+        return ['IDR', 'not-a-currency'];
+    }
+}

--- a/tests/Unit/Services/PaymentGatewayManagerTest.php
+++ b/tests/Unit/Services/PaymentGatewayManagerTest.php
@@ -5,6 +5,8 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use OpenKOS\Platform\Payment\PaymentRegistry;
 use OpenKOS\Platform\Settings\SettingsManager;
 use Tests\Support\Fakes\BrokenManagerTestPaymentGateway;
+use Tests\Support\Fakes\CurrencyAwareManagerTestPaymentGateway;
+use Tests\Support\Fakes\MalformedCurrencyManagerTestPaymentGateway;
 use Tests\Support\Fakes\ManagerTestPaymentGateway;
 use Tests\Support\Fakes\MismatchedManagerTestPaymentGateway;
 use Tests\TestCase;
@@ -43,7 +45,55 @@ it('returns provider metadata without exposing secret values', function () {
         ->and($provider['configuration_schema']['secret_key']['visible_when'])->toBe([
             'field' => 'environment',
             'value' => 'sandbox',
-        ]);
+        ])
+        ->and($provider['supported_currencies'])->toBeNull();
+});
+
+it('exposes and enforces declared gateway currencies', function () {
+    $registry = new PaymentRegistry;
+    $registry->registerGateway('currency-aware', CurrencyAwareManagerTestPaymentGateway::class);
+    $manager = new PaymentGatewayManager($registry, app(SettingsManager::class), app());
+    $gateway = $manager->find('currency-aware');
+
+    expect($gateway)->not->toBeNull()
+        ->and($manager->supportedCurrencies($gateway))->toBe(['IDR'])
+        ->and($manager->supportsCurrency($gateway, 'idr'))->toBeTrue()
+        ->and($manager->supportsCurrency($gateway, 'USD'))->toBeFalse();
+});
+
+it('fails closed for malformed gateway currency declarations', function () {
+    $registry = new PaymentRegistry;
+    $registry->registerGateway('malformed-currency', MalformedCurrencyManagerTestPaymentGateway::class);
+    $manager = new PaymentGatewayManager($registry, app(SettingsManager::class), app());
+    $gateway = $manager->find('malformed-currency');
+
+    expect($gateway)->not->toBeNull()
+        ->and($manager->supportsCurrency($gateway, 'IDR'))->toBeFalse()
+        ->and($manager->all()[0]['status'])->toBe('unavailable');
+});
+
+it('preserves an explicitly empty currency declaration', function () {
+    $gateway = new class extends CurrencyAwareManagerTestPaymentGateway
+    {
+        public function key(): string
+        {
+            return 'no-currencies';
+        }
+
+        /**
+         * @return list<string>
+         */
+        public function supportedCurrencies(): array
+        {
+            return [];
+        }
+    };
+    $registry = new PaymentRegistry;
+    $registry->registerGateway('no-currencies', $gateway);
+    $manager = new PaymentGatewayManager($registry, app(SettingsManager::class), app());
+
+    expect($manager->supportedCurrencies($gateway))->toBe([])
+        ->and($manager->supportsCurrency($gateway, 'IDR'))->toBeFalse();
 });
 
 it('resolves only a configured active gateway', function () {

--- a/tests/Unit/Services/PaymentGatewayManagerTest.php
+++ b/tests/Unit/Services/PaymentGatewayManagerTest.php
@@ -131,6 +131,7 @@ it('keeps broken providers visible without making enumeration throw', function (
 
     expect($provider['status'])->toBe('unavailable')
         ->and($provider['error'])->toBe('This payment gateway is unavailable.')
+        ->and($provider['supported_currencies'])->toBeNull()
         ->and($gateway->find('broken/gateway'))->toBeNull();
 });
 


### PR DESCRIPTION
## Summary

- Enforce gateway currency capability in signed payment flows
- Keep unavailable gateway payloads shape-complete
- Prevent frontend rendering errors for unknown currency capabilities
- Keep the platform lockfile on immutable 0.2.3 reference e205d385

## Verification

- 947 tests passed
- 1 test skipped
- 4416 assertions passed
- Frontend build, type checks, lint, and targeted formatting passed

OPE-166