### PR TITLE
feat(plugins): add runtime management

### DIFF
--- a/app/Http/Controllers/Settings/PluginController.php
+++ b/app/Http/Controllers/Settings/PluginController.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Http\Controllers\Settings;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Settings\InstallPluginRequest;
+use App\Services\Platform\PluginManagementService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Validation\ValidationException;
+use Inertia\Inertia;
+use Inertia\Response;
+use Throwable;
+
+class PluginController extends Controller
+{
+    public function index(PluginManagementService $plugins): Response
+    {
+        $catalog = $plugins->catalog();
+
+        return Inertia::render('settings/plugins', [
+            'plugins' => $catalog['plugins'],
+            'error' => $catalog['error'],
+            'max_upload_bytes' => (int) config('platform.runtime.max_upload_bytes', 64 * 1024 * 1024),
+        ]);
+    }
+
+    public function install(InstallPluginRequest $request, PluginManagementService $plugins): RedirectResponse
+    {
+        /** @var UploadedFile $file */
+        $file = $request->file('file');
+
+        try {
+            $plugins->install($file);
+        } catch (Throwable $exception) {
+            report($exception);
+
+            throw ValidationException::withMessages([
+                'file' => $plugins->userMessage($exception),
+            ]);
+        }
+
+        Inertia::flash('toast', [
+            'type' => 'success',
+            'message' => __('Plugin installed. Restart required for changes to take effect.'),
+        ]);
+
+        return to_route('settings.plugins.index');
+    }
+
+    public function enable(string $vendor, string $package, PluginManagementService $plugins): RedirectResponse
+    {
+        return $this->runLifecycle($plugins, $vendor.'/'.$package, fn (string $id): mixed => $plugins->enable($id), __('Plugin enabled. Restart required for changes to take effect.'));
+    }
+
+    public function disable(string $vendor, string $package, PluginManagementService $plugins): RedirectResponse
+    {
+        return $this->runLifecycle($plugins, $vendor.'/'.$package, fn (string $id): mixed => $plugins->disable($id), __('Plugin disabled. Restart required for changes to take effect.'));
+    }
+
+    public function destroy(string $vendor, string $package, PluginManagementService $plugins): RedirectResponse
+    {
+        return $this->runLifecycle($plugins, $vendor.'/'.$package, fn (string $id): mixed => $plugins->remove($id), __('Plugin removed. Restart required for changes to take effect.'));
+    }
+
+    /** @param callable(string): mixed $action */
+    private function runLifecycle(PluginManagementService $plugins, string $id, callable $action, string $success): RedirectResponse
+    {
+        try {
+            $action($id);
+        } catch (Throwable $exception) {
+            report($exception);
+
+            throw ValidationException::withMessages([
+                'plugin' => $plugins->userMessage($exception),
+            ]);
+        }
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => $success]);
+
+        return to_route('settings.plugins.index');
+    }
+}

--- a/app/Http/Requests/Settings/InstallPluginRequest.php
+++ b/app/Http/Requests/Settings/InstallPluginRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests\Settings;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\File;
+
+class InstallPluginRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()?->isOwner() ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'file' => [
+                'required',
+                File::types(['zip'])->max((int) ceil((int) config('platform.runtime.max_upload_bytes', 64 * 1024 * 1024) / 1024)),
+            ],
+        ];
+    }
+}

--- a/app/Providers/PlatformBindingsServiceProvider.php
+++ b/app/Providers/PlatformBindingsServiceProvider.php
@@ -34,6 +34,7 @@ class PlatformBindingsServiceProvider extends ServiceProvider
             ->registerPage(new SettingsPage('payment-gateway', 'Payment Gateway', '/settings/payment-gateway', group: 'Integrations', order: 150, routeName: 'settings.payment-gateway.edit'))
             ->registerPage(new SettingsPage('reminders', 'Reminders', '/settings/reminders', group: 'Notifications', order: 100, routeName: 'settings.reminders.edit'))
             ->registerPage(new SettingsPage('mail', 'Mail', '/settings/mail', group: 'Integrations', order: 100, routeName: 'settings.mail.edit'))
+            ->registerPage(new SettingsPage('plugins', 'Plugins', '/settings/plugins', order: 300, routeName: 'settings.plugins.index'))
             ->registerSetting(new SettingDefinition(
                 key: PaymentGatewayManager::ACTIVE_KEY,
                 label: 'Active payment gateway',

--- a/app/Services/Platform/PluginInstaller.php
+++ b/app/Services/Platform/PluginInstaller.php
@@ -3,10 +3,7 @@
 namespace App\Services\Platform;
 
 use InvalidArgumentException;
-use OpenKOS\Platform\OpenKOSManager;
 use OpenKOS\Platform\Plugin\Plugin;
-use OpenKOS\Platform\Plugin\PluginLoader;
-use OpenKOS\Platform\Plugin\PluginManifest;
 use RuntimeException;
 use Throwable;
 use ZipArchive;
@@ -16,6 +13,8 @@ final class PluginInstaller
     public function __construct(
         private RuntimePluginStore $store,
         private RuntimePluginArtifactValidator $validator,
+        private RuntimePluginGraphValidator $graph,
+        private ComposerPluginDiscovery $composer,
     ) {}
 
     /**
@@ -59,10 +58,9 @@ final class PluginInstaller
                 }
 
                 $metadata = $this->validator->validateInFreshProcess($stagingPath);
-                $this->validateBootSet($metadata, $store);
-
                 $state = $store->readState();
                 $enabled = ! isset($state[$metadata['id']]) || $state[$metadata['id']]['enabled'];
+                $this->graph->validateCandidate($metadata, $enabled, $store, $this->hostPluginClasses());
                 $store->promote($metadata['id'], $stagingPath, $enabled);
                 $stagingPath = null;
 
@@ -96,7 +94,7 @@ final class PluginInstaller
         return $this->store->withLock(function (RuntimePluginStore $store) use ($id): array {
             $path = $store->packagePath($id);
             $metadata = $this->validator->validateInFreshProcess($path, $id);
-            $this->validateBootSet($metadata, $store);
+            $this->graph->validateCandidate($metadata, true, $store, $this->hostPluginClasses());
             $store->setEnabled($id, true);
 
             return $metadata;
@@ -106,6 +104,7 @@ final class PluginInstaller
     public function disable(string $id): void
     {
         $this->store->withLock(function (RuntimePluginStore $store) use ($id): void {
+            $this->assertNoEnabledDependants($id, $store, 'disable');
             $store->setEnabled($id, false);
         });
     }
@@ -113,6 +112,7 @@ final class PluginInstaller
     public function remove(string $id): void
     {
         $this->store->withLock(function (RuntimePluginStore $store) use ($id): void {
+            $this->assertNoEnabledDependants($id, $store, 'remove');
             $store->remove($id);
         });
     }
@@ -201,96 +201,25 @@ final class PluginInstaller
         }
     }
 
-    /**
-     * @param  array{
-     *     id: string,
-     *     name: string,
-     *     version: string,
-     *     description: string,
-     *     entry_class: class-string<Plugin>,
-     *     core_version: string,
-     *     php: string,
-     *     dependencies: array<int, string>
-     * } $metadata
-     */
-    private function validateBootSet(array $metadata, RuntimePluginStore $store): void
+    /** @return array<int, string> */
+    private function hostPluginClasses(): array
     {
-        $hostClasses = [
-            ...config('platform.plugins', []),
-            ...app(ComposerPluginDiscovery::class)->discoverComposerOnly(),
+        return [
+            ...array_values(array_filter(config('platform.plugins', []), 'is_string')),
+            ...$this->composer->discoverComposerOnly(),
         ];
-        $runtimeMetadata = [];
-        $runtimeClasses = [];
-        $state = $store->readState();
+    }
 
-        foreach ($store->installedPackages() as $id => $path) {
-            if ($id === $metadata['id'] || ! ($state[$id]['enabled'] ?? false)) {
-                continue;
-            }
+    private function assertNoEnabledDependants(string $id, RuntimePluginStore $store, string $action): void
+    {
+        $dependants = $this->graph->enabledDependants($id, $store, $this->hostPluginClasses());
 
-            $runtimeMetadata[] = $this->validator->validateInFreshProcess($path, $id);
-            $runtimeClasses[] = $runtimeMetadata[array_key_last($runtimeMetadata)]['entry_class'];
+        if ($dependants === []) {
+            return;
         }
 
-        if (in_array($metadata['entry_class'], $hostClasses, true)) {
-            throw new RuntimePluginConflictException(
-                "Runtime plugin entry class [{$metadata['entry_class']}] conflicts with a Composer or explicit plugin. Neither copy will load.",
-            );
-        }
-
-        foreach ($runtimeClasses as $class) {
-            if (in_array($class, $hostClasses, true) || $class === $metadata['entry_class']) {
-                throw new RuntimePluginConflictException(
-                    "Runtime plugin entry class [{$class}] conflicts with a Composer or explicit plugin. Neither copy will load.",
-                );
-            }
-        }
-
-        $classes = [...$hostClasses, ...$runtimeClasses];
-        $classes = array_values(array_unique($classes));
-        $plugins = [];
-
-        foreach ($classes as $class) {
-            if (! is_string($class) || ! class_exists($class) || ! is_a($class, Plugin::class, true)) {
-                throw new InvalidArgumentException("Plugin class [{$class}] is invalid.");
-            }
-
-            $plugins[] = app()->make($class);
-        }
-
-        foreach ([...$runtimeMetadata, $metadata] as $pluginMetadata) {
-            $plugins[] = new class($pluginMetadata) extends Plugin
-            {
-                /**
-                 * @param  array{
-                 *     id: string,
-                 *     name: string,
-                 *     version: string,
-                 *     description: string,
-                 *     entry_class: class-string<Plugin>,
-                 *     core_version: string,
-                 *     php: string,
-                 *     dependencies: array<int, string>
-                 * }  $metadata
-                 */
-                public function __construct(private array $metadata) {}
-
-                public function manifest(): PluginManifest
-                {
-                    return new PluginManifest(
-                        id: $this->metadata['id'],
-                        name: $this->metadata['name'],
-                        version: $this->metadata['version'],
-                        description: $this->metadata['description'],
-                        coreVersion: $this->metadata['core_version'],
-                        dependencies: $this->metadata['dependencies'],
-                    );
-                }
-
-                public function register(OpenKOSManager $platform): void {}
-            };
-        }
-
-        (new PluginLoader)->prepare($plugins, config('platform.version', '0.2.0'));
+        throw new RuntimePluginDependencyException(
+            "Cannot {$action} {$id} because ".implode(', ', $dependants).' depends on it.',
+        );
     }
 }

--- a/app/Services/Platform/PluginManagementService.php
+++ b/app/Services/Platform/PluginManagementService.php
@@ -1,0 +1,327 @@
+<?php
+
+namespace App\Services\Platform;
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use OpenKOS\Platform\Plugin\Plugin;
+use Throwable;
+
+class PluginManagementService
+{
+    public function __construct(
+        private RuntimePluginStore $store,
+        private RuntimePluginArtifactValidator $validator,
+        private ComposerPluginDiscovery $composer,
+        private PluginInstaller $installer,
+    ) {}
+
+    /**
+     * @return array{plugins: array<int, array<string, mixed>>, error: string|null}
+     */
+    public function catalog(): array
+    {
+        $legacy = $this->legacyPlugins();
+        $runtime = [];
+        $error = null;
+
+        try {
+            $runtime = $this->runtimePlugins();
+        } catch (Throwable $exception) {
+            report($exception);
+            $error = __('Runtime plugin state could not be read. Check the application logs for details.');
+        }
+
+        $this->markConflicts($runtime, $legacy);
+
+        return [
+            'plugins' => [...$legacy, ...$runtime],
+            'error' => $error,
+        ];
+    }
+
+    /**
+     * @return array{
+     *     id: string,
+     *     name: string,
+     *     version: string,
+     *     description: string,
+     *     entry_class: class-string<Plugin>,
+     *     core_version: string,
+     *     php: string,
+     *     dependencies: array<int, string>
+     * }
+     */
+    public function install(UploadedFile $file): array
+    {
+        $disk = Storage::disk('local');
+        $path = $file->storeAs('plugin-uploads', Str::uuid()->toString().'.zip', 'local');
+
+        if (! is_string($path)) {
+            throw new \RuntimeException('Plugin upload could not be stored.');
+        }
+
+        try {
+            return $this->installer->install($disk->path($path));
+        } finally {
+            $disk->delete($path);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function enable(string $id): array
+    {
+        return $this->installer->enable($id);
+    }
+
+    public function disable(string $id): void
+    {
+        $this->installer->disable($id);
+    }
+
+    public function remove(string $id): void
+    {
+        $this->installer->remove($id);
+    }
+
+    public function userMessage(Throwable $exception): string
+    {
+        $message = strtolower($exception->getMessage());
+
+        if ($exception instanceof RuntimePluginConflictException || str_contains($message, 'conflict')) {
+            return __('This plugin conflicts with an explicit or Composer-installed plugin. Disable or remove the runtime copy.');
+        }
+
+        if (
+            str_contains($message, 'constraint')
+            || str_contains($message, 'dependency')
+            || str_contains($message, 'php version')
+            || str_contains($message, 'not installed')
+            || str_contains($message, 'absent')
+            || str_contains($message, 'not bundled')
+        ) {
+            return __('This plugin is not compatible with the current OpenKOS or PHP installation.');
+        }
+
+        return __('The plugin artifact was rejected. Check that it is a valid prepared runtime plugin ZIP.');
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    private function runtimePlugins(): array
+    {
+        $state = $this->store->readState();
+        $packages = $this->store->installedPackages();
+        $rows = [];
+
+        foreach ($packages as $id => $path) {
+            $enabled = $state[$id]['enabled'] ?? false;
+
+            try {
+                $metadata = $this->validator->validateInFreshProcess($path, $id);
+                $rows[] = $this->runtimeRow($metadata, $enabled);
+            } catch (Throwable $exception) {
+                report($exception);
+                $preview = $this->manifestPreview($path, $id);
+                $status = $this->validationStatus($exception);
+                $rows[] = [
+                    ...$preview,
+                    'source' => 'runtime',
+                    'status' => $status,
+                    'enabled' => $enabled,
+                    'error' => $status === 'incompatible'
+                        ? __('This plugin is not compatible with the current OpenKOS or PHP installation.')
+                        : __('This plugin is incomplete or failed validation. Disable or remove it, then install a valid artifact.'),
+                    'can_enable' => false,
+                    'can_disable' => $enabled,
+                    'can_remove' => true,
+                ];
+            }
+        }
+
+        foreach (array_diff_key($state, $packages) as $id => $entry) {
+            $rows[] = [
+                'id' => $id,
+                'name' => $id,
+                'version' => null,
+                'description' => '',
+                'entry_class' => null,
+                'core_version' => null,
+                'php' => null,
+                'dependencies' => [],
+                'source' => 'runtime',
+                'status' => 'missing',
+                'enabled' => $entry['enabled'],
+                'error' => __('Plugin state exists without an installed package. Remove the stale state entry.'),
+                'can_enable' => false,
+                'can_disable' => $entry['enabled'],
+                'can_remove' => true,
+            ];
+        }
+
+        return $rows;
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    private function legacyPlugins(): array
+    {
+        $configured = array_values(array_filter(config('platform.plugins', []), 'is_string'));
+        $discovered = [];
+
+        try {
+            $discovered = $this->composer->discoverComposerOnly();
+        } catch (Throwable $exception) {
+            report($exception);
+        }
+
+        $rows = [];
+
+        foreach (array_values(array_unique([...$configured, ...$discovered])) as $class) {
+            try {
+                if (! class_exists($class) || ! is_a($class, Plugin::class, true)) {
+                    throw new \InvalidArgumentException('Plugin class is invalid.');
+                }
+
+                $manifest = app()->make($class)->manifest();
+                $rows[] = [
+                    'id' => $manifest->id,
+                    'name' => $manifest->name,
+                    'version' => $manifest->version,
+                    'description' => $manifest->description,
+                    'entry_class' => $class,
+                    'core_version' => $manifest->coreVersion,
+                    'php' => null,
+                    'dependencies' => $manifest->dependencies,
+                    'source' => in_array($class, $configured, true) ? 'explicit' : 'composer',
+                    'status' => 'legacy',
+                    'enabled' => true,
+                    'error' => null,
+                    'can_enable' => false,
+                    'can_disable' => false,
+                    'can_remove' => false,
+                ];
+            } catch (Throwable $exception) {
+                report($exception);
+            }
+        }
+
+        return $rows;
+    }
+
+    /** @param array<string, mixed> $metadata */
+    private function runtimeRow(array $metadata, bool $enabled): array
+    {
+        return [
+            ...$metadata,
+            'source' => 'runtime',
+            'status' => $enabled ? 'enabled' : 'disabled',
+            'enabled' => $enabled,
+            'error' => null,
+            'can_enable' => ! $enabled,
+            'can_disable' => $enabled,
+            'can_remove' => true,
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function manifestPreview(string $path, string $id): array
+    {
+        $preview = [
+            'id' => $id,
+            'name' => $id,
+            'version' => null,
+            'description' => '',
+            'entry_class' => null,
+            'core_version' => null,
+            'php' => null,
+            'dependencies' => [],
+        ];
+        $manifestPath = $path.'/manifest.json';
+
+        if (! is_file($manifestPath) || is_link($manifestPath)) {
+            return $preview;
+        }
+
+        $contents = file_get_contents($manifestPath);
+
+        if ($contents === false) {
+            return $preview;
+        }
+
+        try {
+            $manifest = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+        } catch (Throwable) {
+            return $preview;
+        }
+
+        if (! is_array($manifest)) {
+            return $preview;
+        }
+
+        foreach (['id', 'name', 'version', 'description', 'entry_class', 'core_version', 'php'] as $key) {
+            if (is_string($manifest[$key] ?? null) && $manifest[$key] !== '') {
+                $preview[$key] = $manifest[$key];
+            }
+        }
+
+        if (is_array($manifest['dependencies'] ?? null)) {
+            $preview['dependencies'] = array_values(array_filter($manifest['dependencies'], 'is_string'));
+        }
+
+        return $preview;
+    }
+
+    private function validationStatus(Throwable $exception): string
+    {
+        $message = strtolower($exception->getMessage());
+
+        return str_contains($message, 'constraint')
+            || str_contains($message, 'dependency')
+            || str_contains($message, 'php version')
+            || str_contains($message, 'not installed')
+            || str_contains($message, 'absent')
+            || str_contains($message, 'not bundled')
+            ? 'incompatible'
+            : 'broken';
+    }
+
+    /** @param array<int, array<string, mixed>> $runtime @param array<int, array<string, mixed>> $legacy */
+    private function markConflicts(array &$runtime, array &$legacy): void
+    {
+        $legacyIds = array_count_values(array_column($legacy, 'id'));
+        $legacyClasses = array_column($legacy, 'entry_class');
+
+        foreach ($legacy as &$plugin) {
+            if (($legacyIds[$plugin['id']] ?? 0) > 1) {
+                $this->markConflict($plugin, __('Multiple Composer or explicit plugins declare the same identity.'));
+            }
+        }
+        unset($plugin);
+
+        foreach ($runtime as &$plugin) {
+            if (in_array($plugin['id'], array_column($legacy, 'id'), true) || in_array($plugin['entry_class'], $legacyClasses, true)) {
+                $this->markConflict($plugin, __('A Composer or explicit plugin has the same identity; this runtime copy is not loaded.'));
+
+                foreach ($legacy as &$legacyPlugin) {
+                    if ($legacyPlugin['id'] === $plugin['id'] || $legacyPlugin['entry_class'] === $plugin['entry_class']) {
+                        $this->markConflict($legacyPlugin, __('A runtime plugin has the same identity; the Composer or explicit copy takes precedence.'));
+                    }
+                }
+                unset($legacyPlugin);
+            }
+        }
+        unset($plugin);
+    }
+
+    /** @param array<string, mixed> $plugin */
+    private function markConflict(array &$plugin, string $message): void
+    {
+        $plugin['status'] = 'conflict';
+        $plugin['error'] = $message;
+        $plugin['can_enable'] = false;
+        $plugin['can_disable'] = $plugin['source'] === 'runtime' && $plugin['enabled'];
+        $plugin['can_remove'] = $plugin['source'] === 'runtime';
+    }
+}

--- a/app/Services/Platform/PluginManagementService.php
+++ b/app/Services/Platform/PluginManagementService.php
@@ -15,6 +15,7 @@ class PluginManagementService
         private RuntimePluginArtifactValidator $validator,
         private ComposerPluginDiscovery $composer,
         private PluginInstaller $installer,
+        private RuntimePluginGraphValidator $graph,
     ) {}
 
     /**
@@ -91,6 +92,10 @@ class PluginManagementService
     {
         $message = strtolower($exception->getMessage());
 
+        if ($exception instanceof RuntimePluginDependencyException) {
+            return __($exception->getMessage());
+        }
+
         if ($exception instanceof RuntimePluginConflictException || str_contains($message, 'conflict')) {
             return __('This plugin conflicts with an explicit or Composer-installed plugin. Disable or remove the runtime copy.');
         }
@@ -114,36 +119,74 @@ class PluginManagementService
     {
         $state = $this->store->readState();
         $packages = $this->store->installedPackages();
+        $runtime = [];
         $rows = [];
 
         foreach ($packages as $id => $path) {
             $enabled = $state[$id]['enabled'] ?? false;
 
             try {
-                $metadata = $this->validator->validateInFreshProcess($path, $id);
-                $rows[] = $this->runtimeRow($metadata, $enabled);
+                $runtime[$id] = [
+                    'metadata' => $this->validator->validateInFreshProcess($path, $id),
+                    'enabled' => $enabled,
+                ];
             } catch (Throwable $exception) {
                 report($exception);
-                $preview = $this->manifestPreview($path, $id);
-                $status = $this->validationStatus($exception);
-                $rows[] = [
-                    ...$preview,
-                    'source' => 'runtime',
-                    'status' => $status,
+                $runtime[$id] = [
+                    'metadata' => null,
                     'enabled' => $enabled,
-                    'error' => $status === 'incompatible'
-                        ? __('This plugin is not compatible with the current OpenKOS or PHP installation.')
-                        : __('This plugin is incomplete or failed validation. Disable or remove it, then install a valid artifact.'),
-                    'can_enable' => false,
-                    'can_disable' => $enabled,
-                    'can_remove' => true,
+                    'status' => $this->validationStatus($exception),
+                    'error' => $this->validationError($exception),
                 ];
             }
+        }
+
+        $health = $this->graph->validate($runtime, $this->hostPluginClasses());
+
+        foreach ($packages as $id => $path) {
+            $entry = $runtime[$id];
+            $enabled = $entry['enabled'];
+
+            if (is_array($entry['metadata'])) {
+                $metadata = $entry['metadata'];
+                $issue = $health['issues'][$id] ?? null;
+
+                if ($issue !== null) {
+                    $rows[] = [
+                        ...$this->runtimeRow($metadata, $enabled),
+                        'status' => $issue['status'],
+                        'error' => __($issue['error']),
+                        'can_enable' => false,
+                        'can_disable' => $enabled,
+                        'can_remove' => true,
+                    ];
+
+                    continue;
+                }
+
+                $rows[] = $this->runtimeRow($metadata, $enabled);
+
+                continue;
+            }
+
+            $status = $entry['status'];
+            $rows[] = [
+                ...$this->manifestPreview($path, $id),
+                'source' => 'runtime',
+                'status' => $status,
+                'enabled' => $enabled,
+                'error' => $entry['error'],
+                'can_enable' => false,
+                'can_disable' => $enabled,
+                'can_remove' => true,
+            ];
         }
 
         foreach (array_diff_key($state, $packages) as $id => $entry) {
             $rows[] = [
                 'id' => $id,
+                'managed_id' => $id,
+                'declared_id' => null,
                 'name' => $id,
                 'version' => null,
                 'description' => '',
@@ -187,6 +230,8 @@ class PluginManagementService
                 $manifest = app()->make($class)->manifest();
                 $rows[] = [
                     'id' => $manifest->id,
+                    'managed_id' => $manifest->id,
+                    'declared_id' => $manifest->id,
                     'name' => $manifest->name,
                     'version' => $manifest->version,
                     'description' => $manifest->description,
@@ -215,6 +260,8 @@ class PluginManagementService
     {
         return [
             ...$metadata,
+            'managed_id' => $metadata['id'],
+            'declared_id' => $metadata['id'],
             'source' => 'runtime',
             'status' => $enabled ? 'enabled' : 'disabled',
             'enabled' => $enabled,
@@ -230,6 +277,8 @@ class PluginManagementService
     {
         $preview = [
             'id' => $id,
+            'managed_id' => $id,
+            'declared_id' => null,
             'name' => $id,
             'version' => null,
             'description' => '',
@@ -262,7 +311,11 @@ class PluginManagementService
 
         foreach (['id', 'name', 'version', 'description', 'entry_class', 'core_version', 'php'] as $key) {
             if (is_string($manifest[$key] ?? null) && $manifest[$key] !== '') {
-                $preview[$key] = $manifest[$key];
+                if ($key === 'id') {
+                    $preview['declared_id'] = $manifest[$key];
+                } else {
+                    $preview[$key] = $manifest[$key];
+                }
             }
         }
 
@@ -287,6 +340,33 @@ class PluginManagementService
             : 'broken';
     }
 
+    private function validationError(Throwable $exception): string
+    {
+        $message = strtolower($exception->getMessage());
+
+        if (str_contains($message, 'does not match installed package')) {
+            return __('Manifest plugin ID does not match installed package identity.');
+        }
+
+        return $this->validationStatus($exception) === 'incompatible'
+            ? __('This plugin is not compatible with the current OpenKOS or PHP installation.')
+            : __('This plugin is incomplete or failed validation. Disable or remove it, then install a valid artifact.');
+    }
+
+    /** @return array<int, string> */
+    private function hostPluginClasses(): array
+    {
+        $classes = array_values(array_filter(config('platform.plugins', []), 'is_string'));
+
+        try {
+            $classes = [...$classes, ...$this->composer->discoverComposerOnly()];
+        } catch (Throwable $exception) {
+            report($exception);
+        }
+
+        return array_values(array_unique(array_filter($classes, 'is_string')));
+    }
+
     /** @param array<int, array<string, mixed>> $runtime @param array<int, array<string, mixed>> $legacy */
     private function markConflicts(array &$runtime, array &$legacy): void
     {
@@ -301,6 +381,10 @@ class PluginManagementService
         unset($plugin);
 
         foreach ($runtime as &$plugin) {
+            if (in_array($plugin['status'], ['broken', 'incompatible', 'missing'], true)) {
+                continue;
+            }
+
             if (in_array($plugin['id'], array_column($legacy, 'id'), true) || in_array($plugin['entry_class'], $legacyClasses, true)) {
                 $this->markConflict($plugin, __('A Composer or explicit plugin has the same identity; this runtime copy is not loaded.'));
 

--- a/app/Services/Platform/RuntimePluginDependencyException.php
+++ b/app/Services/Platform/RuntimePluginDependencyException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Services\Platform;
+
+use RuntimeException;
+
+final class RuntimePluginDependencyException extends RuntimeException {}

--- a/app/Services/Platform/RuntimePluginDiscovery.php
+++ b/app/Services/Platform/RuntimePluginDiscovery.php
@@ -28,11 +28,11 @@ final class RuntimePluginDiscovery
             return $this->store->withLock(function (RuntimePluginStore $store) use ($existingClasses): array {
                 $state = $store->readState();
                 $packages = $store->installedPackages();
-                $this->assertNoComposerConflicts($packages, $state, $existingClasses);
+                $conflictingIds = $this->assertNoComposerConflicts($packages, $state, $existingClasses);
                 $plugins = [];
 
                 foreach ($packages as $id => $path) {
-                    if (! ($state[$id]['enabled'] ?? false)) {
+                    if (! ($state[$id]['enabled'] ?? false) || in_array($id, $conflictingIds, true)) {
                         continue;
                     }
 
@@ -50,10 +50,6 @@ final class RuntimePluginDiscovery
                 return $plugins;
             });
         } catch (Throwable $exception) {
-            if ($exception instanceof RuntimePluginConflictException) {
-                throw $exception;
-            }
-
             Log::error('Runtime plugin discovery failed.', [
                 'path' => $this->store->rootPath(),
                 'exception' => $exception,
@@ -67,10 +63,12 @@ final class RuntimePluginDiscovery
      * @param  array<string, string>  $packages
      * @param  array<string, array{enabled: bool}>  $state
      * @param  array<int, string>  $existingClasses
+     * @return array<int, string>
      */
-    private function assertNoComposerConflicts(array $packages, array $state, array $existingClasses): void
+    private function assertNoComposerConflicts(array $packages, array $state, array $existingClasses): array
     {
         $existingIds = [];
+        $conflictingIds = [];
         foreach ($existingClasses as $class) {
             if (! is_string($class) || ! class_exists($class) || ! is_a($class, Plugin::class, true)) {
                 continue;
@@ -101,11 +99,15 @@ final class RuntimePluginDiscovery
             }
 
             if (in_array($entryClass, $existingClasses, true) || isset($existingIds[$id])) {
-                throw new RuntimePluginConflictException(
-                    "Runtime plugin [{$id}] conflicts with a Composer or explicit plugin. Neither copy will load.",
-                );
+                $conflictingIds[] = $id;
+                Log::warning('Runtime plugin skipped because a Composer or explicit plugin takes precedence.', [
+                    'plugin' => $id,
+                    'path' => $path,
+                ]);
             }
         }
+
+        return $conflictingIds;
     }
 
     private function readEntryClass(string $path): string

--- a/app/Services/Platform/RuntimePluginDiscovery.php
+++ b/app/Services/Platform/RuntimePluginDiscovery.php
@@ -12,6 +12,7 @@ final class RuntimePluginDiscovery
     public function __construct(
         private RuntimePluginStore $store,
         private RuntimePluginArtifactValidator $validator,
+        private RuntimePluginGraphValidator $graph,
     ) {}
 
     /**
@@ -29,22 +30,46 @@ final class RuntimePluginDiscovery
                 $state = $store->readState();
                 $packages = $store->installedPackages();
                 $conflictingIds = $this->assertNoComposerConflicts($packages, $state, $existingClasses);
-                $plugins = [];
+                $runtime = [];
 
                 foreach ($packages as $id => $path) {
-                    if (! ($state[$id]['enabled'] ?? false) || in_array($id, $conflictingIds, true)) {
-                        continue;
-                    }
+                    $enabled = $state[$id]['enabled'] ?? false;
 
                     try {
-                        $plugins[] = $this->validator->validate($path, $id)['entry_class'];
+                        $runtime[$id] = [
+                            'metadata' => $this->validator->validate($path, $id),
+                            'enabled' => $enabled,
+                        ];
                     } catch (Throwable $exception) {
                         Log::error('Runtime plugin could not be loaded.', [
                             'plugin' => $id,
                             'path' => $path,
                             'exception' => $exception,
                         ]);
+                        $runtime[$id] = [
+                            'metadata' => null,
+                            'enabled' => $enabled,
+                            'status' => 'broken',
+                            'error' => 'Runtime plugin artifact validation failed.',
+                        ];
                     }
+                }
+
+                $report = $this->graph->validate($runtime, $existingClasses);
+                $plugins = [];
+
+                foreach ($report['issues'] as $id => $issue) {
+                    if (($runtime[$id]['enabled'] ?? false) && ! in_array($id, $conflictingIds, true)) {
+                        Log::error('Runtime plugin skipped because its boot graph is invalid.', [
+                            'plugin' => $id,
+                            'status' => $issue['status'],
+                            'error' => $issue['error'],
+                        ]);
+                    }
+                }
+
+                foreach ($report['loadable'] as $id) {
+                    $plugins[] = $runtime[$id]['metadata']['entry_class'];
                 }
 
                 return $plugins;

--- a/app/Services/Platform/RuntimePluginGraphValidator.php
+++ b/app/Services/Platform/RuntimePluginGraphValidator.php
@@ -1,0 +1,419 @@
+<?php
+
+namespace App\Services\Platform;
+
+use OpenKOS\Platform\Plugin\Plugin;
+use OpenKOS\Platform\Plugin\PluginLoader;
+use Throwable;
+
+final class RuntimePluginGraphValidator
+{
+    public function __construct(private RuntimePluginArtifactValidator $validator) {}
+
+    /**
+     * @param  array<string, array{
+     *     metadata: array<string, mixed>|null,
+     *     enabled: bool,
+     *     status?: string,
+     *     error?: string
+     * }>  $plugins
+     * @param  array<int, string>  $hostClasses
+     * @return array{
+     *     loadable: array<int, string>,
+     *     issues: array<string, array{status: string, error: string}>
+     * }
+     */
+    public function validate(array $plugins, array $hostClasses): array
+    {
+        [$hostIds] = $this->hostIdentity($hostClasses);
+        $issues = [];
+        $entryClasses = [];
+
+        foreach ($plugins as $id => $plugin) {
+            if (isset($plugin['status'], $plugin['error'])) {
+                $issues[$id] = [
+                    'status' => $plugin['status'],
+                    'error' => $plugin['error'],
+                ];
+
+                continue;
+            }
+
+            $metadata = $plugin['metadata'];
+
+            if (! is_array($metadata) || ($metadata['id'] ?? null) !== $id) {
+                $this->addIssue($issues, $id, 'broken', 'Runtime plugin metadata does not match its managed identity.');
+
+                continue;
+            }
+
+            if (is_string($metadata['entry_class'] ?? null)) {
+                $entryClasses[$metadata['entry_class']][] = $id;
+            }
+
+            if (
+                isset($hostIds[$id])
+                || in_array($metadata['entry_class'] ?? null, $hostClasses, true)
+            ) {
+                $this->addIssue($issues, $id, 'conflict', "Runtime plugin [{$id}] conflicts with a Composer or explicit plugin.");
+
+                continue;
+            }
+
+            try {
+                if (! (new PluginLoader)->satisfies(
+                    (string) config('platform.version', '0.2.0'),
+                    (string) ($metadata['core_version'] ?? '*'),
+                )) {
+                    $this->addIssue(
+                        $issues,
+                        $id,
+                        'incompatible',
+                        "Runtime plugin [{$id}] is incompatible with the current OpenKOS version.",
+                    );
+                }
+            } catch (Throwable) {
+                $this->addIssue(
+                    $issues,
+                    $id,
+                    'incompatible',
+                    "Runtime plugin [{$id}] declares an invalid OpenKOS version constraint.",
+                );
+            }
+        }
+
+        foreach ($entryClasses as $entryClass => $ids) {
+            if (count($ids) < 2) {
+                continue;
+            }
+
+            foreach ($ids as $id) {
+                $this->addIssue(
+                    $issues,
+                    $id,
+                    'conflict',
+                    "Runtime plugin [{$id}] conflicts with another runtime plugin entry class [{$entryClass}].",
+                );
+            }
+        }
+
+        do {
+            $changed = false;
+
+            foreach ($plugins as $id => $plugin) {
+                if (isset($issues[$id]) || ! $plugin['enabled'] || ! is_array($plugin['metadata'])) {
+                    continue;
+                }
+
+                foreach ($plugin['metadata']['dependencies'] ?? [] as $dependency) {
+                    if (isset($hostIds[$dependency])) {
+                        continue;
+                    }
+
+                    if (! isset($plugins[$dependency])) {
+                        $changed = $this->addIssue(
+                            $issues,
+                            $id,
+                            'broken',
+                            "Runtime plugin [{$id}] depends on missing plugin [{$dependency}].",
+                        ) || $changed;
+
+                        break;
+                    }
+
+                    if (! $plugins[$dependency]['enabled']) {
+                        $changed = $this->addIssue(
+                            $issues,
+                            $id,
+                            'broken',
+                            "Runtime plugin [{$id}] depends on disabled plugin [{$dependency}].",
+                        ) || $changed;
+
+                        break;
+                    }
+
+                    if (isset($issues[$dependency])) {
+                        $changed = $this->addIssue(
+                            $issues,
+                            $id,
+                            'broken',
+                            "Runtime plugin [{$id}] depends on unavailable plugin [{$dependency}].",
+                        ) || $changed;
+
+                        break;
+                    }
+                }
+            }
+
+            foreach ($this->cycleNodes($plugins, $issues, $hostIds) as $cycle) {
+                $changed = $this->addIssue(
+                    $issues,
+                    $cycle,
+                    'broken',
+                    'Runtime plugin dependency cycle detected.',
+                ) || $changed;
+            }
+        } while ($changed);
+
+        $loadable = [];
+        foreach ($plugins as $id => $plugin) {
+            if ($plugin['enabled'] && ! isset($issues[$id])) {
+                $loadable[] = $id;
+            }
+        }
+
+        return ['loadable' => $loadable, 'issues' => $issues];
+    }
+
+    /**
+     * @param  array<string, array{
+     *     metadata: array<string, mixed>|null,
+     *     enabled: bool,
+     *     status?: string,
+     *     error?: string
+     * }>  $plugins
+     * @param  array<int, string>  $hostClasses
+     */
+    public function validateCandidate(array $metadata, bool $enabled, RuntimePluginStore $store, array $hostClasses): void
+    {
+        $state = $store->readState();
+        $plugins = [];
+
+        foreach ($store->installedPackages() as $id => $path) {
+            if ($id === $metadata['id']) {
+                continue;
+            }
+
+            $packageEnabled = $state[$id]['enabled'] ?? false;
+
+            try {
+                $plugins[$id] = [
+                    'metadata' => $this->validator->validateInFreshProcess($path, $id),
+                    'enabled' => $packageEnabled,
+                ];
+            } catch (Throwable $exception) {
+                $plugins[$id] = [
+                    'metadata' => null,
+                    'enabled' => $packageEnabled,
+                    'status' => $this->validationStatus($exception),
+                    'error' => $this->validationError($exception),
+                ];
+            }
+        }
+
+        $plugins[$metadata['id']] = [
+            'metadata' => $metadata,
+            'enabled' => $enabled,
+        ];
+
+        $result = $this->validate($plugins, $hostClasses);
+        $idsToCheck = array_keys(array_filter(
+            $plugins,
+            fn (array $plugin, string $id): bool => $id === $metadata['id'] || $plugin['enabled'],
+            ARRAY_FILTER_USE_BOTH,
+        ));
+
+        foreach ($idsToCheck as $id) {
+            if (isset($result['issues'][$id])) {
+                $issue = $result['issues'][$id];
+
+                if ($id === $metadata['id'] && $issue['status'] === 'conflict') {
+                    throw new RuntimePluginConflictException($issue['error']);
+                }
+
+                throw new RuntimeException($issue['error']);
+            }
+        }
+    }
+
+    /**
+     * @param  array<int, string>  $hostClasses
+     * @return array<int, string>
+     */
+    public function enabledDependants(string $id, RuntimePluginStore $store, array $hostClasses): array
+    {
+        [$hostIds, $validHostClasses] = $this->hostIdentity($hostClasses);
+
+        if (isset($hostIds[$id])) {
+            return [];
+        }
+
+        $state = $store->readState();
+        $dependants = [];
+
+        foreach ($store->installedPackages() as $packageId => $path) {
+            if ($packageId === $id || ! ($state[$packageId]['enabled'] ?? false)) {
+                continue;
+            }
+
+            try {
+                $metadata = $this->validator->validateInFreshProcess($path, $packageId);
+            } catch (Throwable) {
+                continue;
+            }
+
+            if (in_array($id, $metadata['dependencies'], true)) {
+                $dependants[] = $packageId;
+            }
+        }
+
+        foreach ($this->hostMetadata($validHostClasses) as $metadata) {
+            if (in_array($id, $metadata['dependencies'], true)) {
+                $dependants[] = $metadata['id'];
+            }
+        }
+
+        sort($dependants, SORT_STRING);
+
+        return array_values(array_unique($dependants));
+    }
+
+    /**
+     * @param  array<string, array{
+     *     metadata: array<string, mixed>|null,
+     *     enabled: bool,
+     *     status?: string,
+     *     error?: string
+     * }>  $plugins
+     * @param  array<string, array{status: string, error: string}>  $issues
+     * @param  array<string, bool>  $hostIds
+     * @return array<int, string>
+     */
+    private function cycleNodes(array $plugins, array $issues, array $hostIds): array
+    {
+        $cycles = [];
+        $visiting = [];
+        $visited = [];
+
+        $visit = function (string $id, array $path) use (&$visit, &$cycles, &$visiting, &$visited, $plugins, $issues, $hostIds): void {
+            if (isset($visited[$id]) || isset($issues[$id]) || ! ($plugins[$id]['enabled'] ?? false)) {
+                return;
+            }
+
+            if (isset($visiting[$id])) {
+                $start = array_search($id, $path, true);
+                if (is_int($start)) {
+                    foreach (array_slice($path, $start) as $cycleId) {
+                        $cycles[$cycleId] = true;
+                    }
+                }
+
+                return;
+            }
+
+            $visiting[$id] = true;
+            $path[] = $id;
+
+            foreach ($plugins[$id]['metadata']['dependencies'] ?? [] as $dependency) {
+                if (isset($hostIds[$dependency]) || ! isset($plugins[$dependency])) {
+                    continue;
+                }
+
+                $visit($dependency, $path);
+            }
+
+            unset($visiting[$id]);
+            $visited[$id] = true;
+        };
+
+        foreach (array_keys($plugins) as $id) {
+            $visit($id, []);
+        }
+
+        return array_keys($cycles);
+    }
+
+    /**
+     * @param  array<int, string>  $hostClasses
+     * @return array{0: array<string, bool>, 1: array<int, string>}
+     */
+    private function hostIdentity(array $hostClasses): array
+    {
+        $validClasses = [];
+        $ids = [];
+
+        foreach (array_values(array_unique(array_filter($hostClasses, 'is_string'))) as $class) {
+            if (! class_exists($class) || ! is_a($class, Plugin::class, true)) {
+                continue;
+            }
+
+            try {
+                $metadata = app()->make($class)->manifest();
+            } catch (Throwable) {
+                continue;
+            }
+
+            $validClasses[] = $class;
+            $ids[$metadata->id] = true;
+        }
+
+        return [$ids, $validClasses];
+    }
+
+    /**
+     * @param  array<int, string>  $hostClasses
+     * @return array<int, array{id: string, dependencies: array<int, string>}>
+     */
+    private function hostMetadata(array $hostClasses): array
+    {
+        $metadata = [];
+
+        foreach ($hostClasses as $class) {
+            if (! class_exists($class) || ! is_a($class, Plugin::class, true)) {
+                continue;
+            }
+
+            try {
+                $manifest = app()->make($class)->manifest();
+            } catch (Throwable) {
+                continue;
+            }
+
+            $metadata[] = [
+                'id' => $manifest->id,
+                'dependencies' => $manifest->dependencies,
+            ];
+        }
+
+        return $metadata;
+    }
+
+    /** @param array<string, array{status: string, error: string}> $issues */
+    private function addIssue(array &$issues, string $id, string $status, string $error): bool
+    {
+        if (isset($issues[$id])) {
+            return false;
+        }
+
+        $issues[$id] = ['status' => $status, 'error' => $error];
+
+        return true;
+    }
+
+    private function validationStatus(Throwable $exception): string
+    {
+        $message = strtolower($exception->getMessage());
+
+        return str_contains($message, 'constraint')
+            || str_contains($message, 'dependency')
+            || str_contains($message, 'php version')
+            || str_contains($message, 'not installed')
+            || str_contains($message, 'absent')
+            || str_contains($message, 'not bundled')
+            ? 'incompatible'
+            : 'broken';
+    }
+
+    private function validationError(Throwable $exception): string
+    {
+        $message = strtolower($exception->getMessage());
+
+        if (str_contains($message, 'does not match installed package')) {
+            return 'Manifest plugin ID does not match installed package identity.';
+        }
+
+        return $this->validationStatus($exception) === 'incompatible'
+            ? 'This plugin is not compatible with the current OpenKOS or PHP installation.'
+            : 'This plugin is incomplete or failed validation.';
+    }
+}

--- a/config/platform.php
+++ b/config/platform.php
@@ -30,6 +30,7 @@ return [
     'runtime' => [
         'enabled' => true,
         'path' => env('OPENKOS_PLUGIN_PATH', storage_path('app/private/plugins')),
+        'max_upload_bytes' => 64 * 1024 * 1024,
         'max_files' => 5000,
         'max_uncompressed_bytes' => 268_435_456,
         'shared_packages' => [

--- a/resources/js/lib/platform.ts
+++ b/resources/js/lib/platform.ts
@@ -48,6 +48,7 @@ const settingsPageIconMap: Record<string, LucideIcon> = {
     mail: Mail,
     whatsapp: MessageCircle,
     'payment-gateway': Plug,
+    plugins: Puzzle,
 };
 
 export function canSee(permission: string | null, auth: Auth): boolean {

--- a/resources/js/pages/settings/plugins.tsx
+++ b/resources/js/pages/settings/plugins.tsx
@@ -112,11 +112,11 @@ export default function Plugins({
     }
 
     function runAction(plugin: PlatformPlugin, action: 'enable' | 'disable') {
-        const parts = routeParts(plugin.id);
+        const parts = routeParts(plugin.managed_id);
         const route = action === 'enable' ? enable(parts) : disable(parts);
 
         setActionError(null);
-        setProcessingPlugin(plugin.id);
+        setProcessingPlugin(plugin.managed_id);
         router.post(
             route.url,
             {},
@@ -136,8 +136,8 @@ export default function Plugins({
         const plugin = removeConfirmation;
         setRemoveConfirmation(null);
         setActionError(null);
-        setProcessingPlugin(plugin.id);
-        router.delete(destroy(routeParts(plugin.id)).url, {
+        setProcessingPlugin(plugin.managed_id);
+        router.delete(destroy(routeParts(plugin.managed_id)).url, {
             preserveScroll: true,
             onError: (errors) => setActionError(errors.plugin ?? null),
             onFinish: () => setProcessingPlugin(null),
@@ -249,13 +249,13 @@ export default function Plugins({
                 ) : (
                     <div className="grid gap-4 lg:grid-cols-2">
                         {plugins.map((plugin) => (
-                            <Card key={`${plugin.source}:${plugin.id}`}>
+                            <Card key={`${plugin.source}:${plugin.managed_id}`}>
                                 <CardHeader>
                                     <div className="flex flex-wrap items-start justify-between gap-3">
                                         <div>
                                             <CardTitle>{plugin.name}</CardTitle>
                                             <CardDescription className="mt-1 font-mono">
-                                                {plugin.id}
+                                                {plugin.managed_id}
                                             </CardDescription>
                                         </div>
                                         <Badge
@@ -295,6 +295,20 @@ export default function Plugins({
                                                 {plugin.version ?? t('Unknown')}
                                             </dd>
                                         </div>
+                                        {plugin.declared_id &&
+                                            plugin.declared_id !==
+                                                plugin.managed_id && (
+                                                <div className="sm:col-span-2">
+                                                    <dt className="text-muted-foreground">
+                                                        {t(
+                                                            'Declared plugin ID',
+                                                        )}
+                                                    </dt>
+                                                    <dd className="font-mono break-all">
+                                                        {plugin.declared_id}
+                                                    </dd>
+                                                </div>
+                                            )}
                                         {plugin.core_version && (
                                             <div>
                                                 <dt className="text-muted-foreground">
@@ -352,7 +366,7 @@ export default function Plugins({
                                                     size="sm"
                                                     disabled={
                                                         processingPlugin ===
-                                                        plugin.id
+                                                        plugin.managed_id
                                                     }
                                                     onClick={() =>
                                                         runAction(
@@ -371,7 +385,7 @@ export default function Plugins({
                                                     variant="outline"
                                                     disabled={
                                                         processingPlugin ===
-                                                        plugin.id
+                                                        plugin.managed_id
                                                     }
                                                     onClick={() =>
                                                         runAction(
@@ -390,7 +404,7 @@ export default function Plugins({
                                                     variant="destructive"
                                                     disabled={
                                                         processingPlugin ===
-                                                        plugin.id
+                                                        plugin.managed_id
                                                     }
                                                     onClick={() =>
                                                         setRemoveConfirmation(

--- a/resources/js/pages/settings/plugins.tsx
+++ b/resources/js/pages/settings/plugins.tsx
@@ -1,0 +1,476 @@
+import { Head, router, useForm } from '@inertiajs/react';
+import { useRef, useState } from 'react';
+import InputError from '@/components/shared/input-error';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from '@/components/ui/card';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { t } from '@/lib/i18n';
+import {
+    destroy,
+    disable,
+    enable,
+    index,
+    install,
+} from '@/routes/settings/plugins';
+import type { PlatformPlugin } from '@/types/platform';
+
+type Props = {
+    plugins: PlatformPlugin[];
+    error: string | null;
+    max_upload_bytes: number;
+};
+
+const statusVariants: Record<
+    PlatformPlugin['status'],
+    'default' | 'secondary' | 'destructive' | 'outline'
+> = {
+    enabled: 'default',
+    disabled: 'secondary',
+    legacy: 'outline',
+    incompatible: 'destructive',
+    broken: 'destructive',
+    conflict: 'destructive',
+    missing: 'destructive',
+};
+
+function formatBytes(bytes: number): string {
+    return `${Math.max(1, Math.round(bytes / 1024 / 1024))} MB`;
+}
+
+function routeParts(id: string): { vendor: string; package: string } {
+    const [vendor, packageName] = id.split('/');
+
+    return { vendor, package: packageName };
+}
+
+function statusLabel(status: PlatformPlugin['status']): string {
+    return {
+        enabled: t('Enabled'),
+        disabled: t('Disabled'),
+        legacy: t('Legacy'),
+        incompatible: t('Incompatible'),
+        broken: t('Broken'),
+        conflict: t('Conflict'),
+        missing: t('Missing'),
+    }[status];
+}
+
+export default function Plugins({
+    plugins,
+    error,
+    max_upload_bytes: maxUploadBytes,
+}: Props) {
+    const fileInput = useRef<HTMLInputElement>(null);
+    const [uploadConfirmationOpen, setUploadConfirmationOpen] = useState(false);
+    const [removeConfirmation, setRemoveConfirmation] =
+        useState<PlatformPlugin | null>(null);
+    const [processingPlugin, setProcessingPlugin] = useState<string | null>(
+        null,
+    );
+    const [actionError, setActionError] = useState<string | null>(null);
+    const uploadForm = useForm<{ file: File | null }>({ file: null });
+
+    function requestUpload(event: React.FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+
+        if (uploadForm.data.file) {
+            setUploadConfirmationOpen(true);
+        }
+    }
+
+    function confirmUpload() {
+        setUploadConfirmationOpen(false);
+        uploadForm.submit(install(), {
+            forceFormData: true,
+            preserveScroll: true,
+            onSuccess: () => {
+                uploadForm.reset();
+
+                if (fileInput.current) {
+                    fileInput.current.value = '';
+                }
+            },
+        });
+    }
+
+    function runAction(plugin: PlatformPlugin, action: 'enable' | 'disable') {
+        const parts = routeParts(plugin.id);
+        const route = action === 'enable' ? enable(parts) : disable(parts);
+
+        setActionError(null);
+        setProcessingPlugin(plugin.id);
+        router.post(
+            route.url,
+            {},
+            {
+                preserveScroll: true,
+                onError: (errors) => setActionError(errors.plugin ?? null),
+                onFinish: () => setProcessingPlugin(null),
+            },
+        );
+    }
+
+    function confirmRemove() {
+        if (!removeConfirmation) {
+            return;
+        }
+
+        const plugin = removeConfirmation;
+        setRemoveConfirmation(null);
+        setActionError(null);
+        setProcessingPlugin(plugin.id);
+        router.delete(destroy(routeParts(plugin.id)).url, {
+            preserveScroll: true,
+            onError: (errors) => setActionError(errors.plugin ?? null),
+            onFinish: () => setProcessingPlugin(null),
+        });
+    }
+
+    return (
+        <>
+            <Head title={t('Plugins')} />
+
+            <div className="space-y-6">
+                <div>
+                    <h1 className="text-lg font-medium">{t('Plugins')}</h1>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                        {t(
+                            'Inspect and manage trusted OpenKOS plugin packages.',
+                        )}
+                    </p>
+                </div>
+
+                <Alert>
+                    <AlertTitle>{t('Only install trusted plugins')}</AlertTitle>
+                    <AlertDescription>
+                        {t(
+                            'Uploaded plugins execute server-side code. ZIP files are validated before activation, but only install artifacts from a trusted source.',
+                        )}
+                    </AlertDescription>
+                </Alert>
+
+                {error && (
+                    <Alert variant="destructive">
+                        <AlertTitle>
+                            {t('Runtime plugins unavailable')}
+                        </AlertTitle>
+                        <AlertDescription>{error}</AlertDescription>
+                    </Alert>
+                )}
+
+                {actionError && (
+                    <Alert variant="destructive">
+                        <AlertTitle>{t('Plugin action failed')}</AlertTitle>
+                        <AlertDescription>{actionError}</AlertDescription>
+                    </Alert>
+                )}
+
+                <Card>
+                    <CardHeader>
+                        <CardTitle>{t('Install plugin')}</CardTitle>
+                        <CardDescription>
+                            {t(
+                                'Upload a prepared runtime plugin ZIP, up to :size.',
+                                {
+                                    size: formatBytes(maxUploadBytes),
+                                },
+                            )}
+                        </CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                        <form onSubmit={requestUpload} className="grid gap-3">
+                            <Label htmlFor="plugin_file">
+                                {t('Plugin ZIP')}
+                            </Label>
+                            <Input
+                                ref={fileInput}
+                                id="plugin_file"
+                                type="file"
+                                accept=".zip,application/zip"
+                                onChange={(event) =>
+                                    uploadForm.setData(
+                                        'file',
+                                        event.target.files?.[0] ?? null,
+                                    )
+                                }
+                                disabled={uploadForm.processing}
+                            />
+                            <InputError message={uploadForm.errors.file} />
+                            {uploadForm.progress && (
+                                <p className="text-sm text-muted-foreground">
+                                    {t('Uploading')}{' '}
+                                    {uploadForm.progress.percentage}%
+                                </p>
+                            )}
+                            <div>
+                                <Button
+                                    type="submit"
+                                    disabled={
+                                        !uploadForm.data.file ||
+                                        uploadForm.processing
+                                    }
+                                >
+                                    {uploadForm.processing
+                                        ? t('Installing...')
+                                        : t('Upload and install')}
+                                </Button>
+                            </div>
+                        </form>
+                    </CardContent>
+                </Card>
+
+                {plugins.length === 0 ? (
+                    <Alert>
+                        <AlertTitle>{t('No plugins found')}</AlertTitle>
+                        <AlertDescription>
+                            {t(
+                                'Upload a prepared runtime plugin ZIP to get started.',
+                            )}
+                        </AlertDescription>
+                    </Alert>
+                ) : (
+                    <div className="grid gap-4 lg:grid-cols-2">
+                        {plugins.map((plugin) => (
+                            <Card key={`${plugin.source}:${plugin.id}`}>
+                                <CardHeader>
+                                    <div className="flex flex-wrap items-start justify-between gap-3">
+                                        <div>
+                                            <CardTitle>{plugin.name}</CardTitle>
+                                            <CardDescription className="mt-1 font-mono">
+                                                {plugin.id}
+                                            </CardDescription>
+                                        </div>
+                                        <Badge
+                                            variant={
+                                                statusVariants[plugin.status]
+                                            }
+                                        >
+                                            {statusLabel(plugin.status)}
+                                        </Badge>
+                                    </div>
+                                </CardHeader>
+                                <CardContent className="space-y-4">
+                                    <p className="text-sm text-muted-foreground">
+                                        {plugin.description ||
+                                            t('No description provided.')}
+                                    </p>
+
+                                    <dl className="grid gap-3 text-sm sm:grid-cols-2">
+                                        <div>
+                                            <dt className="text-muted-foreground">
+                                                {t('Source')}
+                                            </dt>
+                                            <dd>
+                                                {plugin.source === 'runtime'
+                                                    ? t('Runtime ZIP')
+                                                    : plugin.source ===
+                                                        'explicit'
+                                                      ? t('Built-in / explicit')
+                                                      : t('Composer-installed')}
+                                            </dd>
+                                        </div>
+                                        <div>
+                                            <dt className="text-muted-foreground">
+                                                {t('Version')}
+                                            </dt>
+                                            <dd>
+                                                {plugin.version ?? t('Unknown')}
+                                            </dd>
+                                        </div>
+                                        {plugin.core_version && (
+                                            <div>
+                                                <dt className="text-muted-foreground">
+                                                    {t('OpenKOS requirement')}
+                                                </dt>
+                                                <dd className="font-mono">
+                                                    {plugin.core_version}
+                                                </dd>
+                                            </div>
+                                        )}
+                                        {plugin.php && (
+                                            <div>
+                                                <dt className="text-muted-foreground">
+                                                    {t('PHP requirement')}
+                                                </dt>
+                                                <dd className="font-mono">
+                                                    {plugin.php}
+                                                </dd>
+                                            </div>
+                                        )}
+                                        {plugin.entry_class && (
+                                            <div className="sm:col-span-2">
+                                                <dt className="text-muted-foreground">
+                                                    {t('Entry class')}
+                                                </dt>
+                                                <dd className="font-mono break-all">
+                                                    {plugin.entry_class}
+                                                </dd>
+                                            </div>
+                                        )}
+                                    </dl>
+
+                                    {plugin.dependencies.length > 0 && (
+                                        <p className="text-xs text-muted-foreground">
+                                            {t('Dependencies')}:{' '}
+                                            {plugin.dependencies.join(', ')}
+                                        </p>
+                                    )}
+
+                                    {plugin.error && (
+                                        <Alert variant="destructive">
+                                            <AlertDescription>
+                                                {plugin.error}
+                                            </AlertDescription>
+                                        </Alert>
+                                    )}
+
+                                    {(plugin.can_enable ||
+                                        plugin.can_disable ||
+                                        plugin.can_remove) && (
+                                        <div className="flex flex-wrap gap-2">
+                                            {plugin.can_enable && (
+                                                <Button
+                                                    type="button"
+                                                    size="sm"
+                                                    disabled={
+                                                        processingPlugin ===
+                                                        plugin.id
+                                                    }
+                                                    onClick={() =>
+                                                        runAction(
+                                                            plugin,
+                                                            'enable',
+                                                        )
+                                                    }
+                                                >
+                                                    {t('Enable')}
+                                                </Button>
+                                            )}
+                                            {plugin.can_disable && (
+                                                <Button
+                                                    type="button"
+                                                    size="sm"
+                                                    variant="outline"
+                                                    disabled={
+                                                        processingPlugin ===
+                                                        plugin.id
+                                                    }
+                                                    onClick={() =>
+                                                        runAction(
+                                                            plugin,
+                                                            'disable',
+                                                        )
+                                                    }
+                                                >
+                                                    {t('Disable')}
+                                                </Button>
+                                            )}
+                                            {plugin.can_remove && (
+                                                <Button
+                                                    type="button"
+                                                    size="sm"
+                                                    variant="destructive"
+                                                    disabled={
+                                                        processingPlugin ===
+                                                        plugin.id
+                                                    }
+                                                    onClick={() =>
+                                                        setRemoveConfirmation(
+                                                            plugin,
+                                                        )
+                                                    }
+                                                >
+                                                    {t('Remove')}
+                                                </Button>
+                                            )}
+                                        </div>
+                                    )}
+                                </CardContent>
+                            </Card>
+                        ))}
+                    </div>
+                )}
+            </div>
+
+            <Dialog
+                open={uploadConfirmationOpen}
+                onOpenChange={setUploadConfirmationOpen}
+            >
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>
+                            {t('Install trusted plugin?')}
+                        </DialogTitle>
+                        <DialogDescription>
+                            {t(
+                                'This ZIP will be validated and installed as server-side code. Because its plugin identity is not known until validation, it may replace an existing runtime plugin with the same validated ID.',
+                            )}
+                        </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                        <DialogClose asChild>
+                            <Button type="button" variant="outline">
+                                {t('Cancel')}
+                            </Button>
+                        </DialogClose>
+                        <Button type="button" onClick={confirmUpload}>
+                            {t('Validate and install')}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+
+            <Dialog
+                open={removeConfirmation !== null}
+                onOpenChange={(open) => !open && setRemoveConfirmation(null)}
+            >
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>{t('Remove runtime plugin?')}</DialogTitle>
+                        <DialogDescription>
+                            {t(
+                                'This removes only the runtime package and its activation state. Plugin-owned database data will not be deleted. A restart is required for changes to take effect.',
+                            )}
+                        </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                        <DialogClose asChild>
+                            <Button type="button" variant="outline">
+                                {t('Cancel')}
+                            </Button>
+                        </DialogClose>
+                        <Button
+                            type="button"
+                            variant="destructive"
+                            onClick={confirmRemove}
+                        >
+                            {t('Remove plugin')}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        </>
+    );
+}
+
+Plugins.layout = {
+    breadcrumbs: [{ title: t('Plugins'), href: index().url }],
+};

--- a/resources/js/types/platform.ts
+++ b/resources/js/types/platform.ts
@@ -27,6 +27,8 @@ export type PlatformPage = {
 
 export type PlatformPlugin = {
     id: string;
+    managed_id: string;
+    declared_id: string | null;
     name: string;
     version: string | null;
     description: string;

--- a/resources/js/types/platform.ts
+++ b/resources/js/types/platform.ts
@@ -25,6 +25,31 @@ export type PlatformPage = {
     group?: string | null;
 };
 
+export type PlatformPlugin = {
+    id: string;
+    name: string;
+    version: string | null;
+    description: string;
+    entry_class: string | null;
+    core_version: string | null;
+    php: string | null;
+    dependencies: string[];
+    source: 'runtime' | 'composer' | 'explicit';
+    status:
+        | 'enabled'
+        | 'disabled'
+        | 'legacy'
+        | 'incompatible'
+        | 'broken'
+        | 'conflict'
+        | 'missing';
+    enabled: boolean;
+    error: string | null;
+    can_enable: boolean;
+    can_disable: boolean;
+    can_remove: boolean;
+};
+
 export type Platform = {
     navigation: Record<string, PlatformNavigationItem[]>; // keyed by group, e.g. 'main'
     workspaces: Record<string, PlatformWorkspaceTab[]>; // keyed by workspace, e.g. 'property'

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\Settings\AboutController;
 use App\Http\Controllers\Settings\GeneralController;
 use App\Http\Controllers\Settings\MailController;
 use App\Http\Controllers\Settings\PaymentGatewayController;
+use App\Http\Controllers\Settings\PluginController;
 use App\Http\Controllers\Settings\ProfileController;
 use App\Http\Controllers\Settings\PropertyTypeController;
 use App\Http\Controllers\Settings\ReminderController;
@@ -69,6 +70,18 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::post('settings/property-types', [PropertyTypeController::class, 'store'])->name('settings.property-types.store');
         Route::patch('settings/property-types/{propertyType}', [PropertyTypeController::class, 'update'])->name('settings.property-types.update');
         Route::delete('settings/property-types/{propertyType}', [PropertyTypeController::class, 'destroy'])->name('settings.property-types.destroy');
+
+        Route::get('settings/plugins', [PluginController::class, 'index'])->name('settings.plugins.index');
+        Route::post('settings/plugins', [PluginController::class, 'install'])->name('settings.plugins.install');
+        Route::post('settings/plugins/{vendor}/{package}/enable', [PluginController::class, 'enable'])
+            ->where(['vendor' => '[a-z0-9][a-z0-9._-]*', 'package' => '[a-z0-9][a-z0-9._-]*'])
+            ->name('settings.plugins.enable');
+        Route::post('settings/plugins/{vendor}/{package}/disable', [PluginController::class, 'disable'])
+            ->where(['vendor' => '[a-z0-9][a-z0-9._-]*', 'package' => '[a-z0-9][a-z0-9._-]*'])
+            ->name('settings.plugins.disable');
+        Route::delete('settings/plugins/{vendor}/{package}', [PluginController::class, 'destroy'])
+            ->where(['vendor' => '[a-z0-9][a-z0-9._-]*', 'package' => '[a-z0-9][a-z0-9._-]*'])
+            ->name('settings.plugins.destroy');
 
         // Catch-all for plugin-defined settings pages — must be last so explicit routes match first.
         Route::get('settings/{page}', [SettingValuesController::class, 'edit'])->name('settings.dynamic.edit');

--- a/tests/Feature/Platform/RuntimePluginTest.php
+++ b/tests/Feature/Platform/RuntimePluginTest.php
@@ -142,14 +142,16 @@ it('reports an enabled package with a malformed manifest without booting it', fu
         ->expectsOutputToContain('Invalid (enabled)');
 });
 
-it('rejects a runtime plugin that conflicts with an explicit plugin', function (): void {
+it('skips a runtime plugin that conflicts with an explicit plugin', function (): void {
     $artifact = makeRuntimePluginArtifact();
 
     $this->artisan('plugin:install', ['zip' => $artifact['zip']])->assertSuccessful();
+    require_once $this->runtimePluginPath.'/'.$artifact['id'].'/vendor/autoload.php';
     config(['platform.plugins' => [$artifact['class']]]);
 
     expect(fn (): mixed => $this->bootPlatformWithIsolatedRegistries())
-        ->toThrow(RuntimeException::class, 'conflicts');
+        ->not->toThrow(RuntimeException::class);
+    expect(app(PermissionRegistry::class)->all())->toHaveKey('runtime-fixture.view');
 });
 
 it('rejects an entry-class conflict before activating a runtime plugin', function (): void {

--- a/tests/Feature/Platform/SharedPlatformPropsTest.php
+++ b/tests/Feature/Platform/SharedPlatformPropsTest.php
@@ -27,5 +27,9 @@ it('shares platform registry data with every Inertia page', function () {
             ->where('platform.settings.4.key', 'mail')
             ->where('platform.settings.4.group', 'Integrations')
             ->where('platform.settings.5.key', 'payment-gateway')
-            ->where('platform.settings.5.group', 'Integrations'));
+            ->where('platform.settings.5.group', 'Integrations')
+            ->where('platform.settings.6.key', 'security')
+            ->where('platform.settings.6.group', 'Account')
+            ->where('platform.settings.7.key', 'plugins')
+            ->where('platform.settings.7.group', null));
 });

--- a/tests/Feature/PluginSettingsTest.php
+++ b/tests/Feature/PluginSettingsTest.php
@@ -1,0 +1,246 @@
+<?php
+
+use App\Models\User;
+use App\Services\Platform\PluginInstaller;
+use Database\Seeders\RoleAndPermissionSeeder;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Inertia\Testing\AssertableInertia as Assert;
+use OpenKOS\Core\Contracts\PluginDiscovery;
+use OpenKOS\Plugins\Mail\MailPlugin;
+
+beforeEach(function (): void {
+    $this->runtimePluginPath = sys_get_temp_dir().'/openkos-settings-runtime-'.bin2hex(random_bytes(8));
+    $this->originalRuntimePath = config('platform.runtime.path');
+
+    config([
+        'platform.runtime.path' => $this->runtimePluginPath,
+        'platform.plugins' => [],
+    ]);
+    app()->forgetInstance(PluginDiscovery::class);
+    $this->seed(RoleAndPermissionSeeder::class);
+    Storage::fake('local');
+});
+
+afterEach(function (): void {
+    File::deleteDirectory($this->runtimePluginPath);
+    config([
+        'platform.runtime.path' => $this->originalRuntimePath,
+    ]);
+});
+
+it('redirects guests and forbids non-owners from plugin management', function (): void {
+    $this->get(route('settings.plugins.index'))
+        ->assertRedirect(route('login'));
+
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->get(route('settings.plugins.index'))
+        ->assertForbidden();
+
+    $this->actingAs($user)
+        ->post(route('settings.plugins.install'))
+        ->assertForbidden();
+
+    $this->actingAs($user)
+        ->delete(route('settings.plugins.destroy', ['vendor' => 'acme', 'package' => 'runtime']))
+        ->assertForbidden();
+});
+
+it('shows owners a safe plugin catalog without creating runtime storage', function (): void {
+    $response = $this->actingAs(User::factory()->owner()->create())
+        ->get(route('settings.plugins.index'));
+
+    $response->assertInertia(fn (Assert $page) => $page
+        ->component('settings/plugins')
+        ->has('plugins')
+        ->where('error', null)
+        ->where('max_upload_bytes', 64 * 1024 * 1024));
+    $response->assertDontSee($this->runtimePluginPath);
+    expect(is_dir($this->runtimePluginPath))->toBeFalse();
+});
+
+it('installs a valid upload and always removes the temporary file', function (): void {
+    $artifact = makePluginSettingsArtifact();
+    $composerBefore = file_get_contents(base_path('composer.json'));
+    $lockBefore = file_get_contents(base_path('composer.lock'));
+    $owner = User::factory()->owner()->create();
+
+    $this->actingAs($owner)
+        ->post(route('settings.plugins.install'), [
+            'file' => new UploadedFile($artifact['zip'], 'runtime.zip', 'application/zip', null, true),
+        ])
+        ->assertRedirect(route('settings.plugins.index'));
+
+    $plugins = $this->actingAs($owner)
+        ->get(route('settings.plugins.index'))
+        ->inertiaProps('plugins');
+
+    expect(Storage::disk('local')->allFiles('plugin-uploads'))->toBe([])
+        ->and(file_get_contents(base_path('composer.json')))->toBe($composerBefore)
+        ->and(file_get_contents(base_path('composer.lock')))->toBe($lockBefore)
+        ->and(is_file($this->runtimePluginPath.'/'.$artifact['id'].'/manifest.json'))->toBeTrue()
+        ->and(collect($plugins)->firstWhere('id', $artifact['id']))->toMatchArray([
+            'source' => 'runtime',
+            'status' => 'enabled',
+        ]);
+});
+
+it('cleans up an upload when the installer rejects it', function (): void {
+    $this->actingAs(User::factory()->owner()->create())
+        ->post(route('settings.plugins.install'), [
+            'file' => UploadedFile::fake()->create('runtime.zip', 10, 'application/zip'),
+        ])
+        ->assertSessionHasErrors('file');
+
+    expect(Storage::disk('local')->allFiles('plugin-uploads'))->toBe([]);
+});
+
+it('delegates runtime lifecycle actions and reports restart requirements', function (): void {
+    $artifact = makePluginSettingsArtifact();
+    app(PluginInstaller::class)->install($artifact['zip']);
+    $owner = User::factory()->owner()->create();
+    [$vendor, $package] = explode('/', $artifact['id']);
+
+    $this->actingAs($owner)
+        ->post(route('settings.plugins.disable', ['vendor' => $vendor, 'package' => $package]))
+        ->assertRedirect(route('settings.plugins.index'))
+        ->assertInertiaFlash('toast', [
+            'type' => 'success',
+            'message' => 'Plugin disabled. Restart required for changes to take effect.',
+        ]);
+
+    $this->actingAs($owner)
+        ->post(route('settings.plugins.enable', ['vendor' => $vendor, 'package' => $package]))
+        ->assertRedirect(route('settings.plugins.index'))
+        ->assertInertiaFlash('toast', [
+            'type' => 'success',
+            'message' => 'Plugin enabled. Restart required for changes to take effect.',
+        ]);
+
+    $this->actingAs($owner)
+        ->delete(route('settings.plugins.destroy', ['vendor' => $vendor, 'package' => $package]))
+        ->assertRedirect(route('settings.plugins.index'))
+        ->assertInertiaFlash('toast', [
+            'type' => 'success',
+            'message' => 'Plugin removed. Restart required for changes to take effect.',
+        ]);
+
+    expect(is_dir($this->runtimePluginPath.'/'.$artifact['id']))->toBeFalse();
+});
+
+it('rejects non-zip uploads at the HTTP boundary', function (): void {
+    $this->actingAs(User::factory()->owner()->create())
+        ->post(route('settings.plugins.install'), [
+            'file' => UploadedFile::fake()->create('runtime.txt', 10, 'text/plain'),
+        ])
+        ->assertSessionHasErrors('file');
+});
+
+it('shows legacy plugins without exposing runtime lifecycle actions', function (): void {
+    config(['platform.plugins' => [MailPlugin::class]]);
+
+    $response = $this->actingAs(User::factory()->owner()->create())
+        ->get(route('settings.plugins.index'));
+    $plugins = $response->inertiaProps('plugins');
+    $mail = collect($plugins)->firstWhere('id', 'openkos/mail');
+
+    expect($mail)->toMatchArray([
+        'source' => 'explicit',
+        'status' => 'legacy',
+        'can_enable' => false,
+        'can_disable' => false,
+        'can_remove' => false,
+    ]);
+});
+
+it('shows runtime and explicit duplicates as a recoverable conflict', function (): void {
+    $artifact = makePluginSettingsArtifact();
+    app(PluginInstaller::class)->install($artifact['zip']);
+    require_once $this->runtimePluginPath.'/'.$artifact['id'].'/vendor/autoload.php';
+    config(['platform.plugins' => [$artifact['class']]]);
+
+    $response = $this->actingAs(User::factory()->owner()->create())
+        ->get(route('settings.plugins.index'));
+    $plugins = $response->inertiaProps('plugins');
+    $runtime = collect($plugins)->firstWhere('source', 'runtime');
+
+    expect($runtime)->toMatchArray([
+        'id' => $artifact['id'],
+        'status' => 'conflict',
+        'can_enable' => false,
+        'can_remove' => true,
+    ]);
+});
+
+it('shows incomplete runtime packages with safe recovery guidance', function (): void {
+    $artifact = makePluginSettingsArtifact();
+    app(PluginInstaller::class)->install($artifact['zip']);
+    File::delete($this->runtimePluginPath.'/'.$artifact['id'].'/manifest.json');
+
+    $response = $this->actingAs(User::factory()->owner()->create())
+        ->get(route('settings.plugins.index'));
+    $plugins = $response->inertiaProps('plugins');
+    $runtime = collect($plugins)->firstWhere('id', $artifact['id']);
+
+    expect($runtime)->toMatchArray([
+        'status' => 'broken',
+        'can_enable' => false,
+        'can_remove' => true,
+    ]);
+    $response->assertDontSee($this->runtimePluginPath);
+});
+
+/** @return array{zip: string, id: string, class: string} */
+function makePluginSettingsArtifact(): array
+{
+    $suffix = (string) random_int(100000, 999999);
+    $id = "settings/runtime-{$suffix}";
+    $classShort = "Runtime{$suffix}Plugin";
+    $entryClass = "SettingsRuntime\\{$classShort}";
+    $manifest = [
+        'id' => $id,
+        'name' => 'Settings Runtime Fixture',
+        'version' => '1.0.0',
+        'description' => 'Settings runtime fixture.',
+        'entry_class' => $entryClass,
+        'core_version' => '^0.2',
+        'php' => '^8.3',
+        'dependencies' => [],
+    ];
+    $source = "<?php\n\nnamespace SettingsRuntime;\n\nuse OpenKOS\\Platform\\OpenKOSManager;\nuse OpenKOS\\Platform\\Plugin\\Plugin;\nuse OpenKOS\\Platform\\Plugin\\PluginManifest;\n\nfinal class {$classShort} extends Plugin\n{\n    public function manifest(): PluginManifest\n    {\n        return new PluginManifest(\n            id: '{$id}',\n            name: 'Settings Runtime Fixture',\n            version: '1.0.0',\n            description: 'Settings runtime fixture.',\n            coreVersion: '^0.2',\n        );\n    }\n\n    public function register(OpenKOSManager \$platform): void {}\n}\n";
+
+    $directory = sys_get_temp_dir().'/openkos-settings-zip-'.bin2hex(random_bytes(8));
+    mkdir($directory, 0750, true);
+    $zipPath = $directory.'.zip';
+    $zip = new ZipArchive;
+    $zip->open($zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+    $files = [
+        'manifest.json' => json_encode($manifest, JSON_THROW_ON_ERROR),
+        'composer.json' => json_encode([
+            'name' => $id,
+            'type' => 'library',
+            'require' => ['php' => '^8.3', 'openkos/platform' => '^0.2'],
+            'autoload' => ['psr-4' => ['SettingsRuntime\\' => 'src/']],
+            'extra' => ['openkos' => ['plugin' => $entryClass]],
+        ], JSON_THROW_ON_ERROR),
+        'composer.lock' => json_encode([
+            'packages' => [['name' => 'openkos/platform', 'version' => '0.2.2']],
+            'packages-dev' => [],
+        ], JSON_THROW_ON_ERROR),
+        'src/'.$classShort.'.php' => $source,
+        'vendor/autoload.php' => "<?php\nspl_autoload_register(static function (string \$class): void {\n    if (\$class === '{$entryClass}') {\n        require_once __DIR__.'/../src/{$classShort}.php';\n    }\n});\n",
+        'vendor/composer/installed.php' => "<?php\nreturn ['versions' => []];\n",
+    ];
+
+    foreach ($files as $path => $contents) {
+        $zip->addFromString($path, $contents);
+    }
+
+    $zip->close();
+    File::deleteDirectory($directory);
+
+    return ['zip' => $zipPath, 'id' => $id, 'class' => $entryClass];
+}

--- a/tests/Feature/PluginSettingsTest.php
+++ b/tests/Feature/PluginSettingsTest.php
@@ -2,6 +2,9 @@
 
 use App\Models\User;
 use App\Services\Platform\PluginInstaller;
+use App\Services\Platform\RuntimePluginDiscovery;
+use App\Services\Platform\RuntimePluginGraphValidator;
+use App\Services\Platform\RuntimePluginStore;
 use Database\Seeders\RoleAndPermissionSeeder;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\File;
@@ -193,8 +196,178 @@ it('shows incomplete runtime packages with safe recovery guidance', function ():
     $response->assertDontSee($this->runtimePluginPath);
 });
 
+it('rejects disabling or removing a runtime dependency of an enabled plugin', function (): void {
+    $dependency = makePluginSettingsArtifact();
+    $dependent = makePluginSettingsArtifact(['dependencies' => [$dependency['id']]]);
+    app(PluginInstaller::class)->install($dependency['zip']);
+    app(PluginInstaller::class)->install($dependent['zip']);
+    $owner = User::factory()->owner()->create();
+    [$vendor, $package] = explode('/', $dependency['id']);
+
+    $this->actingAs($owner)
+        ->post(route('settings.plugins.disable', ['vendor' => $vendor, 'package' => $package]))
+        ->assertSessionHasErrors('plugin', "Cannot disable {$dependency['id']} because {$dependent['id']} depends on it.");
+
+    $this->actingAs($owner)
+        ->delete(route('settings.plugins.destroy', ['vendor' => $vendor, 'package' => $package]))
+        ->assertSessionHasErrors('plugin', "Cannot remove {$dependency['id']} because {$dependent['id']} depends on it.");
+
+    expect(app(RuntimePluginStore::class)->readState())
+        ->toMatchArray([$dependency['id'] => ['enabled' => true]])
+        ->and(is_dir($this->runtimePluginPath.'/'.$dependency['id']))->toBeTrue();
+});
+
+it('marks enabled runtime dependency cycles as unavailable', function (): void {
+    $report = app(RuntimePluginGraphValidator::class)->validate([
+        'settings/cycle-a' => [
+            'metadata' => [
+                'id' => 'settings/cycle-a',
+                'entry_class' => 'SettingsRuntime\\CycleAPlugin',
+                'core_version' => '*',
+                'dependencies' => ['settings/cycle-b'],
+            ],
+            'enabled' => true,
+        ],
+        'settings/cycle-b' => [
+            'metadata' => [
+                'id' => 'settings/cycle-b',
+                'entry_class' => 'SettingsRuntime\\CycleBPlugin',
+                'core_version' => '*',
+                'dependencies' => ['settings/cycle-a'],
+            ],
+            'enabled' => true,
+        ],
+    ], []);
+
+    expect($report['loadable'])->toBe([])
+        ->and($report['issues'])->toMatchArray([
+            'settings/cycle-a' => ['status' => 'broken', 'error' => 'Runtime plugin dependency cycle detected.'],
+            'settings/cycle-b' => ['status' => 'broken', 'error' => 'Runtime plugin dependency cycle detected.'],
+        ]);
+});
+
+it('marks duplicate runtime entry classes as conflicts', function (): void {
+    $metadata = fn (string $id): array => [
+        'id' => $id,
+        'entry_class' => 'SettingsRuntime\\DuplicatePlugin',
+        'core_version' => '*',
+        'dependencies' => [],
+    ];
+    $report = app(RuntimePluginGraphValidator::class)->validate([
+        'settings/duplicate-a' => ['metadata' => $metadata('settings/duplicate-a'), 'enabled' => true],
+        'settings/duplicate-b' => ['metadata' => $metadata('settings/duplicate-b'), 'enabled' => true],
+    ], []);
+
+    expect($report['loadable'])->toBe([])
+        ->and($report['issues'])->toMatchArray([
+            'settings/duplicate-a' => [
+                'status' => 'conflict',
+                'error' => 'Runtime plugin [settings/duplicate-a] conflicts with another runtime plugin entry class [SettingsRuntime\\DuplicatePlugin].',
+            ],
+            'settings/duplicate-b' => [
+                'status' => 'conflict',
+                'error' => 'Runtime plugin [settings/duplicate-b] conflicts with another runtime plugin entry class [SettingsRuntime\\DuplicatePlugin].',
+            ],
+        ]);
+});
+
+it('keeps the plugins page available when a runtime dependency is missing or disabled', function (): void {
+    $dependency = makePluginSettingsArtifact();
+    $dependent = makePluginSettingsArtifact(['dependencies' => [$dependency['id']]]);
+    app(PluginInstaller::class)->install($dependency['zip']);
+    app(PluginInstaller::class)->install($dependent['zip']);
+    app(RuntimePluginStore::class)->withLock(function (RuntimePluginStore $store) use ($dependency): void {
+        $store->setEnabled($dependency['id'], false);
+    });
+
+    $missing = makePluginSettingsArtifact(['dependencies' => ['missing/plugin']]);
+    $missingPath = $this->runtimePluginPath.'/'.$missing['id'];
+    File::makeDirectory($missingPath, 0750, true);
+    $zip = new ZipArchive;
+    $zip->open($missing['zip']);
+    $zip->extractTo($missingPath);
+    $zip->close();
+    $state = app(RuntimePluginStore::class)->readState();
+    $state[$missing['id']] = ['enabled' => true];
+    app(RuntimePluginStore::class)->writeState($state);
+
+    expect(app(RuntimePluginDiscovery::class)->discover())->toBe([]);
+
+    $plugins = $this->actingAs(User::factory()->owner()->create())
+        ->get(route('settings.plugins.index'))
+        ->assertSuccessful()
+        ->inertiaProps('plugins');
+
+    expect(collect($plugins)->firstWhere('id', $missing['id']))->toMatchArray([
+        'managed_id' => $missing['id'],
+        'status' => 'broken',
+        'can_enable' => false,
+        'can_remove' => true,
+    ])
+        ->and(collect($plugins)->firstWhere('id', $dependent['id']))->toMatchArray([
+            'status' => 'broken',
+            'can_enable' => false,
+        ])
+        ->and(collect($plugins)->firstWhere('id', $dependent['id'])['error'])
+        ->toContain("disabled plugin [{$dependency['id']}]");
+});
+
+it('surfaces a runtime plugin that is incompatible with the current core', function (): void {
+    $artifact = makePluginSettingsArtifact(['core_version' => '^9.0']);
+    $path = $this->runtimePluginPath.'/'.$artifact['id'];
+    File::makeDirectory($path, 0750, true);
+    $zip = new ZipArchive;
+    $zip->open($artifact['zip']);
+    $zip->extractTo($path);
+    $zip->close();
+    file_put_contents($this->runtimePluginPath.'/state.json', json_encode([
+        $artifact['id'] => ['enabled' => true],
+    ], JSON_THROW_ON_ERROR));
+
+    $plugins = $this->actingAs(User::factory()->owner()->create())
+        ->get(route('settings.plugins.index'))
+        ->assertSuccessful()
+        ->inertiaProps('plugins');
+
+    expect(collect($plugins)->firstWhere('id', $artifact['id']))->toMatchArray([
+        'status' => 'incompatible',
+        'can_enable' => false,
+        'can_disable' => true,
+        'can_remove' => true,
+    ]);
+});
+
+it('uses the managed package identity to recover a mismatched manifest', function (): void {
+    $artifact = makePluginSettingsArtifact();
+    app(PluginInstaller::class)->install($artifact['zip']);
+    $manifestPath = $this->runtimePluginPath.'/'.$artifact['id'].'/manifest.json';
+    $manifest = json_decode(file_get_contents($manifestPath), true, 512, JSON_THROW_ON_ERROR);
+    $manifest['id'] = 'other/declared-id';
+    file_put_contents($manifestPath, json_encode($manifest, JSON_THROW_ON_ERROR));
+    $owner = User::factory()->owner()->create();
+    [$vendor, $package] = explode('/', $artifact['id']);
+
+    $plugins = $this->actingAs($owner)
+        ->get(route('settings.plugins.index'))
+        ->inertiaProps('plugins');
+
+    expect(collect($plugins)->firstWhere('managed_id', $artifact['id']))->toMatchArray([
+        'id' => $artifact['id'],
+        'managed_id' => $artifact['id'],
+        'declared_id' => 'other/declared-id',
+        'status' => 'broken',
+        'can_remove' => true,
+    ]);
+
+    $this->actingAs($owner)
+        ->delete(route('settings.plugins.destroy', ['vendor' => $vendor, 'package' => $package]))
+        ->assertRedirect(route('settings.plugins.index'));
+
+    expect(is_dir($this->runtimePluginPath.'/'.$artifact['id']))->toBeFalse();
+});
+
 /** @return array{zip: string, id: string, class: string} */
-function makePluginSettingsArtifact(): array
+function makePluginSettingsArtifact(array $overrides = []): array
 {
     $suffix = (string) random_int(100000, 999999);
     $id = "settings/runtime-{$suffix}";
@@ -209,8 +382,11 @@ function makePluginSettingsArtifact(): array
         'core_version' => '^0.2',
         'php' => '^8.3',
         'dependencies' => [],
+        ...$overrides,
     ];
+    $dependencies = var_export($manifest['dependencies'], true);
     $source = "<?php\n\nnamespace SettingsRuntime;\n\nuse OpenKOS\\Platform\\OpenKOSManager;\nuse OpenKOS\\Platform\\Plugin\\Plugin;\nuse OpenKOS\\Platform\\Plugin\\PluginManifest;\n\nfinal class {$classShort} extends Plugin\n{\n    public function manifest(): PluginManifest\n    {\n        return new PluginManifest(\n            id: '{$id}',\n            name: 'Settings Runtime Fixture',\n            version: '1.0.0',\n            description: 'Settings runtime fixture.',\n            coreVersion: '^0.2',\n        );\n    }\n\n    public function register(OpenKOSManager \$platform): void {}\n}\n";
+    $source = str_replace("coreVersion: '^0.2',", "coreVersion: '{$manifest['core_version']}',\n            dependencies: {$dependencies},", $source);
 
     $directory = sys_get_temp_dir().'/openkos-settings-zip-'.bin2hex(random_bytes(8));
     mkdir($directory, 0750, true);


### PR DESCRIPTION
## Summary

- Add owner-facing runtime plugin catalog and lifecycle actions.
- Keep invalid runtime graphs out of boot and expose recovery states.
- Guard dependency disable/remove operations and preserve managed package identities.
- Surface restart-required messaging after lifecycle changes.

## Testing

- 35 affected backend tests passed.
- TypeScript, ESLint, Prettier, and Vite build passed.