### PR TITLE
fix(plugins): harden runtime artifact validation

### DIFF
--- a/app/Console/Commands/DisableRuntimePluginCommand.php
+++ b/app/Console/Commands/DisableRuntimePluginCommand.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\Platform\PluginInstaller;
+use Illuminate\Console\Command;
+use Throwable;
+
+final class DisableRuntimePluginCommand extends Command
+{
+    protected $signature = 'plugin:disable {id : Runtime plugin ID}';
+
+    protected $description = 'Disable an installed runtime plugin without deleting its files.';
+
+    public function handle(PluginInstaller $installer): int
+    {
+        try {
+            $installer->disable((string) $this->argument('id'));
+        } catch (Throwable $exception) {
+            $this->error($exception->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $this->info("Runtime plugin [{$this->argument('id')}] disabled.");
+        $this->warn('Restart FrankenPHP, queue workers, and the scheduler to apply the change.');
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/EnableRuntimePluginCommand.php
+++ b/app/Console/Commands/EnableRuntimePluginCommand.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\Platform\PluginInstaller;
+use Illuminate\Console\Command;
+use Throwable;
+
+final class EnableRuntimePluginCommand extends Command
+{
+    protected $signature = 'plugin:enable {id : Runtime plugin ID}';
+
+    protected $description = 'Validate and enable an installed runtime plugin.';
+
+    public function handle(PluginInstaller $installer): int
+    {
+        try {
+            $metadata = $installer->enable((string) $this->argument('id'));
+        } catch (Throwable $exception) {
+            $this->error($exception->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $this->info("Runtime plugin [{$metadata['id']}] enabled.");
+        $this->warn('Restart FrankenPHP, queue workers, and the scheduler to apply the change.');
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/InstallRuntimePluginCommand.php
+++ b/app/Console/Commands/InstallRuntimePluginCommand.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\Platform\PluginInstaller;
+use Illuminate\Console\Command;
+use Throwable;
+
+final class InstallRuntimePluginCommand extends Command
+{
+    protected $signature = 'plugin:install {zip : Path to a prepared plugin ZIP}';
+
+    protected $description = 'Install or update a prepared runtime plugin ZIP.';
+
+    public function handle(PluginInstaller $installer): int
+    {
+        try {
+            $metadata = $installer->install((string) $this->argument('zip'));
+        } catch (Throwable $exception) {
+            $this->error($exception->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $this->info("Runtime plugin [{$metadata['id']}] version {$metadata['version']} installed.");
+        $this->warn('Restart FrankenPHP, queue workers, and the scheduler to apply the change.');
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/ListRuntimePluginsCommand.php
+++ b/app/Console/Commands/ListRuntimePluginsCommand.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\Platform\RuntimePluginArtifactValidator;
+use App\Services\Platform\RuntimePluginStore;
+use Illuminate\Console\Command;
+use Throwable;
+
+final class ListRuntimePluginsCommand extends Command
+{
+    protected $signature = 'plugin:list';
+
+    protected $description = 'List installed runtime plugins and their state.';
+
+    public function handle(RuntimePluginStore $store, RuntimePluginArtifactValidator $validator): int
+    {
+        try {
+            $rows = $store->withLock(function (RuntimePluginStore $store) use ($validator): array {
+                $state = $store->readState();
+                $rows = [];
+
+                foreach ($store->installedPackages() as $id => $path) {
+                    $enabled = $state[$id]['enabled'] ?? false;
+
+                    try {
+                        $metadata = $validator->validate($path, $id);
+                        $rows[] = [$id, $metadata['version'], $enabled ? 'Enabled' : 'Disabled'];
+                    } catch (Throwable $exception) {
+                        $rows[] = [$id, 'unknown', $enabled ? 'Invalid (enabled)' : 'Invalid (disabled)'];
+                        report($exception);
+                    }
+                }
+
+                foreach (array_diff_key($state, $store->installedPackages()) as $id => $entry) {
+                    $rows[] = [$id, 'missing', $entry['enabled'] ? 'Missing (enabled)' : 'Missing (disabled)'];
+                }
+
+                return $rows;
+            });
+        } catch (Throwable $exception) {
+            $this->error($exception->getMessage());
+
+            return self::FAILURE;
+        }
+
+        if ($rows === []) {
+            $this->info('No runtime plugins are installed.');
+
+            return self::SUCCESS;
+        }
+
+        $this->table(['Plugin', 'Version', 'State'], $rows);
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/RemoveRuntimePluginCommand.php
+++ b/app/Console/Commands/RemoveRuntimePluginCommand.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\Platform\PluginInstaller;
+use Illuminate\Console\Command;
+use Throwable;
+
+final class RemoveRuntimePluginCommand extends Command
+{
+    protected $signature = 'plugin:remove {id : Runtime plugin ID} {--force : Do not ask for confirmation}';
+
+    protected $description = 'Remove an installed runtime plugin without dropping its data.';
+
+    public function handle(PluginInstaller $installer): int
+    {
+        if (! $this->option('force') && ! $this->confirm('Remove the runtime plugin package?')) {
+            return self::SUCCESS;
+        }
+
+        try {
+            $installer->remove((string) $this->argument('id'));
+        } catch (Throwable $exception) {
+            $this->error($exception->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $this->info("Runtime plugin [{$this->argument('id')}] removed. Plugin data was not dropped.");
+        $this->warn('Restart FrankenPHP, queue workers, and the scheduler to apply the change.');
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Services/Platform/ComposerPluginDiscovery.php
+++ b/app/Services/Platform/ComposerPluginDiscovery.php
@@ -9,10 +9,41 @@ use OpenKOS\Platform\Plugin\Plugin;
 
 final class ComposerPluginDiscovery implements PluginDiscovery
 {
+    public function __construct(private RuntimePluginDiscovery $runtime) {}
+
     /**
      * @return array<int, class-string<Plugin>>
      */
     public function discover(): array
+    {
+        $composerPlugins = $this->discoverComposerOnly();
+        $runtimePlugins = $this->runtime->discover([
+            ...config('platform.plugins', []),
+            ...$composerPlugins,
+        ]);
+
+        $duplicateClasses = array_intersect($composerPlugins, $runtimePlugins);
+        if ($duplicateClasses !== []) {
+            throw new InvalidArgumentException(
+                'Runtime plugin entry class conflicts with an existing plugin: '.implode(', ', $duplicateClasses),
+            );
+        }
+
+        return array_values(array_unique([...$composerPlugins, ...$runtimePlugins]));
+    }
+
+    /**
+     * @return array<int, class-string<Plugin>>
+     */
+    public function discoverComposerOnly(): array
+    {
+        return $this->discoverComposerPlugins();
+    }
+
+    /**
+     * @return array<int, class-string<Plugin>>
+     */
+    private function discoverComposerPlugins(): array
     {
         $disabledPackages = config('platform.discovery.disabled_packages', []);
         $packages = InstalledVersions::getInstalledPackages();

--- a/app/Services/Platform/PluginInstaller.php
+++ b/app/Services/Platform/PluginInstaller.php
@@ -3,8 +3,10 @@
 namespace App\Services\Platform;
 
 use InvalidArgumentException;
+use OpenKOS\Platform\OpenKOSManager;
 use OpenKOS\Platform\Plugin\Plugin;
 use OpenKOS\Platform\Plugin\PluginLoader;
+use OpenKOS\Platform\Plugin\PluginManifest;
 use RuntimeException;
 use Throwable;
 use ZipArchive;
@@ -56,8 +58,8 @@ final class PluginInstaller
                     throw new RuntimeException('Plugin ZIP could not be extracted into staging storage.');
                 }
 
-                $metadata = $this->validator->validate($stagingPath);
-                $this->validateBootSet($metadata, $stagingPath, $store);
+                $metadata = $this->validator->validateInFreshProcess($stagingPath);
+                $this->validateBootSet($metadata, $store);
 
                 $state = $store->readState();
                 $enabled = ! isset($state[$metadata['id']]) || $state[$metadata['id']]['enabled'];
@@ -93,8 +95,8 @@ final class PluginInstaller
     {
         return $this->store->withLock(function (RuntimePluginStore $store) use ($id): array {
             $path = $store->packagePath($id);
-            $metadata = $this->validator->validate($path, $id);
-            $this->validateBootSet($metadata, $path, $store);
+            $metadata = $this->validator->validateInFreshProcess($path, $id);
+            $this->validateBootSet($metadata, $store);
             $store->setEnabled($id, true);
 
             return $metadata;
@@ -117,10 +119,11 @@ final class PluginInstaller
 
     private function validateArchiveEntries(ZipArchive $archive): void
     {
-        $count = 0;
+        $entryCount = 0;
         $size = 0;
         $maxFiles = (int) config('platform.runtime.max_files', 5000);
         $maxSize = (int) config('platform.runtime.max_uncompressed_bytes', 268_435_456);
+        $seen = [];
 
         for ($index = 0; $index < $archive->numFiles; $index++) {
             $stat = $archive->statIndex($index);
@@ -131,6 +134,7 @@ final class PluginInstaller
 
             $name = $stat['name'];
             $normalizedName = str_replace('\\', '/', $name);
+            $normalizedPath = rtrim($normalizedName, '/');
             $segments = explode('/', $normalizedName);
             $isDirectory = str_ends_with($normalizedName, '/');
 
@@ -140,10 +144,18 @@ final class PluginInstaller
                 str_starts_with($normalizedName, '/') ||
                 preg_match('/^[A-Za-z]:\//', $normalizedName) === 1 ||
                 in_array('..', $segments, true) ||
+                in_array('.', $segments, true) ||
                 in_array('', array_slice($segments, 0, -1), true)
             ) {
                 throw new InvalidArgumentException("Plugin ZIP contains an unsafe path [{$name}].");
             }
+
+            if ($normalizedPath === '' || isset($seen[$normalizedPath])) {
+                throw new InvalidArgumentException("Plugin ZIP contains a duplicate path [{$name}].");
+            }
+
+            $seen[$normalizedPath] = true;
+            $entryCount++;
 
             $topLevel = $segments[0] ?? '';
             if (! in_array($topLevel, [
@@ -176,11 +188,10 @@ final class PluginInstaller
             }
 
             if (! $isDirectory) {
-                $count++;
                 $size += (int) ($stat['size'] ?? 0);
             }
 
-            if ($count > $maxFiles || $size > $maxSize) {
+            if ($entryCount > $maxFiles || $size > $maxSize) {
                 throw new InvalidArgumentException('Plugin ZIP exceeds the configured archive limits.');
             }
 
@@ -202,12 +213,13 @@ final class PluginInstaller
      *     dependencies: array<int, string>
      * } $metadata
      */
-    private function validateBootSet(array $metadata, string $stagingPath, RuntimePluginStore $store): void
+    private function validateBootSet(array $metadata, RuntimePluginStore $store): void
     {
         $hostClasses = [
             ...config('platform.plugins', []),
             ...app(ComposerPluginDiscovery::class)->discoverComposerOnly(),
         ];
+        $runtimeMetadata = [];
         $runtimeClasses = [];
         $state = $store->readState();
 
@@ -216,14 +228,18 @@ final class PluginInstaller
                 continue;
             }
 
-            $runtimeClasses[] = $this->validator->validate($path, $id)['entry_class'];
+            $runtimeMetadata[] = $this->validator->validateInFreshProcess($path, $id);
+            $runtimeClasses[] = $runtimeMetadata[array_key_last($runtimeMetadata)]['entry_class'];
         }
 
-        require_once $stagingPath.'/vendor/autoload.php';
-        $runtimeClasses[] = $metadata['entry_class'];
+        if (in_array($metadata['entry_class'], $hostClasses, true)) {
+            throw new RuntimePluginConflictException(
+                "Runtime plugin entry class [{$metadata['entry_class']}] conflicts with a Composer or explicit plugin. Neither copy will load.",
+            );
+        }
 
         foreach ($runtimeClasses as $class) {
-            if (in_array($class, $hostClasses, true)) {
+            if (in_array($class, $hostClasses, true) || $class === $metadata['entry_class']) {
                 throw new RuntimePluginConflictException(
                     "Runtime plugin entry class [{$class}] conflicts with a Composer or explicit plugin. Neither copy will load.",
                 );
@@ -240,6 +256,39 @@ final class PluginInstaller
             }
 
             $plugins[] = app()->make($class);
+        }
+
+        foreach ([...$runtimeMetadata, $metadata] as $pluginMetadata) {
+            $plugins[] = new class($pluginMetadata) extends Plugin
+            {
+                /**
+                 * @param  array{
+                 *     id: string,
+                 *     name: string,
+                 *     version: string,
+                 *     description: string,
+                 *     entry_class: class-string<Plugin>,
+                 *     core_version: string,
+                 *     php: string,
+                 *     dependencies: array<int, string>
+                 * }  $metadata
+                 */
+                public function __construct(private array $metadata) {}
+
+                public function manifest(): PluginManifest
+                {
+                    return new PluginManifest(
+                        id: $this->metadata['id'],
+                        name: $this->metadata['name'],
+                        version: $this->metadata['version'],
+                        description: $this->metadata['description'],
+                        coreVersion: $this->metadata['core_version'],
+                        dependencies: $this->metadata['dependencies'],
+                    );
+                }
+
+                public function register(OpenKOSManager $platform): void {}
+            };
         }
 
         (new PluginLoader)->prepare($plugins, config('platform.version', '0.2.0'));

--- a/app/Services/Platform/PluginInstaller.php
+++ b/app/Services/Platform/PluginInstaller.php
@@ -1,0 +1,236 @@
+<?php
+
+namespace App\Services\Platform;
+
+use InvalidArgumentException;
+use OpenKOS\Platform\Plugin\Plugin;
+use OpenKOS\Platform\Plugin\PluginLoader;
+use RuntimeException;
+use Throwable;
+use ZipArchive;
+
+final class PluginInstaller
+{
+    public function __construct(
+        private RuntimePluginStore $store,
+        private RuntimePluginArtifactValidator $validator,
+    ) {}
+
+    /**
+     * @return array{
+     *     id: string,
+     *     name: string,
+     *     version: string,
+     *     description: string,
+     *     entry_class: class-string<Plugin>,
+     *     core_version: string,
+     *     php: string,
+     *     dependencies: array<int, string>
+     * }
+     */
+    public function install(string $zipPath): array
+    {
+        if (! config('platform.runtime.enabled', true)) {
+            throw new RuntimeException('Runtime plugin installation is disabled.');
+        }
+
+        if (! is_file($zipPath) || is_link($zipPath)) {
+            throw new InvalidArgumentException('Plugin ZIP file does not exist or is unsafe.');
+        }
+
+        return $this->store->withLock(function (RuntimePluginStore $store) use ($zipPath): array {
+            $archive = new ZipArchive;
+            $opened = $archive->open($zipPath);
+
+            if ($opened !== true) {
+                throw new InvalidArgumentException('Plugin ZIP file cannot be opened.');
+            }
+
+            $stagingPath = null;
+
+            try {
+                $this->validateArchiveEntries($archive);
+                $stagingPath = $store->createStagingPath('incoming');
+
+                if (! $archive->extractTo($stagingPath)) {
+                    throw new RuntimeException('Plugin ZIP could not be extracted into staging storage.');
+                }
+
+                $metadata = $this->validator->validate($stagingPath);
+                $this->validateBootSet($metadata, $stagingPath, $store);
+
+                $state = $store->readState();
+                $enabled = ! isset($state[$metadata['id']]) || $state[$metadata['id']]['enabled'];
+                $store->promote($metadata['id'], $stagingPath, $enabled);
+                $stagingPath = null;
+
+                return $metadata;
+            } catch (Throwable $exception) {
+                if (is_string($stagingPath)) {
+                    $store->discardStaging($stagingPath);
+                }
+
+                throw $exception;
+            } finally {
+                $archive->close();
+            }
+        });
+    }
+
+    /**
+     * @return array{
+     *     id: string,
+     *     name: string,
+     *     version: string,
+     *     description: string,
+     *     entry_class: class-string<Plugin>,
+     *     core_version: string,
+     *     php: string,
+     *     dependencies: array<int, string>
+     * }
+     */
+    public function enable(string $id): array
+    {
+        return $this->store->withLock(function (RuntimePluginStore $store) use ($id): array {
+            $path = $store->packagePath($id);
+            $metadata = $this->validator->validate($path, $id);
+            $this->validateBootSet($metadata, $path, $store);
+            $store->setEnabled($id, true);
+
+            return $metadata;
+        });
+    }
+
+    public function disable(string $id): void
+    {
+        $this->store->withLock(function (RuntimePluginStore $store) use ($id): void {
+            $store->setEnabled($id, false);
+        });
+    }
+
+    public function remove(string $id): void
+    {
+        $this->store->withLock(function (RuntimePluginStore $store) use ($id): void {
+            $store->remove($id);
+        });
+    }
+
+    private function validateArchiveEntries(ZipArchive $archive): void
+    {
+        $count = 0;
+        $size = 0;
+        $maxFiles = (int) config('platform.runtime.max_files', 5000);
+        $maxSize = (int) config('platform.runtime.max_uncompressed_bytes', 268_435_456);
+
+        for ($index = 0; $index < $archive->numFiles; $index++) {
+            $stat = $archive->statIndex($index);
+
+            if (! is_array($stat) || ! is_string($stat['name'] ?? null)) {
+                throw new InvalidArgumentException('Plugin ZIP contains an unreadable entry.');
+            }
+
+            $name = $stat['name'];
+            $normalizedName = str_replace('\\', '/', $name);
+            $segments = explode('/', $normalizedName);
+            $isDirectory = str_ends_with($normalizedName, '/');
+
+            if (
+                $normalizedName === '' ||
+                str_contains($normalizedName, "\0") ||
+                str_starts_with($normalizedName, '/') ||
+                preg_match('/^[A-Za-z]:\//', $normalizedName) === 1 ||
+                in_array('..', $segments, true) ||
+                in_array('', array_slice($segments, 0, -1), true)
+            ) {
+                throw new InvalidArgumentException("Plugin ZIP contains an unsafe path [{$name}].");
+            }
+
+            $topLevel = $segments[0] ?? '';
+            if (! in_array($topLevel, [
+                'manifest.json',
+                'composer.json',
+                'composer.lock',
+                'src',
+                'vendor',
+                'config',
+                'routes',
+                'database',
+                'resources',
+            ], true)) {
+                throw new InvalidArgumentException("Plugin ZIP contains an unexpected path [{$name}].");
+            }
+
+            $externalAttributes = 0;
+            $operatingSystem = 0;
+            if ($archive->getExternalAttributesIndex($index, $operatingSystem, $externalAttributes)) {
+                $mode = ($externalAttributes >> 16) & 0xF000;
+                $permissions = ($externalAttributes >> 16) & 0111;
+
+                if ($mode === 0xA000) {
+                    throw new InvalidArgumentException("Plugin ZIP contains a symlink [{$name}].");
+                }
+
+                if (! $isDirectory && $permissions !== 0) {
+                    throw new InvalidArgumentException("Plugin ZIP contains an executable entry [{$name}].");
+                }
+            }
+
+            if (! $isDirectory) {
+                $count++;
+                $size += (int) ($stat['size'] ?? 0);
+            }
+
+            if ($count > $maxFiles || $size > $maxSize) {
+                throw new InvalidArgumentException('Plugin ZIP exceeds the configured archive limits.');
+            }
+
+            if (preg_match('/(^|\/)(install|post-install|pre-install)\.(php|sh|bash|bat|cmd|exe)$/i', $normalizedName)) {
+                throw new InvalidArgumentException("Plugin ZIP contains an install script [{$name}].");
+            }
+        }
+    }
+
+    /**
+     * @param  array{
+     *     id: string,
+     *     name: string,
+     *     version: string,
+     *     description: string,
+     *     entry_class: class-string<Plugin>,
+     *     core_version: string,
+     *     php: string,
+     *     dependencies: array<int, string>
+     * } $metadata
+     */
+    private function validateBootSet(array $metadata, string $stagingPath, RuntimePluginStore $store): void
+    {
+        $classes = [
+            ...config('platform.plugins', []),
+            ...app(ComposerPluginDiscovery::class)->discoverComposerOnly(),
+        ];
+        $state = $store->readState();
+
+        foreach ($store->installedPackages() as $id => $path) {
+            if ($id === $metadata['id'] || ! ($state[$id]['enabled'] ?? false)) {
+                continue;
+            }
+
+            $classes[] = $this->validator->validate($path, $id)['entry_class'];
+        }
+
+        require_once $stagingPath.'/vendor/autoload.php';
+        $classes[] = $metadata['entry_class'];
+        $classes = array_values(array_unique($classes));
+        $plugins = [];
+
+        foreach ($classes as $class) {
+            if (! is_string($class) || ! class_exists($class) || ! is_a($class, Plugin::class, true)) {
+                throw new InvalidArgumentException("Plugin class [{$class}] is invalid.");
+            }
+
+            $plugins[] = app()->make($class);
+        }
+
+        (new PluginLoader)->prepare($plugins, config('platform.version', '0.2.0'));
+    }
+}

--- a/app/Services/Platform/PluginInstaller.php
+++ b/app/Services/Platform/PluginInstaller.php
@@ -204,10 +204,11 @@ final class PluginInstaller
      */
     private function validateBootSet(array $metadata, string $stagingPath, RuntimePluginStore $store): void
     {
-        $classes = [
+        $hostClasses = [
             ...config('platform.plugins', []),
             ...app(ComposerPluginDiscovery::class)->discoverComposerOnly(),
         ];
+        $runtimeClasses = [];
         $state = $store->readState();
 
         foreach ($store->installedPackages() as $id => $path) {
@@ -215,11 +216,21 @@ final class PluginInstaller
                 continue;
             }
 
-            $classes[] = $this->validator->validate($path, $id)['entry_class'];
+            $runtimeClasses[] = $this->validator->validate($path, $id)['entry_class'];
         }
 
         require_once $stagingPath.'/vendor/autoload.php';
-        $classes[] = $metadata['entry_class'];
+        $runtimeClasses[] = $metadata['entry_class'];
+
+        foreach ($runtimeClasses as $class) {
+            if (in_array($class, $hostClasses, true)) {
+                throw new RuntimePluginConflictException(
+                    "Runtime plugin entry class [{$class}] conflicts with a Composer or explicit plugin. Neither copy will load.",
+                );
+            }
+        }
+
+        $classes = [...$hostClasses, ...$runtimeClasses];
         $classes = array_values(array_unique($classes));
         $plugins = [];
 

--- a/app/Services/Platform/RuntimePluginArtifactValidator.php
+++ b/app/Services/Platform/RuntimePluginArtifactValidator.php
@@ -6,6 +6,7 @@ use Composer\InstalledVersions;
 use Composer\Semver\Semver;
 use InvalidArgumentException;
 use OpenKOS\Platform\Plugin\Plugin;
+use Symfony\Component\Process\Process;
 use Throwable;
 
 final class RuntimePluginArtifactValidator
@@ -110,6 +111,67 @@ final class RuntimePluginArtifactValidator
     }
 
     /**
+     * @return array{
+     *     id: string,
+     *     name: string,
+     *     version: string,
+     *     description: string,
+     *     entry_class: class-string<Plugin>,
+     *     core_version: string,
+     *     php: string,
+     *     dependencies: array<int, string>
+     * }
+     */
+    public function validateInFreshProcess(string $directory, ?string $expectedId = null): array
+    {
+        try {
+            $runtimeConfig = json_encode(config('platform.runtime'), JSON_THROW_ON_ERROR);
+        } catch (Throwable $exception) {
+            throw new InvalidArgumentException('Runtime plugin configuration cannot be serialized.', previous: $exception);
+        }
+
+        $process = new Process([
+            PHP_BINARY,
+            base_path('bin/validate-runtime-plugin.php'),
+            $directory,
+            $expectedId ?? '',
+            $runtimeConfig,
+            (string) config('platform.version', '0.2.0'),
+        ], base_path());
+        $process->setTimeout(60);
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            $message = trim($process->getErrorOutput() ?: $process->getOutput());
+
+            throw new InvalidArgumentException($message !== '' ? $message : 'Runtime plugin validation failed.');
+        }
+
+        try {
+            $metadata = json_decode($process->getOutput(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (Throwable $exception) {
+            throw new InvalidArgumentException('Runtime plugin validation returned malformed metadata.', previous: $exception);
+        }
+
+        if (! is_array($metadata)) {
+            throw new InvalidArgumentException('Runtime plugin validation returned malformed metadata.');
+        }
+
+        /** @var array{
+         *     id: string,
+         *     name: string,
+         *     version: string,
+         *     description: string,
+         *     entry_class: class-string<Plugin>,
+         *     core_version: string,
+         *     php: string,
+         *     dependencies: array<int, string>
+         * } $metadata
+         */
+        return $metadata;
+    }
+
+    /**
      * @param  array<string, mixed>  $manifest
      * @return array{
      *     id: string,
@@ -207,6 +269,12 @@ final class RuntimePluginArtifactValidator
 
         $bundledPackages = $this->bundledPackages($directory.'/vendor/composer/installed.php');
 
+        foreach (array_keys($bundledPackages) as $package) {
+            if ($this->isSharedPackage($package)) {
+                throw new InvalidArgumentException("Runtime plugin must not bundle host package [{$package}].");
+            }
+        }
+
         foreach ($requires as $package => $constraint) {
             if (! is_string($package) || ! is_string($constraint)) {
                 throw new InvalidArgumentException('Runtime plugin Composer requirements must be valid strings.');
@@ -227,10 +295,6 @@ final class RuntimePluginArtifactValidator
             }
 
             if ($this->isSharedPackage($package)) {
-                if (isset($bundledPackages[$package])) {
-                    throw new InvalidArgumentException("Runtime plugin must not bundle host package [{$package}].");
-                }
-
                 if (! InstalledVersions::isInstalled($package)) {
                     throw new InvalidArgumentException("Host package [{$package}] is not installed.");
                 }
@@ -247,6 +311,14 @@ final class RuntimePluginArtifactValidator
             if (! isset($lockedPackages[$package]) && ! InstalledVersions::isInstalled($package)) {
                 throw new InvalidArgumentException(
                     "Runtime plugin dependency [{$package}] is absent from composer.lock and the host.",
+                );
+            }
+
+            if (isset($bundledPackages[$package])) {
+                $this->assertSatisfies(
+                    $bundledPackages[$package],
+                    $constraint,
+                    "Bundled package [{$package}]",
                 );
             }
 
@@ -267,7 +339,7 @@ final class RuntimePluginArtifactValidator
     }
 
     /**
-     * @return array<string, true>
+     * @return array<string, string>
      */
     private function bundledPackages(string $installedPath): array
     {
@@ -283,10 +355,12 @@ final class RuntimePluginArtifactValidator
         }
 
         $packages = [];
-        foreach (array_keys($versions) as $package) {
-            if (is_string($package)) {
-                $packages[$package] = true;
+        foreach ($versions as $package => $metadata) {
+            if (! is_string($package) || ! is_array($metadata) || ! is_string($metadata['pretty_version'] ?? null)) {
+                throw new InvalidArgumentException('Runtime plugin vendor package metadata is malformed.');
             }
+
+            $packages[$package] = $metadata['pretty_version'];
         }
 
         return $packages;
@@ -348,8 +422,9 @@ final class RuntimePluginArtifactValidator
 
         $iterator = new \RecursiveIteratorIterator(
             new \RecursiveDirectoryIterator($realDirectory, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::SELF_FIRST,
         );
-        $fileCount = 0;
+        $entryCount = 0;
         $size = 0;
 
         foreach ($iterator as $file) {
@@ -360,6 +435,8 @@ final class RuntimePluginArtifactValidator
             if ($file->isLink() || is_link($path)) {
                 throw new InvalidArgumentException("Runtime plugin artifact contains symlink [{$relative}].");
             }
+
+            $entryCount++;
 
             if ($topLevel === '' || ! in_array($topLevel, [
                 'manifest.json',
@@ -376,7 +453,6 @@ final class RuntimePluginArtifactValidator
             }
 
             if ($file->isFile()) {
-                $fileCount++;
                 $size += $file->getSize();
 
                 if (($file->getPerms() & 0111) !== 0) {
@@ -389,7 +465,7 @@ final class RuntimePluginArtifactValidator
             }
         }
 
-        if ($fileCount > (int) config('platform.runtime.max_files', 5000)) {
+        if ($entryCount > (int) config('platform.runtime.max_files', 5000)) {
             throw new InvalidArgumentException('Runtime plugin artifact exceeds the maximum file count.');
         }
 

--- a/app/Services/Platform/RuntimePluginArtifactValidator.php
+++ b/app/Services/Platform/RuntimePluginArtifactValidator.php
@@ -1,0 +1,420 @@
+<?php
+
+namespace App\Services\Platform;
+
+use Composer\InstalledVersions;
+use Composer\Semver\Semver;
+use InvalidArgumentException;
+use OpenKOS\Platform\Plugin\Plugin;
+use Throwable;
+
+final class RuntimePluginArtifactValidator
+{
+    /**
+     * @return array{
+     *     id: string,
+     *     name: string,
+     *     version: string,
+     *     description: string,
+     *     entry_class: class-string<Plugin>,
+     *     core_version: string,
+     *     php: string,
+     *     dependencies: array<int, string>
+     * }
+     */
+    public function validate(string $directory, ?string $expectedId = null): array
+    {
+        if (! is_dir($directory) || is_link($directory)) {
+            throw new InvalidArgumentException('Runtime plugin artifact directory is missing or unsafe.');
+        }
+
+        $this->validateTree($directory);
+
+        $manifest = $this->readJsonFile($directory.'/manifest.json', 'manifest.json');
+        $composer = $this->readJsonFile($directory.'/composer.json', 'composer.json');
+        $lock = $this->readJsonFile($directory.'/composer.lock', 'composer.lock');
+
+        $metadata = $this->validateManifest($manifest);
+
+        if ($expectedId !== null && $metadata['id'] !== $expectedId) {
+            throw new InvalidArgumentException(
+                "Runtime plugin manifest ID [{$metadata['id']}] does not match installed package [{$expectedId}].",
+            );
+        }
+
+        $this->validateComposerMetadata($metadata, $composer, $lock, $directory);
+
+        $autoload = $directory.'/vendor/autoload.php';
+        if (! is_file($autoload)) {
+            throw new InvalidArgumentException('Runtime plugin artifact must include vendor/autoload.php.');
+        }
+
+        require_once $autoload;
+
+        $entryClass = $metadata['entry_class'];
+
+        if (! class_exists($entryClass)) {
+            throw new InvalidArgumentException("Runtime plugin entry class [{$entryClass}] does not exist.");
+        }
+
+        if (! is_a($entryClass, Plugin::class, true)) {
+            throw new InvalidArgumentException(
+                "Runtime plugin entry class [{$entryClass}] must extend ".Plugin::class.'.',
+            );
+        }
+
+        $reflection = new \ReflectionClass($entryClass);
+        $entryFile = $reflection->getFileName();
+        $realDirectory = realpath($directory);
+
+        $resolvedEntryFile = is_string($entryFile) ? realpath($entryFile) : false;
+        $sourceMarker = is_string($entryFile) ? DIRECTORY_SEPARATOR.'src'.DIRECTORY_SEPARATOR : '';
+        $sourcePosition = is_string($entryFile) ? strrpos($entryFile, $sourceMarker) : false;
+        $relativeSource = is_int($sourcePosition)
+            ? substr($entryFile, $sourcePosition + strlen($sourceMarker))
+            : '';
+        $entryFileRelocatedFromStaging = is_string($entryFile)
+            && $resolvedEntryFile === false
+            && str_contains($entryFile, DIRECTORY_SEPARATOR.'.staging'.DIRECTORY_SEPARATOR)
+            && $relativeSource !== ''
+            && is_file($directory.'/src/'.$relativeSource);
+
+        if (
+            ! is_string($entryFile) ||
+            ! is_string($realDirectory) ||
+            (! str_starts_with($resolvedEntryFile ?: '', $realDirectory.DIRECTORY_SEPARATOR) && ! $entryFileRelocatedFromStaging)
+        ) {
+            throw new InvalidArgumentException(
+                "Runtime plugin entry class [{$entryClass}] is not loaded from the artifact.",
+            );
+        }
+
+        /** @var Plugin $plugin */
+        $plugin = app()->make($entryClass);
+        $pluginManifest = $plugin->manifest();
+
+        if (
+            $pluginManifest->id !== $metadata['id'] ||
+            $pluginManifest->name !== $metadata['name'] ||
+            $pluginManifest->version !== $metadata['version'] ||
+            $pluginManifest->description !== $metadata['description'] ||
+            $pluginManifest->coreVersion !== $metadata['core_version'] ||
+            $pluginManifest->dependencies !== $metadata['dependencies']
+        ) {
+            throw new InvalidArgumentException(
+                "Runtime plugin manifest for [{$metadata['id']}] does not match its entry class.",
+            );
+        }
+
+        return $metadata;
+    }
+
+    /**
+     * @param  array<string, mixed>  $manifest
+     * @return array{
+     *     id: string,
+     *     name: string,
+     *     version: string,
+     *     description: string,
+     *     entry_class: class-string<Plugin>,
+     *     core_version: string,
+     *     php: string,
+     *     dependencies: array<int, string>
+     * }
+     */
+    private function validateManifest(array $manifest): array
+    {
+        $required = ['id', 'name', 'version', 'entry_class', 'core_version', 'php', 'dependencies'];
+
+        foreach ($required as $key) {
+            if (! array_key_exists($key, $manifest)) {
+                throw new InvalidArgumentException("Runtime plugin manifest is missing [{$key}].");
+            }
+        }
+
+        foreach (['id', 'name', 'version', 'entry_class', 'core_version', 'php'] as $key) {
+            if (! is_string($manifest[$key]) || trim($manifest[$key]) === '') {
+                throw new InvalidArgumentException("Runtime plugin manifest field [{$key}] must be a non-empty string.");
+            }
+        }
+
+        if (! preg_match('/^[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*$/', $manifest['id'])) {
+            throw new InvalidArgumentException("Runtime plugin ID [{$manifest['id']}] is unsafe.");
+        }
+
+        if (! is_array($manifest['dependencies']) || array_is_list($manifest['dependencies']) === false) {
+            throw new InvalidArgumentException('Runtime plugin dependencies must be a list.');
+        }
+
+        foreach ($manifest['dependencies'] as $dependency) {
+            if (! is_string($dependency) || ! preg_match('/^[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*$/', $dependency)) {
+                throw new InvalidArgumentException('Runtime plugin dependencies must contain safe plugin IDs.');
+            }
+        }
+
+        /** @var array{
+         *     id: string,
+         *     name: string,
+         *     version: string,
+         *     description?: string,
+         *     entry_class: class-string<Plugin>,
+         *     core_version: string,
+         *     php: string,
+         *     dependencies: array<int, string>
+         * } $manifest
+         */
+        return [
+            'id' => $manifest['id'],
+            'name' => $manifest['name'],
+            'version' => $manifest['version'],
+            'description' => is_string($manifest['description'] ?? '') ? $manifest['description'] : '',
+            'entry_class' => $manifest['entry_class'],
+            'core_version' => $manifest['core_version'],
+            'php' => $manifest['php'],
+            'dependencies' => array_values($manifest['dependencies']),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $metadata
+     * @param  array<string, mixed>  $composer
+     * @param  array<string, mixed>  $lock
+     */
+    private function validateComposerMetadata(array $metadata, array $composer, array $lock, string $directory): void
+    {
+        $this->assertSatisfies(PHP_VERSION, $metadata['php'], 'Runtime plugin PHP');
+
+        if (($composer['name'] ?? null) !== $metadata['id']) {
+            throw new InvalidArgumentException('Runtime plugin composer name must match manifest ID.');
+        }
+
+        $declaredPlugin = data_get($composer, 'extra.openkos.plugin');
+        if ($declaredPlugin !== $metadata['entry_class']) {
+            throw new InvalidArgumentException('Runtime plugin Composer metadata must match manifest entry class.');
+        }
+
+        if (! is_array($lock['packages'] ?? null)) {
+            throw new InvalidArgumentException('Runtime plugin composer.lock must contain packages.');
+        }
+
+        $requires = is_array($composer['require'] ?? null) ? $composer['require'] : [];
+        $lockedPackages = [];
+        foreach ([...$lock['packages'], ...(is_array($lock['packages-dev'] ?? null) ? $lock['packages-dev'] : [])] as $package) {
+            if (is_array($package) && is_string($package['name'] ?? null)) {
+                $lockedPackages[$package['name']] = true;
+            }
+        }
+
+        $bundledPackages = $this->bundledPackages($directory.'/vendor/composer/installed.php');
+
+        foreach ($requires as $package => $constraint) {
+            if (! is_string($package) || ! is_string($constraint)) {
+                throw new InvalidArgumentException('Runtime plugin Composer requirements must be valid strings.');
+            }
+
+            if ($package === 'php') {
+                $this->assertSatisfies(PHP_VERSION, $constraint, 'PHP');
+
+                continue;
+            }
+
+            if (str_starts_with($package, 'ext-')) {
+                if (! extension_loaded(substr($package, 4))) {
+                    throw new InvalidArgumentException("Required PHP extension [{$package}] is not installed.");
+                }
+
+                continue;
+            }
+
+            if ($this->isSharedPackage($package)) {
+                if (isset($bundledPackages[$package])) {
+                    throw new InvalidArgumentException("Runtime plugin must not bundle host package [{$package}].");
+                }
+
+                if (! InstalledVersions::isInstalled($package)) {
+                    throw new InvalidArgumentException("Host package [{$package}] is not installed.");
+                }
+
+                $this->assertSatisfies(
+                    (string) InstalledVersions::getPrettyVersion($package),
+                    $constraint,
+                    "Host package [{$package}]",
+                );
+
+                continue;
+            }
+
+            if (! isset($lockedPackages[$package]) && ! InstalledVersions::isInstalled($package)) {
+                throw new InvalidArgumentException(
+                    "Runtime plugin dependency [{$package}] is absent from composer.lock and the host.",
+                );
+            }
+
+            if (InstalledVersions::isInstalled($package)) {
+                $this->assertSatisfies(
+                    (string) InstalledVersions::getPrettyVersion($package),
+                    $constraint,
+                    "Host package [{$package}]",
+                );
+            } elseif (! isset($bundledPackages[$package])) {
+                throw new InvalidArgumentException(
+                    "Runtime plugin dependency [{$package}] is not bundled in vendor/.",
+                );
+            }
+        }
+
+        $this->assertNoComposerInstallScripts($composer);
+    }
+
+    /**
+     * @return array<string, true>
+     */
+    private function bundledPackages(string $installedPath): array
+    {
+        if (! is_file($installedPath)) {
+            throw new InvalidArgumentException('Runtime plugin vendor metadata is missing.');
+        }
+
+        $installed = require $installedPath;
+        $versions = is_array($installed['versions'] ?? null) ? $installed['versions'] : $installed;
+
+        if (! is_array($versions)) {
+            throw new InvalidArgumentException('Runtime plugin vendor metadata is malformed.');
+        }
+
+        $packages = [];
+        foreach (array_keys($versions) as $package) {
+            if (is_string($package)) {
+                $packages[$package] = true;
+            }
+        }
+
+        return $packages;
+    }
+
+    /**
+     * @param  array<string, mixed>  $composer
+     */
+    private function assertNoComposerInstallScripts(array $composer): void
+    {
+        $scripts = $composer['scripts'] ?? [];
+
+        if (! is_array($scripts)) {
+            throw new InvalidArgumentException('Runtime plugin Composer scripts must be an object.');
+        }
+
+        foreach (array_keys($scripts) as $script) {
+            if (is_string($script) && preg_match('/^(pre|post)-(install|update)-cmd$/', $script)) {
+                throw new InvalidArgumentException("Runtime plugin Composer script [{$script}] is not allowed.");
+            }
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $value
+     * @return array<string, mixed>
+     */
+    private function readJsonFile(string $path, string $label): array
+    {
+        if (! is_file($path) || is_link($path)) {
+            throw new InvalidArgumentException("Runtime plugin artifact is missing [{$label}].");
+        }
+
+        $contents = file_get_contents($path);
+
+        if ($contents === false) {
+            throw new InvalidArgumentException("Runtime plugin artifact [{$label}] cannot be read.");
+        }
+
+        try {
+            $value = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+        } catch (Throwable $exception) {
+            throw new InvalidArgumentException("Runtime plugin artifact [{$label}] is malformed.", previous: $exception);
+        }
+
+        if (! is_array($value)) {
+            throw new InvalidArgumentException("Runtime plugin artifact [{$label}] must contain an object.");
+        }
+
+        return $value;
+    }
+
+    private function validateTree(string $directory): void
+    {
+        $realDirectory = realpath($directory);
+        if (! is_string($realDirectory)) {
+            throw new InvalidArgumentException('Runtime plugin artifact directory cannot be resolved.');
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($realDirectory, \FilesystemIterator::SKIP_DOTS),
+        );
+        $fileCount = 0;
+        $size = 0;
+
+        foreach ($iterator as $file) {
+            $path = $file->getPathname();
+            $relative = ltrim(str_replace($realDirectory, '', $path), DIRECTORY_SEPARATOR);
+            $topLevel = explode(DIRECTORY_SEPARATOR, $relative, 2)[0] ?? '';
+
+            if ($file->isLink() || is_link($path)) {
+                throw new InvalidArgumentException("Runtime plugin artifact contains symlink [{$relative}].");
+            }
+
+            if ($topLevel === '' || ! in_array($topLevel, [
+                'manifest.json',
+                'composer.json',
+                'composer.lock',
+                'src',
+                'vendor',
+                'config',
+                'routes',
+                'database',
+                'resources',
+            ], true)) {
+                throw new InvalidArgumentException("Runtime plugin artifact contains unexpected path [{$relative}].");
+            }
+
+            if ($file->isFile()) {
+                $fileCount++;
+                $size += $file->getSize();
+
+                if (($file->getPerms() & 0111) !== 0) {
+                    throw new InvalidArgumentException("Runtime plugin artifact contains executable file [{$relative}].");
+                }
+
+                if (preg_match('/(^|\/)(install|post-install|pre-install)\.(php|sh|bash|bat|cmd|exe)$/i', $relative)) {
+                    throw new InvalidArgumentException("Runtime plugin artifact contains an install script [{$relative}].");
+                }
+            }
+        }
+
+        if ($fileCount > (int) config('platform.runtime.max_files', 5000)) {
+            throw new InvalidArgumentException('Runtime plugin artifact exceeds the maximum file count.');
+        }
+
+        if ($size > (int) config('platform.runtime.max_uncompressed_bytes', 268_435_456)) {
+            throw new InvalidArgumentException('Runtime plugin artifact exceeds the maximum extracted size.');
+        }
+    }
+
+    private function isSharedPackage(string $package): bool
+    {
+        return in_array($package, config('platform.runtime.shared_packages', []), true)
+            || collect(config('platform.runtime.shared_package_prefixes', []))
+                ->contains(fn (string $prefix): bool => str_starts_with($package, $prefix));
+    }
+
+    private function assertSatisfies(string $version, string $constraint, string $subject): void
+    {
+        try {
+            $satisfies = Semver::satisfies($version, $constraint);
+        } catch (Throwable $exception) {
+            throw new InvalidArgumentException("{$subject} constraint [{$constraint}] is invalid.", previous: $exception);
+        }
+
+        if (! $satisfies) {
+            throw new InvalidArgumentException("{$subject} version [{$version}] does not satisfy [{$constraint}].");
+        }
+    }
+}

--- a/app/Services/Platform/RuntimePluginConflictException.php
+++ b/app/Services/Platform/RuntimePluginConflictException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Services\Platform;
+
+use RuntimeException;
+
+final class RuntimePluginConflictException extends RuntimeException {}

--- a/app/Services/Platform/RuntimePluginDiscovery.php
+++ b/app/Services/Platform/RuntimePluginDiscovery.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace App\Services\Platform;
+
+use Illuminate\Support\Facades\Log;
+use InvalidArgumentException;
+use OpenKOS\Platform\Plugin\Plugin;
+use Throwable;
+
+final class RuntimePluginDiscovery
+{
+    public function __construct(
+        private RuntimePluginStore $store,
+        private RuntimePluginArtifactValidator $validator,
+    ) {}
+
+    /**
+     * @param  array<int, string>  $existingClasses
+     * @return array<int, class-string<Plugin>>
+     */
+    public function discover(array $existingClasses = []): array
+    {
+        if (! config('platform.runtime.enabled', true)) {
+            return [];
+        }
+
+        try {
+            return $this->store->withLock(function (RuntimePluginStore $store) use ($existingClasses): array {
+                $state = $store->readState();
+                $packages = $store->installedPackages();
+                $this->assertNoComposerConflicts($packages, $state, $existingClasses);
+                $plugins = [];
+
+                foreach ($packages as $id => $path) {
+                    if (! ($state[$id]['enabled'] ?? false)) {
+                        continue;
+                    }
+
+                    try {
+                        $plugins[] = $this->validator->validate($path, $id)['entry_class'];
+                    } catch (Throwable $exception) {
+                        Log::error('Runtime plugin could not be loaded.', [
+                            'plugin' => $id,
+                            'path' => $path,
+                            'exception' => $exception,
+                        ]);
+                    }
+                }
+
+                return $plugins;
+            });
+        } catch (Throwable $exception) {
+            if ($exception instanceof RuntimePluginConflictException) {
+                throw $exception;
+            }
+
+            Log::error('Runtime plugin discovery failed.', [
+                'path' => $this->store->rootPath(),
+                'exception' => $exception,
+            ]);
+
+            return [];
+        }
+    }
+
+    /**
+     * @param  array<string, string>  $packages
+     * @param  array<string, array{enabled: bool}>  $state
+     * @param  array<int, string>  $existingClasses
+     */
+    private function assertNoComposerConflicts(array $packages, array $state, array $existingClasses): void
+    {
+        $existingIds = [];
+        foreach ($existingClasses as $class) {
+            if (! is_string($class) || ! class_exists($class) || ! is_a($class, Plugin::class, true)) {
+                continue;
+            }
+
+            try {
+                $existingIds[app()->make($class)->manifest()->id] = $class;
+            } catch (Throwable) {
+                continue;
+            }
+        }
+
+        foreach ($packages as $id => $path) {
+            if (! ($state[$id]['enabled'] ?? false)) {
+                continue;
+            }
+
+            try {
+                $entryClass = $this->readEntryClass($path);
+            } catch (Throwable $exception) {
+                Log::error('Runtime plugin manifest could not be inspected for conflicts.', [
+                    'plugin' => $id,
+                    'path' => $path,
+                    'exception' => $exception,
+                ]);
+
+                continue;
+            }
+
+            if (in_array($entryClass, $existingClasses, true) || isset($existingIds[$id])) {
+                throw new RuntimePluginConflictException(
+                    "Runtime plugin [{$id}] conflicts with a Composer or explicit plugin. Neither copy will load.",
+                );
+            }
+        }
+    }
+
+    private function readEntryClass(string $path): string
+    {
+        $manifestPath = $path.'/manifest.json';
+        if (! is_file($manifestPath)) {
+            throw new InvalidArgumentException('Runtime plugin manifest is missing.');
+        }
+
+        $contents = file_get_contents($manifestPath);
+        if ($contents === false) {
+            throw new InvalidArgumentException('Runtime plugin manifest cannot be read.');
+        }
+
+        try {
+            $manifest = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+        } catch (Throwable $exception) {
+            throw new InvalidArgumentException('Runtime plugin manifest is malformed.', previous: $exception);
+        }
+
+        if (! is_array($manifest) || ! is_string($manifest['entry_class'] ?? null)) {
+            throw new InvalidArgumentException('Runtime plugin manifest entry class is missing.');
+        }
+
+        return $manifest['entry_class'];
+    }
+}

--- a/app/Services/Platform/RuntimePluginStore.php
+++ b/app/Services/Platform/RuntimePluginStore.php
@@ -13,11 +13,18 @@ final class RuntimePluginStore
     public function __construct()
     {
         $configuredPath = (string) config('platform.runtime.path');
-        $this->root = str_starts_with($configuredPath, DIRECTORY_SEPARATOR)
+        $path = str_starts_with($configuredPath, DIRECTORY_SEPARATOR)
             ? rtrim($configuredPath, DIRECTORY_SEPARATOR)
             : base_path(trim($configuredPath, DIRECTORY_SEPARATOR));
+        $this->root = $this->canonicalizePath($path);
+        $basePath = realpath(base_path());
 
-        if ($this->root === '' || $this->root === base_path() || $this->root === DIRECTORY_SEPARATOR) {
+        if (
+            ! is_string($basePath) ||
+            $this->root === DIRECTORY_SEPARATOR ||
+            $this->root === $basePath ||
+            str_starts_with($basePath, $this->root.DIRECTORY_SEPARATOR)
+        ) {
             throw new RuntimeException('Runtime plugin storage must be a dedicated directory.');
         }
     }
@@ -548,5 +555,38 @@ final class RuntimePluginStore
     private function isValidId(string $id): bool
     {
         return preg_match('/^[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*$/', $id) === 1;
+    }
+
+    private function canonicalizePath(string $path): string
+    {
+        if ($path === '') {
+            throw new RuntimeException('Runtime plugin storage must be a dedicated directory.');
+        }
+
+        $missing = [];
+        $current = $path;
+
+        while (! file_exists($current)) {
+            $parent = dirname($current);
+
+            if ($parent === $current) {
+                throw new RuntimeException('Runtime plugin storage path cannot be resolved.');
+            }
+
+            array_unshift($missing, basename($current));
+            $current = $parent;
+        }
+
+        $resolved = realpath($current);
+
+        if (! is_string($resolved)) {
+            throw new RuntimeException('Runtime plugin storage path cannot be resolved.');
+        }
+
+        foreach ($missing as $segment) {
+            $resolved .= DIRECTORY_SEPARATOR.$segment;
+        }
+
+        return rtrim($resolved, DIRECTORY_SEPARATOR) ?: DIRECTORY_SEPARATOR;
     }
 }

--- a/app/Services/Platform/RuntimePluginStore.php
+++ b/app/Services/Platform/RuntimePluginStore.php
@@ -54,6 +54,10 @@ final class RuntimePluginStore
     {
         $path = $this->statePath();
 
+        if (is_link($path)) {
+            throw new RuntimeException('Runtime plugin state is corrupted. Repair or remove '.$path.' before continuing.');
+        }
+
         if (! is_file($path)) {
             return [];
         }
@@ -97,6 +101,10 @@ final class RuntimePluginStore
     public function writeState(array $state): void
     {
         $this->ensureDirectory($this->root);
+
+        if (is_link($this->statePath())) {
+            throw new RuntimeException('Could not persist runtime plugin state through a symlink.');
+        }
 
         try {
             $contents = json_encode($state, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR).PHP_EOL;
@@ -307,6 +315,10 @@ final class RuntimePluginStore
     {
         $path = $this->recoveryMarkerPath();
 
+        if (is_link($path)) {
+            throw new RuntimeException('Runtime plugin recovery marker is unsafe.');
+        }
+
         if (! is_file($path)) {
             return;
         }
@@ -328,7 +340,9 @@ final class RuntimePluginStore
             ! in_array($marker['operation'] ?? null, ['swap', 'remove'], true) ||
             ! in_array($marker['phase'] ?? null, ['prepared', 'old_preserved', 'new_active', 'committed'], true) ||
             ! is_string($marker['id'] ?? null) ||
-            ! isset($marker['backup'])
+            ! is_string($marker['backup'] ?? null) ||
+            ! str_starts_with($marker['backup'], '.backup/') ||
+            (isset($marker['staging']) && $marker['staging'] !== null && (! is_string($marker['staging']) || ! str_starts_with($marker['staging'], '.staging/')))
         ) {
             throw new RuntimeException('Runtime plugin recovery marker is invalid.');
         }
@@ -428,6 +442,10 @@ final class RuntimePluginStore
      */
     private function writeRecoveryMarker(array $marker): void
     {
+        if (is_link($this->recoveryMarkerPath())) {
+            throw new RuntimeException('Could not persist runtime plugin recovery state through a symlink.');
+        }
+
         $contents = json_encode($marker, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR).PHP_EOL;
         $temporaryPath = $this->recoveryMarkerPath().'.tmp';
 

--- a/app/Services/Platform/RuntimePluginStore.php
+++ b/app/Services/Platform/RuntimePluginStore.php
@@ -1,0 +1,534 @@
+<?php
+
+namespace App\Services\Platform;
+
+use Closure;
+use RuntimeException;
+use Throwable;
+
+final class RuntimePluginStore
+{
+    private string $root;
+
+    public function __construct()
+    {
+        $configuredPath = (string) config('platform.runtime.path');
+        $this->root = str_starts_with($configuredPath, DIRECTORY_SEPARATOR)
+            ? rtrim($configuredPath, DIRECTORY_SEPARATOR)
+            : base_path(trim($configuredPath, DIRECTORY_SEPARATOR));
+
+        if ($this->root === '' || $this->root === base_path() || $this->root === DIRECTORY_SEPARATOR) {
+            throw new RuntimeException('Runtime plugin storage must be a dedicated directory.');
+        }
+    }
+
+    public function rootPath(): string
+    {
+        return $this->root;
+    }
+
+    public function withLock(Closure $callback): mixed
+    {
+        $this->ensureDirectory($this->root);
+
+        $handle = fopen($this->root.'/.lock', 'c+');
+
+        if ($handle === false || ! flock($handle, LOCK_EX)) {
+            throw new RuntimeException('Could not lock runtime plugin storage.');
+        }
+
+        try {
+            $this->recoverPendingOperation();
+
+            return $callback($this);
+        } finally {
+            flock($handle, LOCK_UN);
+            fclose($handle);
+        }
+    }
+
+    /**
+     * @return array<string, array{enabled: bool}>
+     */
+    public function readState(): array
+    {
+        $path = $this->statePath();
+
+        if (! is_file($path)) {
+            return [];
+        }
+
+        $contents = file_get_contents($path);
+
+        if ($contents === false) {
+            throw new RuntimeException('Could not read runtime plugin state.');
+        }
+
+        try {
+            $state = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+        } catch (Throwable $exception) {
+            throw new RuntimeException(
+                'Runtime plugin state is corrupted. Repair or remove '.$path.' before continuing.',
+                previous: $exception,
+            );
+        }
+
+        if (! is_array($state)) {
+            throw new RuntimeException(
+                'Runtime plugin state is corrupted. Repair or remove '.$path.' before continuing.',
+            );
+        }
+
+        foreach ($state as $id => $entry) {
+            if (! is_string($id) || ! $this->isValidId($id) || ! is_array($entry) || ! is_bool($entry['enabled'] ?? null)) {
+                throw new RuntimeException(
+                    'Runtime plugin state is corrupted. Repair or remove '.$path.' before continuing.',
+                );
+            }
+        }
+
+        /** @var array<string, array{enabled: bool}> $state */
+        return $state;
+    }
+
+    /**
+     * @param  array<string, array{enabled: bool}>  $state
+     */
+    public function writeState(array $state): void
+    {
+        $this->ensureDirectory($this->root);
+
+        try {
+            $contents = json_encode($state, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR).PHP_EOL;
+        } catch (Throwable $exception) {
+            throw new RuntimeException('Could not encode runtime plugin state.', previous: $exception);
+        }
+
+        $temporaryPath = $this->root.'/.state-'.bin2hex(random_bytes(8)).'.tmp';
+
+        if (file_put_contents($temporaryPath, $contents, LOCK_EX) === false || ! rename($temporaryPath, $this->statePath())) {
+            @unlink($temporaryPath);
+
+            throw new RuntimeException('Could not persist runtime plugin state.');
+        }
+
+        @chmod($this->statePath(), 0640);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function installedPackages(): array
+    {
+        $packages = [];
+
+        if (! is_dir($this->root)) {
+            return $packages;
+        }
+
+        foreach (scandir($this->root) ?: [] as $vendor) {
+            if ($vendor === '.' || $vendor === '..' || str_starts_with($vendor, '.')) {
+                continue;
+            }
+
+            $vendorPath = $this->root.DIRECTORY_SEPARATOR.$vendor;
+
+            if (! is_dir($vendorPath) || is_link($vendorPath)) {
+                continue;
+            }
+
+            foreach (scandir($vendorPath) ?: [] as $package) {
+                if ($package === '.' || $package === '..' || str_starts_with($package, '.')) {
+                    continue;
+                }
+
+                $id = $vendor.'/'.$package;
+                $packagePath = $vendorPath.DIRECTORY_SEPARATOR.$package;
+
+                if ($this->isValidId($id) && is_dir($packagePath) && ! is_link($packagePath)) {
+                    $packages[$id] = $packagePath;
+                }
+            }
+        }
+
+        ksort($packages, SORT_STRING);
+
+        return $packages;
+    }
+
+    public function packagePath(string $id): string
+    {
+        $this->assertValidId($id);
+
+        return $this->root.DIRECTORY_SEPARATOR.str_replace('/', DIRECTORY_SEPARATOR, $id);
+    }
+
+    public function createStagingPath(string $id): string
+    {
+        if (preg_match('/^[a-z0-9._-]+$/', $id) !== 1) {
+            throw new RuntimeException("Invalid runtime plugin staging label [{$id}].");
+        }
+
+        $path = $this->root.'/.staging/'.str_replace('/', '-', $id).'-'.bin2hex(random_bytes(8));
+        $this->ensureDirectory($path);
+
+        return $path;
+    }
+
+    public function discardStaging(string $path): void
+    {
+        $relativePath = $this->relativeManagedPath($path);
+
+        if (! str_starts_with($relativePath, '.staging/')) {
+            throw new RuntimeException('Only staging paths can be discarded.');
+        }
+
+        $this->deleteDirectory($path);
+    }
+
+    public function promote(string $id, string $stagingPath, bool $enabled): void
+    {
+        $this->assertValidId($id);
+
+        $activePath = $this->packagePath($id);
+        $relativeStagingPath = $this->relativeManagedPath($stagingPath);
+        $backupPath = $this->root.'/.backup/'.str_replace('/', '-', $id).'-'.bin2hex(random_bytes(8));
+        $relativeBackupPath = $this->relativeManagedPath($backupPath);
+        $hadActivePackage = is_dir($activePath) && ! is_link($activePath);
+        $state = $this->readState();
+        $marker = [
+            'operation' => 'swap',
+            'id' => $id,
+            'staging' => $relativeStagingPath,
+            'backup' => $relativeBackupPath,
+            'had_active' => $hadActivePackage,
+            'previous_entry' => $state[$id] ?? null,
+            'next_entry' => ['enabled' => $enabled],
+            'phase' => 'prepared',
+        ];
+
+        $this->writeRecoveryMarker($marker);
+
+        try {
+            if ($hadActivePackage) {
+                $this->ensureDirectory(dirname($backupPath));
+                $this->renameOrFail($activePath, $backupPath);
+                $marker['phase'] = 'old_preserved';
+                $this->writeRecoveryMarker($marker);
+            }
+
+            $this->ensureDirectory(dirname($activePath));
+            $this->renameOrFail($stagingPath, $activePath);
+            $marker['phase'] = 'new_active';
+            $this->writeRecoveryMarker($marker);
+
+            $state[$id] = ['enabled' => $enabled];
+            $this->writeState($state);
+            $marker['phase'] = 'committed';
+            $this->writeRecoveryMarker($marker);
+
+            $this->deleteDirectory($backupPath);
+            $this->deleteDirectory($this->root.'/.staging');
+            $this->removeRecoveryMarker();
+        } catch (Throwable $exception) {
+            try {
+                $this->recoverPendingOperation();
+            } catch (Throwable $recoveryException) {
+                throw new RuntimeException(
+                    'Runtime plugin installation failed and automatic recovery also failed.',
+                    previous: $recoveryException,
+                );
+            }
+
+            throw $exception;
+        }
+    }
+
+    public function setEnabled(string $id, bool $enabled): void
+    {
+        $this->assertValidId($id);
+
+        if (! is_dir($this->packagePath($id))) {
+            throw new RuntimeException("Runtime plugin [{$id}] is not installed.");
+        }
+
+        $state = $this->readState();
+        $state[$id] = ['enabled' => $enabled];
+        $this->writeState($state);
+    }
+
+    public function remove(string $id): void
+    {
+        $this->assertValidId($id);
+
+        $activePath = $this->packagePath($id);
+        $state = $this->readState();
+
+        if (! is_dir($activePath)) {
+            unset($state[$id]);
+            $this->writeState($state);
+
+            return;
+        }
+
+        $backupPath = $this->root.'/.backup/'.str_replace('/', '-', $id).'-remove-'.bin2hex(random_bytes(8));
+        $marker = [
+            'operation' => 'remove',
+            'id' => $id,
+            'staging' => null,
+            'backup' => $this->relativeManagedPath($backupPath),
+            'had_active' => true,
+            'phase' => 'prepared',
+        ];
+
+        $this->writeRecoveryMarker($marker);
+
+        try {
+            $this->ensureDirectory(dirname($backupPath));
+            $this->renameOrFail($activePath, $backupPath);
+            $marker['phase'] = 'old_preserved';
+            $this->writeRecoveryMarker($marker);
+
+            unset($state[$id]);
+            $this->writeState($state);
+            $marker['phase'] = 'committed';
+            $this->writeRecoveryMarker($marker);
+
+            $this->deleteDirectory($backupPath);
+            $this->removeRecoveryMarker();
+        } catch (Throwable $exception) {
+            $this->recoverPendingOperation();
+
+            throw $exception;
+        }
+    }
+
+    private function recoverPendingOperation(): void
+    {
+        $path = $this->recoveryMarkerPath();
+
+        if (! is_file($path)) {
+            return;
+        }
+
+        $contents = file_get_contents($path);
+
+        if ($contents === false) {
+            throw new RuntimeException('Runtime plugin recovery marker cannot be read.');
+        }
+
+        try {
+            $marker = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+        } catch (Throwable $exception) {
+            throw new RuntimeException('Runtime plugin recovery marker is corrupted.', previous: $exception);
+        }
+
+        if (
+            ! is_array($marker) ||
+            ! in_array($marker['operation'] ?? null, ['swap', 'remove'], true) ||
+            ! in_array($marker['phase'] ?? null, ['prepared', 'old_preserved', 'new_active', 'committed'], true) ||
+            ! is_string($marker['id'] ?? null) ||
+            ! isset($marker['backup'])
+        ) {
+            throw new RuntimeException('Runtime plugin recovery marker is invalid.');
+        }
+
+        $id = $marker['id'];
+        $backupPath = $this->managedPath($marker['backup']);
+        $stagingPath = isset($marker['staging']) && is_string($marker['staging'])
+            ? $this->managedPath($marker['staging'])
+            : null;
+        $activePath = $this->packagePath($id);
+
+        if ($marker['phase'] === 'committed') {
+            if (! is_dir($activePath)) {
+                if (! is_dir($backupPath)) {
+                    throw new RuntimeException("Runtime plugin [{$id}] cannot be recovered: active package is missing.");
+                }
+
+                $this->restorePreviousState($marker);
+                $this->ensureDirectory(dirname($activePath));
+                $this->renameOrFail($backupPath, $activePath);
+            }
+
+            $this->deleteDirectory($backupPath);
+            $this->deleteDirectory($stagingPath);
+            $this->removeRecoveryMarker();
+
+            return;
+        }
+
+        if ($marker['phase'] === 'prepared') {
+            if (($marker['had_active'] ?? false) && ! is_dir($activePath) && is_dir($backupPath)) {
+                $this->ensureDirectory(dirname($activePath));
+                $this->renameOrFail($backupPath, $activePath);
+            } elseif (! ($marker['had_active'] ?? false) && is_dir($activePath)) {
+                $this->deleteDirectory($activePath);
+            }
+
+            $this->deleteDirectory($stagingPath);
+            $this->deleteDirectory($backupPath);
+            $this->removeRecoveryMarker();
+
+            return;
+        }
+
+        if ($marker['phase'] === 'new_active' && is_dir($activePath)) {
+            $state = $this->readState();
+            $nextEntry = $marker['next_entry'] ?? null;
+
+            if (! is_array($nextEntry) || ! is_bool($nextEntry['enabled'] ?? null)) {
+                throw new RuntimeException('Runtime plugin recovery marker has invalid next state.');
+            }
+
+            $state[$id] = ['enabled' => $nextEntry['enabled']];
+            $this->writeState($state);
+            $this->deleteDirectory($backupPath);
+            $this->deleteDirectory($stagingPath);
+            $this->removeRecoveryMarker();
+
+            return;
+        }
+
+        if (! is_dir($backupPath)) {
+            throw new RuntimeException("Runtime plugin [{$id}] cannot be recovered: backup is missing.");
+        }
+
+        if (is_dir($activePath)) {
+            $this->deleteDirectory($activePath);
+        }
+
+        $this->restorePreviousState($marker);
+        $this->ensureDirectory(dirname($activePath));
+        $this->renameOrFail($backupPath, $activePath);
+        $this->deleteDirectory($stagingPath);
+        $this->removeRecoveryMarker();
+    }
+
+    /**
+     * @param  array<string, mixed>  $marker
+     */
+    private function restorePreviousState(array $marker): void
+    {
+        $id = $marker['id'];
+        $state = $this->readState();
+        $previousEntry = $marker['previous_entry'] ?? null;
+
+        if (is_array($previousEntry) && is_bool($previousEntry['enabled'] ?? null)) {
+            $state[$id] = ['enabled' => $previousEntry['enabled']];
+        } else {
+            unset($state[$id]);
+        }
+
+        $this->writeState($state);
+    }
+
+    /**
+     * @param  array<string, mixed>  $marker
+     */
+    private function writeRecoveryMarker(array $marker): void
+    {
+        $contents = json_encode($marker, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR).PHP_EOL;
+        $temporaryPath = $this->recoveryMarkerPath().'.tmp';
+
+        if (file_put_contents($temporaryPath, $contents, LOCK_EX) === false || ! rename($temporaryPath, $this->recoveryMarkerPath())) {
+            @unlink($temporaryPath);
+
+            throw new RuntimeException('Could not persist runtime plugin recovery state.');
+        }
+    }
+
+    private function removeRecoveryMarker(): void
+    {
+        @unlink($this->recoveryMarkerPath());
+    }
+
+    private function statePath(): string
+    {
+        return $this->root.'/state.json';
+    }
+
+    private function recoveryMarkerPath(): string
+    {
+        return $this->root.'/recovery.json';
+    }
+
+    private function relativeManagedPath(string $path): string
+    {
+        $prefix = $this->root.DIRECTORY_SEPARATOR;
+
+        if (! str_starts_with($path, $prefix)) {
+            throw new RuntimeException('Runtime plugin path is outside the managed storage directory.');
+        }
+
+        return str_replace(DIRECTORY_SEPARATOR, '/', substr($path, strlen($prefix)));
+    }
+
+    private function managedPath(string $relativePath): string
+    {
+        if ($relativePath === '' || str_contains($relativePath, '..') || str_starts_with($relativePath, '/')) {
+            throw new RuntimeException('Runtime plugin recovery path is unsafe.');
+        }
+
+        $path = $this->root.DIRECTORY_SEPARATOR.str_replace('/', DIRECTORY_SEPARATOR, $relativePath);
+
+        if (! str_starts_with($path, $this->root.DIRECTORY_SEPARATOR)) {
+            throw new RuntimeException('Runtime plugin recovery path is outside managed storage.');
+        }
+
+        return $path;
+    }
+
+    private function ensureDirectory(string $path): void
+    {
+        if (is_dir($path)) {
+            return;
+        }
+
+        if (! mkdir($path, 0750, true) && ! is_dir($path)) {
+            throw new RuntimeException("Could not create runtime plugin directory [{$path}].");
+        }
+    }
+
+    private function deleteDirectory(?string $path): void
+    {
+        if ($path === null || ! file_exists($path)) {
+            return;
+        }
+
+        if (is_link($path) || is_file($path)) {
+            unlink($path);
+
+            return;
+        }
+
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+
+            $this->deleteDirectory($path.DIRECTORY_SEPARATOR.$entry);
+        }
+
+        rmdir($path);
+    }
+
+    private function renameOrFail(string $from, string $to): void
+    {
+        if (! rename($from, $to)) {
+            throw new RuntimeException("Could not move runtime plugin path from [{$from}] to [{$to}].");
+        }
+    }
+
+    private function assertValidId(string $id): void
+    {
+        if (! $this->isValidId($id)) {
+            throw new RuntimeException("Invalid runtime plugin ID [{$id}].");
+        }
+    }
+
+    private function isValidId(string $id): bool
+    {
+        return preg_match('/^[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*$/', $id) === 1;
+    }
+}

--- a/bin/validate-runtime-plugin.php
+++ b/bin/validate-runtime-plugin.php
@@ -1,0 +1,42 @@
+<?php
+
+use App\Services\Platform\RuntimePluginArtifactValidator;
+use Illuminate\Container\Container;
+use Illuminate\Foundation\Bootstrap\HandleExceptions;
+use Illuminate\Foundation\Bootstrap\LoadConfiguration;
+use Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables;
+use Illuminate\Foundation\Bootstrap\RegisterFacades;
+use Illuminate\Foundation\Bootstrap\RegisterProviders;
+use Illuminate\Foundation\Bootstrap\SetRequestForConsole;
+
+require dirname(__DIR__).'/vendor/autoload.php';
+
+$app = require dirname(__DIR__).'/bootstrap/app.php';
+$app->bootstrapWith([
+    LoadEnvironmentVariables::class,
+    LoadConfiguration::class,
+    HandleExceptions::class,
+    RegisterFacades::class,
+    SetRequestForConsole::class,
+    RegisterProviders::class,
+]);
+
+if (! $app instanceof Container) {
+    fwrite(STDERR, "Could not bootstrap the validation process.\n");
+    exit(1);
+}
+
+$runtimeConfig = json_decode($argv[3] ?? '', true);
+$app->make('config')->set('platform.runtime', is_array($runtimeConfig) ? $runtimeConfig : []);
+$app->make('config')->set('platform.version', $argv[4] ?? '0.2.0');
+
+try {
+    $metadata = app(RuntimePluginArtifactValidator::class)->validate(
+        $argv[1] ?? '',
+        ($argv[2] ?? '') !== '' ? $argv[2] : null,
+    );
+    fwrite(STDOUT, json_encode($metadata, JSON_THROW_ON_ERROR));
+} catch (Throwable $exception) {
+    fwrite(STDERR, $exception->getMessage()."\n");
+    exit(1);
+}

--- a/config/platform.php
+++ b/config/platform.php
@@ -27,6 +27,22 @@ return [
         'disabled_packages' => [],
     ],
 
+    'runtime' => [
+        'enabled' => true,
+        'path' => env('OPENKOS_PLUGIN_PATH', storage_path('app/private/plugins')),
+        'max_files' => 5000,
+        'max_uncompressed_bytes' => 268_435_456,
+        'shared_packages' => [
+            'composer/semver',
+            'laravel/framework',
+            'openkos/platform',
+        ],
+        'shared_package_prefixes' => [
+            'illuminate/',
+            'laravel/',
+        ],
+    ],
+
     /*
     |--------------------------------------------------------------------------
     | Plugins

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -80,6 +80,12 @@ backup process before replacing the host. If the application is later scaled
 across hosts, move these uploads to shared object storage or shared storage
 before doing so.
 
+Runtime plugin packages use the same private persistent storage under
+`storage/app/private/plugins`. Keep that path available to the web, queue, and scheduler
+containers. After installing, enabling, disabling, or updating a runtime plugin, restart
+FrankenPHP workers, queue workers, and the scheduler so each process boots the new plugin
+set. Runtime plugin installation never changes the root Composer files.
+
 ## Image tags
 
 Stable version tags publish `1.2.3`, `1.2`, `1`, and `latest`.

--- a/docs/platform.md
+++ b/docs/platform.md
@@ -267,6 +267,44 @@ in the standalone package and enabled by the OpenKOS application.
 Installing a Composer plugin grants trusted in-process PHP execution; disabled packages
 are not sandboxed. Frontend assets remain out of scope and must still be handled by the host.
 
+### Runtime ZIP plugins
+
+OpenKOS also accepts prepared runtime plugin artifacts without changing the root
+`composer.json`, `composer.lock`, or `vendor/` directory. Runtime packages live in the
+persistent `storage/app/private/plugins` directory by default and are discovered only
+when enabled in the separate `state.json` file.
+
+An artifact must contain `manifest.json`, `composer.json`, `composer.lock`, `src/`, and
+a bundled `vendor/autoload.php`. The runtime entrypoint must be an
+`OpenKOS\\Platform\\Plugin\\Plugin` subclass. The manifest's `id`, `version`, entry class,
+core constraint, PHP constraint, and plugin dependencies must match the entry class and
+Composer metadata.
+
+Runtime installation is intentionally a strict plugin contract. Laravel service
+providers are not runtime entrypoints; a package such as Fonnte must expose an OpenKOS
+`Plugin` class and may delegate internally as needed.
+
+Use the operator-only CLI lifecycle:
+
+```text
+php artisan plugin:install /path/to/plugin.zip
+php artisan plugin:list
+php artisan plugin:enable openkos/example
+php artisan plugin:disable openkos/example
+php artisan plugin:remove openkos/example --force
+```
+
+Installation and state changes are durable immediately but take effect after a fresh
+application process starts. Restart FrankenPHP workers, queue workers, and the scheduler
+after changing runtime plugins. If a plugin ships migrations or permissions, run
+`php artisan migrate` and `php artisan platform:permissions:sync` separately.
+
+Runtime and Composer copies of the same plugin ID or entry class are conflicts; neither
+copy is loaded. Runtime artifacts are trusted in-process code, so the installer rejects
+unsafe archive paths, symlinks, executable entries, install scripts, incompatible host
+dependencies, and oversized archives before activation. Host-provided packages such as
+Laravel, Illuminate, Composer Semver, and the OpenKOS platform must not be bundled.
+
 ### Security & permission boundaries
 
 Plugins run **in-process with full application access** — there is no sandbox. The trust

--- a/docs/platform.md
+++ b/docs/platform.md
@@ -284,6 +284,11 @@ Runtime installation is intentionally a strict plugin contract. Laravel service
 providers are not runtime entrypoints; a package such as Fonnte must expose an OpenKOS
 `Plugin` class and may delegate internally as needed.
 
+The installer validates each artifact in a fresh PHP process before promotion, so an
+already-loaded class from an older version cannot be mistaken for the staged version.
+Archive entry names are normalized and bounded, and bundled dependency versions must
+satisfy the artifact's Composer constraints.
+
 Use the operator-only CLI lifecycle:
 
 ```text

--- a/tests/Feature/Platform/RuntimePluginStoreTest.php
+++ b/tests/Feature/Platform/RuntimePluginStoreTest.php
@@ -104,3 +104,19 @@ it('raises an operational error for corrupted state', function (): void {
     expect(fn (): array => $store->withLock(fn (RuntimePluginStore $store): array => $store->readState()))
         ->toThrow(RuntimeException::class, 'state is corrupted');
 });
+
+it('rejects recovery paths outside their managed directories', function (): void {
+    $store = app(RuntimePluginStore::class);
+    mkdir($this->runtimePluginPath, 0750, true);
+    file_put_contents($this->runtimePluginPath.'/recovery.json', json_encode([
+        'operation' => 'swap',
+        'id' => 'acme/recovery',
+        'staging' => '.staging/incoming',
+        'backup' => 'state.json',
+        'had_active' => true,
+        'phase' => 'old_preserved',
+    ], JSON_THROW_ON_ERROR));
+
+    expect(fn (): mixed => $store->withLock(fn (): null => null))
+        ->toThrow(RuntimeException::class, 'recovery marker is invalid');
+});

--- a/tests/Feature/Platform/RuntimePluginStoreTest.php
+++ b/tests/Feature/Platform/RuntimePluginStoreTest.php
@@ -120,3 +120,11 @@ it('rejects recovery paths outside their managed directories', function (): void
     expect(fn (): mixed => $store->withLock(fn (): null => null))
         ->toThrow(RuntimeException::class, 'recovery marker is invalid');
 });
+
+it('rejects the application root as runtime plugin storage', function (): void {
+    config(['platform.runtime.path' => base_path('.')]);
+    app()->forgetInstance(RuntimePluginStore::class);
+
+    expect(fn (): RuntimePluginStore => app(RuntimePluginStore::class))
+        ->toThrow(RuntimeException::class, 'dedicated directory');
+});

--- a/tests/Feature/Platform/RuntimePluginStoreTest.php
+++ b/tests/Feature/Platform/RuntimePluginStoreTest.php
@@ -1,0 +1,106 @@
+<?php
+
+use App\Services\Platform\RuntimePluginStore;
+use Illuminate\Support\Facades\File;
+
+beforeEach(function (): void {
+    $this->runtimePluginPath = sys_get_temp_dir().'/openkos-runtime-store-'.bin2hex(random_bytes(8));
+    $this->originalRuntimePath = config('platform.runtime.path');
+    config(['platform.runtime.path' => $this->runtimePluginPath]);
+});
+
+afterEach(function (): void {
+    File::deleteDirectory($this->runtimePluginPath);
+    config(['platform.runtime.path' => $this->originalRuntimePath]);
+});
+
+it('restores the previous package after an interrupted swap', function (): void {
+    $store = app(RuntimePluginStore::class);
+    $activePath = $this->runtimePluginPath.'/acme/recovery';
+    $backupPath = $this->runtimePluginPath.'/.backup/acme-recovery-test';
+
+    mkdir($backupPath, 0750, true);
+    file_put_contents($backupPath.'/version.txt', 'old');
+    mkdir($this->runtimePluginPath.'/.staging/incoming', 0750, true);
+    file_put_contents($this->runtimePluginPath.'/.staging/incoming/version.txt', 'new');
+    file_put_contents($this->runtimePluginPath.'/recovery.json', json_encode([
+        'operation' => 'swap',
+        'id' => 'acme/recovery',
+        'staging' => '.staging/incoming',
+        'backup' => '.backup/acme-recovery-test',
+        'had_active' => true,
+        'phase' => 'old_preserved',
+    ], JSON_THROW_ON_ERROR));
+
+    $store->withLock(fn (): null => null);
+
+    expect(file_get_contents($activePath.'/version.txt'))->toBe('old')
+        ->and(is_dir($backupPath))->toBeFalse()
+        ->and(is_file($this->runtimePluginPath.'/recovery.json'))->toBeFalse();
+});
+
+it('keeps the new package after a committed swap recovery', function (): void {
+    $store = app(RuntimePluginStore::class);
+    $activePath = $this->runtimePluginPath.'/acme/recovery';
+    $backupPath = $this->runtimePluginPath.'/.backup/acme-recovery-test';
+
+    mkdir($activePath, 0750, true);
+    file_put_contents($activePath.'/version.txt', 'new');
+    mkdir($backupPath, 0750, true);
+    file_put_contents($backupPath.'/version.txt', 'old');
+    file_put_contents($this->runtimePluginPath.'/recovery.json', json_encode([
+        'operation' => 'swap',
+        'id' => 'acme/recovery',
+        'staging' => '.staging/incoming',
+        'backup' => '.backup/acme-recovery-test',
+        'had_active' => true,
+        'phase' => 'committed',
+    ], JSON_THROW_ON_ERROR));
+
+    $store->withLock(fn (): null => null);
+
+    expect(file_get_contents($activePath.'/version.txt'))->toBe('new')
+        ->and(is_dir($backupPath))->toBeFalse()
+        ->and(is_file($this->runtimePluginPath.'/recovery.json'))->toBeFalse();
+});
+
+it('finishes an active swap after the new package is promoted', function (): void {
+    $store = app(RuntimePluginStore::class);
+    $activePath = $this->runtimePluginPath.'/acme/recovery';
+    $backupPath = $this->runtimePluginPath.'/.backup/acme-recovery-test';
+
+    mkdir($activePath, 0750, true);
+    file_put_contents($activePath.'/version.txt', 'new');
+    mkdir($backupPath, 0750, true);
+    file_put_contents($backupPath.'/version.txt', 'old');
+    file_put_contents($this->runtimePluginPath.'/state.json', json_encode([
+        'acme/recovery' => ['enabled' => false],
+    ], JSON_THROW_ON_ERROR));
+    file_put_contents($this->runtimePluginPath.'/recovery.json', json_encode([
+        'operation' => 'swap',
+        'id' => 'acme/recovery',
+        'staging' => '.staging/incoming',
+        'backup' => '.backup/acme-recovery-test',
+        'had_active' => true,
+        'previous_entry' => ['enabled' => false],
+        'next_entry' => ['enabled' => true],
+        'phase' => 'new_active',
+    ], JSON_THROW_ON_ERROR));
+
+    $store->withLock(fn (): null => null);
+
+    expect(file_get_contents($activePath.'/version.txt'))->toBe('new')
+        ->and(json_decode(file_get_contents($this->runtimePluginPath.'/state.json'), true, 512, JSON_THROW_ON_ERROR))
+        ->toMatchArray(['acme/recovery' => ['enabled' => true]])
+        ->and(is_dir($backupPath))->toBeFalse()
+        ->and(is_file($this->runtimePluginPath.'/recovery.json'))->toBeFalse();
+});
+
+it('raises an operational error for corrupted state', function (): void {
+    $store = app(RuntimePluginStore::class);
+    mkdir($this->runtimePluginPath, 0750, true);
+    file_put_contents($this->runtimePluginPath.'/state.json', '{broken');
+
+    expect(fn (): array => $store->withLock(fn (RuntimePluginStore $store): array => $store->readState()))
+        ->toThrow(RuntimeException::class, 'state is corrupted');
+});

--- a/tests/Feature/Platform/RuntimePluginTest.php
+++ b/tests/Feature/Platform/RuntimePluginTest.php
@@ -107,6 +107,17 @@ it('rejects a runtime plugin that conflicts with an explicit plugin', function (
         ->toThrow(RuntimeException::class, 'conflicts');
 });
 
+it('rejects an entry-class conflict before activating a runtime plugin', function (): void {
+    $artifact = makeRuntimePluginArtifact();
+    config(['platform.plugins' => [$artifact['class']]]);
+
+    $this->artisan('plugin:install', ['zip' => $artifact['zip']])
+        ->assertFailed()
+        ->expectsOutputToContain('conflicts');
+
+    expect(is_dir($this->runtimePluginPath.'/'.$artifact['id']))->toBeFalse();
+});
+
 it('fails on corrupted runtime state instead of treating it as disabled', function (): void {
     mkdir($this->runtimePluginPath, 0750, true);
     file_put_contents($this->runtimePluginPath.'/state.json', '{broken');

--- a/tests/Feature/Platform/RuntimePluginTest.php
+++ b/tests/Feature/Platform/RuntimePluginTest.php
@@ -54,6 +54,21 @@ it('does not boot a disabled runtime plugin', function (): void {
     expect(app(PermissionRegistry::class)->all())->not->toHaveKey('runtime-fixture.view');
 });
 
+it('validates updates in a fresh process after the previous class was loaded', function (): void {
+    $first = makeRuntimePluginArtifact();
+
+    $this->artisan('plugin:install', ['zip' => $first['zip']])->assertSuccessful();
+    $this->bootPlatformWithIsolatedRegistries();
+
+    $classShort = basename(str_replace('\\', '/', $first['class']));
+    $second = makeRuntimePluginArtifact(['version' => '2.0.0'], $first['id'], $classShort);
+
+    $this->artisan('plugin:install', ['zip' => $second['zip']])->assertSuccessful();
+
+    expect(file_get_contents($this->runtimePluginPath.'/'.$first['id'].'/src/'.$classShort.'.php'))
+        ->toContain("version: '2.0.0'");
+});
+
 it('revalidates an installed plugin before enabling it', function (): void {
     $artifact = makeRuntimePluginArtifact();
 
@@ -84,6 +99,36 @@ it('rejects artifacts that exceed the configured archive limit', function (): vo
 
     $this->artisan('plugin:install', ['zip' => $zip])
         ->assertFailed();
+});
+
+it('counts archive directories toward the entry limit', function (): void {
+    config(['platform.runtime.max_files' => 1]);
+    $zip = makeDirectoryHeavyZip();
+
+    $this->artisan('plugin:install', ['zip' => $zip])->assertFailed();
+});
+
+it('validates bundled dependency versions and rejects bundled host packages', function (): void {
+    $artifact = makeRuntimePluginArtifact(
+        id: null,
+        classShort: null,
+        bundledPackages: ['acme/dependency' => '1.0.0'],
+        additionalRequirements: ['acme/dependency' => '^2.0'],
+    );
+
+    $this->artisan('plugin:install', ['zip' => $artifact['zip']])
+        ->assertFailed()
+        ->expectsOutputToContain('Bundled package [acme/dependency] version [1.0.0]');
+
+    $hostPackageArtifact = makeRuntimePluginArtifact(
+        id: null,
+        classShort: null,
+        bundledPackages: ['laravel/framework' => '13.0.0'],
+    );
+
+    $this->artisan('plugin:install', ['zip' => $hostPackageArtifact['zip']])
+        ->assertFailed()
+        ->expectsOutputToContain('must not bundle host package [laravel/framework]');
 });
 
 it('reports an enabled package with a malformed manifest without booting it', function (): void {
@@ -129,13 +174,20 @@ it('fails on corrupted runtime state instead of treating it as disabled', functi
 
 /**
  * @param  array<string, mixed>  $overrides
+ * @param  array<string, string>  $bundledPackages
+ * @param  array<string, string>  $additionalRequirements
  * @return array{zip: string, id: string, class: string}
  */
-function makeRuntimePluginArtifact(array $overrides = []): array
-{
+function makeRuntimePluginArtifact(
+    array $overrides = [],
+    ?string $id = null,
+    ?string $classShort = null,
+    array $bundledPackages = [],
+    array $additionalRequirements = [],
+): array {
     $suffix = (string) random_int(100000, 999999);
-    $id = "acme/runtime-{$suffix}";
-    $classShort = "Runtime{$suffix}Plugin";
+    $id ??= "acme/runtime-{$suffix}";
+    $classShort ??= "Runtime{$suffix}Plugin";
     $entryClass = "RuntimeArtifact\\{$classShort}";
     $manifest = [
         'id' => $id,
@@ -149,11 +201,12 @@ function makeRuntimePluginArtifact(array $overrides = []): array
         ...$overrides,
     ];
     $composer = [
-        'name' => $id,
+        'name' => $manifest['id'],
         'type' => 'library',
         'require' => [
             'php' => '^8.3',
             'openkos/platform' => '^0.2',
+            ...$additionalRequirements,
         ],
         'autoload' => ['psr-4' => ['RuntimeArtifact\\' => 'src/']],
         'extra' => ['openkos' => ['plugin' => $entryClass]],
@@ -164,13 +217,23 @@ function makeRuntimePluginArtifact(array $overrides = []): array
         'manifest.json' => json_encode($manifest, JSON_THROW_ON_ERROR),
         'composer.json' => json_encode($composer, JSON_THROW_ON_ERROR),
         'composer.lock' => json_encode([
-            'packages' => [['name' => 'openkos/platform', 'version' => '0.2.2']],
+            'packages' => [
+                ['name' => 'openkos/platform', 'version' => '0.2.2'],
+                ...array_map(
+                    fn (string $version, string $name): array => ['name' => $name, 'version' => $version],
+                    $bundledPackages,
+                    array_keys($bundledPackages),
+                ),
+            ],
             'packages-dev' => [],
         ], JSON_THROW_ON_ERROR),
         'src/'.$classShort.'.php' => $source,
         'vendor/autoload.php' => "<?php\nspl_autoload_register(static function (string \$class): void {\n    if (\$class === '{$entryClass}') {\n        require_once __DIR__.'/../src/{$classShort}.php';\n    }\n});\n",
-        'vendor/composer/installed.php' => "<?php\nreturn ['versions' => []];\n",
-    ], $id, $entryClass);
+        'vendor/composer/installed.php' => "<?php\nreturn ['versions' => ".var_export(array_map(
+            fn (string $version): array => ['pretty_version' => $version],
+            $bundledPackages,
+        ), true)."];\n",
+    ], $manifest['id'], $entryClass);
 }
 
 /**
@@ -193,4 +256,19 @@ function makeZip(array $files, string $id = 'acme/invalid', string $class = 'Run
     File::deleteDirectory($directory);
 
     return ['zip' => $zipPath, 'id' => $id, 'class' => $class];
+}
+
+function makeDirectoryHeavyZip(): string
+{
+    $directory = sys_get_temp_dir().'/openkos-directory-heavy-'.bin2hex(random_bytes(8));
+    mkdir($directory, 0750, true);
+    $zipPath = $directory.'.zip';
+    $zip = new ZipArchive;
+    $zip->open($zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+    $zip->addEmptyDir('src');
+    $zip->addFromString('manifest.json', '{}');
+    $zip->close();
+    File::deleteDirectory($directory);
+
+    return $zipPath;
 }

--- a/tests/Feature/Platform/RuntimePluginTest.php
+++ b/tests/Feature/Platform/RuntimePluginTest.php
@@ -1,0 +1,185 @@
+<?php
+
+use Illuminate\Support\Facades\File;
+use OpenKOS\Core\Contracts\PluginDiscovery;
+use OpenKOS\Platform\Permission\PermissionRegistry;
+
+beforeEach(function (): void {
+    $this->runtimePluginPath = sys_get_temp_dir().'/openkos-runtime-'.bin2hex(random_bytes(8));
+    $this->originalRuntimeConfig = [
+        'platform.plugins' => config('platform.plugins'),
+        'platform.runtime.path' => config('platform.runtime.path'),
+        'platform.runtime.max_files' => config('platform.runtime.max_files'),
+        'platform.runtime.max_uncompressed_bytes' => config('platform.runtime.max_uncompressed_bytes'),
+    ];
+    config([
+        'platform.plugins' => [],
+        'platform.runtime.path' => $this->runtimePluginPath,
+    ]);
+    app()->forgetInstance(PluginDiscovery::class);
+});
+
+afterEach(function (): void {
+    File::deleteDirectory($this->runtimePluginPath);
+    config($this->originalRuntimeConfig);
+});
+
+it('installs and boots a valid runtime plugin without changing root Composer files', function (): void {
+    $artifact = makeRuntimePluginArtifact();
+    $composerBefore = file_get_contents(base_path('composer.json'));
+    $lockBefore = file_get_contents(base_path('composer.lock'));
+
+    $this->artisan('plugin:install', ['zip' => $artifact['zip']])
+        ->assertSuccessful();
+
+    expect(file_get_contents(base_path('composer.json')))->toBe($composerBefore)
+        ->and(file_get_contents(base_path('composer.lock')))->toBe($lockBefore)
+        ->and(is_file($this->runtimePluginPath.'/'.$artifact['id'].'/manifest.json'))->toBeTrue()
+        ->and(json_decode(file_get_contents($this->runtimePluginPath.'/state.json'), true, 512, JSON_THROW_ON_ERROR))
+        ->toMatchArray([$artifact['id'] => ['enabled' => true]]);
+
+    $this->bootPlatformWithIsolatedRegistries();
+
+    expect(app(PermissionRegistry::class)->all())->toHaveKey('runtime-fixture.view');
+});
+
+it('does not boot a disabled runtime plugin', function (): void {
+    $artifact = makeRuntimePluginArtifact();
+
+    $this->artisan('plugin:install', ['zip' => $artifact['zip']])->assertSuccessful();
+    $this->artisan('plugin:disable', ['id' => $artifact['id']])->assertSuccessful();
+
+    $this->bootPlatformWithIsolatedRegistries();
+
+    expect(app(PermissionRegistry::class)->all())->not->toHaveKey('runtime-fixture.view');
+});
+
+it('revalidates an installed plugin before enabling it', function (): void {
+    $artifact = makeRuntimePluginArtifact();
+
+    $this->artisan('plugin:install', ['zip' => $artifact['zip']])->assertSuccessful();
+    $this->artisan('plugin:disable', ['id' => $artifact['id']])->assertSuccessful();
+    File::deleteDirectory($this->runtimePluginPath.'/'.$artifact['id'].'/vendor');
+
+    $this->artisan('plugin:enable', ['id' => $artifact['id']])
+        ->assertFailed();
+
+    expect(json_decode(file_get_contents($this->runtimePluginPath.'/state.json'), true, 512, JSON_THROW_ON_ERROR))
+        ->toMatchArray([$artifact['id'] => ['enabled' => false]]);
+});
+
+it('rejects unsafe ZIP paths before extraction', function (): void {
+    $zip = makeZip(['../outside.txt' => 'unsafe']);
+
+    $this->artisan('plugin:install', ['zip' => $zip])
+        ->assertFailed();
+
+    expect(count(glob($this->runtimePluginPath.'/.staging/*') ?: []))->toBe(0)
+        ->and(count(glob($this->runtimePluginPath.'/*/*') ?: []))->toBe(0);
+});
+
+it('rejects artifacts that exceed the configured archive limit', function (): void {
+    config(['platform.runtime.max_uncompressed_bytes' => 3]);
+    $zip = makeZip(['manifest.json' => '12345']);
+
+    $this->artisan('plugin:install', ['zip' => $zip])
+        ->assertFailed();
+});
+
+it('reports an enabled package with a malformed manifest without booting it', function (): void {
+    $artifact = makeRuntimePluginArtifact();
+
+    $this->artisan('plugin:install', ['zip' => $artifact['zip']])->assertSuccessful();
+    file_put_contents($this->runtimePluginPath.'/'.$artifact['id'].'/manifest.json', '{broken');
+
+    $this->artisan('plugin:list')
+        ->assertSuccessful()
+        ->expectsOutputToContain('Invalid (enabled)');
+});
+
+it('rejects a runtime plugin that conflicts with an explicit plugin', function (): void {
+    $artifact = makeRuntimePluginArtifact();
+
+    $this->artisan('plugin:install', ['zip' => $artifact['zip']])->assertSuccessful();
+    config(['platform.plugins' => [$artifact['class']]]);
+
+    expect(fn (): mixed => $this->bootPlatformWithIsolatedRegistries())
+        ->toThrow(RuntimeException::class, 'conflicts');
+});
+
+it('fails on corrupted runtime state instead of treating it as disabled', function (): void {
+    mkdir($this->runtimePluginPath, 0750, true);
+    file_put_contents($this->runtimePluginPath.'/state.json', '{broken');
+
+    $this->artisan('plugin:list')
+        ->assertFailed()
+        ->expectsOutputToContain('state is corrupted');
+});
+
+/**
+ * @param  array<string, mixed>  $overrides
+ * @return array{zip: string, id: string, class: string}
+ */
+function makeRuntimePluginArtifact(array $overrides = []): array
+{
+    $suffix = (string) random_int(100000, 999999);
+    $id = "acme/runtime-{$suffix}";
+    $classShort = "Runtime{$suffix}Plugin";
+    $entryClass = "RuntimeArtifact\\{$classShort}";
+    $manifest = [
+        'id' => $id,
+        'name' => 'Runtime Fixture',
+        'version' => '1.0.0',
+        'description' => 'Runtime fixture plugin.',
+        'entry_class' => $entryClass,
+        'core_version' => '^0.2',
+        'php' => '^8.3',
+        'dependencies' => [],
+        ...$overrides,
+    ];
+    $composer = [
+        'name' => $id,
+        'type' => 'library',
+        'require' => [
+            'php' => '^8.3',
+            'openkos/platform' => '^0.2',
+        ],
+        'autoload' => ['psr-4' => ['RuntimeArtifact\\' => 'src/']],
+        'extra' => ['openkos' => ['plugin' => $entryClass]],
+    ];
+    $source = "<?php\n\nnamespace RuntimeArtifact;\n\nuse OpenKOS\\Platform\\OpenKOSManager;\nuse OpenKOS\\Platform\\Plugin\\Plugin;\nuse OpenKOS\\Platform\\Plugin\\PluginManifest;\n\nfinal class {$classShort} extends Plugin\n{\n    public function manifest(): PluginManifest\n    {\n        return new PluginManifest(\n            id: '{$manifest['id']}',\n            name: '{$manifest['name']}',\n            version: '{$manifest['version']}',\n            description: '{$manifest['description']}',\n            coreVersion: '{$manifest['core_version']}',\n            dependencies: [],\n        );\n    }\n\n    public function register(OpenKOSManager \$platform): void\n    {\n        \$platform->permissions()->register('runtime-fixture.view', 'Runtime Fixture');\n    }\n}\n";
+
+    return makeZip([
+        'manifest.json' => json_encode($manifest, JSON_THROW_ON_ERROR),
+        'composer.json' => json_encode($composer, JSON_THROW_ON_ERROR),
+        'composer.lock' => json_encode([
+            'packages' => [['name' => 'openkos/platform', 'version' => '0.2.2']],
+            'packages-dev' => [],
+        ], JSON_THROW_ON_ERROR),
+        'src/'.$classShort.'.php' => $source,
+        'vendor/autoload.php' => "<?php\nspl_autoload_register(static function (string \$class): void {\n    if (\$class === '{$entryClass}') {\n        require_once __DIR__.'/../src/{$classShort}.php';\n    }\n});\n",
+        'vendor/composer/installed.php' => "<?php\nreturn ['versions' => []];\n",
+    ], $id, $entryClass);
+}
+
+/**
+ * @param  array<string, string>  $files
+ * @return array{zip: string, id: string, class: string}
+ */
+function makeZip(array $files, string $id = 'acme/invalid', string $class = 'RuntimeArtifact\\InvalidPlugin'): array
+{
+    $directory = sys_get_temp_dir().'/openkos-zip-'.bin2hex(random_bytes(8));
+    mkdir($directory, 0750, true);
+    $zipPath = $directory.'.zip';
+    $zip = new ZipArchive;
+    $zip->open($zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+
+    foreach ($files as $path => $contents) {
+        $zip->addFromString($path, $contents);
+    }
+
+    $zip->close();
+    File::deleteDirectory($directory);
+
+    return ['zip' => $zipPath, 'id' => $id, 'class' => $class];
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,8 @@
 
 namespace Tests;
 
+use App\Services\Platform\RuntimePluginDiscovery;
+use App\Services\Platform\RuntimePluginStore;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 use Laravel\Fortify\Features;
 use OpenKOS\Platform\Dashboard\DashboardRegistry;
@@ -29,6 +31,8 @@ abstract class TestCase extends BaseTestCase
             PaymentRegistry::class,
             PermissionRegistry::class,
             OpenKOSManager::class,
+            RuntimePluginDiscovery::class,
+            RuntimePluginStore::class,
         ] as $singleton) {
             app()->forgetInstance($singleton);
         }


### PR DESCRIPTION
## Summary

- Validate runtime plugin artifacts in a fresh PHP process to avoid stale loaded classes during install and update.
- Enforce canonical dedicated plugin storage roots and safer ZIP entry limits.
- Reject duplicate normalized archive paths and bundled host-owned packages.
- Verify bundled and host dependency versions satisfy Composer constraints.
- Add recovery, archive-limit, dependency, and stale-class regression coverage.

## Validation

- `php artisan test --compact tests/Feature/Platform/RuntimePluginStoreTest.php tests/Feature/Platform/RuntimePluginTest.php tests/Feature/Platform/ComposerPluginDiscoveryTest.php tests/Feature/Platform/PluginBootTest.php tests/Feature/Platform/PluginResourcesTest.php tests/Feature/Providers/ServiceProviderTest.php`
- 42 passed, 1 skipped

Refs OPE-169