### PR TITLE
feat(billing): support configurable currencies

### DIFF
--- a/app/Console/Commands/InstallCommand.php
+++ b/app/Console/Commands/InstallCommand.php
@@ -73,7 +73,9 @@ class InstallCommand extends Command
         Setting::set('site_name', $siteName);
         Setting::set('country_code', $country);
         Setting::set('locale', 'en');
-        Setting::set('currency', $country === 'ID' ? 'IDR' : 'USD');
+        $currency = $country === 'ID' ? 'IDR' : 'USD';
+        Setting::set('currency', $currency);
+        Setting::set('supported_currencies', [$currency]);
         Setting::set('timezone', $timezone);
 
         $this->info('Locale set to en. Internationalization (i18n) is planned for a future release.');

--- a/app/Http/Controllers/Settings/GeneralController.php
+++ b/app/Http/Controllers/Settings/GeneralController.php
@@ -7,10 +7,13 @@ use App\Actions\Settings\UpdateSettings;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Settings\UpdateBrandingRequest;
 use App\Models\Setting;
+use App\Models\UnitRate;
 use App\Services\Payments\MoneyConverter;
+use App\Services\Settings\InstallationCurrencySettings;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -19,56 +22,113 @@ class GeneralController extends Controller
     public function __construct(
         private UpdateSettings $updateSettings,
         private UpdateBranding $updateBranding,
+        private InstallationCurrencySettings $currencies,
     ) {}
 
     public function edit(): Response
     {
+        $settings = Setting::some([
+            'site_name',
+            'country_code',
+            'locale',
+            'currency',
+            'timezone',
+            'lease_id_prefix',
+            'invoice_id_prefix',
+            'invoice_pdf_enabled',
+        ]);
+        $settings['supported_currencies'] = $this->currencies->supported();
+
         return Inertia::render('settings/general', [
-            'settings' => Setting::some([
-                'site_name',
-                'country_code',
-                'locale',
-                'currency',
-                'timezone',
-                'lease_id_prefix',
-                'invoice_id_prefix',
-                'invoice_pdf_enabled',
-            ]),
+            'settings' => $settings,
             'timezone_list' => timezone_identifiers_list(),
         ]);
     }
 
     public function update(Request $request): RedirectResponse
     {
+        $this->normalizeCurrencyInput($request);
+
+        $previousSupported = $this->currencies->supported();
+        $hasStoredSupportedCurrencies = $this->currencies->hasStoredSupportedCurrencies();
+
         $validated = $request->validate([
             'site_name' => ['sometimes', 'required', 'string', 'max:255'],
             'country_code' => ['sometimes', 'required', 'string', 'size:2', 'regex:/^[A-Z]+$/'],
             'locale' => ['sometimes', 'required', 'string', 'max:10'],
-            'currency' => [
-                'sometimes',
-                'required',
-                'string',
-                'size:3',
-                'regex:/^[A-Z]+$/',
-                function (string $attribute, mixed $value, \Closure $fail): void {
-                    try {
-                        app(MoneyConverter::class)->normalizeCurrency((string) $value);
-                    } catch (\Throwable) {
-                        $fail(__('This currency is not supported.'));
-                    }
-                },
-            ],
+            'currency' => ['sometimes', 'required', 'string', 'size:3', 'regex:/^[A-Z]{3}$/', Rule::in(array_keys(app(MoneyConverter::class)->scales()))],
+            'supported_currencies' => ['sometimes', 'required', 'array', 'list', 'min:1'],
+            'supported_currencies.*' => ['required', 'string', 'size:3', 'regex:/^[A-Z]{3}$/', 'distinct:strict', Rule::in(array_keys(app(MoneyConverter::class)->scales()))],
             'timezone' => ['sometimes', 'required', 'string', Rule::in(timezone_identifiers_list())],
             'lease_id_prefix' => ['sometimes', 'required', 'string', 'max:10', 'regex:/^[A-Z]+$/'],
             'invoice_id_prefix' => ['sometimes', 'required', 'string', 'max:10', 'regex:/^[A-Z]+$/'],
             'invoice_pdf_enabled' => ['sometimes', 'boolean'],
         ]);
 
+        $nextDefault = $validated['currency'] ?? $this->currencies->default();
+        if (array_key_exists('supported_currencies', $validated)) {
+            try {
+                $validated['supported_currencies'] = $this->currencies->normalize(
+                    $validated['supported_currencies'],
+                );
+                $this->currencies->normalize($validated['supported_currencies'], $nextDefault);
+            } catch (\Throwable $exception) {
+                throw ValidationException::withMessages([
+                    'supported_currencies' => __($exception->getMessage()),
+                ]);
+            }
+        } elseif ($hasStoredSupportedCurrencies && ! in_array($nextDefault, $previousSupported, true)) {
+            throw ValidationException::withMessages([
+                'currency' => __('The default currency must be included in supported currencies.'),
+            ]);
+        }
+
+        $nextSupported = $validated['supported_currencies']
+            ?? ($hasStoredSupportedCurrencies ? $previousSupported : [$nextDefault]);
+        $removedCurrencies = array_values(array_diff($previousSupported, $nextSupported));
+
         $this->updateSettings->execute($validated, $request->user());
 
-        Inertia::flash('toast', ['type' => 'success', 'message' => __('General settings updated.')]);
+        $activeRemovedCurrencies = empty($removedCurrencies)
+            ? []
+            : UnitRate::query()
+                ->whereIn('currency', $removedCurrencies)
+                ->where('is_active', true)
+                ->distinct()
+                ->orderBy('currency')
+                ->pluck('currency')
+                ->all();
+
+        if ($activeRemovedCurrencies !== []) {
+            Inertia::flash('toast', [
+                'type' => 'warning',
+                'message' => __('General settings updated. Active rates still use: :currencies.', [
+                    'currencies' => implode(', ', $activeRemovedCurrencies),
+                ]),
+            ]);
+        } else {
+            Inertia::flash('toast', ['type' => 'success', 'message' => __('General settings updated.')]);
+        }
 
         return back();
+    }
+
+    private function normalizeCurrencyInput(Request $request): void
+    {
+        if ($request->exists('currency') && is_string($request->input('currency'))) {
+            $request->merge(['currency' => strtoupper(trim($request->input('currency')))]);
+        }
+
+        if ($request->exists('supported_currencies') && is_array($request->input('supported_currencies'))) {
+            $request->merge([
+                'supported_currencies' => array_map(
+                    static fn (mixed $currency): mixed => is_string($currency)
+                        ? strtoupper(trim($currency))
+                        : $currency,
+                    array_values($request->input('supported_currencies')),
+                ),
+            ]);
+        }
     }
 
     public function updateBranding(UpdateBrandingRequest $request, string $asset): RedirectResponse

--- a/app/Http/Controllers/Settings/GeneralController.php
+++ b/app/Http/Controllers/Settings/GeneralController.php
@@ -55,17 +55,21 @@ class GeneralController extends Controller
             return DB::transaction(function () use ($request): RedirectResponse {
                 $this->currencies->lockForUpdate();
 
-                return $this->persistUpdate($request);
+                return $this->persistUpdate($request, useFreshCurrencySettings: true);
             });
         }
 
         return $this->persistUpdate($request);
     }
 
-    private function persistUpdate(Request $request): RedirectResponse
+    private function persistUpdate(Request $request, bool $useFreshCurrencySettings = false): RedirectResponse
     {
-        $previousSupported = $this->currencies->supported();
-        $hasStoredSupportedCurrencies = $this->currencies->hasStoredSupportedCurrencies();
+        $previousSupported = $useFreshCurrencySettings
+            ? $this->currencies->freshSupported()
+            : $this->currencies->supported();
+        $hasStoredSupportedCurrencies = $this->currencies->hasStoredSupportedCurrencies(
+            fresh: $useFreshCurrencySettings,
+        );
 
         $validated = $request->validate([
             'site_name' => ['sometimes', 'required', 'string', 'max:255'],
@@ -80,7 +84,11 @@ class GeneralController extends Controller
             'invoice_pdf_enabled' => ['sometimes', 'boolean'],
         ]);
 
-        $nextDefault = $validated['currency'] ?? $this->currencies->default();
+        $nextDefault = $validated['currency'] ?? (
+            $useFreshCurrencySettings
+                ? $this->currencies->default(fresh: true)
+                : $this->currencies->default()
+        );
         if (array_key_exists('supported_currencies', $validated)) {
             try {
                 $validated['supported_currencies'] = $this->currencies->normalize(
@@ -140,7 +148,7 @@ class GeneralController extends Controller
                     static fn (mixed $currency): mixed => is_string($currency)
                         ? strtoupper(trim($currency))
                         : $currency,
-                    array_values($request->input('supported_currencies')),
+                    $request->input('supported_currencies'),
                 ),
             ]);
         }

--- a/app/Http/Controllers/Settings/GeneralController.php
+++ b/app/Http/Controllers/Settings/GeneralController.php
@@ -12,6 +12,7 @@ use App\Services\Payments\MoneyConverter;
 use App\Services\Settings\InstallationCurrencySettings;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
@@ -37,6 +38,7 @@ class GeneralController extends Controller
             'invoice_id_prefix',
             'invoice_pdf_enabled',
         ]);
+        $settings['currency'] = $this->currencies->default();
         $settings['supported_currencies'] = $this->currencies->supported();
 
         return Inertia::render('settings/general', [
@@ -49,6 +51,19 @@ class GeneralController extends Controller
     {
         $this->normalizeCurrencyInput($request);
 
+        if ($request->exists('currency') || $request->exists('supported_currencies')) {
+            return DB::transaction(function () use ($request): RedirectResponse {
+                $this->currencies->lockForUpdate();
+
+                return $this->persistUpdate($request);
+            });
+        }
+
+        return $this->persistUpdate($request);
+    }
+
+    private function persistUpdate(Request $request): RedirectResponse
+    {
         $previousSupported = $this->currencies->supported();
         $hasStoredSupportedCurrencies = $this->currencies->hasStoredSupportedCurrencies();
 

--- a/app/Http/Controllers/UnitController.php
+++ b/app/Http/Controllers/UnitController.php
@@ -31,6 +31,7 @@ class UnitController extends Controller
 {
     public function __construct(
         private InstallationCurrencySettings $currencies,
+        private MoneyConverter $money,
     ) {}
 
     public function show(Property $property, Unit $unit): Response
@@ -371,18 +372,31 @@ class UnitController extends Controller
      */
     private function assertNewRateCurrenciesSupported(array $rates): void
     {
-        foreach ($rates as $rate) {
+        $this->currencies->lockForUpdate();
+
+        $defaultCurrency = $this->currencies->default(fresh: true);
+        $supportedCurrencies = $this->currencies->freshSupported();
+
+        foreach ($rates as $index => $rate) {
             if (isset($rate['id'])) {
                 continue;
             }
 
             $currency = isset($rate['currency'])
-                ? app(MoneyConverter::class)->normalizeCurrency($rate['currency'])
-                : $this->currencies->default(fresh: true);
+                ? $this->money->normalizeCurrency($rate['currency'])
+                : $defaultCurrency;
 
-            if (! $this->currencies->supports($currency, fresh: true)) {
+            if (! in_array($currency, $supportedCurrencies, true)) {
                 throw ValidationException::withMessages([
-                    'rates' => __('This currency is not enabled for new pricing rates.'),
+                    "rates.{$index}.currency" => __('This currency is not enabled for new pricing rates.'),
+                ]);
+            }
+
+            try {
+                $this->money->normalizeAmount((string) $rate['amount'], $currency);
+            } catch (\Throwable) {
+                throw ValidationException::withMessages([
+                    "rates.{$index}.amount" => __('The amount has too many decimal places for this currency.'),
                 ]);
             }
         }

--- a/app/Http/Controllers/UnitController.php
+++ b/app/Http/Controllers/UnitController.php
@@ -11,6 +11,8 @@ use App\Models\MaintenanceTicket;
 use App\Models\Property;
 use App\Models\Tenant;
 use App\Models\Unit;
+use App\Services\Payments\MoneyConverter;
+use App\Services\Settings\InstallationCurrencySettings;
 use App\Tables\Column;
 use App\Tables\Filter;
 use App\Tables\Table;
@@ -27,6 +29,10 @@ use Inertia\Response;
 
 class UnitController extends Controller
 {
+    public function __construct(
+        private InstallationCurrencySettings $currencies,
+    ) {}
+
     public function show(Property $property, Unit $unit): Response
     {
         $this->authorize('view', $unit);
@@ -172,6 +178,8 @@ class UnitController extends Controller
         unset($validated['rates']);
 
         DB::transaction(function () use ($property, $validated, $rates): void {
+            $this->assertNewRateCurrenciesSupported($rates);
+
             $unit = $property->units()->create($validated);
 
             foreach ($rates as $rate) {
@@ -209,6 +217,8 @@ class UnitController extends Controller
                         'updated_at' => __('This unit changed while you were editing it. Refresh and try again.'),
                     ]);
                 }
+
+                $this->assertNewRateCurrenciesSupported($rates);
 
                 $lockedUnit->update($validated);
 
@@ -354,5 +364,27 @@ class UnitController extends Controller
             'property' => $property->only('id', 'slug', 'name'),
             'unit' => $unit->only('id', 'slug', 'name', 'floor'),
         ]);
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $rates
+     */
+    private function assertNewRateCurrenciesSupported(array $rates): void
+    {
+        foreach ($rates as $rate) {
+            if (isset($rate['id'])) {
+                continue;
+            }
+
+            $currency = isset($rate['currency'])
+                ? app(MoneyConverter::class)->normalizeCurrency($rate['currency'])
+                : $this->currencies->default(fresh: true);
+
+            if (! $this->currencies->supports($currency, fresh: true)) {
+                throw ValidationException::withMessages([
+                    'rates' => __('This currency is not enabled for new pricing rates.'),
+                ]);
+            }
+        }
     }
 }

--- a/app/Http/Controllers/UnitController.php
+++ b/app/Http/Controllers/UnitController.php
@@ -370,8 +370,22 @@ class UnitController extends Controller
     /**
      * @param  array<int, array<string, mixed>>  $rates
      */
-    private function assertNewRateCurrenciesSupported(array $rates): void
+    private function assertNewRateCurrenciesSupported(array &$rates): void
     {
+        $hasNewRate = false;
+
+        foreach ($rates as $rate) {
+            if (! isset($rate['id'])) {
+                $hasNewRate = true;
+
+                break;
+            }
+        }
+
+        if (! $hasNewRate) {
+            return;
+        }
+
         $this->currencies->lockForUpdate();
 
         $defaultCurrency = $this->currencies->default(fresh: true);
@@ -393,10 +407,14 @@ class UnitController extends Controller
             }
 
             try {
-                $this->money->normalizeAmount((string) $rate['amount'], $currency);
+                $rates[$index]['currency'] = $currency;
+                $rates[$index]['amount'] = $this->money->normalizeAmount(
+                    (string) $rate['amount'],
+                    $currency,
+                );
             } catch (\Throwable) {
                 throw ValidationException::withMessages([
-                    "rates.{$index}.amount" => __('The amount has too many decimal places for this currency.'),
+                    "rates.{$index}.amount" => __('The amount is invalid for the selected currency.'),
                 ]);
             }
         }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -64,6 +64,7 @@ class HandleInertiaRequests extends Middleware
                         'branding_favicon_path',
                     ])
                     ->all(),
+                'currency' => app(InstallationCurrencySettings::class)->default(),
                 'supported_currencies' => app(InstallationCurrencySettings::class)->supported(),
             ],
             'branding' => fn () => $this->branding(),

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -4,6 +4,7 @@ namespace App\Http\Middleware;
 
 use App\Models\Setting;
 use App\Services\Payments\MoneyConverter;
+use App\Services\Settings\InstallationCurrencySettings;
 use Closure;
 use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Http\Request;
@@ -53,15 +54,18 @@ class HandleInertiaRequests extends Middleware
             // Integration configs (mail_config, whatsapp_config, payment_gateway_config) hold secrets — SMTP
             // password, API tokens — so they never go into the app-wide share. Their
             // own settings pages load them (masked) separately.
-            'setting' => fn () => collect(Setting::get())
-                ->except([
-                    'mail_config',
-                    'whatsapp_config',
-                    'payment_gateway_config',
-                    'branding_logo_path',
-                    'branding_favicon_path',
-                ])
-                ->all(),
+            'setting' => fn () => [
+                ...collect(Setting::get())
+                    ->except([
+                        'mail_config',
+                        'whatsapp_config',
+                        'payment_gateway_config',
+                        'branding_logo_path',
+                        'branding_favicon_path',
+                    ])
+                    ->all(),
+                'supported_currencies' => app(InstallationCurrencySettings::class)->supported(),
+            ],
             'branding' => fn () => $this->branding(),
             'notificationChannels' => fn () => [
                 'mail' => filled(data_get(Setting::effectiveMailConfig(), 'host')),

--- a/app/Http/Requests/Unit/StoreUnitRequest.php
+++ b/app/Http/Requests/Unit/StoreUnitRequest.php
@@ -6,6 +6,7 @@ use App\Enums\BillingUnit;
 use App\Enums\UnitStatus;
 use App\Rules\MoneyAmount;
 use App\Services\Payments\MoneyConverter;
+use App\Services\Settings\InstallationCurrencySettings;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -88,6 +89,14 @@ class StoreUnitRequest extends FormRequest
                 } catch (\Throwable) {
                     continue;
                 }
+
+                if (! app(InstallationCurrencySettings::class)->supports($currency)) {
+                    $validator->errors()->add(
+                        "rates.{$index}.currency",
+                        __('This currency is not enabled for new pricing rates.'),
+                    );
+                }
+
                 $key = implode('|', [
                     $rate['billing_interval'] ?? '',
                     $rate['billing_unit'] ?? '',

--- a/app/Http/Requests/Unit/StoreUnitRequest.php
+++ b/app/Http/Requests/Unit/StoreUnitRequest.php
@@ -57,10 +57,13 @@ class StoreUnitRequest extends FormRequest
             }
 
             $currency = $rate['currency'] ?? null;
-            $rules["rates.{$index}.amount"] = [
-                'required_with:rates',
-                new MoneyAmount(is_string($currency) ? $currency : null),
-            ];
+            $amountRules = ['required_with:rates'];
+
+            if (is_string($currency)) {
+                $amountRules[] = new MoneyAmount($currency);
+            }
+
+            $rules["rates.{$index}.amount"] = $amountRules;
         }
 
         return $rules;

--- a/app/Http/Requests/Unit/UpdateUnitRequest.php
+++ b/app/Http/Requests/Unit/UpdateUnitRequest.php
@@ -7,6 +7,7 @@ use App\Enums\UnitStatus;
 use App\Models\UnitRate;
 use App\Rules\MoneyAmount;
 use App\Services\Payments\MoneyConverter;
+use App\Services\Settings\InstallationCurrencySettings;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -132,6 +133,14 @@ class UpdateUnitRequest extends FormRequest
                 } catch (\Throwable) {
                     continue;
                 }
+
+                if ($storedRate === null && ! app(InstallationCurrencySettings::class)->supports($currency)) {
+                    $validator->errors()->add(
+                        "rates.{$index}.currency",
+                        __('This currency is not enabled for new pricing rates.'),
+                    );
+                }
+
                 $key = implode('|', [
                     $rate['billing_interval'] ?? '',
                     $rate['billing_unit'] ?? '',

--- a/app/Http/Requests/Unit/UpdateUnitRequest.php
+++ b/app/Http/Requests/Unit/UpdateUnitRequest.php
@@ -73,7 +73,13 @@ class UpdateUnitRequest extends FormRequest
                 ? $storedRate?->currency
                 : (is_string($rate['currency'] ?? null) ? $rate['currency'] : null);
 
-            $rules["rates.{$index}.amount"] = ['required_with:rates', new MoneyAmount($currency)];
+            $amountRules = ['required_with:rates'];
+
+            if ($currency !== null) {
+                $amountRules[] = new MoneyAmount($currency);
+            }
+
+            $rules["rates.{$index}.amount"] = $amountRules;
         }
 
         return $rules;

--- a/app/Repositories/SettingRepository.php
+++ b/app/Repositories/SettingRepository.php
@@ -4,13 +4,22 @@ namespace App\Repositories;
 
 use App\Data\Settings\SettingUpdateData;
 use App\Models\Setting;
+use App\Services\Settings\InstallationCurrencySettings;
 use Illuminate\Support\Facades\DB;
 
 class SettingRepository
 {
+    public function __construct(
+        private InstallationCurrencySettings $currencies,
+    ) {}
+
     public function update(array $data): SettingUpdateData
     {
         return DB::transaction(function () use ($data) {
+            if (array_intersect(array_keys($data), ['currency', 'supported_currencies']) !== []) {
+                $this->currencies->lockForUpdate();
+            }
+
             $original = [];
 
             foreach ($data as $key => $value) {

--- a/app/Services/Settings/InstallationCurrencySettings.php
+++ b/app/Services/Settings/InstallationCurrencySettings.php
@@ -49,6 +49,13 @@ final class InstallationCurrencySettings
         return $this->resolveSupported($configured, $default);
     }
 
+    /**
+     * Lock currency settings for a transaction that changes currency settings
+     * or creates new rate variants.
+     *
+     * This relies on row-level SELECT ... FOR UPDATE support from the
+     * supported production database drivers. SQLite's lockForUpdate is a no-op.
+     */
     public function lockForUpdate(): void
     {
         Setting::query()
@@ -57,16 +64,19 @@ final class InstallationCurrencySettings
             ->get();
     }
 
-    public function hasStoredSupportedCurrencies(): bool
+    public function hasStoredSupportedCurrencies(bool $fresh = false): bool
     {
-        $configured = Setting::get('supported_currencies');
+        $configured = $fresh
+            ? $this->storedValue('supported_currencies')
+            : Setting::get('supported_currencies');
 
         if (! is_array($configured) || $configured === []) {
             return false;
         }
 
         try {
-            $this->normalize($configured, $this->default());
+            $default = $fresh ? $this->freshDefault() : $this->default();
+            $this->normalize($configured, $default);
 
             return true;
         } catch (\Throwable) {

--- a/app/Services/Settings/InstallationCurrencySettings.php
+++ b/app/Services/Settings/InstallationCurrencySettings.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace App\Services\Settings;
+
+use App\Models\Setting;
+use App\Services\Payments\MoneyConverter;
+use InvalidArgumentException;
+
+final class InstallationCurrencySettings
+{
+    public function __construct(
+        private MoneyConverter $money,
+    ) {}
+
+    public function default(bool $fresh = false): string
+    {
+        if ($fresh) {
+            return $this->freshDefault();
+        }
+
+        try {
+            return $this->money->normalizeCurrency(Setting::get('currency'));
+        } catch (\Throwable) {
+            return $this->money->normalizeCurrency(config('settings.currency.default', 'IDR'));
+        }
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function supported(): array
+    {
+        return $this->resolveSupported(Setting::get('supported_currencies'), $this->default());
+    }
+
+    /**
+     * Resolve the latest committed settings directly from the database.
+     *
+     * This is used immediately before creating a new rate so a scoped
+     * settings snapshot cannot allow a currency removed by another request.
+     *
+     * @return array<int, string>
+     */
+    public function freshSupported(): array
+    {
+        $default = $this->freshDefault();
+        $configured = $this->storedValue('supported_currencies');
+
+        return $this->resolveSupported($configured, $default);
+    }
+
+    public function hasStoredSupportedCurrencies(): bool
+    {
+        $configured = Setting::get('supported_currencies');
+
+        if (! is_array($configured) || $configured === []) {
+            return false;
+        }
+
+        try {
+            $this->normalize($configured, $this->default());
+
+            return true;
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+
+    public function supports(?string $currency, bool $fresh = false): bool
+    {
+        try {
+            $normalized = $currency === null
+                ? ($fresh ? $this->freshDefault() : $this->default())
+                : $this->money->normalizeCurrency($currency);
+        } catch (\Throwable) {
+            return false;
+        }
+
+        $supported = $fresh ? $this->freshSupported() : $this->supported();
+
+        return in_array($normalized, $supported, true);
+    }
+
+    /**
+     * @param  array<int, mixed>  $currencies
+     * @return array<int, string>
+     */
+    public function normalize(array $currencies, ?string $default = null): array
+    {
+        if ($currencies === []) {
+            throw new InvalidArgumentException('At least one supported currency is required.');
+        }
+
+        $normalized = [];
+        foreach ($currencies as $currency) {
+            if (! is_string($currency)) {
+                throw new InvalidArgumentException('Supported currencies must be ISO 4217 codes.');
+            }
+
+            $normalized[] = strtoupper(trim($currency));
+        }
+
+        $normalized = array_values(array_unique($normalized));
+
+        foreach ($normalized as $currency) {
+            $this->money->normalizeCurrency($currency);
+        }
+
+        if ($default !== null) {
+            $default = $this->money->normalizeCurrency($default);
+
+            if (! in_array($default, $normalized, true)) {
+                throw new InvalidArgumentException('The default currency must be supported.');
+            }
+        }
+
+        return $normalized;
+    }
+
+    private function freshDefault(): string
+    {
+        try {
+            return $this->money->normalizeCurrency($this->storedValue('currency'));
+        } catch (\Throwable) {
+            return $this->money->normalizeCurrency(config('settings.currency.default', 'IDR'));
+        }
+    }
+
+    private function storedValue(string $key): mixed
+    {
+        return Setting::query()->where('key', $key)->first()?->resolveValue();
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function resolveSupported(mixed $configured, string $default): array
+    {
+        if (! is_array($configured) || $configured === []) {
+            return [$default];
+        }
+
+        try {
+            return $this->normalize($configured, $default);
+        } catch (\Throwable) {
+            return [$default];
+        }
+    }
+}

--- a/app/Services/Settings/InstallationCurrencySettings.php
+++ b/app/Services/Settings/InstallationCurrencySettings.php
@@ -49,6 +49,14 @@ final class InstallationCurrencySettings
         return $this->resolveSupported($configured, $default);
     }
 
+    public function lockForUpdate(): void
+    {
+        Setting::query()
+            ->whereIn('key', ['currency', 'supported_currencies'])
+            ->lockForUpdate()
+            ->get();
+    }
+
     public function hasStoredSupportedCurrencies(): bool
     {
         $configured = Setting::get('supported_currencies');

--- a/config/settings.php
+++ b/config/settings.php
@@ -8,6 +8,7 @@ return [
     'country_code' => ['default' => 'ID', 'cast' => 'string'],
     'locale' => ['default' => 'id', 'cast' => 'string'],
     'currency' => ['default' => 'IDR', 'cast' => 'string'],
+    'supported_currencies' => ['default' => null, 'cast' => 'array'],
     'timezone' => ['default' => 'Asia/Jakarta', 'cast' => 'string'],
     'lease_id_prefix' => ['default' => 'LSX', 'cast' => 'string'],
     'invoice_pdf_enabled' => ['default' => false, 'cast' => 'boolean'],

--- a/resources/js/pages/properties/units/rates.tsx
+++ b/resources/js/pages/properties/units/rates.tsx
@@ -79,12 +79,15 @@ export default function UnitRates({
     property: Property;
     unit: Unit;
 }) {
-    const { app, setting } = usePage<{
-        app: { currency_scales: Record<string, number> };
-        setting: { currency: string };
+    const { setting } = usePage<{
+        setting: { currency: string; supported_currencies: string[] };
     }>().props;
-    const currencies = Object.keys(app.currency_scales).sort();
     const defaultCurrency = setting.currency.toUpperCase();
+    const supportedCurrencies = setting.supported_currencies.includes(
+        defaultCurrency,
+    )
+        ? setting.supported_currencies
+        : [defaultCurrency, ...setting.supported_currencies];
     const [currencyFilter, setCurrencyFilter] = useState('all');
     const [statusFilter, setStatusFilter] = useState('active');
     const [editingRateId, setEditingRateId] = useState<number | null>(null);
@@ -109,6 +112,14 @@ export default function UnitRates({
             notes: unit.notes ?? '',
             updated_at: unit.updated_at ?? null,
         });
+    const currencies = Array.from(
+        new Set([
+            ...supportedCurrencies,
+            ...data.rates.map((rate) =>
+                (rate.currency ?? defaultCurrency).toUpperCase(),
+            ),
+        ]),
+    ).sort();
 
     const visibleRates = data.rates.filter((rate) => {
         const currency = (rate.currency ?? defaultCurrency).toUpperCase();
@@ -465,7 +476,7 @@ export default function UnitRates({
                                     <SelectValue />
                                 </SelectTrigger>
                                 <SelectContent>
-                                    {currencies.map((currency) => (
+                                    {supportedCurrencies.map((currency) => (
                                         <SelectItem
                                             key={currency}
                                             value={currency}

--- a/resources/js/pages/settings/general.tsx
+++ b/resources/js/pages/settings/general.tsx
@@ -11,6 +11,7 @@ import {
     CardHeader,
     CardTitle,
 } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
@@ -41,6 +42,7 @@ export default function General({
         country_code: string;
         locale: string;
         currency: string;
+        supported_currencies: string[];
         timezone: string;
         lease_id_prefix: string;
         invoice_id_prefix: string;
@@ -48,7 +50,8 @@ export default function General({
     };
     timezone_list: string[];
 }) {
-    const { branding } = usePage<{
+    const { app, branding } = usePage<{
+        app: { currency_scales: Record<string, number> };
         branding: {
             logoUrl: string;
             faviconUrl: string;
@@ -58,6 +61,12 @@ export default function General({
             hasConfiguredFavicon: boolean;
         };
     }>().props;
+    const currencyOptions = Object.keys(app.currency_scales).sort();
+    const currencyNames = new Intl.DisplayNames(['en'], { type: 'currency' });
+
+    function currencyLabel(currency: string): string {
+        return `${currency} — ${currencyNames.of(currency) ?? currency}`;
+    }
     const [uploadingBranding, setUploadingBranding] =
         useState<BrandingAsset | null>(null);
     const [brandingErrors, setBrandingErrors] = useState<
@@ -72,8 +81,41 @@ export default function General({
         country_code: settings.country_code,
         locale: settings.locale,
         currency: settings.currency,
+        supported_currencies: settings.supported_currencies,
         timezone: settings.timezone,
     });
+
+    function setDefaultCurrency(currency: string): void {
+        localizationForm.setData((current) => ({
+            ...current,
+            currency,
+            supported_currencies: current.supported_currencies.includes(
+                currency,
+            )
+                ? current.supported_currencies
+                : [...current.supported_currencies, currency],
+        }));
+    }
+
+    function toggleSupportedCurrency(currency: string, checked: boolean): void {
+        if (!checked && currency === localizationForm.data.currency) {
+            return;
+        }
+
+        localizationForm.setData(
+            'supported_currencies',
+            checked
+                ? Array.from(
+                      new Set([
+                          ...localizationForm.data.supported_currencies,
+                          currency,
+                      ]),
+                  )
+                : localizationForm.data.supported_currencies.filter(
+                      (item) => item !== currency,
+                  ),
+        );
+    }
 
     const referenceForm = useForm({
         lease_id_prefix: settings.lease_id_prefix,
@@ -160,7 +202,10 @@ export default function General({
                             },
                         ] as const
                     ).map((item) => (
-                        <div key={item.asset} className="space-y-4 rounded-lg border p-4">
+                        <div
+                            key={item.asset}
+                            className="space-y-4 rounded-lg border p-4"
+                        >
                             <div className="flex items-center gap-4">
                                 <div className="flex size-20 items-center justify-center rounded-md border bg-muted/30 p-2">
                                     <img
@@ -170,7 +215,9 @@ export default function General({
                                     />
                                 </div>
                                 <div>
-                                    <h3 className="font-medium">{item.title}</h3>
+                                    <h3 className="font-medium">
+                                        {item.title}
+                                    </h3>
                                     <p className="text-sm text-muted-foreground">
                                         {item.description}
                                     </p>
@@ -352,28 +399,92 @@ export default function General({
                                     )}
                                 </div>
 
-                                <div className="grid max-w-xs gap-2">
-                                    <Label htmlFor="currency">Currency</Label>
-                                    <Input
-                                        id="currency"
-                                        name="currency"
+                                <div className="grid max-w-md gap-2">
+                                    <Label htmlFor="currency">
+                                        Default currency
+                                    </Label>
+                                    <Select
                                         value={localizationForm.data.currency}
-                                        onChange={(e) =>
-                                            localizationForm.setData(
-                                                'currency',
-                                                e.target.value.toUpperCase(),
-                                            )
-                                        }
-                                        maxLength={3}
-                                        className="font-mono uppercase"
-                                        placeholder="ISO 4217"
-                                        required
-                                    />
+                                        onValueChange={setDefaultCurrency}
+                                    >
+                                        <SelectTrigger id="currency">
+                                            <SelectValue />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {currencyOptions.map((currency) => (
+                                                <SelectItem
+                                                    key={currency}
+                                                    value={currency}
+                                                >
+                                                    {currencyLabel(currency)}
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
                                     {localizationForm.errors.currency && (
                                         <p className="text-sm text-red-600">
                                             {localizationForm.errors.currency}
                                         </p>
                                     )}
+                                </div>
+
+                                <div className="grid max-w-md gap-2">
+                                    <div>
+                                        <Label>Supported currencies</Label>
+                                        <p className="text-sm text-muted-foreground">
+                                            Available for new pricing and
+                                            billing rates. Existing records keep
+                                            their original currency.
+                                        </p>
+                                    </div>
+                                    <div className="grid max-h-72 gap-2 overflow-y-auto rounded-md border p-3 sm:grid-cols-2">
+                                        {currencyOptions.map((currency) => {
+                                            const isSupported =
+                                                localizationForm.data.supported_currencies.includes(
+                                                    currency,
+                                                );
+                                            const isDefault =
+                                                localizationForm.data
+                                                    .currency === currency;
+
+                                            return (
+                                                <label
+                                                    key={currency}
+                                                    className="flex items-start gap-2 rounded-md p-2 text-sm hover:bg-muted/50"
+                                                >
+                                                    <Checkbox
+                                                        checked={isSupported}
+                                                        disabled={isDefault}
+                                                        onCheckedChange={(
+                                                            checked,
+                                                        ) =>
+                                                            toggleSupportedCurrency(
+                                                                currency,
+                                                                checked ===
+                                                                    true,
+                                                            )
+                                                        }
+                                                    />
+                                                    <span>
+                                                        <span className="block font-mono font-medium">
+                                                            {currency}
+                                                        </span>
+                                                        <span className="block text-xs text-muted-foreground">
+                                                            {currencyNames.of(
+                                                                currency,
+                                                            ) ?? currency}
+                                                        </span>
+                                                    </span>
+                                                </label>
+                                            );
+                                        })}
+                                    </div>
+                                    <InputError
+                                        message={
+                                            localizationForm.errors
+                                                .supported_currencies
+                                        }
+                                    />
                                 </div>
 
                                 <div className="grid max-w-xs gap-2">

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -23,6 +23,7 @@ declare module '@inertiajs/core' {
                 country_code: string;
                 locale: string;
                 currency: string;
+                supported_currencies: string[];
                 timezone: string;
             };
             branding: {

--- a/tests/Feature/InstallCommandTest.php
+++ b/tests/Feature/InstallCommandTest.php
@@ -26,6 +26,7 @@ test('install command creates owner account and settings', function () {
     expect(Setting::get('country_code'))->toBe('ID');
     expect(Setting::get('locale'))->toBe('en');
     expect(Setting::get('currency'))->toBe('IDR');
+    expect(Setting::get('supported_currencies'))->toBe(['IDR']);
     expect(Setting::get('timezone'))->toBe('Asia/Jakarta');
 });
 
@@ -44,6 +45,7 @@ test('install command stores other country defaults', function () {
     expect(Setting::get('site_name'))->toBe('My Boarding');
     expect(Setting::get('country_code'))->toBe('XX');
     expect(Setting::get('currency'))->toBe('USD');
+    expect(Setting::get('supported_currencies'))->toBe(['USD']);
     expect(Setting::get('timezone'))->toBe('UTC');
 });
 

--- a/tests/Feature/Settings/GeneralSettingsTest.php
+++ b/tests/Feature/Settings/GeneralSettingsTest.php
@@ -4,6 +4,7 @@ use App\Models\Setting;
 use App\Models\Tenant;
 use App\Models\Unit;
 use App\Models\User;
+use Illuminate\Support\Facades\DB;
 
 uses()->beforeEach(function () {
     $this->seed(RoleAndPermissionSeeder::class);
@@ -80,6 +81,29 @@ describe('General settings page', function () {
             );
     });
 
+    it('reads currency settings fresh after acquiring the transaction lock', function () {
+        $owner = User::factory()->owner()->create();
+        Setting::set('currency', 'IDR');
+        Setting::set('supported_currencies', ['IDR', 'USD']);
+        $unit = Unit::factory()->create();
+        Setting::get('site_name');
+
+        DB::table('settings')->where('key', 'currency')->update(['value' => 'USD']);
+        DB::table('settings')
+            ->where('key', 'supported_currencies')
+            ->update(['value' => json_encode(['USD'], JSON_THROW_ON_ERROR)]);
+
+        $this->actingAs($owner)
+            ->patch(route('settings.general.update'), [
+                'currency' => 'USD',
+                'supported_currencies' => ['USD'],
+            ])
+            ->assertRedirect()
+            ->assertSessionHas('inertia.flash_data.toast.type', 'success');
+
+        expect($unit->rates()->where('currency', 'IDR')->where('is_active', true)->exists())->toBeTrue();
+    });
+
     it('updates all general settings', function () {
         $owner = User::factory()->owner()->create();
 
@@ -144,6 +168,7 @@ describe('General settings page', function () {
         'empty' => [[], 'supported_currencies'],
         'unknown' => [['USD', 'ZZZ'], 'supported_currencies.1'],
         'default excluded' => [['IDR'], 'supported_currencies'],
+        'associative' => [['default' => 'USD'], 'supported_currencies'],
     ]);
 
     it('changes the legacy fallback with the new default currency', function () {

--- a/tests/Feature/Settings/GeneralSettingsTest.php
+++ b/tests/Feature/Settings/GeneralSettingsTest.php
@@ -66,6 +66,20 @@ describe('General settings page', function () {
             );
     });
 
+    it('exposes the canonical currency when persisted storage is non-canonical', function () {
+        $owner = User::factory()->owner()->create();
+        Setting::set('currency', ' usd ');
+
+        $this->actingAs($owner)
+            ->get(route('settings.general.edit'))
+            ->assertInertia(fn ($page) => $page
+                ->where('settings.currency', 'USD')
+                ->where('settings.supported_currencies', ['USD'])
+                ->where('setting.currency', 'USD')
+                ->where('setting.supported_currencies', ['USD'])
+            );
+    });
+
     it('updates all general settings', function () {
         $owner = User::factory()->owner()->create();
 

--- a/tests/Feature/Settings/GeneralSettingsTest.php
+++ b/tests/Feature/Settings/GeneralSettingsTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\Setting;
 use App\Models\Tenant;
+use App\Models\Unit;
 use App\Models\User;
 
 uses()->beforeEach(function () {
@@ -56,6 +57,7 @@ describe('General settings page', function () {
                 ->has('settings.country_code')
                 ->has('settings.locale')
                 ->has('settings.currency')
+                ->where('settings.supported_currencies', ['IDR'])
                 ->has('settings.timezone')
                 ->has('settings.lease_id_prefix')
                 ->has('settings.invoice_id_prefix')
@@ -88,6 +90,75 @@ describe('General settings page', function () {
         expect(Setting::get('lease_id_prefix'))->toBe('LSE');
         expect(Setting::get('invoice_id_prefix'))->toBe('INV');
         expect(Setting::get('invoice_pdf_enabled'))->toBeTrue();
+    });
+
+    it('normalizes and stores supported currencies', function () {
+        $owner = User::factory()->owner()->create();
+
+        $this->actingAs($owner)
+            ->patch(route('settings.general.update'), [
+                'currency' => ' usd ',
+                'supported_currencies' => [' idr ', 'usd'],
+            ])
+            ->assertRedirect();
+
+        expect(Setting::get('currency'))->toBe('USD')
+            ->and(Setting::get('supported_currencies'))->toBe(['IDR', 'USD']);
+    });
+
+    it('rejects case-insensitive duplicate supported currencies', function () {
+        $owner = User::factory()->owner()->create();
+
+        $this->actingAs($owner)
+            ->patch(route('settings.general.update'), [
+                'currency' => 'IDR',
+                'supported_currencies' => ['idr', 'IDR'],
+            ])
+            ->assertSessionHasErrors('supported_currencies.1');
+    });
+
+    it('rejects empty, unknown, and default-excluding supported currencies', function (array $supported, string $error): void {
+        $owner = User::factory()->owner()->create();
+
+        $this->actingAs($owner)
+            ->patch(route('settings.general.update'), [
+                'currency' => 'USD',
+                'supported_currencies' => $supported,
+            ])
+            ->assertSessionHasErrors($error);
+    })->with([
+        'empty' => [[], 'supported_currencies'],
+        'unknown' => [['USD', 'ZZZ'], 'supported_currencies.1'],
+        'default excluded' => [['IDR'], 'supported_currencies'],
+    ]);
+
+    it('changes the legacy fallback with the new default currency', function () {
+        $owner = User::factory()->owner()->create();
+        Setting::set('currency', 'IDR');
+
+        $this->actingAs($owner)
+            ->patch(route('settings.general.update'), ['currency' => 'USD'])
+            ->assertRedirect();
+
+        expect(Setting::get('currency'))->toBe('USD')
+            ->and(Setting::get('supported_currencies'))->toBeNull();
+    });
+
+    it('warns when removing a currency used by active rates', function () {
+        $owner = User::factory()->owner()->create();
+        $unit = Unit::factory()->create();
+        Setting::set('currency', 'IDR');
+        Setting::set('supported_currencies', ['IDR', 'USD']);
+
+        $this->actingAs($owner)
+            ->patch(route('settings.general.update'), [
+                'currency' => 'USD',
+                'supported_currencies' => ['USD'],
+            ])
+            ->assertRedirect()
+            ->assertSessionHas('inertia.flash_data.toast.type', 'warning');
+
+        expect($unit->rates()->where('currency', 'IDR')->where('is_active', true)->exists())->toBeTrue();
     });
 
     it('validates country_code is 2 uppercase letters', function () {

--- a/tests/Feature/UnitTest.php
+++ b/tests/Feature/UnitTest.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\DB;
 
 uses()->beforeEach(function () {
     $this->seed(RoleAndPermissionSeeder::class);
+    Setting::set('supported_currencies', ['IDR', 'USD']);
 });
 
 describe('authorization', function () {
@@ -136,6 +137,7 @@ describe('CRUD', function () {
             ->assertOk()
             ->assertInertia(fn ($page) => $page
                 ->component('properties/units/rates')
+                ->where('setting.supported_currencies', ['IDR', 'USD'])
                 ->where('unit.rates.1.currency', 'USD')
             );
     });
@@ -519,6 +521,59 @@ describe('active rates ordering', function () {
 });
 
 describe('currency-specific rates', function () {
+    it('rejects new rate variants outside supported currencies', function () {
+        $user = User::factory()->owner()->create();
+        $property = Property::factory()->create();
+        Setting::set('supported_currencies', ['IDR']);
+
+        $this->actingAs($user)
+            ->post(route('properties.units.store', $property), [
+                'name' => 'Unit 101',
+                'capacity' => 1,
+                'rates' => [[
+                    'billing_interval' => 1,
+                    'billing_unit' => 'month',
+                    'amount' => '95.00',
+                    'currency' => 'USD',
+                ]],
+            ])
+            ->assertSessionHasErrors('rates.0.currency');
+    });
+
+    it('keeps existing rates usable after their currency is removed', function () {
+        $user = User::factory()->owner()->create();
+        $property = Property::factory()->create();
+        $unit = Unit::factory()->for($property)->create();
+        $rate = $unit->rates()->create([
+            'billing_interval' => 1,
+            'billing_unit' => 'month',
+            'amount' => '95.00',
+            'currency' => 'USD',
+            'is_active' => true,
+        ]);
+        Setting::set('supported_currencies', ['IDR']);
+
+        $this->actingAs($user)
+            ->put(route('properties.units.update', [$property, $unit]), [
+                'name' => $unit->name,
+                'capacity' => $unit->capacity,
+                'updated_at' => $unit->updated_at->toISOString(),
+                'rates' => [[
+                    'id' => $rate->id,
+                    'billing_interval' => $rate->billing_interval,
+                    'billing_unit' => $rate->billing_unit->value,
+                    'amount' => '100.00',
+                    'currency' => 'USD',
+                    'is_active' => false,
+                ]],
+            ])
+            ->assertRedirect()
+            ->assertSessionHasNoErrors();
+
+        expect($rate->fresh()->amount)->toBe('100.000')
+            ->and($rate->fresh()->is_active)->toBeFalse();
+    });
+
     it('allows independent prices for the same billing period in different currencies', function () {
         $user = User::factory()->owner()->create();
         $property = Property::factory()->create();

--- a/tests/Feature/UnitTest.php
+++ b/tests/Feature/UnitTest.php
@@ -540,6 +540,37 @@ describe('currency-specific rates', function () {
             ->assertSessionHasErrors('rates.0.currency');
     });
 
+    it('uses the fresh default currency for omitted new-rate currency values', function () {
+        $user = User::factory()->owner()->create();
+        $property = Property::factory()->create();
+        Setting::set('currency', 'IDR');
+        Setting::set('supported_currencies', ['IDR', 'USD']);
+        Setting::get('site_name');
+
+        DB::table('settings')->where('key', 'currency')->update(['value' => 'USD']);
+        DB::table('settings')
+            ->where('key', 'supported_currencies')
+            ->update(['value' => json_encode(['USD'], JSON_THROW_ON_ERROR)]);
+
+        $this->actingAs($user)
+            ->post(route('properties.units.store', $property), [
+                'name' => 'Unit 101',
+                'capacity' => 1,
+                'rates' => [[
+                    'billing_interval' => 1,
+                    'billing_unit' => 'month',
+                    'amount' => '95.25',
+                ]],
+            ])
+            ->assertRedirect()
+            ->assertSessionHasNoErrors();
+
+        $unit = Unit::query()->where('name', 'Unit 101')->firstOrFail();
+
+        expect($unit->rates()->value('currency'))->toBe('USD')
+            ->and($unit->rates()->value('amount'))->toBe('95.250');
+    });
+
     it('keeps existing rates usable after their currency is removed', function () {
         $user = User::factory()->owner()->create();
         $property = Property::factory()->create();

--- a/tests/Unit/Services/InstallationCurrencySettingsTest.php
+++ b/tests/Unit/Services/InstallationCurrencySettingsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use App\Models\Setting;
+use App\Services\Settings\InstallationCurrencySettings;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+it('falls back to the default currency when supported currencies are missing', function () {
+    Setting::set('currency', 'USD');
+
+    expect(app(InstallationCurrencySettings::class)->supported())->toBe(['USD']);
+});
+
+it('preserves normalized supported-currency order', function () {
+    $settings = app(InstallationCurrencySettings::class);
+
+    expect($settings->normalize([' usd ', 'IDR'], default: 'USD'))
+        ->toBe(['USD', 'IDR']);
+});
+
+it('falls back safely when persisted supported currencies are malformed', function () {
+    Setting::set('currency', 'IDR');
+    Setting::set('supported_currencies', ['unknown']);
+
+    expect(app(InstallationCurrencySettings::class)->supported())->toBe(['IDR']);
+});

--- a/tests/Unit/Services/InstallationCurrencySettingsTest.php
+++ b/tests/Unit/Services/InstallationCurrencySettingsTest.php
@@ -3,6 +3,7 @@
 use App\Models\Setting;
 use App\Services\Settings\InstallationCurrencySettings;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 uses(TestCase::class, RefreshDatabase::class);
@@ -25,4 +26,24 @@ it('falls back safely when persisted supported currencies are malformed', functi
     Setting::set('supported_currencies', ['unknown']);
 
     expect(app(InstallationCurrencySettings::class)->supported())->toBe(['IDR']);
+});
+
+it('emits row-level locking SQL on supported production database drivers', function () {
+    if (! in_array(DB::getDriverName(), ['pgsql', 'mysql', 'mariadb'], true)) {
+        $this->markTestSkipped('SQLite does not provide row-level SELECT ... FOR UPDATE locking.');
+    }
+
+    Setting::set('currency', 'IDR');
+    Setting::set('supported_currencies', ['IDR']);
+    DB::connection()->flushQueryLog();
+    DB::connection()->enableQueryLog();
+
+    DB::transaction(function (): void {
+        app(InstallationCurrencySettings::class)->lockForUpdate();
+    });
+
+    expect(collect(DB::connection()->getQueryLog())
+        ->pluck('query')
+        ->contains(fn (string $query): bool => str_contains(strtolower($query), 'for update')))
+        ->toBeTrue();
 });


### PR DESCRIPTION
## Summary

- Add installation supported-currency settings with canonical normalization and legacy fallback behavior.
- Enforce supported currencies and currency precision for new unit-rate variants.
- Serialize settings changes and new-rate creation with fresh database reads after row locks.
- Preserve existing rates in removed currencies and expose canonical currency props.

## Verification

- 963 tests passed, 2 skipped
- Pint, TypeScript, ESLint, and production build passed

Refs OPE-168