### PR TITLE
fix(plugins): harden runtime recovery

### DIFF
--- a/app/Console/Commands/ListRuntimePluginsCommand.php
+++ b/app/Console/Commands/ListRuntimePluginsCommand.php
@@ -2,12 +2,8 @@
 
 namespace App\Console\Commands;
 
-use App\Services\Platform\ComposerPluginDiscovery;
-use App\Services\Platform\RuntimePluginArtifactValidator;
-use App\Services\Platform\RuntimePluginDiscovery;
-use App\Services\Platform\RuntimePluginStore;
+use App\Services\Platform\PluginManagementService;
 use Illuminate\Console\Command;
-use Throwable;
 
 final class ListRuntimePluginsCommand extends Command
 {
@@ -15,63 +11,28 @@ final class ListRuntimePluginsCommand extends Command
 
     protected $description = 'List installed runtime plugins and their state.';
 
-    public function handle(
-        RuntimePluginStore $store,
-        RuntimePluginArtifactValidator $validator,
-        RuntimePluginDiscovery $discovery,
-        ComposerPluginDiscovery $composer,
-    ): int {
-        try {
-            $rows = $store->withLock(function (RuntimePluginStore $store) use ($validator, $discovery, $composer): array {
-                $state = $store->readState();
-                $packages = $store->installedPackages();
-                $existingClasses = array_values(array_filter(config('platform.plugins', []), 'is_string'));
+    public function handle(PluginManagementService $management): int
+    {
+        $catalog = $management->catalog();
 
-                try {
-                    $existingClasses = [...$existingClasses, ...$composer->discoverComposerOnly()];
-                } catch (Throwable $exception) {
-                    report($exception);
-                }
-
-                $conflictingIds = $discovery->conflictingIds($packages, $state, $existingClasses);
-                $rows = [];
-
-                foreach ($packages as $id => $path) {
-                    $enabled = $state[$id]['enabled'] ?? false;
-
-                    if (in_array($id, $conflictingIds, true)) {
-                        try {
-                            $version = $validator->inspectStaticMetadata($path, $id)['version'];
-                        } catch (Throwable) {
-                            $version = 'unknown';
-                        }
-
-                        $rows[] = [$id, $version, 'Conflict'];
-
-                        continue;
-                    }
-
-                    try {
-                        $metadata = $enabled
-                            ? $validator->validate($path, $id)
-                            : $validator->inspectStaticMetadata($path, $id);
-                        $rows[] = [$id, $metadata['version'], $enabled ? 'Enabled' : 'Disabled'];
-                    } catch (Throwable $exception) {
-                        $rows[] = [$id, 'unknown', $enabled ? 'Invalid (enabled)' : 'Invalid (disabled)'];
-                        report($exception);
-                    }
-                }
-
-                foreach (array_diff_key($state, $store->installedPackages()) as $id => $entry) {
-                    $rows[] = [$id, 'missing', $entry['enabled'] ? 'Missing (enabled)' : 'Missing (disabled)'];
-                }
-
-                return $rows;
-            }, false);
-        } catch (Throwable $exception) {
-            $this->error($exception->getMessage());
+        if ($catalog['error'] !== null) {
+            $this->error($catalog['error']);
 
             return self::FAILURE;
+        }
+
+        $rows = [];
+
+        foreach ($catalog['plugins'] as $plugin) {
+            if (($plugin['source'] ?? null) !== 'runtime') {
+                continue;
+            }
+
+            $rows[] = [
+                $plugin['managed_id'] ?? $plugin['id'],
+                $plugin['version'] ?? (($plugin['status'] ?? null) === 'missing_package' ? 'missing' : 'unknown'),
+                $this->stateLabel($plugin),
+            ];
         }
 
         if ($rows === []) {
@@ -83,5 +44,23 @@ final class ListRuntimePluginsCommand extends Command
         $this->table(['Plugin', 'Version', 'State'], $rows);
 
         return self::SUCCESS;
+    }
+
+    /** @param array<string, mixed> $plugin */
+    private function stateLabel(array $plugin): string
+    {
+        return match ($plugin['status'] ?? null) {
+            'enabled' => 'Enabled',
+            'disabled' => 'Disabled',
+            'conflict' => 'Conflict',
+            'incompatible' => 'Incompatible',
+            'broken' => ($plugin['enabled'] ?? false) ? 'Invalid (enabled)' : 'Invalid (disabled)',
+            'missing_package' => ($plugin['enabled'] ?? false) ? 'Missing (enabled)' : 'Missing (disabled)',
+            'orphaned_state' => 'Orphaned state',
+            'orphaned_runtime_artifact' => 'Orphaned artifact',
+            'pending_recovery' => 'Pending recovery',
+            'unrecoverable_recovery' => 'Unrecoverable recovery',
+            default => ucfirst(str_replace('_', ' ', (string) ($plugin['status'] ?? 'Unknown'))),
+        };
     }
 }

--- a/app/Console/Commands/ListRuntimePluginsCommand.php
+++ b/app/Console/Commands/ListRuntimePluginsCommand.php
@@ -60,6 +60,7 @@ final class ListRuntimePluginsCommand extends Command
             'orphaned_runtime_artifact' => 'Orphaned artifact',
             'pending_recovery' => 'Pending recovery',
             'unrecoverable_recovery' => 'Unrecoverable recovery',
+            'load_failed' => 'Load failed',
             default => ucfirst(str_replace('_', ' ', (string) ($plugin['status'] ?? 'Unknown'))),
         };
     }

--- a/app/Console/Commands/ListRuntimePluginsCommand.php
+++ b/app/Console/Commands/ListRuntimePluginsCommand.php
@@ -2,7 +2,9 @@
 
 namespace App\Console\Commands;
 
+use App\Services\Platform\ComposerPluginDiscovery;
 use App\Services\Platform\RuntimePluginArtifactValidator;
+use App\Services\Platform\RuntimePluginDiscovery;
 use App\Services\Platform\RuntimePluginStore;
 use Illuminate\Console\Command;
 use Throwable;
@@ -13,15 +15,41 @@ final class ListRuntimePluginsCommand extends Command
 
     protected $description = 'List installed runtime plugins and their state.';
 
-    public function handle(RuntimePluginStore $store, RuntimePluginArtifactValidator $validator): int
-    {
+    public function handle(
+        RuntimePluginStore $store,
+        RuntimePluginArtifactValidator $validator,
+        RuntimePluginDiscovery $discovery,
+        ComposerPluginDiscovery $composer,
+    ): int {
         try {
-            $rows = $store->withLock(function (RuntimePluginStore $store) use ($validator): array {
+            $rows = $store->withLock(function (RuntimePluginStore $store) use ($validator, $discovery, $composer): array {
                 $state = $store->readState();
+                $packages = $store->installedPackages();
+                $existingClasses = array_values(array_filter(config('platform.plugins', []), 'is_string'));
+
+                try {
+                    $existingClasses = [...$existingClasses, ...$composer->discoverComposerOnly()];
+                } catch (Throwable $exception) {
+                    report($exception);
+                }
+
+                $conflictingIds = $discovery->conflictingIds($packages, $state, $existingClasses);
                 $rows = [];
 
-                foreach ($store->installedPackages() as $id => $path) {
+                foreach ($packages as $id => $path) {
                     $enabled = $state[$id]['enabled'] ?? false;
+
+                    if (in_array($id, $conflictingIds, true)) {
+                        try {
+                            $version = $validator->inspectStaticMetadata($path, $id)['version'];
+                        } catch (Throwable) {
+                            $version = 'unknown';
+                        }
+
+                        $rows[] = [$id, $version, 'Conflict'];
+
+                        continue;
+                    }
 
                     try {
                         $metadata = $enabled
@@ -39,7 +67,7 @@ final class ListRuntimePluginsCommand extends Command
                 }
 
                 return $rows;
-            });
+            }, false);
         } catch (Throwable $exception) {
             $this->error($exception->getMessage());
 

--- a/app/Console/Commands/ListRuntimePluginsCommand.php
+++ b/app/Console/Commands/ListRuntimePluginsCommand.php
@@ -24,7 +24,9 @@ final class ListRuntimePluginsCommand extends Command
                     $enabled = $state[$id]['enabled'] ?? false;
 
                     try {
-                        $metadata = $validator->validate($path, $id);
+                        $metadata = $enabled
+                            ? $validator->validate($path, $id)
+                            : $validator->inspectStaticMetadata($path, $id);
                         $rows[] = [$id, $metadata['version'], $enabled ? 'Enabled' : 'Disabled'];
                     } catch (Throwable $exception) {
                         $rows[] = [$id, 'unknown', $enabled ? 'Invalid (enabled)' : 'Invalid (disabled)'];

--- a/app/Http/Controllers/Settings/PluginController.php
+++ b/app/Http/Controllers/Settings/PluginController.php
@@ -64,10 +64,13 @@ class PluginController extends Controller
         return $this->runLifecycle($plugins, $vendor.'/'.$package, fn (string $id): mixed => $plugins->remove($id, $request->boolean('force')), __('Plugin removed. Restart required for changes to take effect.'));
     }
 
-    public function cleanup(PluginManagementService $plugins): RedirectResponse
+    public function cleanup(Request $request, PluginManagementService $plugins): RedirectResponse
     {
         try {
-            $plugins->cleanupOrphanedMetadata();
+            $plugins->cleanupOrphanedMetadata(
+                $request->string('recovery_id')->trim()->toString() ?: null,
+                $request->string('cleanup_key')->trim()->toString() ?: null,
+            );
         } catch (Throwable $exception) {
             report($exception);
 

--- a/app/Http/Controllers/Settings/PluginController.php
+++ b/app/Http/Controllers/Settings/PluginController.php
@@ -64,6 +64,23 @@ class PluginController extends Controller
         return $this->runLifecycle($plugins, $vendor.'/'.$package, fn (string $id): mixed => $plugins->remove($id, $request->boolean('force')), __('Plugin removed. Restart required for changes to take effect.'));
     }
 
+    public function cleanup(PluginManagementService $plugins): RedirectResponse
+    {
+        try {
+            $plugins->cleanupOrphanedMetadata();
+        } catch (Throwable $exception) {
+            report($exception);
+
+            throw ValidationException::withMessages([
+                'plugin' => $plugins->userMessage($exception),
+            ]);
+        }
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Runtime plugin metadata cleaned.')]);
+
+        return to_route('settings.plugins.index');
+    }
+
     /** @param callable(string): mixed $action */
     private function runLifecycle(PluginManagementService $plugins, string $id, callable $action, string $success): RedirectResponse
     {

--- a/app/Http/Controllers/Settings/PluginController.php
+++ b/app/Http/Controllers/Settings/PluginController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Settings\InstallPluginRequest;
 use App\Services\Platform\PluginManagementService;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
@@ -53,14 +54,14 @@ class PluginController extends Controller
         return $this->runLifecycle($plugins, $vendor.'/'.$package, fn (string $id): mixed => $plugins->enable($id), __('Plugin enabled. Restart required for changes to take effect.'));
     }
 
-    public function disable(string $vendor, string $package, PluginManagementService $plugins): RedirectResponse
+    public function disable(Request $request, string $vendor, string $package, PluginManagementService $plugins): RedirectResponse
     {
-        return $this->runLifecycle($plugins, $vendor.'/'.$package, fn (string $id): mixed => $plugins->disable($id), __('Plugin disabled. Restart required for changes to take effect.'));
+        return $this->runLifecycle($plugins, $vendor.'/'.$package, fn (string $id): mixed => $plugins->disable($id, $request->boolean('force')), __('Plugin disabled. Restart required for changes to take effect.'));
     }
 
-    public function destroy(string $vendor, string $package, PluginManagementService $plugins): RedirectResponse
+    public function destroy(Request $request, string $vendor, string $package, PluginManagementService $plugins): RedirectResponse
     {
-        return $this->runLifecycle($plugins, $vendor.'/'.$package, fn (string $id): mixed => $plugins->remove($id), __('Plugin removed. Restart required for changes to take effect.'));
+        return $this->runLifecycle($plugins, $vendor.'/'.$package, fn (string $id): mixed => $plugins->remove($id, $request->boolean('force')), __('Plugin removed. Restart required for changes to take effect.'));
     }
 
     /** @param callable(string): mixed $action */

--- a/app/Providers/PlatformBindingsServiceProvider.php
+++ b/app/Providers/PlatformBindingsServiceProvider.php
@@ -14,7 +14,8 @@ class PlatformBindingsServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
-        $this->app->singleton(PluginDiscovery::class, ComposerPluginDiscovery::class);
+        $this->app->singleton(ComposerPluginDiscovery::class);
+        $this->app->alias(ComposerPluginDiscovery::class, PluginDiscovery::class);
     }
 
     public function boot(): void

--- a/app/Services/Platform/ComposerPluginDiscovery.php
+++ b/app/Services/Platform/ComposerPluginDiscovery.php
@@ -22,7 +22,14 @@ final class ComposerPluginDiscovery implements PluginDiscovery
             ...$composerPlugins,
         ]);
 
-        $duplicateClasses = array_intersect($composerPlugins, $runtimePlugins);
+        $composerClassNames = array_fill_keys(array_map(
+            fn (string $class): string => $this->canonicalClassName($class),
+            $composerPlugins,
+        ), true);
+        $duplicateClasses = array_values(array_filter(
+            $runtimePlugins,
+            fn (string $class): bool => isset($composerClassNames[$this->canonicalClassName($class)]),
+        ));
         if ($duplicateClasses !== []) {
             throw new InvalidArgumentException(
                 'Runtime plugin entry class conflicts with an existing plugin: '.implode(', ', $duplicateClasses),
@@ -116,5 +123,10 @@ final class ComposerPluginDiscovery implements PluginDiscovery
         }
 
         return $metadata;
+    }
+
+    private function canonicalClassName(string $class): string
+    {
+        return strtolower(ltrim(trim($class), '\\'));
     }
 }

--- a/app/Services/Platform/ComposerPluginDiscovery.php
+++ b/app/Services/Platform/ComposerPluginDiscovery.php
@@ -47,6 +47,12 @@ final class ComposerPluginDiscovery implements PluginDiscovery
         return $this->discoverComposerPlugins();
     }
 
+    /** @return array{status: string, error: string}|null */
+    public function runtimeFailureFor(string $id): ?array
+    {
+        return $this->runtime->failureFor($id);
+    }
+
     /**
      * @return array<int, class-string<Plugin>>
      */

--- a/app/Services/Platform/PluginInstaller.php
+++ b/app/Services/Platform/PluginInstaller.php
@@ -15,6 +15,7 @@ final class PluginInstaller
         private RuntimePluginArtifactValidator $validator,
         private RuntimePluginGraphValidator $graph,
         private ComposerPluginDiscovery $composer,
+        private RuntimePluginDiscovery $discovery,
     ) {}
 
     /**
@@ -93,12 +94,22 @@ final class PluginInstaller
     {
         return $this->store->withLock(function (RuntimePluginStore $store) use ($id): array {
             $path = $store->packagePath($id);
+            $state = $store->readState();
+
+            if (in_array($id, $this->discovery->conflictingIds(
+                [$id => $path],
+                [...$state, $id => ['enabled' => true]],
+                $this->hostPluginClasses(),
+            ), true)) {
+                throw new RuntimePluginConflictException('Runtime plugin conflicts with a Composer or explicit plugin.');
+            }
+
             $metadata = $this->validator->validateInFreshProcess($path, $id);
             $this->graph->validateCandidate($metadata, true, $store, $this->hostPluginClasses());
             $store->setEnabled($id, true);
 
             return $metadata;
-        });
+        }, true, $id);
     }
 
     public function disable(string $id, bool $force = false): void
@@ -117,7 +128,7 @@ final class PluginInstaller
 
             $this->assertNoEnabledDependants($id, $store, 'disable', $force);
             $store->setEnabled($id, false);
-        });
+        }, true, $id);
     }
 
     public function remove(string $id, bool $force = false): void
@@ -174,9 +185,33 @@ final class PluginInstaller
         }, ! $force);
     }
 
-    public function cleanupOrphanedMetadata(): void
+    public function cleanupOrphanedMetadata(?string $recoveryId = null, ?string $cleanupKey = null): void
     {
-        $this->store->withLock(function (RuntimePluginStore $store): void {
+        $this->store->withLock(function (RuntimePluginStore $store) use ($recoveryId, $cleanupKey): void {
+            if ($cleanupKey === 'orphaned-artifacts') {
+                $store->forceCleanupOrphanedArtifacts();
+
+                return;
+            }
+
+            if (str_starts_with($cleanupKey ?? '', 'recovery:')) {
+                $store->forceCleanupRecovery(substr($cleanupKey, strlen('recovery:')));
+
+                return;
+            }
+
+            if ($cleanupKey !== null) {
+                $store->forceCleanupFilesystemAnomaly($cleanupKey);
+
+                return;
+            }
+
+            if ($recoveryId !== null) {
+                $store->forceCleanupRecovery($recoveryId);
+
+                return;
+            }
+
             $store->forceCleanupOrphanedMetadata();
         }, false);
     }

--- a/app/Services/Platform/PluginInstaller.php
+++ b/app/Services/Platform/PluginInstaller.php
@@ -101,20 +101,77 @@ final class PluginInstaller
         });
     }
 
-    public function disable(string $id): void
+    public function disable(string $id, bool $force = false): void
     {
-        $this->store->withLock(function (RuntimePluginStore $store) use ($id): void {
-            $this->assertNoEnabledDependants($id, $store, 'disable');
+        $this->store->withLock(function (RuntimePluginStore $store) use ($id, $force): void {
+            if ($force) {
+                try {
+                    $store->readState();
+                } catch (Throwable $exception) {
+                    throw new RuntimeException(
+                        'Runtime plugin state is corrupted. Remove the package to recover it.',
+                        previous: $exception,
+                    );
+                }
+            }
+
+            $this->assertNoEnabledDependants($id, $store, 'disable', $force);
             $store->setEnabled($id, false);
         });
     }
 
-    public function remove(string $id): void
+    public function remove(string $id, bool $force = false): void
     {
-        $this->store->withLock(function (RuntimePluginStore $store) use ($id): void {
-            $this->assertNoEnabledDependants($id, $store, 'remove');
+        $this->store->withLock(function (RuntimePluginStore $store) use ($id, $force): void {
+            $recoveryStatus = $store->recoveryStatus();
+
+            if ($force && $recoveryStatus === 'pending') {
+                try {
+                    $store->recoverPendingOperation();
+                    $recoveryStatus = $store->recoveryStatus();
+                } catch (Throwable $exception) {
+                    if ($store->recoveryStatus() !== 'corrupt') {
+                        try {
+                            $store->readState();
+                        } catch (Throwable) {
+                            $store->forceRemove($id, true);
+
+                            return;
+                        }
+
+                        throw $exception;
+                    }
+
+                    $recoveryStatus = 'corrupt';
+                }
+            }
+
+            if ($force) {
+                try {
+                    $store->readState();
+                } catch (Throwable) {
+                    if ($recoveryStatus === 'pending') {
+                        $store->forceRemove($id, true);
+
+                        return;
+                    }
+
+                    $store->forceRemove($id);
+
+                    return;
+                }
+            }
+
+            $this->assertNoEnabledDependants($id, $store, 'remove', $force);
+
+            if ($force && $recoveryStatus === 'corrupt') {
+                $store->forceRemove($id);
+
+                return;
+            }
+
             $store->remove($id);
-        });
+        }, ! $force);
     }
 
     private function validateArchiveEntries(ZipArchive $archive): void
@@ -210,11 +267,15 @@ final class PluginInstaller
         ];
     }
 
-    private function assertNoEnabledDependants(string $id, RuntimePluginStore $store, string $action): void
+    private function assertNoEnabledDependants(string $id, RuntimePluginStore $store, string $action, bool $force = false): void
     {
         $dependants = $this->graph->enabledDependants($id, $store, $this->hostPluginClasses());
 
         if ($dependants === []) {
+            return;
+        }
+
+        if ($force && $this->graph->canForceRecover($id, $store, $this->hostPluginClasses())) {
             return;
         }
 

--- a/app/Services/Platform/PluginInstaller.php
+++ b/app/Services/Platform/PluginInstaller.php
@@ -41,6 +41,10 @@ final class PluginInstaller
         }
 
         return $this->store->withLock(function (RuntimePluginStore $store) use ($zipPath): array {
+            if ($store->recoveryStatus() === RuntimePluginStore::RECOVERY_ORPHANED_ARTIFACT) {
+                throw new RuntimeException('Orphaned runtime artifacts must be cleaned before installation.');
+            }
+
             $archive = new ZipArchive;
             $opened = $archive->open($zipPath);
 
@@ -187,9 +191,21 @@ final class PluginInstaller
 
     public function cleanupOrphanedMetadata(?string $recoveryId = null, ?string $cleanupKey = null): void
     {
+        if ($cleanupKey === 'internal:.lock') {
+            $this->store->forceCleanupFilesystemAnomaly($cleanupKey);
+
+            return;
+        }
+
         $this->store->withLock(function (RuntimePluginStore $store) use ($recoveryId, $cleanupKey): void {
             if ($cleanupKey === 'orphaned-artifacts') {
                 $store->forceCleanupOrphanedArtifacts();
+
+                return;
+            }
+
+            if ($cleanupKey === 'orphaned-recovery') {
+                $store->forceCleanupUnknownRecovery();
 
                 return;
             }

--- a/app/Services/Platform/PluginInstaller.php
+++ b/app/Services/Platform/PluginInstaller.php
@@ -2,6 +2,7 @@
 
 namespace App\Services\Platform;
 
+use Illuminate\Support\Facades\File;
 use InvalidArgumentException;
 use OpenKOS\Platform\Plugin\Plugin;
 use RuntimeException;
@@ -40,11 +41,9 @@ final class PluginInstaller
             throw new InvalidArgumentException('Plugin ZIP file does not exist or is unsafe.');
         }
 
-        return $this->store->withLock(function (RuntimePluginStore $store) use ($zipPath): array {
-            if ($store->recoveryStatus() === RuntimePluginStore::RECOVERY_ORPHANED_ARTIFACT) {
-                throw new RuntimeException('Orphaned runtime artifacts must be cleaned before installation.');
-            }
+        $inspectionPath = null;
 
+        try {
             $archive = new ZipArchive;
             $opened = $archive->open($zipPath);
 
@@ -52,47 +51,65 @@ final class PluginInstaller
                 throw new InvalidArgumentException('Plugin ZIP file cannot be opened.');
             }
 
-            $stagingPath = null;
-
             try {
                 $this->validateArchiveEntries($archive);
-                $stagingPath = $store->createStagingPath('incoming');
+                $inspectionPath = $this->createInspectionPath();
 
-                if (! $archive->extractTo($stagingPath)) {
-                    throw new RuntimeException('Plugin ZIP could not be extracted into staging storage.');
+                if (! $archive->extractTo($inspectionPath)) {
+                    throw new RuntimeException('Plugin ZIP could not be extracted for inspection.');
                 }
-
-                $state = $store->readState();
-                $staticMetadata = $this->validator->inspectStaticMetadata($stagingPath);
-                $enabled = ! isset($state[$staticMetadata['id']]) || $state[$staticMetadata['id']]['enabled'];
-                $candidatePackages = $store->installedPackages();
-                $candidatePackages[$staticMetadata['id']] = $stagingPath;
-
-                if (in_array($staticMetadata['id'], $this->discovery->conflictingIds(
-                    $candidatePackages,
-                    [...$state, $staticMetadata['id'] => ['enabled' => $enabled]],
-                    $this->hostPluginClasses(),
-                    true,
-                ), true)) {
-                    throw new RuntimePluginConflictException('Runtime plugin conflicts with an existing plugin.');
-                }
-
-                $metadata = $this->validator->validateInFreshProcess($stagingPath, $staticMetadata['id']);
-                $this->graph->validateCandidate($metadata, $enabled, $store, $this->hostPluginClasses());
-                $store->promote($metadata['id'], $stagingPath, $enabled);
-                $stagingPath = null;
-
-                return $metadata;
-            } catch (Throwable $exception) {
-                if (is_string($stagingPath)) {
-                    $store->discardStaging($stagingPath);
-                }
-
-                throw $exception;
             } finally {
                 $archive->close();
             }
-        });
+
+            $staticMetadata = $this->validator->inspectStaticMetadata($inspectionPath);
+            $pluginId = $staticMetadata['id'];
+
+            return $this->store->withLock(function (RuntimePluginStore $store) use (&$inspectionPath, $pluginId): array {
+                $stagingPath = null;
+
+                try {
+                    $stagingPath = $store->createStagingPath('incoming');
+
+                    if (! rename($inspectionPath, $stagingPath)) {
+                        throw new RuntimeException('Plugin ZIP could not be moved into staging storage.');
+                    }
+
+                    $inspectionPath = null;
+                    $state = $store->readState();
+                    $staticMetadata = $this->validator->inspectStaticMetadata($stagingPath, $pluginId);
+                    $enabled = ! isset($state[$pluginId]) || $state[$pluginId]['enabled'];
+                    $candidatePackages = $store->installedPackages();
+                    $candidatePackages[$pluginId] = $stagingPath;
+
+                    if (in_array($pluginId, $this->discovery->conflictingIds(
+                        $candidatePackages,
+                        [...$state, $pluginId => ['enabled' => $enabled]],
+                        $this->hostPluginClasses(),
+                        true,
+                    ), true)) {
+                        throw new RuntimePluginConflictException('Runtime plugin conflicts with an existing plugin.');
+                    }
+
+                    $metadata = $this->validator->validateInFreshProcess($stagingPath, $staticMetadata['id']);
+                    $this->graph->validateCandidate($metadata, $enabled, $store, $this->hostPluginClasses());
+                    $store->promote($metadata['id'], $stagingPath, $enabled);
+                    $stagingPath = null;
+
+                    return $metadata;
+                } catch (Throwable $exception) {
+                    if (is_string($stagingPath)) {
+                        $store->discardStaging($stagingPath);
+                    }
+
+                    throw $exception;
+                }
+            }, true, $pluginId);
+        } finally {
+            if (is_string($inspectionPath)) {
+                $this->discardInspectionPath($inspectionPath);
+            }
+        }
     }
 
     /**
@@ -110,11 +127,11 @@ final class PluginInstaller
     public function enable(string $id): array
     {
         return $this->store->withLock(function (RuntimePluginStore $store) use ($id): array {
-            $path = $store->packagePath($id);
+            $path = $store->installedPackagePath($id);
             $state = $store->readState();
 
             if (in_array($id, $this->discovery->conflictingIds(
-                [...$store->installedPackages(), $id => $path],
+                $store->installedPackages(),
                 [...$state, $id => ['enabled' => true]],
                 $this->hostPluginClasses(),
             ), true)) {
@@ -153,9 +170,9 @@ final class PluginInstaller
         $this->store->withLock(function (RuntimePluginStore $store) use ($id, $force): void {
             $recoveryStatus = $store->recoveryStatus();
 
-            if ($force && $recoveryStatus === RuntimePluginStore::RECOVERY_PENDING && $store->recoveryIdentity() === $id) {
+            if ($force && $recoveryStatus === RuntimePluginStore::RECOVERY_PENDING && $store->hasRecoveryFor($id)) {
                 try {
-                    $store->recoverPendingOperation();
+                    $store->recoverPendingOperation($id);
                     $recoveryStatus = $store->recoveryStatus();
                 } catch (Throwable $exception) {
                     if ($store->recoveryStatus() !== RuntimePluginStore::RECOVERY_UNRECOVERABLE) {
@@ -192,7 +209,7 @@ final class PluginInstaller
 
             $this->assertNoEnabledDependants($id, $store, 'remove', $force);
 
-            if ($force && $recoveryStatus === RuntimePluginStore::RECOVERY_UNRECOVERABLE) {
+            if ($force && $recoveryStatus === RuntimePluginStore::RECOVERY_UNRECOVERABLE && $store->hasRecoveryFor($id)) {
                 $store->forceRemove($id);
 
                 return;
@@ -326,6 +343,28 @@ final class PluginInstaller
             if (preg_match('/(^|\/)(install|post-install|pre-install)\.(php|sh|bash|bat|cmd|exe)$/i', $normalizedName)) {
                 throw new InvalidArgumentException("Plugin ZIP contains an install script [{$name}].");
             }
+        }
+    }
+
+    private function createInspectionPath(): string
+    {
+        $path = dirname($this->store->rootPath()).'/.openkos-plugin-'.bin2hex(random_bytes(8));
+
+        if (! mkdir($path, 0750) || ! is_dir($path) || is_link($path)) {
+            throw new RuntimeException('Could not create temporary plugin inspection storage.');
+        }
+
+        return $path;
+    }
+
+    private function discardInspectionPath(string $path): void
+    {
+        if (is_link($path) || (! is_dir($path) && file_exists($path))) {
+            throw new RuntimeException('Temporary plugin inspection storage is unsafe.');
+        }
+
+        if (is_dir($path) && (! File::deleteDirectory($path) || is_dir($path))) {
+            throw new RuntimeException('Could not clean temporary plugin inspection storage.');
         }
     }
 

--- a/app/Services/Platform/PluginInstaller.php
+++ b/app/Services/Platform/PluginInstaller.php
@@ -241,7 +241,13 @@ final class PluginInstaller
             }
 
             if (str_starts_with($cleanupKey ?? '', 'recovery:')) {
-                $store->forceCleanupRecovery(substr($cleanupKey, strlen('recovery:')));
+                $recoveryId = substr($cleanupKey, strlen('recovery:'));
+
+                if ($recoveryId === '') {
+                    throw new RuntimeException('Runtime plugin recovery identity is missing.');
+                }
+
+                $store->forceCleanupRecovery($recoveryId);
 
                 return;
             }

--- a/app/Services/Platform/PluginInstaller.php
+++ b/app/Services/Platform/PluginInstaller.php
@@ -62,9 +62,22 @@ final class PluginInstaller
                     throw new RuntimeException('Plugin ZIP could not be extracted into staging storage.');
                 }
 
-                $metadata = $this->validator->validateInFreshProcess($stagingPath);
                 $state = $store->readState();
-                $enabled = ! isset($state[$metadata['id']]) || $state[$metadata['id']]['enabled'];
+                $staticMetadata = $this->validator->inspectStaticMetadata($stagingPath);
+                $enabled = ! isset($state[$staticMetadata['id']]) || $state[$staticMetadata['id']]['enabled'];
+                $candidatePackages = $store->installedPackages();
+                $candidatePackages[$staticMetadata['id']] = $stagingPath;
+
+                if (in_array($staticMetadata['id'], $this->discovery->conflictingIds(
+                    $candidatePackages,
+                    [...$state, $staticMetadata['id'] => ['enabled' => $enabled]],
+                    $this->hostPluginClasses(),
+                    true,
+                ), true)) {
+                    throw new RuntimePluginConflictException('Runtime plugin conflicts with an existing plugin.');
+                }
+
+                $metadata = $this->validator->validateInFreshProcess($stagingPath, $staticMetadata['id']);
                 $this->graph->validateCandidate($metadata, $enabled, $store, $this->hostPluginClasses());
                 $store->promote($metadata['id'], $stagingPath, $enabled);
                 $stagingPath = null;
@@ -101,11 +114,11 @@ final class PluginInstaller
             $state = $store->readState();
 
             if (in_array($id, $this->discovery->conflictingIds(
-                [$id => $path],
+                [...$store->installedPackages(), $id => $path],
                 [...$state, $id => ['enabled' => true]],
                 $this->hostPluginClasses(),
             ), true)) {
-                throw new RuntimePluginConflictException('Runtime plugin conflicts with a Composer or explicit plugin.');
+                throw new RuntimePluginConflictException('Runtime plugin conflicts with an existing plugin.');
             }
 
             $metadata = $this->validator->validateInFreshProcess($path, $id);
@@ -140,7 +153,7 @@ final class PluginInstaller
         $this->store->withLock(function (RuntimePluginStore $store) use ($id, $force): void {
             $recoveryStatus = $store->recoveryStatus();
 
-            if ($force && $recoveryStatus === RuntimePluginStore::RECOVERY_PENDING) {
+            if ($force && $recoveryStatus === RuntimePluginStore::RECOVERY_PENDING && $store->recoveryIdentity() === $id) {
                 try {
                     $store->recoverPendingOperation();
                     $recoveryStatus = $store->recoveryStatus();
@@ -186,7 +199,7 @@ final class PluginInstaller
             }
 
             $store->remove($id);
-        }, ! $force);
+        }, ! $force, $id);
     }
 
     public function cleanupOrphanedMetadata(?string $recoveryId = null, ?string $cleanupKey = null): void

--- a/app/Services/Platform/PluginInstaller.php
+++ b/app/Services/Platform/PluginInstaller.php
@@ -125,12 +125,12 @@ final class PluginInstaller
         $this->store->withLock(function (RuntimePluginStore $store) use ($id, $force): void {
             $recoveryStatus = $store->recoveryStatus();
 
-            if ($force && $recoveryStatus === 'pending') {
+            if ($force && $recoveryStatus === RuntimePluginStore::RECOVERY_PENDING) {
                 try {
                     $store->recoverPendingOperation();
                     $recoveryStatus = $store->recoveryStatus();
                 } catch (Throwable $exception) {
-                    if ($store->recoveryStatus() !== 'corrupt') {
+                    if ($store->recoveryStatus() !== RuntimePluginStore::RECOVERY_UNRECOVERABLE) {
                         try {
                             $store->readState();
                         } catch (Throwable) {
@@ -142,7 +142,7 @@ final class PluginInstaller
                         throw $exception;
                     }
 
-                    $recoveryStatus = 'corrupt';
+                    $recoveryStatus = RuntimePluginStore::RECOVERY_UNRECOVERABLE;
                 }
             }
 
@@ -150,7 +150,7 @@ final class PluginInstaller
                 try {
                     $store->readState();
                 } catch (Throwable) {
-                    if ($recoveryStatus === 'pending') {
+                    if ($recoveryStatus === RuntimePluginStore::RECOVERY_PENDING) {
                         $store->forceRemove($id, true);
 
                         return;
@@ -164,7 +164,7 @@ final class PluginInstaller
 
             $this->assertNoEnabledDependants($id, $store, 'remove', $force);
 
-            if ($force && $recoveryStatus === 'corrupt') {
+            if ($force && $recoveryStatus === RuntimePluginStore::RECOVERY_UNRECOVERABLE) {
                 $store->forceRemove($id);
 
                 return;
@@ -172,6 +172,13 @@ final class PluginInstaller
 
             $store->remove($id);
         }, ! $force);
+    }
+
+    public function cleanupOrphanedMetadata(): void
+    {
+        $this->store->withLock(function (RuntimePluginStore $store): void {
+            $store->forceCleanupOrphanedMetadata();
+        }, false);
     }
 
     private function validateArchiveEntries(ZipArchive $archive): void

--- a/app/Services/Platform/PluginManagementService.php
+++ b/app/Services/Platform/PluginManagementService.php
@@ -147,7 +147,11 @@ class PluginManagementService
 
         $packages = $this->store->managedPackageEntries();
         $hostClasses = $this->hostPluginClasses();
-        $conflictingIds = $this->discovery->conflictingIds($packages, $state, $hostClasses);
+        $conflictingIds = $this->discovery->conflictingIds(
+            $this->store->installedPackages(),
+            $state,
+            $hostClasses,
+        );
         $runtime = [];
         $rows = [];
         $filesystemAnomalies = $this->store->managedFilesystemAnomalies();
@@ -330,65 +334,62 @@ class PluginManagementService
             $rows[] = $this->filesystemAnomalyRow($key, $path);
         }
 
-        $recoveryIdentity = $this->store->recoveryIdentity();
-        if (
-            $recoveryIdentity !== null
-            && ! in_array($recoveryIdentity, array_column($rows, 'managed_id'), true)
-        ) {
-            $rows[] = $this->recoveryRow($recoveryStatus, $recoveryIdentity);
-        } elseif (
-            $recoveryIdentity === null
-            && $recoveryStatus === RuntimePluginStore::RECOVERY_UNRECOVERABLE
-            && ! array_key_exists('internal:recovery.json', $filesystemAnomalies)
-        ) {
-            $rows[] = $this->orphanedMetadataRow($recoveryStatus, cleanupKey: 'orphaned-recovery');
-        } elseif ($recoveryIdentity === null && $recoveryStatus === RuntimePluginStore::RECOVERY_ORPHANED_ARTIFACT) {
+        $recoveryRecords = $this->store->recoveryRecords();
+
+        foreach ($recoveryRecords as $record) {
+            $recoveryId = $record['id'];
+
+            if ($recoveryId === null) {
+                if (! $this->hasRecoveryFilesystemAnomaly($filesystemAnomalies)) {
+                    $rows[] = $this->orphanedMetadataRow(
+                        $record['status'],
+                        cleanupKey: $record['cleanup_key'],
+                    );
+                }
+
+                continue;
+            }
+
+            $matched = false;
+
+            foreach ($rows as &$row) {
+                if (
+                    $row['source'] !== 'runtime'
+                    || ($row['cleanup_key'] ?? null) !== null
+                    || $row['managed_id'] !== $recoveryId
+                ) {
+                    continue;
+                }
+
+                $matched = true;
+
+                if ($record['status'] === RuntimePluginStore::RECOVERY_PENDING) {
+                    $row['status'] = RuntimePluginStore::RECOVERY_PENDING;
+                    $row['error'] = __('Runtime plugin recovery is pending and will complete before the next lifecycle change.');
+                    $row['can_enable'] = false;
+                    $row['can_disable'] = false;
+                    $row['can_remove'] = true;
+                    $row['can_force_recovery'] = false;
+                } elseif ($record['status'] === RuntimePluginStore::RECOVERY_UNRECOVERABLE) {
+                    $row['status'] = RuntimePluginStore::RECOVERY_UNRECOVERABLE;
+                    $row['error'] = __('Runtime plugin recovery cannot be completed. Force remove this package or clean up orphaned metadata.');
+                    $row['can_enable'] = false;
+                    $row['can_disable'] = false;
+                    $row['can_remove'] = false;
+                    $row['can_force_recovery'] = true;
+                }
+            }
+            unset($row);
+
+            if (! $matched) {
+                $rows[] = $this->recoveryRow($record['status'], $recoveryId);
+            }
+        }
+
+        if ($recoveryRecords === [] && $recoveryStatus === RuntimePluginStore::RECOVERY_ORPHANED_ARTIFACT) {
             $rows[] = $this->orphanedMetadataRow($recoveryStatus, cleanupKey: 'orphaned-artifacts');
-        } elseif ($recoveryIdentity === null && $rows === [] && $recoveryStatus !== RuntimePluginStore::RECOVERY_HEALTHY) {
+        } elseif ($recoveryRecords === [] && $rows === [] && $recoveryStatus !== RuntimePluginStore::RECOVERY_HEALTHY) {
             $rows[] = $this->orphanedMetadataRow($recoveryStatus);
-        }
-
-        if ($recoveryStatus === RuntimePluginStore::RECOVERY_PENDING) {
-            foreach ($rows as &$row) {
-                if (
-                    $row['source'] !== 'runtime'
-                    || ($row['cleanup_key'] ?? null) !== null
-                    || ($recoveryIdentity !== null && $row['managed_id'] !== $recoveryIdentity)
-                ) {
-                    continue;
-                }
-
-                $row['status'] = RuntimePluginStore::RECOVERY_PENDING;
-                $row['error'] = __('Runtime plugin recovery is pending and will complete before the next lifecycle change.');
-                $row['can_enable'] = false;
-                $row['can_disable'] = false;
-                $row['can_remove'] = true;
-                $row['can_force_recovery'] = false;
-            }
-            unset($row);
-        }
-
-        if ($recoveryStatus === RuntimePluginStore::RECOVERY_UNRECOVERABLE) {
-            foreach ($rows as &$row) {
-                if (
-                    $row['source'] !== 'runtime'
-                    || ($row['cleanup_key'] ?? null) !== null
-                ) {
-                    continue;
-                }
-
-                if ($recoveryIdentity === null || $row['managed_id'] !== $recoveryIdentity) {
-                    continue;
-                }
-
-                $row['status'] = RuntimePluginStore::RECOVERY_UNRECOVERABLE;
-                $row['error'] = __('Runtime plugin recovery cannot be completed. Force remove this package or clean up orphaned metadata.');
-                $row['can_enable'] = false;
-                $row['can_disable'] = false;
-                $row['can_remove'] = false;
-                $row['can_force_recovery'] = true;
-            }
-            unset($row);
         }
 
         return $rows;
@@ -440,41 +441,47 @@ class PluginManagementService
             $rows[] = $this->orphanedMetadataRow('orphaned_state', $recoveryStatus);
         }
 
-        $recoveryIdentity = $this->store->recoveryIdentity();
-        if (
-            $recoveryIdentity !== null
-            && ! in_array($recoveryIdentity, array_column($rows, 'managed_id'), true)
-        ) {
-            $rows[] = $this->recoveryRow($recoveryStatus, $recoveryIdentity);
-        } elseif (
-            $recoveryIdentity === null
-            && $recoveryStatus === RuntimePluginStore::RECOVERY_UNRECOVERABLE
-            && ! array_key_exists('internal:recovery.json', $filesystemAnomalies)
-        ) {
-            $rows[] = $this->orphanedMetadataRow($recoveryStatus, cleanupKey: 'orphaned-recovery');
-        } elseif ($recoveryIdentity === null && $recoveryStatus === RuntimePluginStore::RECOVERY_ORPHANED_ARTIFACT) {
-            $rows[] = $this->orphanedMetadataRow($recoveryStatus, cleanupKey: 'orphaned-artifacts');
-        }
+        $recoveryRecords = $this->store->recoveryRecords();
 
-        if ($recoveryStatus === RuntimePluginStore::RECOVERY_UNRECOVERABLE) {
+        foreach ($recoveryRecords as $record) {
+            $recoveryId = $record['id'];
+
+            if ($recoveryId === null) {
+                if (! $this->hasRecoveryFilesystemAnomaly($filesystemAnomalies)) {
+                    $rows[] = $this->orphanedMetadataRow(
+                        $record['status'],
+                        cleanupKey: $record['cleanup_key'],
+                    );
+                }
+
+                continue;
+            }
+
+            $matched = false;
+
             foreach ($rows as &$row) {
-                if (($row['cleanup_key'] ?? null) !== null) {
+                if (($row['cleanup_key'] ?? null) !== null || $row['managed_id'] !== $recoveryId) {
                     continue;
                 }
 
-                if ($recoveryIdentity === null || $row['managed_id'] !== $recoveryIdentity) {
-                    continue;
-                }
-
-                $row['status'] = RuntimePluginStore::RECOVERY_UNRECOVERABLE;
+                $matched = true;
+                $row['status'] = $record['status'];
                 $row['error'] = __('Runtime plugin state and recovery metadata cannot be completed. Clean up orphaned metadata.');
                 $row['can_enable'] = false;
                 $row['can_disable'] = false;
                 $row['can_remove'] = false;
-                $row['can_force_recovery'] = $row['managed_id'] !== null;
-                $row['can_cleanup'] = $row['managed_id'] === null;
+                $row['can_force_recovery'] = true;
+                $row['can_cleanup'] = false;
             }
             unset($row);
+
+            if (! $matched) {
+                $rows[] = $this->recoveryRow($record['status'], $recoveryId);
+            }
+        }
+
+        if ($recoveryRecords === [] && $recoveryStatus === RuntimePluginStore::RECOVERY_ORPHANED_ARTIFACT) {
+            $rows[] = $this->orphanedMetadataRow($recoveryStatus, cleanupKey: 'orphaned-artifacts');
         }
 
         return $rows;
@@ -615,7 +622,7 @@ class PluginManagementService
             'can_disable' => false,
             'can_remove' => false,
             'can_force_recovery' => false,
-            'can_cleanup' => $status === RuntimePluginStore::RECOVERY_UNRECOVERABLE,
+            'can_cleanup' => true,
             'cleanup_key' => 'recovery:'.$id,
         ];
     }
@@ -660,11 +667,27 @@ class PluginManagementService
 
     private function canCleanupFilesystemPath(string $path): bool
     {
+        if (@lstat($path) === false || @scandir(dirname($path)) === false) {
+            return false;
+        }
+
         if (is_link($path)) {
             return true;
         }
 
         return ! is_dir($path) || @scandir($path) !== false;
+    }
+
+    /** @param array<string, string> $anomalies */
+    private function hasRecoveryFilesystemAnomaly(array $anomalies): bool
+    {
+        foreach (array_keys($anomalies) as $key) {
+            if ($key === 'internal:.recovery' || str_starts_with($key, 'internal:.recovery/')) {
+                return true;
+            }
+        }
+
+        return array_key_exists('internal:recovery.json', $anomalies);
     }
 
     /** @return array<string, mixed> */
@@ -772,6 +795,10 @@ class PluginManagementService
     {
         $legacyIds = array_count_values(array_column($legacy, 'id'));
         $legacyClasses = array_column($legacy, 'entry_class');
+        $legacyClassNames = array_map(
+            fn (mixed $class): string => is_string($class) ? $this->canonicalClassName($class) : '',
+            $legacyClasses,
+        );
 
         foreach ($legacy as &$plugin) {
             if (($legacyIds[$plugin['id']] ?? 0) > 1) {
@@ -792,11 +819,17 @@ class PluginManagementService
                 continue;
             }
 
-            if (in_array($plugin['id'], array_column($legacy, 'id'), true) || in_array($plugin['entry_class'], $legacyClasses, true)) {
+            if (
+                in_array($plugin['id'], array_column($legacy, 'id'), true)
+                || in_array($this->canonicalClassName((string) $plugin['entry_class']), $legacyClassNames, true)
+            ) {
                 $this->markConflict($plugin, __('A Composer or explicit plugin has the same identity; this runtime copy is not loaded.'));
 
                 foreach ($legacy as &$legacyPlugin) {
-                    if ($legacyPlugin['id'] === $plugin['id'] || $legacyPlugin['entry_class'] === $plugin['entry_class']) {
+                    if (
+                        $legacyPlugin['id'] === $plugin['id']
+                        || $this->canonicalClassName((string) $legacyPlugin['entry_class']) === $this->canonicalClassName((string) $plugin['entry_class'])
+                    ) {
                         $this->markConflict($legacyPlugin, __('A runtime plugin has the same identity; the Composer or explicit copy takes precedence.'));
                     }
                 }
@@ -815,5 +848,10 @@ class PluginManagementService
         $plugin['can_disable'] = $plugin['source'] === 'runtime' && $plugin['enabled'];
         $plugin['can_remove'] = $plugin['source'] === 'runtime';
         $plugin['can_force_recovery'] = $plugin['source'] === 'runtime';
+    }
+
+    private function canonicalClassName(string $class): string
+    {
+        return strtolower(ltrim(trim($class), '\\'));
     }
 }

--- a/app/Services/Platform/PluginManagementService.php
+++ b/app/Services/Platform/PluginManagementService.php
@@ -78,14 +78,14 @@ class PluginManagementService
         return $this->installer->enable($id);
     }
 
-    public function disable(string $id): void
+    public function disable(string $id, bool $force = false): void
     {
-        $this->installer->disable($id);
+        $this->installer->disable($id, $force);
     }
 
-    public function remove(string $id): void
+    public function remove(string $id, bool $force = false): void
     {
-        $this->installer->remove($id);
+        $this->installer->remove($id, $force);
     }
 
     public function userMessage(Throwable $exception): string
@@ -117,7 +117,16 @@ class PluginManagementService
     /** @return array<int, array<string, mixed>> */
     private function runtimePlugins(): array
     {
-        $state = $this->store->readState();
+        $recoveryStatus = $this->store->recoveryStatus();
+
+        try {
+            $state = $this->store->readState();
+        } catch (Throwable $exception) {
+            report($exception);
+
+            return $this->runtimePluginsWithCorruptState();
+        }
+
         $packages = $this->store->installedPackages();
         $runtime = [];
         $rows = [];
@@ -159,6 +168,7 @@ class PluginManagementService
                         'can_enable' => false,
                         'can_disable' => $enabled,
                         'can_remove' => true,
+                        'can_force_recovery' => true,
                     ];
 
                     continue;
@@ -179,6 +189,7 @@ class PluginManagementService
                 'can_enable' => false,
                 'can_disable' => $enabled,
                 'can_remove' => true,
+                'can_force_recovery' => true,
             ];
         }
 
@@ -199,8 +210,47 @@ class PluginManagementService
                 'enabled' => $entry['enabled'],
                 'error' => __('Plugin state exists without an installed package. Remove the stale state entry.'),
                 'can_enable' => false,
-                'can_disable' => $entry['enabled'],
+                'can_disable' => false,
                 'can_remove' => true,
+                'can_force_recovery' => true,
+            ];
+        }
+
+        if ($recoveryStatus === 'corrupt') {
+            foreach ($rows as &$row) {
+                if ($row['source'] !== 'runtime') {
+                    continue;
+                }
+
+                $row['status'] = 'broken';
+                $row['error'] = __('Runtime plugin recovery metadata is corrupted. Force remove this package to recover it.');
+                $row['can_enable'] = false;
+                $row['can_disable'] = false;
+                $row['can_remove'] = true;
+                $row['can_force_recovery'] = true;
+            }
+            unset($row);
+        }
+
+        return $rows;
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    private function runtimePluginsWithCorruptState(): array
+    {
+        $rows = [];
+
+        foreach ($this->store->installedPackages() as $id => $path) {
+            $rows[] = [
+                ...$this->manifestPreview($path, $id),
+                'source' => 'runtime',
+                'status' => 'broken',
+                'enabled' => false,
+                'error' => __('Runtime plugin state is corrupted. Force remove this package to recover it.'),
+                'can_enable' => false,
+                'can_disable' => false,
+                'can_remove' => true,
+                'can_force_recovery' => true,
             ];
         }
 
@@ -246,6 +296,7 @@ class PluginManagementService
                     'can_enable' => false,
                     'can_disable' => false,
                     'can_remove' => false,
+                    'can_force_recovery' => false,
                 ];
             } catch (Throwable $exception) {
                 report($exception);
@@ -269,6 +320,7 @@ class PluginManagementService
             'can_enable' => ! $enabled,
             'can_disable' => $enabled,
             'can_remove' => true,
+            'can_force_recovery' => false,
         ];
     }
 
@@ -407,5 +459,6 @@ class PluginManagementService
         $plugin['can_enable'] = false;
         $plugin['can_disable'] = $plugin['source'] === 'runtime' && $plugin['enabled'];
         $plugin['can_remove'] = $plugin['source'] === 'runtime';
+        $plugin['can_force_recovery'] = $plugin['source'] === 'runtime';
     }
 }

--- a/app/Services/Platform/PluginManagementService.php
+++ b/app/Services/Platform/PluginManagementService.php
@@ -88,6 +88,11 @@ class PluginManagementService
         $this->installer->remove($id, $force);
     }
 
+    public function cleanupOrphanedMetadata(): void
+    {
+        $this->installer->cleanupOrphanedMetadata();
+    }
+
     public function userMessage(Throwable $exception): string
     {
         $message = strtolower($exception->getMessage());
@@ -98,6 +103,14 @@ class PluginManagementService
 
         if ($exception instanceof RuntimePluginConflictException || str_contains($message, 'conflict')) {
             return __('This plugin conflicts with an explicit or Composer-installed plugin. Disable or remove the runtime copy.');
+        }
+
+        if (str_contains($message, 'could not remove runtime plugin path')) {
+            return __('The runtime plugin could not be removed. Check runtime storage permissions and try again.');
+        }
+
+        if (str_contains($message, 'could not clean runtime lifecycle path')) {
+            return __('Runtime plugin metadata could not be cleaned. Check runtime storage permissions and try again.');
         }
 
         if (
@@ -124,10 +137,10 @@ class PluginManagementService
         } catch (Throwable $exception) {
             report($exception);
 
-            return $this->runtimePluginsWithCorruptState();
+            return $this->runtimePluginsWithCorruptState($recoveryStatus);
         }
 
-        $packages = $this->store->installedPackages();
+        $packages = $this->store->managedPackageEntries();
         $runtime = [];
         $rows = [];
 
@@ -169,6 +182,7 @@ class PluginManagementService
                         'can_disable' => $enabled,
                         'can_remove' => true,
                         'can_force_recovery' => true,
+                        'can_cleanup' => false,
                     ];
 
                     continue;
@@ -180,6 +194,7 @@ class PluginManagementService
             }
 
             $status = $entry['status'];
+            $canRemove = ! is_link($path);
             $rows[] = [
                 ...$this->manifestPreview($path, $id),
                 'source' => 'runtime',
@@ -188,8 +203,9 @@ class PluginManagementService
                 'error' => $entry['error'],
                 'can_enable' => false,
                 'can_disable' => $enabled,
-                'can_remove' => true,
-                'can_force_recovery' => true,
+                'can_remove' => $canRemove,
+                'can_force_recovery' => $canRemove,
+                'can_cleanup' => false,
             ];
         }
 
@@ -206,24 +222,41 @@ class PluginManagementService
                 'php' => null,
                 'dependencies' => [],
                 'source' => 'runtime',
-                'status' => 'missing',
+                'status' => 'missing_package',
                 'enabled' => $entry['enabled'],
                 'error' => __('Plugin state exists without an installed package. Remove the stale state entry.'),
                 'can_enable' => false,
                 'can_disable' => false,
                 'can_remove' => true,
                 'can_force_recovery' => true,
+                'can_cleanup' => false,
             ];
         }
 
-        if ($recoveryStatus === 'corrupt') {
+        if ($recoveryStatus === RuntimePluginStore::RECOVERY_PENDING) {
             foreach ($rows as &$row) {
                 if ($row['source'] !== 'runtime') {
                     continue;
                 }
 
-                $row['status'] = 'broken';
-                $row['error'] = __('Runtime plugin recovery metadata is corrupted. Force remove this package to recover it.');
+                $row['status'] = RuntimePluginStore::RECOVERY_PENDING;
+                $row['error'] = __('Runtime plugin recovery is pending and will complete before the next lifecycle change.');
+                $row['can_enable'] = false;
+                $row['can_disable'] = false;
+                $row['can_remove'] = true;
+                $row['can_force_recovery'] = false;
+            }
+            unset($row);
+        }
+
+        if ($recoveryStatus === RuntimePluginStore::RECOVERY_UNRECOVERABLE) {
+            foreach ($rows as &$row) {
+                if ($row['source'] !== 'runtime') {
+                    continue;
+                }
+
+                $row['status'] = RuntimePluginStore::RECOVERY_UNRECOVERABLE;
+                $row['error'] = __('Runtime plugin recovery cannot be completed. Force remove this package or clean up orphaned metadata.');
                 $row['can_enable'] = false;
                 $row['can_disable'] = false;
                 $row['can_remove'] = true;
@@ -232,15 +265,20 @@ class PluginManagementService
             unset($row);
         }
 
+        if ($rows === [] && $recoveryStatus !== RuntimePluginStore::RECOVERY_HEALTHY) {
+            $rows[] = $this->orphanedMetadataRow($recoveryStatus);
+        }
+
         return $rows;
     }
 
     /** @return array<int, array<string, mixed>> */
-    private function runtimePluginsWithCorruptState(): array
+    private function runtimePluginsWithCorruptState(string $recoveryStatus): array
     {
         $rows = [];
 
-        foreach ($this->store->installedPackages() as $id => $path) {
+        foreach ($this->store->managedPackageEntries() as $id => $path) {
+            $canRemove = ! is_link($path);
             $rows[] = [
                 ...$this->manifestPreview($path, $id),
                 'source' => 'runtime',
@@ -249,9 +287,27 @@ class PluginManagementService
                 'error' => __('Runtime plugin state is corrupted. Force remove this package to recover it.'),
                 'can_enable' => false,
                 'can_disable' => false,
-                'can_remove' => true,
-                'can_force_recovery' => true,
+                'can_remove' => $canRemove,
+                'can_force_recovery' => $canRemove,
+                'can_cleanup' => false,
             ];
+        }
+
+        if ($rows === []) {
+            $rows[] = $this->orphanedMetadataRow('orphaned_state', $recoveryStatus);
+        }
+
+        if ($recoveryStatus === RuntimePluginStore::RECOVERY_UNRECOVERABLE) {
+            foreach ($rows as &$row) {
+                $row['status'] = RuntimePluginStore::RECOVERY_UNRECOVERABLE;
+                $row['error'] = __('Runtime plugin state and recovery metadata cannot be completed. Clean up orphaned metadata.');
+                $row['can_enable'] = false;
+                $row['can_disable'] = false;
+                $row['can_remove'] = $row['managed_id'] !== null;
+                $row['can_force_recovery'] = $row['managed_id'] !== null;
+                $row['can_cleanup'] = $row['managed_id'] === null;
+            }
+            unset($row);
         }
 
         return $rows;
@@ -297,6 +353,7 @@ class PluginManagementService
                     'can_disable' => false,
                     'can_remove' => false,
                     'can_force_recovery' => false,
+                    'can_cleanup' => false,
                 ];
             } catch (Throwable $exception) {
                 report($exception);
@@ -321,6 +378,41 @@ class PluginManagementService
             'can_disable' => $enabled,
             'can_remove' => true,
             'can_force_recovery' => false,
+            'can_cleanup' => false,
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function orphanedMetadataRow(string $status, ?string $recoveryStatus = null): array
+    {
+        $error = $status === 'orphaned_state'
+            ? __('Runtime lifecycle metadata is corrupted without an installed package. Clean it up before installing another plugin.')
+            : __('Runtime plugin recovery cannot be completed without an installed package. Clean up the orphaned lifecycle metadata.');
+
+        if ($recoveryStatus === RuntimePluginStore::RECOVERY_UNRECOVERABLE) {
+            $error = __('Runtime lifecycle metadata is corrupted and cannot be recovered. Clean it up before installing another plugin.');
+        }
+
+        return [
+            'id' => 'Runtime lifecycle metadata',
+            'managed_id' => null,
+            'declared_id' => null,
+            'name' => __('Runtime lifecycle metadata'),
+            'version' => null,
+            'description' => __('No runtime package is installed, but lifecycle metadata still requires recovery.'),
+            'entry_class' => null,
+            'core_version' => null,
+            'php' => null,
+            'dependencies' => [],
+            'source' => 'runtime',
+            'status' => $status,
+            'enabled' => false,
+            'error' => $error,
+            'can_enable' => false,
+            'can_disable' => false,
+            'can_remove' => false,
+            'can_force_recovery' => false,
+            'can_cleanup' => $status !== RuntimePluginStore::RECOVERY_PENDING,
         ];
     }
 
@@ -339,6 +431,11 @@ class PluginManagementService
             'php' => null,
             'dependencies' => [],
         ];
+
+        if (is_link($path) || ! is_dir($path)) {
+            return $preview;
+        }
+
         $manifestPath = $path.'/manifest.json';
 
         if (! is_file($manifestPath) || is_link($manifestPath)) {
@@ -433,7 +530,14 @@ class PluginManagementService
         unset($plugin);
 
         foreach ($runtime as &$plugin) {
-            if (in_array($plugin['status'], ['broken', 'incompatible', 'missing'], true)) {
+            if (in_array($plugin['status'], [
+                'broken',
+                'incompatible',
+                'missing_package',
+                'orphaned_state',
+                RuntimePluginStore::RECOVERY_PENDING,
+                RuntimePluginStore::RECOVERY_UNRECOVERABLE,
+            ], true)) {
                 continue;
             }
 

--- a/app/Services/Platform/PluginManagementService.php
+++ b/app/Services/Platform/PluginManagementService.php
@@ -236,6 +236,12 @@ class PluginManagementService
                     'error' => $this->validationError($exception),
                 ];
             }
+
+            $discoveryFailure = $this->composer->runtimeFailureFor($id);
+            if ($discoveryFailure !== null) {
+                $runtime[$id]['status'] = $discoveryFailure['status'];
+                $runtime[$id]['error'] = $discoveryFailure['error'];
+            }
         }
 
         $health = $this->graph->validate($runtime, $hostClasses);
@@ -268,6 +274,23 @@ class PluginManagementService
                         'can_force_recovery' => true,
                         'can_cleanup' => false,
                         'cleanup_key' => null,
+                    ];
+
+                    continue;
+                }
+
+                $lifecycleFailure = $this->lifecycleFailure($metadata['id'], $metadata['entry_class'] ?? null);
+
+                if ($lifecycleFailure !== null) {
+                    $rows[] = [
+                        ...$this->runtimeRow($metadata, $enabled),
+                        'status' => 'load_failed',
+                        'error' => __('Runtime plugin failed during :phase and was not loaded. Disable or remove it.', [
+                            'phase' => $lifecycleFailure['phase'],
+                        ]),
+                        'can_enable' => false,
+                        'can_disable' => $enabled,
+                        'can_remove' => true,
                     ];
 
                     continue;
@@ -556,6 +579,22 @@ class PluginManagementService
             'can_cleanup' => false,
             'cleanup_key' => null,
         ];
+    }
+
+    /** @return array{phase: string}|null */
+    private function lifecycleFailure(string $id, ?string $entryClass): ?array
+    {
+        $registryClass = 'OpenKOS\\Platform\\Plugin\\PluginLifecycleFailureRegistry';
+
+        if (! class_exists($registryClass) || ! app()->bound($registryClass)) {
+            return null;
+        }
+
+        $failure = app($registryClass)->forPlugin($id, $entryClass);
+
+        return is_array($failure) && is_string($failure['phase'] ?? null)
+            ? ['phase' => $failure['phase']]
+            : null;
     }
 
     /** @return array<string, mixed> */

--- a/app/Services/Platform/PluginManagementService.php
+++ b/app/Services/Platform/PluginManagementService.php
@@ -114,6 +114,10 @@ class PluginManagementService
             return __('Runtime plugin metadata could not be cleaned. Check runtime storage permissions and try again.');
         }
 
+        if (str_contains($message, 'orphaned runtime artifacts')) {
+            return __('Clean up orphaned runtime artifacts before installing another plugin.');
+        }
+
         if (
             str_contains($message, 'constraint')
             || str_contains($message, 'dependency')
@@ -146,6 +150,7 @@ class PluginManagementService
         $conflictingIds = $this->discovery->conflictingIds($packages, $state, $hostClasses);
         $runtime = [];
         $rows = [];
+        $filesystemAnomalies = $this->store->managedFilesystemAnomalies();
 
         foreach ($packages as $id => $path) {
             $enabled = $state[$id]['enabled'] ?? false;
@@ -275,6 +280,10 @@ class PluginManagementService
         }
 
         foreach (array_diff_key($state, $packages) as $id => $entry) {
+            $vendor = strstr($id, '/', true);
+            $blockedByVendorAnomaly = is_string($vendor)
+                && array_key_exists('vendor:'.$vendor, $filesystemAnomalies);
+
             $rows[] = [
                 'id' => $id,
                 'managed_id' => $id,
@@ -289,17 +298,19 @@ class PluginManagementService
                 'source' => 'runtime',
                 'status' => 'missing_package',
                 'enabled' => $entry['enabled'],
-                'error' => __('Plugin state exists without an installed package. Remove the stale state entry.'),
+                'error' => $blockedByVendorAnomaly
+                    ? __('An unsafe vendor path blocks this stale plugin state. Clean up the vendor filesystem anomaly first.')
+                    : __('Plugin state exists without an installed package. Remove the stale state entry.'),
                 'can_enable' => false,
                 'can_disable' => false,
-                'can_remove' => true,
-                'can_force_recovery' => true,
+                'can_remove' => ! $blockedByVendorAnomaly,
+                'can_force_recovery' => ! $blockedByVendorAnomaly,
                 'can_cleanup' => false,
                 'cleanup_key' => null,
             ];
         }
 
-        foreach ($this->store->managedFilesystemAnomalies() as $key => $path) {
+        foreach ($filesystemAnomalies as $key => $path) {
             if (str_starts_with($key, 'package:') && array_key_exists(substr($key, strlen('package:')), $packages)) {
                 continue;
             }
@@ -313,6 +324,12 @@ class PluginManagementService
             && ! in_array($recoveryIdentity, array_column($rows, 'managed_id'), true)
         ) {
             $rows[] = $this->recoveryRow($recoveryStatus, $recoveryIdentity);
+        } elseif (
+            $recoveryIdentity === null
+            && $recoveryStatus === RuntimePluginStore::RECOVERY_UNRECOVERABLE
+            && ! array_key_exists('internal:recovery.json', $filesystemAnomalies)
+        ) {
+            $rows[] = $this->orphanedMetadataRow($recoveryStatus, cleanupKey: 'orphaned-recovery');
         } elseif ($recoveryIdentity === null && $recoveryStatus === RuntimePluginStore::RECOVERY_ORPHANED_ARTIFACT) {
             $rows[] = $this->orphanedMetadataRow($recoveryStatus, cleanupKey: 'orphaned-artifacts');
         } elseif ($recoveryIdentity === null && $rows === [] && $recoveryStatus !== RuntimePluginStore::RECOVERY_HEALTHY) {
@@ -349,6 +366,18 @@ class PluginManagementService
                 }
 
                 if ($recoveryIdentity !== null && $row['managed_id'] !== $recoveryIdentity) {
+                    $row['can_remove'] = false;
+                    $row['can_force_recovery'] = false;
+
+                    continue;
+                }
+
+                if ($recoveryIdentity === null) {
+                    $row['status'] = RuntimePluginStore::RECOVERY_UNRECOVERABLE;
+                    $row['error'] = __('Runtime plugin recovery ownership cannot be determined. Clean up the recovery metadata first.');
+                    $row['can_enable'] = false;
+                    $row['can_disable'] = false;
+                    $row['can_remove'] = false;
                     $row['can_force_recovery'] = false;
 
                     continue;
@@ -358,7 +387,7 @@ class PluginManagementService
                 $row['error'] = __('Runtime plugin recovery cannot be completed. Force remove this package or clean up orphaned metadata.');
                 $row['can_enable'] = false;
                 $row['can_disable'] = false;
-                $row['can_remove'] = true;
+                $row['can_remove'] = false;
                 $row['can_force_recovery'] = true;
             }
             unset($row);
@@ -392,14 +421,16 @@ class PluginManagementService
                 'error' => __('Runtime plugin state is corrupted. Force remove this package to recover it.'),
                 'can_enable' => false,
                 'can_disable' => false,
-                'can_remove' => $canRemove,
+                'can_remove' => false,
                 'can_force_recovery' => $canRemove,
                 'can_cleanup' => false,
                 'cleanup_key' => null,
             ];
         }
 
-        foreach ($this->store->managedFilesystemAnomalies() as $key => $path) {
+        $filesystemAnomalies = $this->store->managedFilesystemAnomalies();
+
+        foreach ($filesystemAnomalies as $key => $path) {
             if (str_starts_with($key, 'package:')) {
                 continue;
             }
@@ -407,7 +438,7 @@ class PluginManagementService
             $rows[] = $this->filesystemAnomalyRow($key);
         }
 
-        if ($rows === []) {
+        if ($rows === [] && $recoveryStatus !== RuntimePluginStore::RECOVERY_UNRECOVERABLE) {
             $rows[] = $this->orphanedMetadataRow('orphaned_state', $recoveryStatus);
         }
 
@@ -417,6 +448,12 @@ class PluginManagementService
             && ! in_array($recoveryIdentity, array_column($rows, 'managed_id'), true)
         ) {
             $rows[] = $this->recoveryRow($recoveryStatus, $recoveryIdentity);
+        } elseif (
+            $recoveryIdentity === null
+            && $recoveryStatus === RuntimePluginStore::RECOVERY_UNRECOVERABLE
+            && ! array_key_exists('internal:recovery.json', $filesystemAnomalies)
+        ) {
+            $rows[] = $this->orphanedMetadataRow($recoveryStatus, cleanupKey: 'orphaned-recovery');
         } elseif ($recoveryIdentity === null && $recoveryStatus === RuntimePluginStore::RECOVERY_ORPHANED_ARTIFACT) {
             $rows[] = $this->orphanedMetadataRow($recoveryStatus, cleanupKey: 'orphaned-artifacts');
         }
@@ -428,6 +465,18 @@ class PluginManagementService
                 }
 
                 if ($recoveryIdentity !== null && $row['managed_id'] !== $recoveryIdentity) {
+                    $row['can_remove'] = false;
+                    $row['can_force_recovery'] = false;
+
+                    continue;
+                }
+
+                if ($recoveryIdentity === null) {
+                    $row['status'] = RuntimePluginStore::RECOVERY_UNRECOVERABLE;
+                    $row['error'] = __('Runtime plugin recovery ownership cannot be determined. Clean up the recovery metadata first.');
+                    $row['can_enable'] = false;
+                    $row['can_disable'] = false;
+                    $row['can_remove'] = false;
                     $row['can_force_recovery'] = false;
 
                     continue;
@@ -437,7 +486,7 @@ class PluginManagementService
                 $row['error'] = __('Runtime plugin state and recovery metadata cannot be completed. Clean up orphaned metadata.');
                 $row['can_enable'] = false;
                 $row['can_disable'] = false;
-                $row['can_remove'] = $row['managed_id'] !== null;
+                $row['can_remove'] = false;
                 $row['can_force_recovery'] = $row['managed_id'] !== null;
                 $row['can_cleanup'] = $row['managed_id'] === null;
             }
@@ -521,6 +570,7 @@ class PluginManagementService
     /** @return array<string, mixed> */
     private function orphanedMetadataRow(string $status, ?string $recoveryStatus = null, ?string $cleanupKey = null): array
     {
+        $unknownRecovery = $cleanupKey === 'orphaned-recovery';
         $error = match ($status) {
             'orphaned_state' => __('Runtime lifecycle metadata is corrupted without an installed package. Clean it up before installing another plugin.'),
             RuntimePluginStore::RECOVERY_ORPHANED_ARTIFACT => __('Stale runtime recovery artifacts were found. Clean them up before installing another plugin.'),
@@ -537,7 +587,9 @@ class PluginManagementService
             'declared_id' => null,
             'name' => __('Runtime lifecycle metadata'),
             'version' => null,
-            'description' => __('No runtime package is installed, but lifecycle metadata still requires recovery.'),
+            'description' => $unknownRecovery
+                ? __('Runtime recovery metadata exists, but its package identity cannot be trusted.')
+                : __('No runtime package is installed, but lifecycle metadata still requires recovery.'),
             'entry_class' => null,
             'core_version' => null,
             'php' => null,

--- a/app/Services/Platform/PluginManagementService.php
+++ b/app/Services/Platform/PluginManagementService.php
@@ -14,6 +14,7 @@ class PluginManagementService
         private RuntimePluginStore $store,
         private RuntimePluginArtifactValidator $validator,
         private ComposerPluginDiscovery $composer,
+        private RuntimePluginDiscovery $discovery,
         private PluginInstaller $installer,
         private RuntimePluginGraphValidator $graph,
     ) {}
@@ -88,9 +89,9 @@ class PluginManagementService
         $this->installer->remove($id, $force);
     }
 
-    public function cleanupOrphanedMetadata(): void
+    public function cleanupOrphanedMetadata(?string $recoveryId = null, ?string $cleanupKey = null): void
     {
-        $this->installer->cleanupOrphanedMetadata();
+        $this->installer->cleanupOrphanedMetadata($recoveryId, $cleanupKey);
     }
 
     public function userMessage(Throwable $exception): string
@@ -141,11 +142,64 @@ class PluginManagementService
         }
 
         $packages = $this->store->managedPackageEntries();
+        $hostClasses = $this->hostPluginClasses();
+        $conflictingIds = $this->discovery->conflictingIds($packages, $state, $hostClasses);
         $runtime = [];
         $rows = [];
 
         foreach ($packages as $id => $path) {
             $enabled = $state[$id]['enabled'] ?? false;
+
+            if (is_link($path)) {
+                $runtime[$id] = [
+                    'metadata' => null,
+                    'enabled' => $enabled,
+                    'status' => 'broken',
+                    'error' => 'Runtime plugin package path is a symlink and cannot be loaded.',
+                    'cleanup_key' => 'package:'.$id,
+                ];
+
+                continue;
+            }
+
+            if (in_array($id, $conflictingIds, true)) {
+                try {
+                    $runtime[$id] = [
+                        'metadata' => $this->validator->inspectStaticMetadata($path, $id),
+                        'enabled' => $enabled,
+                        'status' => 'conflict',
+                        'error' => 'Runtime plugin conflicts with a Composer or explicit plugin.',
+                    ];
+                } catch (Throwable) {
+                    $runtime[$id] = [
+                        'metadata' => null,
+                        'enabled' => $enabled,
+                        'status' => 'conflict',
+                        'error' => 'Runtime plugin conflicts with a Composer or explicit plugin.',
+                    ];
+                }
+
+                continue;
+            }
+
+            if (! $enabled) {
+                try {
+                    $runtime[$id] = [
+                        'metadata' => $this->validator->inspectStaticMetadata($path, $id),
+                        'enabled' => false,
+                    ];
+                } catch (Throwable $exception) {
+                    report($exception);
+                    $runtime[$id] = [
+                        'metadata' => null,
+                        'enabled' => false,
+                        'status' => $this->validationStatus($exception),
+                        'error' => $this->validationError($exception),
+                    ];
+                }
+
+                continue;
+            }
 
             try {
                 $runtime[$id] = [
@@ -163,11 +217,20 @@ class PluginManagementService
             }
         }
 
-        $health = $this->graph->validate($runtime, $this->hostPluginClasses());
+        $health = $this->graph->validate($runtime, $hostClasses);
 
         foreach ($packages as $id => $path) {
             $entry = $runtime[$id];
             $enabled = $entry['enabled'];
+
+            if (isset($entry['cleanup_key'])) {
+                $rows[] = [
+                    ...$this->filesystemAnomalyRow($entry['cleanup_key']),
+                    'enabled' => $enabled,
+                ];
+
+                continue;
+            }
 
             if (is_array($entry['metadata'])) {
                 $metadata = $entry['metadata'];
@@ -183,6 +246,7 @@ class PluginManagementService
                         'can_remove' => true,
                         'can_force_recovery' => true,
                         'can_cleanup' => false,
+                        'cleanup_key' => null,
                     ];
 
                     continue;
@@ -206,6 +270,7 @@ class PluginManagementService
                 'can_remove' => $canRemove,
                 'can_force_recovery' => $canRemove,
                 'can_cleanup' => false,
+                'cleanup_key' => $entry['cleanup_key'] ?? null,
             ];
         }
 
@@ -230,12 +295,37 @@ class PluginManagementService
                 'can_remove' => true,
                 'can_force_recovery' => true,
                 'can_cleanup' => false,
+                'cleanup_key' => null,
             ];
+        }
+
+        foreach ($this->store->managedFilesystemAnomalies() as $key => $path) {
+            if (str_starts_with($key, 'package:') && array_key_exists(substr($key, strlen('package:')), $packages)) {
+                continue;
+            }
+
+            $rows[] = $this->filesystemAnomalyRow($key);
+        }
+
+        $recoveryIdentity = $this->store->recoveryIdentity();
+        if (
+            $recoveryIdentity !== null
+            && ! in_array($recoveryIdentity, array_column($rows, 'managed_id'), true)
+        ) {
+            $rows[] = $this->recoveryRow($recoveryStatus, $recoveryIdentity);
+        } elseif ($recoveryIdentity === null && $recoveryStatus === RuntimePluginStore::RECOVERY_ORPHANED_ARTIFACT) {
+            $rows[] = $this->orphanedMetadataRow($recoveryStatus, cleanupKey: 'orphaned-artifacts');
+        } elseif ($recoveryIdentity === null && $rows === [] && $recoveryStatus !== RuntimePluginStore::RECOVERY_HEALTHY) {
+            $rows[] = $this->orphanedMetadataRow($recoveryStatus);
         }
 
         if ($recoveryStatus === RuntimePluginStore::RECOVERY_PENDING) {
             foreach ($rows as &$row) {
-                if ($row['source'] !== 'runtime') {
+                if (
+                    $row['source'] !== 'runtime'
+                    || ($row['cleanup_key'] ?? null) !== null
+                    || ($recoveryIdentity !== null && $row['managed_id'] !== $recoveryIdentity)
+                ) {
                     continue;
                 }
 
@@ -251,7 +341,16 @@ class PluginManagementService
 
         if ($recoveryStatus === RuntimePluginStore::RECOVERY_UNRECOVERABLE) {
             foreach ($rows as &$row) {
-                if ($row['source'] !== 'runtime') {
+                if (
+                    $row['source'] !== 'runtime'
+                    || ($row['cleanup_key'] ?? null) !== null
+                ) {
+                    continue;
+                }
+
+                if ($recoveryIdentity !== null && $row['managed_id'] !== $recoveryIdentity) {
+                    $row['can_force_recovery'] = false;
+
                     continue;
                 }
 
@@ -265,10 +364,6 @@ class PluginManagementService
             unset($row);
         }
 
-        if ($rows === [] && $recoveryStatus !== RuntimePluginStore::RECOVERY_HEALTHY) {
-            $rows[] = $this->orphanedMetadataRow($recoveryStatus);
-        }
-
         return $rows;
     }
 
@@ -279,6 +374,16 @@ class PluginManagementService
 
         foreach ($this->store->managedPackageEntries() as $id => $path) {
             $canRemove = ! is_link($path);
+
+            if (is_link($path)) {
+                $rows[] = [
+                    ...$this->filesystemAnomalyRow('package:'.$id),
+                    'enabled' => false,
+                ];
+
+                continue;
+            }
+
             $rows[] = [
                 ...$this->manifestPreview($path, $id),
                 'source' => 'runtime',
@@ -290,15 +395,44 @@ class PluginManagementService
                 'can_remove' => $canRemove,
                 'can_force_recovery' => $canRemove,
                 'can_cleanup' => false,
+                'cleanup_key' => null,
             ];
+        }
+
+        foreach ($this->store->managedFilesystemAnomalies() as $key => $path) {
+            if (str_starts_with($key, 'package:')) {
+                continue;
+            }
+
+            $rows[] = $this->filesystemAnomalyRow($key);
         }
 
         if ($rows === []) {
             $rows[] = $this->orphanedMetadataRow('orphaned_state', $recoveryStatus);
         }
 
+        $recoveryIdentity = $this->store->recoveryIdentity();
+        if (
+            $recoveryIdentity !== null
+            && ! in_array($recoveryIdentity, array_column($rows, 'managed_id'), true)
+        ) {
+            $rows[] = $this->recoveryRow($recoveryStatus, $recoveryIdentity);
+        } elseif ($recoveryIdentity === null && $recoveryStatus === RuntimePluginStore::RECOVERY_ORPHANED_ARTIFACT) {
+            $rows[] = $this->orphanedMetadataRow($recoveryStatus, cleanupKey: 'orphaned-artifacts');
+        }
+
         if ($recoveryStatus === RuntimePluginStore::RECOVERY_UNRECOVERABLE) {
             foreach ($rows as &$row) {
+                if (($row['cleanup_key'] ?? null) !== null) {
+                    continue;
+                }
+
+                if ($recoveryIdentity !== null && $row['managed_id'] !== $recoveryIdentity) {
+                    $row['can_force_recovery'] = false;
+
+                    continue;
+                }
+
                 $row['status'] = RuntimePluginStore::RECOVERY_UNRECOVERABLE;
                 $row['error'] = __('Runtime plugin state and recovery metadata cannot be completed. Clean up orphaned metadata.');
                 $row['can_enable'] = false;
@@ -354,6 +488,7 @@ class PluginManagementService
                     'can_remove' => false,
                     'can_force_recovery' => false,
                     'can_cleanup' => false,
+                    'cleanup_key' => null,
                 ];
             } catch (Throwable $exception) {
                 report($exception);
@@ -379,15 +514,18 @@ class PluginManagementService
             'can_remove' => true,
             'can_force_recovery' => false,
             'can_cleanup' => false,
+            'cleanup_key' => null,
         ];
     }
 
     /** @return array<string, mixed> */
-    private function orphanedMetadataRow(string $status, ?string $recoveryStatus = null): array
+    private function orphanedMetadataRow(string $status, ?string $recoveryStatus = null, ?string $cleanupKey = null): array
     {
-        $error = $status === 'orphaned_state'
-            ? __('Runtime lifecycle metadata is corrupted without an installed package. Clean it up before installing another plugin.')
-            : __('Runtime plugin recovery cannot be completed without an installed package. Clean up the orphaned lifecycle metadata.');
+        $error = match ($status) {
+            'orphaned_state' => __('Runtime lifecycle metadata is corrupted without an installed package. Clean it up before installing another plugin.'),
+            RuntimePluginStore::RECOVERY_ORPHANED_ARTIFACT => __('Stale runtime recovery artifacts were found. Clean them up before installing another plugin.'),
+            default => __('Runtime plugin recovery cannot be completed without an installed package. Clean up the orphaned lifecycle metadata.'),
+        };
 
         if ($recoveryStatus === RuntimePluginStore::RECOVERY_UNRECOVERABLE) {
             $error = __('Runtime lifecycle metadata is corrupted and cannot be recovered. Clean it up before installing another plugin.');
@@ -412,7 +550,67 @@ class PluginManagementService
             'can_disable' => false,
             'can_remove' => false,
             'can_force_recovery' => false,
-            'can_cleanup' => $status !== RuntimePluginStore::RECOVERY_PENDING,
+            'can_cleanup' => $cleanupKey !== null || $status !== RuntimePluginStore::RECOVERY_PENDING,
+            'cleanup_key' => $cleanupKey,
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function recoveryRow(string $status, string $id): array
+    {
+        return [
+            'id' => $id,
+            'managed_id' => $id,
+            'declared_id' => null,
+            'name' => __('Runtime plugin recovery'),
+            'version' => null,
+            'description' => __('Recovery metadata exists for a package that is not installed.'),
+            'entry_class' => null,
+            'core_version' => null,
+            'php' => null,
+            'dependencies' => [],
+            'source' => 'runtime',
+            'status' => $status,
+            'enabled' => false,
+            'error' => $status === RuntimePluginStore::RECOVERY_PENDING
+                ? __('Runtime plugin recovery is pending and will complete before the next lifecycle change.')
+                : __('Runtime plugin recovery cannot be completed. Clean up this recovery record.'),
+            'can_enable' => false,
+            'can_disable' => false,
+            'can_remove' => false,
+            'can_force_recovery' => false,
+            'can_cleanup' => $status === RuntimePluginStore::RECOVERY_UNRECOVERABLE,
+            'cleanup_key' => 'recovery:'.$id,
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function filesystemAnomalyRow(string $key): array
+    {
+        $managedId = str_starts_with($key, 'package:') ? substr($key, strlen('package:')) : null;
+        $label = $managedId ?? substr($key, strpos($key, ':') + 1);
+
+        return [
+            'id' => $managedId ?? $key,
+            'managed_id' => $managedId,
+            'declared_id' => null,
+            'name' => __('Unsafe runtime filesystem path'),
+            'version' => null,
+            'description' => __('A managed runtime path is a symlink and was not followed.'),
+            'entry_class' => null,
+            'core_version' => null,
+            'php' => null,
+            'dependencies' => [],
+            'source' => 'runtime',
+            'status' => 'broken',
+            'enabled' => false,
+            'error' => __('Runtime path :path is a symlink. Remove the symlink before installing or loading plugins.', ['path' => $label]),
+            'can_enable' => false,
+            'can_disable' => false,
+            'can_remove' => false,
+            'can_force_recovery' => false,
+            'can_cleanup' => true,
+            'cleanup_key' => $key,
         ];
     }
 

--- a/app/Services/Platform/PluginManagementService.php
+++ b/app/Services/Platform/PluginManagementService.php
@@ -155,6 +155,18 @@ class PluginManagementService
         foreach ($packages as $id => $path) {
             $enabled = $state[$id]['enabled'] ?? false;
 
+            if (array_key_exists('package:'.$id, $filesystemAnomalies)) {
+                $runtime[$id] = [
+                    'metadata' => null,
+                    'enabled' => $enabled,
+                    'status' => 'broken',
+                    'error' => __('Runtime plugin package path is not a real directory.'),
+                    'cleanup_key' => 'package:'.$id,
+                ];
+
+                continue;
+            }
+
             if (is_link($path)) {
                 $runtime[$id] = [
                     'metadata' => null,
@@ -208,7 +220,7 @@ class PluginManagementService
 
             try {
                 $runtime[$id] = [
-                    'metadata' => $this->validator->validateInFreshProcess($path, $id),
+                    'metadata' => $this->validator->inspectStaticMetadata($path, $id),
                     'enabled' => $enabled,
                 ];
             } catch (Throwable $exception) {
@@ -230,7 +242,7 @@ class PluginManagementService
 
             if (isset($entry['cleanup_key'])) {
                 $rows[] = [
-                    ...$this->filesystemAnomalyRow($entry['cleanup_key']),
+                    ...$this->filesystemAnomalyRow($entry['cleanup_key'], $path),
                     'enabled' => $enabled,
                 ];
 
@@ -315,7 +327,7 @@ class PluginManagementService
                 continue;
             }
 
-            $rows[] = $this->filesystemAnomalyRow($key);
+            $rows[] = $this->filesystemAnomalyRow($key, $path);
         }
 
         $recoveryIdentity = $this->store->recoveryIdentity();
@@ -365,21 +377,7 @@ class PluginManagementService
                     continue;
                 }
 
-                if ($recoveryIdentity !== null && $row['managed_id'] !== $recoveryIdentity) {
-                    $row['can_remove'] = false;
-                    $row['can_force_recovery'] = false;
-
-                    continue;
-                }
-
-                if ($recoveryIdentity === null) {
-                    $row['status'] = RuntimePluginStore::RECOVERY_UNRECOVERABLE;
-                    $row['error'] = __('Runtime plugin recovery ownership cannot be determined. Clean up the recovery metadata first.');
-                    $row['can_enable'] = false;
-                    $row['can_disable'] = false;
-                    $row['can_remove'] = false;
-                    $row['can_force_recovery'] = false;
-
+                if ($recoveryIdentity === null || $row['managed_id'] !== $recoveryIdentity) {
                     continue;
                 }
 
@@ -406,7 +404,7 @@ class PluginManagementService
 
             if (is_link($path)) {
                 $rows[] = [
-                    ...$this->filesystemAnomalyRow('package:'.$id),
+                    ...$this->filesystemAnomalyRow('package:'.$id, $path),
                     'enabled' => false,
                 ];
 
@@ -435,7 +433,7 @@ class PluginManagementService
                 continue;
             }
 
-            $rows[] = $this->filesystemAnomalyRow($key);
+            $rows[] = $this->filesystemAnomalyRow($key, $path);
         }
 
         if ($rows === [] && $recoveryStatus !== RuntimePluginStore::RECOVERY_UNRECOVERABLE) {
@@ -464,21 +462,7 @@ class PluginManagementService
                     continue;
                 }
 
-                if ($recoveryIdentity !== null && $row['managed_id'] !== $recoveryIdentity) {
-                    $row['can_remove'] = false;
-                    $row['can_force_recovery'] = false;
-
-                    continue;
-                }
-
-                if ($recoveryIdentity === null) {
-                    $row['status'] = RuntimePluginStore::RECOVERY_UNRECOVERABLE;
-                    $row['error'] = __('Runtime plugin recovery ownership cannot be determined. Clean up the recovery metadata first.');
-                    $row['can_enable'] = false;
-                    $row['can_disable'] = false;
-                    $row['can_remove'] = false;
-                    $row['can_force_recovery'] = false;
-
+                if ($recoveryIdentity === null || $row['managed_id'] !== $recoveryIdentity) {
                     continue;
                 }
 
@@ -637,10 +621,12 @@ class PluginManagementService
     }
 
     /** @return array<string, mixed> */
-    private function filesystemAnomalyRow(string $key): array
+    private function filesystemAnomalyRow(string $key, ?string $path = null): array
     {
         $managedId = str_starts_with($key, 'package:') ? substr($key, strlen('package:')) : null;
         $label = $managedId ?? substr($key, strpos($key, ':') + 1);
+        $canCleanup = $path === null || $this->canCleanupFilesystemPath($path);
+        $isSymlink = $path !== null && is_link($path);
 
         return [
             'id' => $managedId ?? $key,
@@ -648,7 +634,9 @@ class PluginManagementService
             'declared_id' => null,
             'name' => __('Unsafe runtime filesystem path'),
             'version' => null,
-            'description' => __('A managed runtime path is a symlink and was not followed.'),
+            'description' => $isSymlink
+                ? __('A managed runtime path is a symlink and was not followed.')
+                : __('A managed runtime path has an unexpected filesystem type.'),
             'entry_class' => null,
             'core_version' => null,
             'php' => null,
@@ -656,14 +644,27 @@ class PluginManagementService
             'source' => 'runtime',
             'status' => 'broken',
             'enabled' => false,
-            'error' => __('Runtime path :path is a symlink. Remove the symlink before installing or loading plugins.', ['path' => $label]),
+            'error' => $canCleanup
+                ? ($isSymlink
+                    ? __('Runtime path :path is a symlink. Remove the symlink before installing or loading plugins.', ['path' => $label])
+                    : __('Runtime path :path is an unexpected filesystem node and is not used.', ['path' => $label]))
+                : __('Runtime path :path cannot be safely inspected or removed. Fix its permissions before continuing.', ['path' => $label]),
             'can_enable' => false,
             'can_disable' => false,
             'can_remove' => false,
             'can_force_recovery' => false,
-            'can_cleanup' => true,
+            'can_cleanup' => $canCleanup,
             'cleanup_key' => $key,
         ];
+    }
+
+    private function canCleanupFilesystemPath(string $path): bool
+    {
+        if (is_link($path)) {
+            return true;
+        }
+
+        return ! is_dir($path) || @scandir($path) !== false;
     }
 
     /** @return array<string, mixed> */

--- a/app/Services/Platform/RuntimePluginArtifactValidator.php
+++ b/app/Services/Platform/RuntimePluginArtifactValidator.php
@@ -130,12 +130,32 @@ final class RuntimePluginArtifactValidator
             throw new InvalidArgumentException('Runtime plugin artifact directory is missing or unsafe.');
         }
 
+        $this->validateTree($directory);
         $metadata = $this->validateManifest($this->readJsonFile($directory.'/manifest.json', 'manifest.json'));
 
         if ($expectedId !== null && $metadata['id'] !== $expectedId) {
             throw new InvalidArgumentException(
                 "Runtime plugin manifest ID [{$metadata['id']}] does not match installed package [{$expectedId}].",
             );
+        }
+
+        $composer = $this->readJsonFile($directory.'/composer.json', 'composer.json');
+        $lock = $this->readJsonFile($directory.'/composer.lock', 'composer.lock');
+
+        if (! is_array($lock['packages'] ?? null)) {
+            throw new InvalidArgumentException('Runtime plugin composer.lock must contain packages.');
+        }
+
+        if (($composer['name'] ?? null) !== $metadata['id']) {
+            throw new InvalidArgumentException('Runtime plugin composer name must match manifest ID.');
+        }
+
+        if (data_get($composer, 'extra.openkos.plugin') !== $metadata['entry_class']) {
+            throw new InvalidArgumentException('Runtime plugin Composer metadata must match manifest entry class.');
+        }
+
+        if (! is_file($directory.'/vendor/autoload.php') || is_link($directory.'/vendor/autoload.php')) {
+            throw new InvalidArgumentException('Runtime plugin artifact must include vendor/autoload.php.');
         }
 
         return $metadata;
@@ -465,6 +485,10 @@ final class RuntimePluginArtifactValidator
 
             if ($file->isLink() || is_link($path)) {
                 throw new InvalidArgumentException("Runtime plugin artifact contains symlink [{$relative}].");
+            }
+
+            if (! $file->isDir() && ! $file->isFile()) {
+                throw new InvalidArgumentException("Runtime plugin artifact contains unsafe filesystem node [{$relative}].");
             }
 
             $entryCount++;

--- a/app/Services/Platform/RuntimePluginArtifactValidator.php
+++ b/app/Services/Platform/RuntimePluginArtifactValidator.php
@@ -111,6 +111,37 @@ final class RuntimePluginArtifactValidator
     }
 
     /**
+     * Read manifest metadata without loading the runtime package.
+     *
+     * @return array{
+     *     id: string,
+     *     name: string,
+     *     version: string,
+     *     description: string,
+     *     entry_class: class-string<Plugin>,
+     *     core_version: string,
+     *     php: string,
+     *     dependencies: array<int, string>
+     * }
+     */
+    public function inspectStaticMetadata(string $directory, ?string $expectedId = null): array
+    {
+        if (! is_dir($directory) || is_link($directory)) {
+            throw new InvalidArgumentException('Runtime plugin artifact directory is missing or unsafe.');
+        }
+
+        $metadata = $this->validateManifest($this->readJsonFile($directory.'/manifest.json', 'manifest.json'));
+
+        if ($expectedId !== null && $metadata['id'] !== $expectedId) {
+            throw new InvalidArgumentException(
+                "Runtime plugin manifest ID [{$metadata['id']}] does not match installed package [{$expectedId}].",
+            );
+        }
+
+        return $metadata;
+    }
+
+    /**
      * @return array{
      *     id: string,
      *     name: string,

--- a/app/Services/Platform/RuntimePluginArtifactValidator.php
+++ b/app/Services/Platform/RuntimePluginArtifactValidator.php
@@ -251,6 +251,10 @@ final class RuntimePluginArtifactValidator
             }
         }
 
+        if (preg_match('/^(?:[A-Za-z_][A-Za-z0-9_]*\\\\)*[A-Za-z_][A-Za-z0-9_]*$/', $manifest['entry_class']) !== 1) {
+            throw new InvalidArgumentException('Runtime plugin manifest entry_class must be a valid PHP class name.');
+        }
+
         if (! preg_match('/^[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*$/', $manifest['id'])) {
             throw new InvalidArgumentException("Runtime plugin ID [{$manifest['id']}] is unsafe.");
         }

--- a/app/Services/Platform/RuntimePluginDiscovery.php
+++ b/app/Services/Platform/RuntimePluginDiscovery.php
@@ -29,7 +29,7 @@ final class RuntimePluginDiscovery
             return $this->store->withLock(function (RuntimePluginStore $store) use ($existingClasses): array {
                 $state = $store->readState();
                 $packages = $store->installedPackages();
-                $conflictingIds = $this->assertNoComposerConflicts($packages, $state, $existingClasses);
+                $conflictingIds = $this->conflictingIds($packages, $state, $existingClasses);
                 $runtime = [];
 
                 foreach ($packages as $id => $path) {
@@ -39,6 +39,17 @@ final class RuntimePluginDiscovery
                         $runtime[$id] = [
                             'metadata' => null,
                             'enabled' => false,
+                        ];
+
+                        continue;
+                    }
+
+                    if (in_array($id, $conflictingIds, true)) {
+                        $runtime[$id] = [
+                            'metadata' => null,
+                            'enabled' => true,
+                            'status' => 'conflict',
+                            'error' => 'Runtime plugin conflicts with a Composer or explicit plugin.',
                         ];
 
                         continue;
@@ -99,7 +110,7 @@ final class RuntimePluginDiscovery
      * @param  array<int, string>  $existingClasses
      * @return array<int, string>
      */
-    private function assertNoComposerConflicts(array $packages, array $state, array $existingClasses): array
+    public function conflictingIds(array $packages, array $state, array $existingClasses): array
     {
         $existingIds = [];
         $conflictingIds = [];

--- a/app/Services/Platform/RuntimePluginDiscovery.php
+++ b/app/Services/Platform/RuntimePluginDiscovery.php
@@ -110,7 +110,7 @@ final class RuntimePluginDiscovery
      * @param  array<int, string>  $existingClasses
      * @return array<int, string>
      */
-    public function conflictingIds(array $packages, array $state, array $existingClasses): array
+    public function conflictingIds(array $packages, array $state, array $existingClasses, bool $includeDisabled = false): array
     {
         $existingIds = [];
         $conflictingIds = [];
@@ -128,7 +128,7 @@ final class RuntimePluginDiscovery
         }
 
         foreach ($packages as $id => $path) {
-            if (! ($state[$id]['enabled'] ?? false)) {
+            if (! $includeDisabled && ! ($state[$id]['enabled'] ?? false)) {
                 continue;
             }
 
@@ -178,7 +178,7 @@ final class RuntimePluginDiscovery
     private function readEntryClass(string $path): string
     {
         $manifestPath = $path.'/manifest.json';
-        if (! is_file($manifestPath)) {
+        if (! is_file($manifestPath) || is_link($manifestPath)) {
             throw new InvalidArgumentException('Runtime plugin manifest is missing.');
         }
 

--- a/app/Services/Platform/RuntimePluginDiscovery.php
+++ b/app/Services/Platform/RuntimePluginDiscovery.php
@@ -30,7 +30,23 @@ final class RuntimePluginDiscovery
                 $state = $store->readState();
                 $packages = $store->installedPackages();
                 $conflictingIds = $this->conflictingIds($packages, $state, $existingClasses);
+                $recoveryStatus = $store->recoveryStatus();
+                $recoveryStatuses = [];
+
+                foreach ($store->recoveryRecords() as $record) {
+                    if ($record['id'] !== null) {
+                        $recoveryStatuses[$record['id']] = $record['status'];
+                    }
+                }
+
                 $runtime = [];
+
+                if ($recoveryStatuses === [] && $recoveryStatus !== RuntimePluginStore::RECOVERY_HEALTHY) {
+                    Log::error('Runtime plugin discovery found recovery state without a trusted package identity.', [
+                        'path' => $store->rootPath(),
+                        'status' => $recoveryStatus,
+                    ]);
+                }
 
                 foreach ($packages as $id => $path) {
                     $enabled = $state[$id]['enabled'] ?? false;
@@ -39,6 +55,23 @@ final class RuntimePluginDiscovery
                         $runtime[$id] = [
                             'metadata' => null,
                             'enabled' => false,
+                        ];
+
+                        continue;
+                    }
+
+                    if (
+                        isset($recoveryStatuses[$id])
+                        && in_array($recoveryStatuses[$id], [
+                            RuntimePluginStore::RECOVERY_PENDING,
+                            RuntimePluginStore::RECOVERY_UNRECOVERABLE,
+                        ], true)
+                    ) {
+                        $runtime[$id] = [
+                            'metadata' => null,
+                            'enabled' => $enabled,
+                            'status' => $recoveryStatuses[$id],
+                            'error' => 'Runtime plugin recovery must complete before the package can be loaded.',
                         ];
 
                         continue;
@@ -57,11 +90,11 @@ final class RuntimePluginDiscovery
 
                     try {
                         $runtime[$id] = [
-                            'metadata' => $this->validator->validate($path, $id),
+                            'metadata' => $this->validator->inspectStaticMetadata($path, $id),
                             'enabled' => $enabled,
                         ];
                     } catch (Throwable $exception) {
-                        Log::error('Runtime plugin could not be loaded.', [
+                        Log::error('Runtime plugin could not be inspected.', [
                             'plugin' => $id,
                             'path' => $path,
                             'exception' => $exception,
@@ -89,11 +122,30 @@ final class RuntimePluginDiscovery
                 }
 
                 foreach ($report['loadable'] as $id) {
-                    $plugins[] = $runtime[$id]['metadata']['entry_class'];
+                    $path = $packages[$id];
+
+                    try {
+                        $metadata = $this->validator->validateInFreshProcess($path, $id);
+                        require_once $path.'/vendor/autoload.php';
+
+                        if (! class_exists($metadata['entry_class'])) {
+                            throw new InvalidArgumentException(
+                                "Runtime plugin entry class [{$metadata['entry_class']}] does not exist.",
+                            );
+                        }
+
+                        $plugins[] = $metadata['entry_class'];
+                    } catch (Throwable $exception) {
+                        Log::error('Runtime plugin failed fresh-process validation.', [
+                            'plugin' => $id,
+                            'path' => $path,
+                            'exception' => $exception,
+                        ]);
+                    }
                 }
 
                 return $plugins;
-            });
+            }, false);
         } catch (Throwable $exception) {
             Log::error('Runtime plugin discovery failed.', [
                 'path' => $this->store->rootPath(),
@@ -115,6 +167,10 @@ final class RuntimePluginDiscovery
         $existingIds = [];
         $conflictingIds = [];
         $runtimeEntryClasses = [];
+        $existingClassNames = array_fill_keys(array_map(
+            fn (string $class): string => $this->canonicalClassName($class),
+            array_values(array_filter($existingClasses, 'is_string')),
+        ), true);
         foreach ($existingClasses as $class) {
             if (! is_string($class) || ! class_exists($class) || ! is_a($class, Plugin::class, true)) {
                 continue;
@@ -144,9 +200,10 @@ final class RuntimePluginDiscovery
                 continue;
             }
 
-            $runtimeEntryClasses[$entryClass][] = $id;
+            $canonicalEntryClass = $this->canonicalClassName($entryClass);
+            $runtimeEntryClasses[$canonicalEntryClass][] = $id;
 
-            if (in_array($entryClass, $existingClasses, true) || isset($existingIds[$id])) {
+            if (isset($existingClassNames[$canonicalEntryClass]) || isset($existingIds[$id])) {
                 $conflictingIds[] = $id;
                 Log::warning('Runtime plugin skipped because a Composer or explicit plugin takes precedence.', [
                     'plugin' => $id,
@@ -198,5 +255,10 @@ final class RuntimePluginDiscovery
         }
 
         return $manifest['entry_class'];
+    }
+
+    private function canonicalClassName(string $class): string
+    {
+        return strtolower(ltrim(trim($class), '\\'));
     }
 }

--- a/app/Services/Platform/RuntimePluginDiscovery.php
+++ b/app/Services/Platform/RuntimePluginDiscovery.php
@@ -141,7 +141,22 @@ final class RuntimePluginDiscovery
 
                         try {
                             $metadata = $this->validator->validateInFreshProcess($path, $id);
-                            require_once $path.'/vendor/autoload.php';
+                            $packagePath = $store->installedPackagePath($id);
+                            $autoloadPath = $packagePath.'/vendor/autoload.php';
+                            $resolvedPackagePath = realpath($packagePath);
+                            $resolvedAutoloadPath = realpath($autoloadPath);
+
+                            if (
+                                ! is_file($autoloadPath)
+                                || is_link($autoloadPath)
+                                || ! is_string($resolvedPackagePath)
+                                || ! is_string($resolvedAutoloadPath)
+                                || ! str_starts_with($resolvedAutoloadPath, $resolvedPackagePath.DIRECTORY_SEPARATOR)
+                            ) {
+                                throw new InvalidArgumentException('Runtime plugin autoloader path is missing or unsafe.');
+                            }
+
+                            require_once $autoloadPath;
 
                             if (! class_exists($metadata['entry_class'])) {
                                 throw new InvalidArgumentException(

--- a/app/Services/Platform/RuntimePluginDiscovery.php
+++ b/app/Services/Platform/RuntimePluginDiscovery.php
@@ -35,6 +35,15 @@ final class RuntimePluginDiscovery
                 foreach ($packages as $id => $path) {
                     $enabled = $state[$id]['enabled'] ?? false;
 
+                    if (! $enabled) {
+                        $runtime[$id] = [
+                            'metadata' => null,
+                            'enabled' => false,
+                        ];
+
+                        continue;
+                    }
+
                     try {
                         $runtime[$id] = [
                             'metadata' => $this->validator->validate($path, $id),

--- a/app/Services/Platform/RuntimePluginDiscovery.php
+++ b/app/Services/Platform/RuntimePluginDiscovery.php
@@ -9,6 +9,9 @@ use Throwable;
 
 final class RuntimePluginDiscovery
 {
+    /** @var array<string, array{status: string, error: string}> */
+    private array $failures = [];
+
     public function __construct(
         private RuntimePluginStore $store,
         private RuntimePluginArtifactValidator $validator,
@@ -21,6 +24,8 @@ final class RuntimePluginDiscovery
      */
     public function discover(array $existingClasses = []): array
     {
+        $this->failures = [];
+
         if (! config('platform.runtime.enabled', true)) {
             return [];
         }
@@ -109,7 +114,65 @@ final class RuntimePluginDiscovery
                 }
 
                 $report = $this->graph->validate($runtime, $existingClasses);
-                $plugins = [];
+                $validated = [];
+                $pending = $report['loadable'];
+
+                while ($pending !== []) {
+                    $progress = false;
+
+                    foreach ($pending as $key => $id) {
+                        $metadata = $runtime[$id]['metadata'];
+                        $dependenciesReady = true;
+
+                        foreach ($metadata['dependencies'] ?? [] as $dependency) {
+                            if (isset($runtime[$dependency]) && ! isset($validated[$dependency])) {
+                                $dependenciesReady = false;
+                                break;
+                            }
+                        }
+
+                        if (! $dependenciesReady) {
+                            continue;
+                        }
+
+                        unset($pending[$key]);
+                        $progress = true;
+                        $path = $packages[$id];
+
+                        try {
+                            $metadata = $this->validator->validateInFreshProcess($path, $id);
+                            require_once $path.'/vendor/autoload.php';
+
+                            if (! class_exists($metadata['entry_class'])) {
+                                throw new InvalidArgumentException(
+                                    "Runtime plugin entry class [{$metadata['entry_class']}] does not exist.",
+                                );
+                            }
+
+                            $runtime[$id]['metadata'] = $metadata;
+                            $validated[$id] = $metadata['entry_class'];
+                            $report = $this->graph->validate($runtime, $existingClasses);
+                        } catch (Throwable $exception) {
+                            Log::error('Runtime plugin failed fresh-process validation.', [
+                                'plugin' => $id,
+                                'path' => $path,
+                                'exception' => $exception,
+                            ]);
+                            $runtime[$id]['status'] = 'broken';
+                            $runtime[$id]['error'] = 'Runtime plugin failed fresh-process validation.';
+                            $this->failures[$id] = [
+                                'status' => 'broken',
+                                'error' => $runtime[$id]['error'],
+                            ];
+                            $report = $this->graph->validate($runtime, $existingClasses);
+                            $pending = array_values(array_diff($report['loadable'], array_keys($validated)));
+                        }
+                    }
+
+                    if (! $progress) {
+                        break;
+                    }
+                }
 
                 foreach ($report['issues'] as $id => $issue) {
                     if (($runtime[$id]['enabled'] ?? false) && ! in_array($id, $conflictingIds, true)) {
@@ -121,30 +184,10 @@ final class RuntimePluginDiscovery
                     }
                 }
 
-                foreach ($report['loadable'] as $id) {
-                    $path = $packages[$id];
-
-                    try {
-                        $metadata = $this->validator->validateInFreshProcess($path, $id);
-                        require_once $path.'/vendor/autoload.php';
-
-                        if (! class_exists($metadata['entry_class'])) {
-                            throw new InvalidArgumentException(
-                                "Runtime plugin entry class [{$metadata['entry_class']}] does not exist.",
-                            );
-                        }
-
-                        $plugins[] = $metadata['entry_class'];
-                    } catch (Throwable $exception) {
-                        Log::error('Runtime plugin failed fresh-process validation.', [
-                            'plugin' => $id,
-                            'path' => $path,
-                            'exception' => $exception,
-                        ]);
-                    }
-                }
-
-                return $plugins;
+                return array_values(array_filter(
+                    array_map(fn (string $id): ?string => $validated[$id] ?? null, $report['loadable']),
+                    'is_string',
+                ));
             }, false);
         } catch (Throwable $exception) {
             Log::error('Runtime plugin discovery failed.', [
@@ -154,6 +197,12 @@ final class RuntimePluginDiscovery
 
             return [];
         }
+    }
+
+    /** @return array{status: string, error: string}|null */
+    public function failureFor(string $id): ?array
+    {
+        return $this->failures[$id] ?? null;
     }
 
     /**

--- a/app/Services/Platform/RuntimePluginDiscovery.php
+++ b/app/Services/Platform/RuntimePluginDiscovery.php
@@ -114,6 +114,7 @@ final class RuntimePluginDiscovery
     {
         $existingIds = [];
         $conflictingIds = [];
+        $runtimeEntryClasses = [];
         foreach ($existingClasses as $class) {
             if (! is_string($class) || ! class_exists($class) || ! is_a($class, Plugin::class, true)) {
                 continue;
@@ -143,6 +144,8 @@ final class RuntimePluginDiscovery
                 continue;
             }
 
+            $runtimeEntryClasses[$entryClass][] = $id;
+
             if (in_array($entryClass, $existingClasses, true) || isset($existingIds[$id])) {
                 $conflictingIds[] = $id;
                 Log::warning('Runtime plugin skipped because a Composer or explicit plugin takes precedence.', [
@@ -152,7 +155,24 @@ final class RuntimePluginDiscovery
             }
         }
 
-        return $conflictingIds;
+        foreach ($runtimeEntryClasses as $entryClass => $ids) {
+            if (count($ids) < 2) {
+                continue;
+            }
+
+            foreach ($ids as $id) {
+                if (! in_array($id, $conflictingIds, true)) {
+                    $conflictingIds[] = $id;
+                }
+
+                Log::warning('Runtime plugin skipped because another runtime plugin uses the same entry class.', [
+                    'plugin' => $id,
+                    'entry_class' => $entryClass,
+                ]);
+            }
+        }
+
+        return array_values(array_unique($conflictingIds));
     }
 
     private function readEntryClass(string $path): string

--- a/app/Services/Platform/RuntimePluginGraphValidator.php
+++ b/app/Services/Platform/RuntimePluginGraphValidator.php
@@ -176,42 +176,18 @@ final class RuntimePluginGraphValidator
      */
     public function validateCandidate(array $metadata, bool $enabled, RuntimePluginStore $store, array $hostClasses): void
     {
-        $state = $store->readState();
-        $plugins = [];
-
-        foreach ($store->installedPackages() as $id => $path) {
-            if ($id === $metadata['id']) {
-                continue;
-            }
-
-            $packageEnabled = $state[$id]['enabled'] ?? false;
-
-            try {
-                $plugins[$id] = [
-                    'metadata' => $this->validator->validateInFreshProcess($path, $id),
-                    'enabled' => $packageEnabled,
-                ];
-            } catch (Throwable $exception) {
-                $plugins[$id] = [
-                    'metadata' => null,
-                    'enabled' => $packageEnabled,
-                    'status' => $this->validationStatus($exception),
-                    'error' => $this->validationError($exception),
-                ];
-            }
-        }
+        $plugins = $this->installedPlugins($store, $metadata['id']);
 
         $plugins[$metadata['id']] = [
             'metadata' => $metadata,
             'enabled' => $enabled,
         ];
 
+        [$hostIds] = $this->hostIdentity($hostClasses);
         $result = $this->validate($plugins, $hostClasses);
-        $idsToCheck = array_keys(array_filter(
-            $plugins,
-            fn (array $plugin, string $id): bool => $id === $metadata['id'] || $plugin['enabled'],
-            ARRAY_FILTER_USE_BOTH,
-        ));
+        $idsToCheck = $enabled
+            ? $this->dependencyClosure($metadata['id'], $plugins, $hostIds)
+            : [$metadata['id']];
 
         foreach ($idsToCheck as $id) {
             if (isset($result['issues'][$id])) {
@@ -228,9 +204,41 @@ final class RuntimePluginGraphValidator
 
     /**
      * @param  array<int, string>  $hostClasses
+     */
+    public function canForceRecover(string $id, RuntimePluginStore $store, array $hostClasses): bool
+    {
+        $plugins = $this->installedPlugins($store);
+        $result = $this->validate($plugins, $hostClasses);
+
+        if (isset($result['issues'][$id])) {
+            return true;
+        }
+
+        $dependants = $this->dependantsFromPlugins($id, $plugins, $hostClasses);
+
+        return $dependants !== [] && ! array_diff($dependants, array_keys($result['issues']));
+    }
+
+    /**
+     * @param  array<int, string>  $hostClasses
      * @return array<int, string>
      */
     public function enabledDependants(string $id, RuntimePluginStore $store, array $hostClasses): array
+    {
+        return $this->dependantsFromPlugins($id, $this->installedPlugins($store), $hostClasses);
+    }
+
+    /**
+     * @param  array<string, array{
+     *     metadata: array<string, mixed>|null,
+     *     enabled: bool,
+     *     status?: string,
+     *     error?: string
+     * }>  $plugins
+     * @param  array<int, string>  $hostClasses
+     * @return array<int, string>
+     */
+    private function dependantsFromPlugins(string $id, array $plugins, array $hostClasses): array
     {
         [$hostIds, $validHostClasses] = $this->hostIdentity($hostClasses);
 
@@ -238,21 +246,14 @@ final class RuntimePluginGraphValidator
             return [];
         }
 
-        $state = $store->readState();
         $dependants = [];
 
-        foreach ($store->installedPackages() as $packageId => $path) {
-            if ($packageId === $id || ! ($state[$packageId]['enabled'] ?? false)) {
+        foreach ($plugins as $packageId => $plugin) {
+            if ($packageId === $id || ! $plugin['enabled'] || ! is_array($plugin['metadata'])) {
                 continue;
             }
 
-            try {
-                $metadata = $this->validator->validateInFreshProcess($path, $packageId);
-            } catch (Throwable) {
-                continue;
-            }
-
-            if (in_array($id, $metadata['dependencies'], true)) {
+            if (in_array($id, $plugin['metadata']['dependencies'], true)) {
                 $dependants[] = $packageId;
             }
         }
@@ -266,6 +267,83 @@ final class RuntimePluginGraphValidator
         sort($dependants, SORT_STRING);
 
         return array_values(array_unique($dependants));
+    }
+
+    /**
+     * @param  array<string, array{
+     *     metadata: array<string, mixed>|null,
+     *     enabled: bool,
+     *     status?: string,
+     *     error?: string
+     * }>  $plugins
+     * @param  array<string, bool>  $hostIds
+     * @return array<int, string>
+     */
+    private function dependencyClosure(string $id, array $plugins, array $hostIds): array
+    {
+        $closure = [];
+        $pending = [$id];
+
+        while ($pending !== []) {
+            $current = array_pop($pending);
+
+            if (! is_string($current) || isset($closure[$current])) {
+                continue;
+            }
+
+            $closure[$current] = true;
+            $metadata = $plugins[$current]['metadata'] ?? null;
+
+            if (! is_array($metadata)) {
+                continue;
+            }
+
+            foreach ($metadata['dependencies'] ?? [] as $dependency) {
+                if (! isset($hostIds[$dependency]) && isset($plugins[$dependency])) {
+                    $pending[] = $dependency;
+                }
+            }
+        }
+
+        return array_keys($closure);
+    }
+
+    /**
+     * @return array<string, array{
+     *     metadata: array<string, mixed>|null,
+     *     enabled: bool,
+     *     status?: string,
+     *     error?: string
+     * }>
+     */
+    private function installedPlugins(RuntimePluginStore $store, ?string $exceptId = null): array
+    {
+        $state = $store->readState();
+        $plugins = [];
+
+        foreach ($store->installedPackages() as $id => $path) {
+            if ($id === $exceptId) {
+                continue;
+            }
+
+            $enabled = $state[$id]['enabled'] ?? false;
+
+            try {
+                $plugins[$id] = [
+                    'metadata' => $this->validator->validateInFreshProcess($path, $id),
+                    'enabled' => $enabled,
+                ];
+            } catch (Throwable $exception) {
+                $plugins[$id] = [
+                    'metadata' => null,
+                    'enabled' => $enabled,
+                    'status' => $this->validationStatus($exception),
+                    'error' => $this->validationError($exception),
+                ];
+            }
+        }
+
+        return $plugins;
     }
 
     /**

--- a/app/Services/Platform/RuntimePluginGraphValidator.php
+++ b/app/Services/Platform/RuntimePluginGraphValidator.php
@@ -330,7 +330,7 @@ final class RuntimePluginGraphValidator
 
             try {
                 $plugins[$id] = [
-                    'metadata' => $this->validator->validateInFreshProcess($path, $id),
+                    'metadata' => $this->validator->inspectStaticMetadata($path, $id),
                     'enabled' => $enabled,
                 ];
             } catch (Throwable $exception) {

--- a/app/Services/Platform/RuntimePluginGraphValidator.php
+++ b/app/Services/Platform/RuntimePluginGraphValidator.php
@@ -28,6 +28,11 @@ final class RuntimePluginGraphValidator
         [$hostIds] = $this->hostIdentity($hostClasses);
         $issues = [];
         $entryClasses = [];
+        $hostEntryClasses = array_fill_keys(array_map(
+            fn (string $class): string => $this->canonicalClassName($class),
+            array_values(array_filter($hostClasses, 'is_string')),
+        ), true);
+        $entryClassNames = [];
 
         foreach ($plugins as $id => $plugin) {
             if (isset($plugin['status'], $plugin['error'])) {
@@ -48,12 +53,14 @@ final class RuntimePluginGraphValidator
             }
 
             if (is_string($metadata['entry_class'] ?? null)) {
-                $entryClasses[$metadata['entry_class']][] = $id;
+                $canonicalEntryClass = $this->canonicalClassName($metadata['entry_class']);
+                $entryClasses[$canonicalEntryClass][] = $id;
+                $entryClassNames[$canonicalEntryClass] = $metadata['entry_class'];
             }
 
             if (
                 isset($hostIds[$id])
-                || in_array($metadata['entry_class'] ?? null, $hostClasses, true)
+                || isset($hostEntryClasses[$this->canonicalClassName((string) ($metadata['entry_class'] ?? ''))])
             ) {
                 $this->addIssue($issues, $id, 'conflict', "Runtime plugin [{$id}] conflicts with a Composer or explicit plugin.");
 
@@ -92,7 +99,7 @@ final class RuntimePluginGraphValidator
                     $issues,
                     $id,
                     'conflict',
-                    "Runtime plugin [{$id}] conflicts with another runtime plugin entry class [{$entryClass}].",
+                    "Runtime plugin [{$id}] conflicts with another runtime plugin entry class [{$entryClassNames[$entryClass]}].",
                 );
             }
         }
@@ -426,6 +433,11 @@ final class RuntimePluginGraphValidator
         }
 
         return [$ids, $validClasses];
+    }
+
+    private function canonicalClassName(string $class): string
+    {
+        return strtolower(ltrim(trim($class), '\\'));
     }
 
     /**

--- a/app/Services/Platform/RuntimePluginStore.php
+++ b/app/Services/Platform/RuntimePluginStore.php
@@ -34,7 +34,7 @@ final class RuntimePluginStore
         return $this->root;
     }
 
-    public function withLock(Closure $callback): mixed
+    public function withLock(Closure $callback, bool $recover = true): mixed
     {
         $this->ensureDirectory($this->root);
 
@@ -45,13 +45,43 @@ final class RuntimePluginStore
         }
 
         try {
-            $this->recoverPendingOperation();
+            if ($recover) {
+                $this->recoverPendingOperation();
+            }
 
             return $callback($this);
         } finally {
             flock($handle, LOCK_UN);
             fclose($handle);
         }
+    }
+
+    public function recoveryStatus(): string
+    {
+        $path = $this->recoveryMarkerPath();
+
+        if (is_link($path) || (file_exists($path) && ! is_file($path))) {
+            return 'corrupt';
+        }
+
+        if (! is_file($path)) {
+            return 'clear';
+        }
+
+        $contents = file_get_contents($path);
+
+        if ($contents === false) {
+            return 'corrupt';
+        }
+
+        try {
+            $marker = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+            $this->validateRecoveryMarker($marker);
+        } catch (Throwable) {
+            return 'corrupt';
+        }
+
+        return 'pending';
     }
 
     /**
@@ -62,6 +92,10 @@ final class RuntimePluginStore
         $path = $this->statePath();
 
         if (is_link($path)) {
+            throw new RuntimeException('Runtime plugin state is corrupted. Repair or remove '.$path.' before continuing.');
+        }
+
+        if (file_exists($path) && ! is_file($path)) {
             throw new RuntimeException('Runtime plugin state is corrupted. Repair or remove '.$path.' before continuing.');
         }
 
@@ -279,7 +313,8 @@ final class RuntimePluginStore
         $activePath = $this->packagePath($id);
         $state = $this->readState();
 
-        if (! is_dir($activePath)) {
+        if (! is_dir($activePath) || is_link($activePath)) {
+            $this->deleteDirectory($activePath);
             unset($state[$id]);
             $this->writeState($state);
 
@@ -318,7 +353,49 @@ final class RuntimePluginStore
         }
     }
 
-    private function recoverPendingOperation(): void
+    public function forceRemove(string $id, bool $allowPendingRecovery = false): void
+    {
+        $this->assertValidId($id);
+        $recoveryStatus = $this->recoveryStatus();
+
+        if ($recoveryStatus === 'pending') {
+            if (! $allowPendingRecovery) {
+                throw new RuntimeException('Runtime plugin recovery is still pending. Complete recovery before forcing removal.');
+            }
+
+            $contents = file_get_contents($this->recoveryMarkerPath());
+            $marker = is_string($contents) ? json_decode($contents, true) : null;
+
+            $this->validateRecoveryMarker($marker);
+
+            if ($marker['id'] !== $id) {
+                throw new RuntimeException('Runtime plugin recovery belongs to a different package.');
+            }
+
+            $this->deleteDirectory($this->managedPath($marker['backup']));
+            $stagingPath = isset($marker['staging']) && is_string($marker['staging'])
+                ? $this->managedPath($marker['staging'])
+                : null;
+            $this->deleteDirectory($stagingPath);
+            $this->removeRecoveryMarker();
+        }
+
+        $this->deleteDirectory($this->packagePath($id));
+
+        try {
+            $state = $this->readState();
+            unset($state[$id]);
+            $this->writeState($state);
+        } catch (Throwable) {
+            // The managed package is still removable when lifecycle metadata is corrupt.
+        }
+
+        if ($recoveryStatus === 'corrupt') {
+            $this->removeRecoveryMarker();
+        }
+    }
+
+    public function recoverPendingOperation(): void
     {
         $path = $this->recoveryMarkerPath();
 
@@ -342,17 +419,7 @@ final class RuntimePluginStore
             throw new RuntimeException('Runtime plugin recovery marker is corrupted.', previous: $exception);
         }
 
-        if (
-            ! is_array($marker) ||
-            ! in_array($marker['operation'] ?? null, ['swap', 'remove'], true) ||
-            ! in_array($marker['phase'] ?? null, ['prepared', 'old_preserved', 'new_active', 'committed'], true) ||
-            ! is_string($marker['id'] ?? null) ||
-            ! is_string($marker['backup'] ?? null) ||
-            ! str_starts_with($marker['backup'], '.backup/') ||
-            (isset($marker['staging']) && $marker['staging'] !== null && (! is_string($marker['staging']) || ! str_starts_with($marker['staging'], '.staging/')))
-        ) {
-            throw new RuntimeException('Runtime plugin recovery marker is invalid.');
-        }
+        $this->validateRecoveryMarker($marker);
 
         $id = $marker['id'];
         $backupPath = $this->managedPath($marker['backup']);
@@ -444,6 +511,24 @@ final class RuntimePluginStore
         $this->writeState($state);
     }
 
+    private function validateRecoveryMarker(mixed $marker): void
+    {
+        if (
+            ! is_array($marker) ||
+            ! in_array($marker['operation'] ?? null, ['swap', 'remove'], true) ||
+            ! in_array($marker['phase'] ?? null, ['prepared', 'old_preserved', 'new_active', 'committed'], true) ||
+            ! is_string($marker['id'] ?? null) ||
+            ! is_string($marker['backup'] ?? null) ||
+            ! is_bool($marker['had_active'] ?? null) ||
+            ! str_starts_with($marker['backup'], '.backup/') ||
+            (isset($marker['staging']) && $marker['staging'] !== null && (! is_string($marker['staging']) || ! str_starts_with($marker['staging'], '.staging/')))
+        ) {
+            throw new RuntimeException('Runtime plugin recovery marker is invalid.');
+        }
+
+        $this->assertValidId($marker['id']);
+    }
+
     /**
      * @param  array<string, mixed>  $marker
      */
@@ -517,7 +602,7 @@ final class RuntimePluginStore
 
     private function deleteDirectory(?string $path): void
     {
-        if ($path === null || ! file_exists($path)) {
+        if ($path === null || (! file_exists($path) && ! is_link($path))) {
             return;
         }
 

--- a/app/Services/Platform/RuntimePluginStore.php
+++ b/app/Services/Platform/RuntimePluginStore.php
@@ -48,6 +48,9 @@ final class RuntimePluginStore
         $this->ensureDirectory($this->root);
 
         $lockPath = $this->root.'/.lock';
+        if (is_link($lockPath) || (file_exists($lockPath) && ! is_file($lockPath))) {
+            throw new RuntimeException('Runtime plugin lock path is not a regular file.');
+        }
         $this->assertSafeManagedPath($lockPath);
         $handle = fopen($lockPath, 'c+');
 
@@ -59,7 +62,7 @@ final class RuntimePluginStore
             if ($recover) {
                 $recoveryIdentity = $this->recoveryIdentity();
 
-                if ($pluginId === null || $recoveryIdentity === null || $recoveryIdentity === $pluginId) {
+                if ($pluginId === null || $recoveryIdentity === $pluginId) {
                     $this->recoverPendingOperation();
                 }
             }
@@ -269,7 +272,7 @@ final class RuntimePluginStore
             $packages = scandir($vendorPath);
 
             if ($packages === false) {
-                throw new RuntimeException("Could not inspect runtime plugin vendor directory [{$vendor}].");
+                continue;
             }
 
             foreach ($packages as $package) {
@@ -280,7 +283,7 @@ final class RuntimePluginStore
                 $id = $vendor.'/'.$package;
                 $packagePath = $vendorPath.DIRECTORY_SEPARATOR.$package;
 
-                if ($this->isValidId($id) && (is_dir($packagePath) || is_file($packagePath) || is_link($packagePath))) {
+                if ($this->isValidId($id) && (file_exists($packagePath) || is_link($packagePath))) {
                     $entries[$id] = $packagePath;
                 }
             }
@@ -324,65 +327,72 @@ final class RuntimePluginStore
             throw new RuntimeException('Could not inspect runtime plugin storage.');
         }
 
+        $expectedFiles = ['.lock', 'state.json', 'recovery.json', 'recovery.json.tmp'];
+        $expectedDirectories = ['.staging', '.backup'];
+
         foreach ($vendors as $vendor) {
-            if ($vendor === '.' || $vendor === '..' || str_starts_with($vendor, '.')) {
+            if ($vendor === '.' || $vendor === '..') {
                 continue;
             }
 
             $vendorPath = $this->root.'/'.$vendor;
 
-            if (is_link($vendorPath)) {
+            if (in_array($vendor, $expectedFiles, true)) {
+                if (! $this->isRegularFile($vendorPath)) {
+                    $anomalies['internal:'.$vendor] = $vendorPath;
+                }
+
+                continue;
+            }
+
+            if (in_array($vendor, $expectedDirectories, true)) {
+                if (! $this->isRealDirectory($vendorPath)) {
+                    $anomalies['internal:'.$vendor] = $vendorPath;
+                }
+
+                continue;
+            }
+
+            if (str_starts_with($vendor, '.state-') && str_ends_with($vendor, '.tmp')) {
+                if (is_link($vendorPath)) {
+                    $anomalies['internal:'.$vendor] = $vendorPath;
+                }
+
+                continue;
+            }
+
+            if (str_starts_with($vendor, '.')) {
+                $anomalies['internal:'.$vendor] = $vendorPath;
+
+                continue;
+            }
+
+            if (! $this->isRealDirectory($vendorPath)) {
                 $anomalies['vendor:'.$vendor] = $vendorPath;
 
                 continue;
             }
 
-            if (! is_dir($vendorPath)) {
+            $packages = @scandir($vendorPath);
+
+            if ($packages === false) {
+                $anomalies['vendor:'.$vendor] = $vendorPath;
+
                 continue;
             }
 
-            $packages = scandir($vendorPath);
-
-            if ($packages === false) {
-                throw new RuntimeException("Could not inspect runtime plugin vendor directory [{$vendor}].");
-            }
-
             foreach ($packages as $package) {
-                if ($package === '.' || $package === '..' || str_starts_with($package, '.')) {
+                if ($package === '.' || $package === '..') {
                     continue;
                 }
 
                 $id = $vendor.'/'.$package;
                 $packagePath = $vendorPath.'/'.$package;
 
-                if ($this->isValidId($id) && is_link($packagePath)) {
+                if (! $this->isValidId($id)) {
+                    $anomalies['path:'.$vendor.'/'.$package] = $packagePath;
+                } elseif (! $this->isRealDirectory($packagePath)) {
                     $anomalies['package:'.$id] = $packagePath;
-                }
-            }
-        }
-
-        foreach (['.lock', 'state.json', 'recovery.json', 'recovery.json.tmp'] as $name) {
-            $path = $this->root.'/'.$name;
-
-            if (is_link($path) || (file_exists($path) && ! is_file($path))) {
-                $anomalies['internal:'.$name] = $path;
-            }
-        }
-
-        foreach (['.staging', '.backup'] as $name) {
-            $path = $this->root.'/'.$name;
-
-            if (is_link($path)) {
-                $anomalies['internal:'.$name] = $path;
-            }
-        }
-
-        foreach (scandir($this->root) ?: [] as $entry) {
-            if (str_starts_with($entry, '.state-') && str_ends_with($entry, '.tmp')) {
-                $path = $this->root.'/'.$entry;
-
-                if (is_link($path)) {
-                    $anomalies['internal:'.$entry] = $path;
                 }
             }
         }
@@ -622,6 +632,14 @@ final class RuntimePluginStore
                 $this->deleteManagedPath($container);
             }
         }
+
+        if ($this->managedPackageEntries() === []) {
+            $statePath = $this->statePath();
+
+            if (file_exists($statePath) || is_link($statePath)) {
+                $this->deleteManagedPath($statePath);
+            }
+        }
     }
 
     public function forceCleanupFilesystemAnomaly(string $key): void
@@ -824,6 +842,19 @@ final class RuntimePluginStore
         $activePath = $this->packagePath($id);
         $this->assertSafeManagedPath($activePath);
         $state = $this->readState();
+        $recoveryStatus = $this->recoveryStatus();
+        $recoveryIdentity = $this->recoveryIdentity();
+
+        if (
+            in_array($recoveryStatus, [self::RECOVERY_PENDING, self::RECOVERY_UNRECOVERABLE], true)
+            && $recoveryIdentity !== $id
+        ) {
+            $this->deleteDirectory($activePath);
+            unset($state[$id]);
+            $this->writeState($state);
+
+            return;
+        }
 
         if (! is_dir($activePath) || is_link($activePath)) {
             $this->deleteDirectory($activePath);
@@ -872,25 +903,36 @@ final class RuntimePluginStore
         $activePath = $this->packagePath($id);
         $this->assertSafeManagedPath($activePath);
         $recoveryStatus = $this->recoveryStatus();
+        $recoveryIdentity = $this->recoveryIdentity();
+        $preserveUnrelatedRecovery = in_array(
+            $recoveryStatus,
+            [self::RECOVERY_PENDING, self::RECOVERY_UNRECOVERABLE],
+            true,
+        ) && $recoveryIdentity !== $id;
 
-        if (in_array($recoveryStatus, [self::RECOVERY_PENDING, self::RECOVERY_UNRECOVERABLE], true)) {
+        if (
+            in_array($recoveryStatus, [self::RECOVERY_PENDING, self::RECOVERY_UNRECOVERABLE], true)
+            && ! $preserveUnrelatedRecovery
+        ) {
             $this->assertRecoveryBelongsTo($id);
         }
 
         if ($recoveryStatus === self::RECOVERY_PENDING) {
-            if (! $allowPendingRecovery) {
+            if (! $preserveUnrelatedRecovery && ! $allowPendingRecovery) {
                 throw new RuntimeException('Runtime plugin recovery is still pending. Complete recovery before forcing removal.');
             }
 
-            try {
-                $this->recoverPendingOperation();
-                $recoveryStatus = $this->recoveryStatus();
-            } catch (Throwable) {
-                $recoveryStatus = self::RECOVERY_UNRECOVERABLE;
+            if (! $preserveUnrelatedRecovery) {
+                try {
+                    $this->recoverPendingOperation();
+                    $recoveryStatus = $this->recoveryStatus();
+                } catch (Throwable) {
+                    $recoveryStatus = self::RECOVERY_UNRECOVERABLE;
+                }
             }
         }
 
-        if ($recoveryStatus === self::RECOVERY_UNRECOVERABLE) {
+        if ($recoveryStatus === self::RECOVERY_UNRECOVERABLE && ! $preserveUnrelatedRecovery) {
             $this->removeRecoveryMarker();
         }
 
@@ -909,7 +951,9 @@ final class RuntimePluginStore
             $this->writeState($state);
         }
 
-        $this->cleanupRecoveryArtifacts();
+        if (! $preserveUnrelatedRecovery) {
+            $this->cleanupRecoveryArtifacts();
+        }
 
         if ($this->managedPackageEntries() === []) {
             $this->forceCleanupOrphanedMetadata();
@@ -1170,6 +1214,9 @@ final class RuntimePluginStore
 
         $contents = json_encode($marker, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR).PHP_EOL;
         $temporaryPath = $recoveryPath.'.tmp';
+        if (is_link($temporaryPath) || (file_exists($temporaryPath) && ! is_file($temporaryPath))) {
+            throw new RuntimeException('Could not persist runtime plugin recovery state through a non-file path.');
+        }
         $this->assertSafeManagedPath($temporaryPath);
 
         if (file_put_contents($temporaryPath, $contents, LOCK_EX) === false || ! rename($temporaryPath, $recoveryPath)) {
@@ -1224,7 +1271,15 @@ final class RuntimePluginStore
 
     private function managedPath(string $relativePath): string
     {
-        if ($relativePath === '' || str_contains($relativePath, '..') || str_starts_with($relativePath, '/')) {
+        $segments = explode('/', $relativePath);
+
+        if (
+            $relativePath === ''
+            || str_contains($relativePath, '..')
+            || str_starts_with($relativePath, '/')
+            || in_array('', $segments, true)
+            || in_array('.', $segments, true)
+        ) {
             throw new RuntimeException('Runtime plugin recovery path is unsafe.');
         }
 
@@ -1283,7 +1338,7 @@ final class RuntimePluginStore
             return;
         }
 
-        if (is_file($path)) {
+        if (! is_dir($path)) {
             $this->assertSafeManagedPath($path);
 
             if (! @unlink($path) || file_exists($path) || is_link($path)) {
@@ -1291,10 +1346,6 @@ final class RuntimePluginStore
             }
 
             return;
-        }
-
-        if (! is_dir($path)) {
-            throw new RuntimeException("Could not remove runtime plugin path [{$path}].");
         }
 
         $this->assertSafeManagedPath($path);
@@ -1416,6 +1467,16 @@ final class RuntimePluginStore
     private function isValidId(string $id): bool
     {
         return preg_match('/^[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*$/', $id) === 1;
+    }
+
+    private function isRegularFile(string $path): bool
+    {
+        return is_file($path) && ! is_link($path);
+    }
+
+    private function isRealDirectory(string $path): bool
+    {
+        return is_dir($path) && ! is_link($path);
     }
 
     private function canonicalizePath(string $path): string

--- a/app/Services/Platform/RuntimePluginStore.php
+++ b/app/Services/Platform/RuntimePluginStore.php
@@ -965,6 +965,7 @@ final class RuntimePluginStore
             'staging' => null,
             'backup' => $this->relativeManagedPath($backupPath),
             'had_active' => true,
+            'previous_entry' => $state[$id] ?? null,
             'phase' => 'prepared',
         ];
 
@@ -1033,7 +1034,9 @@ final class RuntimePluginStore
 
         $this->deleteDirectory($activePath);
 
-        if (! $stateWasCorrupt) {
+        if ($stateWasCorrupt) {
+            $this->rebuildStateFromManagedPackages($id);
+        } else {
             unset($state[$id]);
             $this->writeState($state);
         }
@@ -1045,6 +1048,19 @@ final class RuntimePluginStore
         if ($this->managedPackageEntries() === [] && $this->recoveryMarkerPaths() === []) {
             $this->forceCleanupOrphanedMetadata();
         }
+    }
+
+    private function rebuildStateFromManagedPackages(?string $excludeId = null): void
+    {
+        $state = [];
+
+        foreach ($this->managedPackageEntries() as $id => $path) {
+            if ($id !== $excludeId) {
+                $state[$id] = ['enabled' => false];
+            }
+        }
+
+        $this->writeState($state);
     }
 
     public function recoverPendingOperation(?string $id = null): void

--- a/app/Services/Platform/RuntimePluginStore.php
+++ b/app/Services/Platform/RuntimePluginStore.php
@@ -936,18 +936,6 @@ final class RuntimePluginStore
         $activePath = $this->packagePath($id);
         $this->assertSafeManagedPath($activePath);
         $state = $this->readState();
-        $recoveryStatus = $this->recoveryStatus();
-
-        if (
-            in_array($recoveryStatus, [self::RECOVERY_PENDING, self::RECOVERY_UNRECOVERABLE], true)
-            && ! $this->hasRecoveryFor($id)
-        ) {
-            $this->deleteDirectory($activePath);
-            unset($state[$id]);
-            $this->writeState($state);
-
-            return;
-        }
 
         if (! is_dir($activePath) || is_link($activePath)) {
             $this->deleteDirectory($activePath);

--- a/app/Services/Platform/RuntimePluginStore.php
+++ b/app/Services/Platform/RuntimePluginStore.php
@@ -14,6 +14,8 @@ final class RuntimePluginStore
 
     public const RECOVERY_UNRECOVERABLE = 'unrecoverable_recovery';
 
+    public const RECOVERY_ORPHANED_ARTIFACT = 'orphaned_runtime_artifact';
+
     private string $root;
 
     public function __construct()
@@ -22,6 +24,7 @@ final class RuntimePluginStore
         $path = str_starts_with($configuredPath, DIRECTORY_SEPARATOR)
             ? rtrim($configuredPath, DIRECTORY_SEPARATOR)
             : base_path(trim($configuredPath, DIRECTORY_SEPARATOR));
+        $this->assertConfiguredPathHasNoSymlink($path);
         $this->root = $this->canonicalizePath($path);
         $basePath = realpath(base_path());
 
@@ -40,7 +43,7 @@ final class RuntimePluginStore
         return $this->root;
     }
 
-    public function withLock(Closure $callback, bool $recover = true): mixed
+    public function withLock(Closure $callback, bool $recover = true, ?string $pluginId = null): mixed
     {
         $this->ensureDirectory($this->root);
 
@@ -54,7 +57,11 @@ final class RuntimePluginStore
 
         try {
             if ($recover) {
-                $this->recoverPendingOperation();
+                $recoveryIdentity = $this->recoveryIdentity();
+
+                if ($pluginId === null || $recoveryIdentity === null || $recoveryIdentity === $pluginId) {
+                    $this->recoverPendingOperation();
+                }
             }
 
             return $callback($this);
@@ -77,7 +84,9 @@ final class RuntimePluginStore
         }
 
         if (! is_file($path)) {
-            return self::RECOVERY_HEALTHY;
+            return $this->orphanedRuntimeArtifactPaths() === []
+                ? self::RECOVERY_HEALTHY
+                : self::RECOVERY_ORPHANED_ARTIFACT;
         }
 
         $contents = file_get_contents($path);
@@ -98,6 +107,37 @@ final class RuntimePluginStore
         }
 
         return self::RECOVERY_PENDING;
+    }
+
+    public function recoveryIdentity(): ?string
+    {
+        $path = $this->recoveryMarkerPath();
+
+        try {
+            $this->assertSafeManagedPath($path);
+        } catch (Throwable) {
+            return null;
+        }
+
+        if (! is_file($path) || is_link($path)) {
+            return null;
+        }
+
+        $contents = file_get_contents($path);
+
+        if ($contents === false) {
+            return null;
+        }
+
+        try {
+            $marker = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+        } catch (Throwable) {
+            return null;
+        }
+
+        $id = is_array($marker) ? $marker['id'] ?? null : null;
+
+        return is_string($id) && $this->isValidId($id) ? $id : null;
     }
 
     /**
@@ -262,6 +302,134 @@ final class RuntimePluginStore
         );
     }
 
+    /**
+     * @return array<string, string>
+     */
+    public function managedFilesystemAnomalies(): array
+    {
+        $anomalies = [];
+
+        if (is_link($this->root) || (file_exists($this->root) && ! is_dir($this->root))) {
+            throw new RuntimeException('Runtime plugin storage is not a safe directory.');
+        }
+
+        if (! is_dir($this->root)) {
+            return $anomalies;
+        }
+
+        $this->assertSafeManagedPath($this->root);
+        $vendors = scandir($this->root);
+
+        if ($vendors === false) {
+            throw new RuntimeException('Could not inspect runtime plugin storage.');
+        }
+
+        foreach ($vendors as $vendor) {
+            if ($vendor === '.' || $vendor === '..' || str_starts_with($vendor, '.')) {
+                continue;
+            }
+
+            $vendorPath = $this->root.'/'.$vendor;
+
+            if (is_link($vendorPath)) {
+                $anomalies['vendor:'.$vendor] = $vendorPath;
+
+                continue;
+            }
+
+            if (! is_dir($vendorPath)) {
+                continue;
+            }
+
+            $packages = scandir($vendorPath);
+
+            if ($packages === false) {
+                throw new RuntimeException("Could not inspect runtime plugin vendor directory [{$vendor}].");
+            }
+
+            foreach ($packages as $package) {
+                if ($package === '.' || $package === '..' || str_starts_with($package, '.')) {
+                    continue;
+                }
+
+                $id = $vendor.'/'.$package;
+                $packagePath = $vendorPath.'/'.$package;
+
+                if ($this->isValidId($id) && is_link($packagePath)) {
+                    $anomalies['package:'.$id] = $packagePath;
+                }
+            }
+        }
+
+        foreach (['state.json', 'recovery.json', 'recovery.json.tmp', '.staging', '.backup'] as $name) {
+            $path = $this->root.'/'.$name;
+
+            if (is_link($path)) {
+                $anomalies['internal:'.$name] = $path;
+            }
+        }
+
+        foreach (scandir($this->root) ?: [] as $entry) {
+            if (str_starts_with($entry, '.state-') && str_ends_with($entry, '.tmp')) {
+                $path = $this->root.'/'.$entry;
+
+                if (is_link($path)) {
+                    $anomalies['internal:'.$entry] = $path;
+                }
+            }
+        }
+
+        ksort($anomalies, SORT_STRING);
+
+        return $anomalies;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function orphanedRuntimeArtifactPaths(): array
+    {
+        $artifacts = [];
+
+        if (is_link($this->root) || (file_exists($this->root) && ! is_dir($this->root))) {
+            throw new RuntimeException('Runtime plugin storage is not a safe directory.');
+        }
+
+        if (! is_dir($this->root)) {
+            return $artifacts;
+        }
+
+        $this->assertSafeManagedPath($this->root);
+
+        foreach (['.staging', '.backup', 'recovery.json.tmp'] as $name) {
+            $path = $this->root.'/'.$name;
+
+            if ((file_exists($path) || is_link($path)) && ! is_link($path)) {
+                $artifacts[$name] = $path;
+            }
+        }
+
+        $entries = scandir($this->root);
+
+        if ($entries === false) {
+            throw new RuntimeException('Could not inspect runtime plugin storage.');
+        }
+
+        foreach ($entries as $entry) {
+            if (! str_starts_with($entry, '.state-') || ! str_ends_with($entry, '.tmp')) {
+                continue;
+            }
+
+            $path = $this->root.'/'.$entry;
+
+            if ((file_exists($path) || is_link($path)) && ! is_link($path)) {
+                $artifacts[$entry] = $path;
+            }
+        }
+
+        return $artifacts;
+    }
+
     public function forceCleanupOrphanedMetadata(): void
     {
         if ($this->managedPackageEntries() !== []) {
@@ -281,6 +449,135 @@ final class RuntimePluginStore
         }
     }
 
+    public function forceCleanupOrphanedArtifacts(): void
+    {
+        if ($this->recoveryMarkerExists()) {
+            throw new RuntimeException('Runtime plugin recovery metadata must be handled before cleaning orphaned artifacts.');
+        }
+
+        foreach ($this->orphanedRuntimeArtifactPaths() as $path) {
+            $this->assertSafeManagedPath($path);
+            $this->deleteDirectory($path);
+        }
+
+        if ($this->orphanedRuntimeArtifactPaths() !== []) {
+            throw new RuntimeException('Could not clean orphaned runtime artifacts.');
+        }
+    }
+
+    public function forceCleanupRecovery(string $id): void
+    {
+        $this->assertValidId($id);
+        $markerPath = $this->recoveryMarkerPath();
+
+        if (! is_file($markerPath) || is_link($markerPath)) {
+            throw new RuntimeException('Runtime plugin recovery metadata is not available.');
+        }
+
+        $contents = file_get_contents($markerPath);
+
+        if ($contents === false) {
+            throw new RuntimeException('Runtime plugin recovery marker cannot be read.');
+        }
+
+        try {
+            $marker = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+        } catch (Throwable $exception) {
+            throw new RuntimeException('Runtime plugin recovery marker is corrupted.', previous: $exception);
+        }
+
+        if (! is_array($marker) || ($marker['id'] ?? null) !== $id) {
+            throw new RuntimeException('Runtime plugin recovery belongs to a different package.');
+        }
+
+        try {
+            $state = $this->readState();
+            if (array_key_exists($id, $state)) {
+                unset($state[$id]);
+                $this->writeState($state);
+            }
+        } catch (Throwable) {
+            if ($this->managedPackageEntries() === []) {
+                $statePath = $this->statePath();
+
+                if (file_exists($statePath) || is_link($statePath)) {
+                    $this->deleteManagedPath($statePath);
+                }
+            }
+        }
+
+        $paths = [$markerPath, $this->root.'/recovery.json.tmp'];
+
+        foreach (['backup', 'staging'] as $key) {
+            if (! array_key_exists($key, $marker)) {
+                continue;
+            }
+
+            $path = $this->recoveryCleanupPath($key, $marker[$key]);
+
+            if ($path !== null) {
+                $paths[] = $path;
+            }
+        }
+
+        foreach (array_unique($paths) as $path) {
+            if (! file_exists($path) && ! is_link($path)) {
+                continue;
+            }
+
+            $this->deleteManagedPath($path);
+        }
+
+        foreach (array_unique($paths) as $path) {
+            if (file_exists($path) || is_link($path)) {
+                throw new RuntimeException("Could not clean runtime lifecycle path [{$path}].");
+            }
+        }
+
+        foreach ([$this->root.'/.staging', $this->root.'/.backup'] as $container) {
+            if (! is_dir($container) || is_link($container)) {
+                continue;
+            }
+
+            $entries = scandir($container);
+
+            if ($entries === false) {
+                throw new RuntimeException("Could not inspect runtime lifecycle path [{$container}].");
+            }
+
+            if ($entries === ['.', '..']) {
+                $this->assertSafeManagedPath($container);
+                $this->deleteDirectory($container);
+            }
+        }
+    }
+
+    public function forceCleanupFilesystemAnomaly(string $key): void
+    {
+        $anomalies = $this->managedFilesystemAnomalies();
+
+        if (! isset($anomalies[$key])) {
+            throw new RuntimeException('Runtime filesystem anomaly is no longer present.');
+        }
+
+        $path = $anomalies[$key];
+        $this->assertSafeManagedLink($path);
+
+        if (! @unlink($path) || file_exists($path) || is_link($path)) {
+            throw new RuntimeException("Could not remove runtime plugin path [{$path}].");
+        }
+
+        if (str_starts_with($key, 'package:')) {
+            try {
+                $state = $this->readState();
+                unset($state[substr($key, strlen('package:'))]);
+                $this->writeState($state);
+            } catch (Throwable) {
+                // The symlink is gone; a corrupt state file remains independently recoverable.
+            }
+        }
+    }
+
     private function cleanupRecoveryArtifacts(): void
     {
         if (! is_dir($this->root)) {
@@ -291,8 +588,7 @@ final class RuntimePluginStore
 
         foreach ($this->recoveryArtifactPaths() as $path) {
             if (file_exists($path) || is_link($path)) {
-                $this->assertSafeManagedPath($path);
-                $this->deleteDirectory($path);
+                $this->deleteManagedPath($path);
             }
         }
 
@@ -311,8 +607,7 @@ final class RuntimePluginStore
             }
 
             $path = $this->root.'/'.$entry;
-            $this->assertSafeManagedPath($path);
-            $this->deleteDirectory($path);
+            $this->deleteManagedPath($path);
         }
 
         foreach ($this->recoveryArtifactPaths() as $path) {
@@ -320,6 +615,13 @@ final class RuntimePluginStore
                 throw new RuntimeException("Could not clean runtime lifecycle path [{$path}].");
             }
         }
+    }
+
+    private function recoveryMarkerExists(): bool
+    {
+        $path = $this->recoveryMarkerPath();
+
+        return file_exists($path) || is_link($path);
     }
 
     public function packagePath(string $id): string
@@ -352,8 +654,7 @@ final class RuntimePluginStore
             throw new RuntimeException('Only staging paths can be discarded.');
         }
 
-        $this->assertSafeManagedPath($path);
-        $this->deleteDirectory($path);
+        $this->deleteManagedPath($path);
     }
 
     public function promote(string $id, string $stagingPath, bool $enabled): void
@@ -770,26 +1071,18 @@ final class RuntimePluginStore
 
     private function assertRecoveryBelongsTo(string $id): void
     {
-        $path = $this->recoveryMarkerPath();
+        $identity = $this->recoveryIdentity();
 
-        if (! is_file($path) || is_link($path)) {
+        if ($identity !== null) {
+            if ($identity !== $id) {
+                throw new RuntimeException('Runtime plugin recovery belongs to a different package.');
+            }
+
             return;
         }
 
-        $contents = file_get_contents($path);
-
-        if ($contents === false) {
-            return;
-        }
-
-        try {
-            $marker = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
-        } catch (Throwable) {
-            return;
-        }
-
-        if (is_array($marker) && is_string($marker['id'] ?? null) && $this->isValidId($marker['id']) && $marker['id'] !== $id) {
-            throw new RuntimeException('Runtime plugin recovery belongs to a different package.');
+        if (count($this->managedPackageEntries()) > 1) {
+            throw new RuntimeException('Runtime plugin recovery owner cannot be determined safely.');
         }
     }
 
@@ -824,8 +1117,7 @@ final class RuntimePluginStore
             return;
         }
 
-        $this->assertSafeManagedPath($path);
-        $this->deleteDirectory($path);
+        $this->deleteManagedPath($path);
     }
 
     /** @return array<int, string> */
@@ -873,6 +1165,21 @@ final class RuntimePluginStore
         }
 
         return $path;
+    }
+
+    private function recoveryCleanupPath(string $key, mixed $relativePath): ?string
+    {
+        $prefix = $key === 'backup' ? '.backup/' : '.staging/';
+
+        if (! is_string($relativePath) || ! str_starts_with($relativePath, $prefix) || $relativePath === $prefix) {
+            return null;
+        }
+
+        try {
+            return $this->managedPath($relativePath);
+        } catch (Throwable) {
+            return null;
+        }
     }
 
     private function ensureDirectory(string $path): void
@@ -926,6 +1233,17 @@ final class RuntimePluginStore
         }
     }
 
+    private function deleteManagedPath(string $path): void
+    {
+        if (is_link($path)) {
+            $this->assertSafeManagedLink($path);
+        } else {
+            $this->assertSafeManagedPath($path);
+        }
+
+        $this->deleteDirectory($path);
+    }
+
     private function assertSafeManagedPath(string $path): void
     {
         if ($path !== $this->root && ! str_starts_with($path, $this->root.DIRECTORY_SEPARATOR)) {
@@ -958,6 +1276,38 @@ final class RuntimePluginStore
             || ($resolved !== $resolvedRoot && ! str_starts_with($resolved, $resolvedRoot.DIRECTORY_SEPARATOR))
         ) {
             throw new RuntimeException('Runtime plugin path is outside managed storage.');
+        }
+    }
+
+    private function assertSafeManagedLink(string $path): void
+    {
+        if (! is_link($path)) {
+            throw new RuntimeException("Runtime plugin path is no longer a symlink [{$path}].");
+        }
+
+        if ($path !== $this->root && ! str_starts_with($path, $this->root.DIRECTORY_SEPARATOR)) {
+            throw new RuntimeException('Runtime plugin path is outside managed storage.');
+        }
+
+        $this->assertSafeManagedPath(dirname($path));
+    }
+
+    private function assertConfiguredPathHasNoSymlink(string $path): void
+    {
+        $current = $path;
+
+        while (true) {
+            if (is_link($current)) {
+                throw new RuntimeException('Runtime plugin storage cannot use a symlinked path.');
+            }
+
+            $parent = dirname($current);
+
+            if ($parent === $current) {
+                return;
+            }
+
+            $current = $parent;
         }
     }
 

--- a/app/Services/Platform/RuntimePluginStore.php
+++ b/app/Services/Platform/RuntimePluginStore.php
@@ -8,6 +8,12 @@ use Throwable;
 
 final class RuntimePluginStore
 {
+    public const RECOVERY_HEALTHY = 'healthy';
+
+    public const RECOVERY_PENDING = 'pending_recovery';
+
+    public const RECOVERY_UNRECOVERABLE = 'unrecoverable_recovery';
+
     private string $root;
 
     public function __construct()
@@ -38,7 +44,9 @@ final class RuntimePluginStore
     {
         $this->ensureDirectory($this->root);
 
-        $handle = fopen($this->root.'/.lock', 'c+');
+        $lockPath = $this->root.'/.lock';
+        $this->assertSafeManagedPath($lockPath);
+        $handle = fopen($lockPath, 'c+');
 
         if ($handle === false || ! flock($handle, LOCK_EX)) {
             throw new RuntimeException('Could not lock runtime plugin storage.');
@@ -58,30 +66,38 @@ final class RuntimePluginStore
 
     public function recoveryStatus(): string
     {
+        if (is_link($this->root) || (file_exists($this->root) && ! is_dir($this->root))) {
+            return self::RECOVERY_UNRECOVERABLE;
+        }
+
         $path = $this->recoveryMarkerPath();
 
         if (is_link($path) || (file_exists($path) && ! is_file($path))) {
-            return 'corrupt';
+            return self::RECOVERY_UNRECOVERABLE;
         }
 
         if (! is_file($path)) {
-            return 'clear';
+            return self::RECOVERY_HEALTHY;
         }
 
         $contents = file_get_contents($path);
 
         if ($contents === false) {
-            return 'corrupt';
+            return self::RECOVERY_UNRECOVERABLE;
         }
 
         try {
             $marker = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
             $this->validateRecoveryMarker($marker);
+
+            if (! $this->isRecoveryMarkerRecoverable($marker)) {
+                return self::RECOVERY_UNRECOVERABLE;
+            }
         } catch (Throwable) {
-            return 'corrupt';
+            return self::RECOVERY_UNRECOVERABLE;
         }
 
-        return 'pending';
+        return self::RECOVERY_PENDING;
     }
 
     /**
@@ -89,7 +105,16 @@ final class RuntimePluginStore
      */
     public function readState(): array
     {
+        if (is_link($this->root) || (file_exists($this->root) && ! is_dir($this->root))) {
+            throw new RuntimeException('Runtime plugin storage is not a safe directory.');
+        }
+
+        if (! is_dir($this->root)) {
+            return [];
+        }
+
         $path = $this->statePath();
+        $this->assertSafeManagedPath($path);
 
         if (is_link($path)) {
             throw new RuntimeException('Runtime plugin state is corrupted. Repair or remove '.$path.' before continuing.');
@@ -142,9 +167,11 @@ final class RuntimePluginStore
     public function writeState(array $state): void
     {
         $this->ensureDirectory($this->root);
+        $statePath = $this->statePath();
+        $this->assertSafeManagedPath($statePath);
 
-        if (is_link($this->statePath())) {
-            throw new RuntimeException('Could not persist runtime plugin state through a symlink.');
+        if (file_exists($statePath) && ! is_file($statePath)) {
+            throw new RuntimeException('Could not persist runtime plugin state through a non-file path.');
         }
 
         try {
@@ -154,28 +181,41 @@ final class RuntimePluginStore
         }
 
         $temporaryPath = $this->root.'/.state-'.bin2hex(random_bytes(8)).'.tmp';
+        $this->assertSafeManagedPath($temporaryPath);
 
-        if (file_put_contents($temporaryPath, $contents, LOCK_EX) === false || ! rename($temporaryPath, $this->statePath())) {
+        if (file_put_contents($temporaryPath, $contents, LOCK_EX) === false || ! rename($temporaryPath, $statePath)) {
             @unlink($temporaryPath);
 
             throw new RuntimeException('Could not persist runtime plugin state.');
         }
 
-        @chmod($this->statePath(), 0640);
+        @chmod($statePath, 0640);
     }
 
     /**
      * @return array<string, string>
      */
-    public function installedPackages(): array
+    public function managedPackageEntries(): array
     {
-        $packages = [];
+        $entries = [];
 
-        if (! is_dir($this->root)) {
-            return $packages;
+        if (is_link($this->root) || (file_exists($this->root) && ! is_dir($this->root))) {
+            throw new RuntimeException('Runtime plugin storage is not a safe directory.');
         }
 
-        foreach (scandir($this->root) ?: [] as $vendor) {
+        if (! is_dir($this->root)) {
+            return $entries;
+        }
+
+        $this->assertSafeManagedPath($this->root);
+
+        $vendors = scandir($this->root);
+
+        if ($vendors === false) {
+            throw new RuntimeException('Could not inspect runtime plugin storage.');
+        }
+
+        foreach ($vendors as $vendor) {
             if ($vendor === '.' || $vendor === '..' || str_starts_with($vendor, '.')) {
                 continue;
             }
@@ -186,7 +226,13 @@ final class RuntimePluginStore
                 continue;
             }
 
-            foreach (scandir($vendorPath) ?: [] as $package) {
+            $packages = scandir($vendorPath);
+
+            if ($packages === false) {
+                throw new RuntimeException("Could not inspect runtime plugin vendor directory [{$vendor}].");
+            }
+
+            foreach ($packages as $package) {
                 if ($package === '.' || $package === '..' || str_starts_with($package, '.')) {
                     continue;
                 }
@@ -194,15 +240,86 @@ final class RuntimePluginStore
                 $id = $vendor.'/'.$package;
                 $packagePath = $vendorPath.DIRECTORY_SEPARATOR.$package;
 
-                if ($this->isValidId($id) && is_dir($packagePath) && ! is_link($packagePath)) {
-                    $packages[$id] = $packagePath;
+                if ($this->isValidId($id) && (is_dir($packagePath) || is_file($packagePath) || is_link($packagePath))) {
+                    $entries[$id] = $packagePath;
                 }
             }
         }
 
-        ksort($packages, SORT_STRING);
+        ksort($entries, SORT_STRING);
 
-        return $packages;
+        return $entries;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function installedPackages(): array
+    {
+        return array_filter(
+            $this->managedPackageEntries(),
+            fn (string $path): bool => is_dir($path) && ! is_link($path),
+        );
+    }
+
+    public function forceCleanupOrphanedMetadata(): void
+    {
+        if ($this->managedPackageEntries() !== []) {
+            throw new RuntimeException('Runtime plugin packages must be removed before cleaning orphaned metadata.');
+        }
+
+        $statePath = $this->statePath();
+        if (file_exists($statePath) || is_link($statePath)) {
+            $this->assertSafeManagedPath($statePath);
+            $this->deleteDirectory($statePath);
+        }
+
+        $this->cleanupRecoveryArtifacts();
+
+        if (file_exists($statePath) || is_link($statePath)) {
+            throw new RuntimeException("Could not clean runtime lifecycle path [{$statePath}].");
+        }
+    }
+
+    private function cleanupRecoveryArtifacts(): void
+    {
+        if (! is_dir($this->root)) {
+            return;
+        }
+
+        $this->assertSafeManagedPath($this->root);
+
+        foreach ($this->recoveryArtifactPaths() as $path) {
+            if (file_exists($path) || is_link($path)) {
+                $this->assertSafeManagedPath($path);
+                $this->deleteDirectory($path);
+            }
+        }
+
+        $entries = scandir($this->root);
+
+        if ($entries === false) {
+            throw new RuntimeException('Could not inspect runtime plugin storage.');
+        }
+
+        foreach ($entries as $entry) {
+            if (
+                (! str_starts_with($entry, '.state-') || ! str_ends_with($entry, '.tmp'))
+                && $entry !== 'recovery.json.tmp'
+            ) {
+                continue;
+            }
+
+            $path = $this->root.'/'.$entry;
+            $this->assertSafeManagedPath($path);
+            $this->deleteDirectory($path);
+        }
+
+        foreach ($this->recoveryArtifactPaths() as $path) {
+            if (file_exists($path) || is_link($path)) {
+                throw new RuntimeException("Could not clean runtime lifecycle path [{$path}].");
+            }
+        }
     }
 
     public function packagePath(string $id): string
@@ -218,8 +335,11 @@ final class RuntimePluginStore
             throw new RuntimeException("Invalid runtime plugin staging label [{$id}].");
         }
 
-        $path = $this->root.'/.staging/'.str_replace('/', '-', $id).'-'.bin2hex(random_bytes(8));
+        $stagingRoot = $this->root.'/.staging';
+        $this->assertSafeManagedPath($stagingRoot);
+        $path = $stagingRoot.'/'.str_replace('/', '-', $id).'-'.bin2hex(random_bytes(8));
         $this->ensureDirectory($path);
+        $this->assertSafeManagedPath($path);
 
         return $path;
     }
@@ -232,6 +352,7 @@ final class RuntimePluginStore
             throw new RuntimeException('Only staging paths can be discarded.');
         }
 
+        $this->assertSafeManagedPath($path);
         $this->deleteDirectory($path);
     }
 
@@ -243,6 +364,9 @@ final class RuntimePluginStore
         $relativeStagingPath = $this->relativeManagedPath($stagingPath);
         $backupPath = $this->root.'/.backup/'.str_replace('/', '-', $id).'-'.bin2hex(random_bytes(8));
         $relativeBackupPath = $this->relativeManagedPath($backupPath);
+        $this->assertSafeManagedPath($activePath);
+        $this->assertSafeManagedPath($stagingPath);
+        $this->assertSafeManagedPath(dirname($backupPath));
         $hadActivePackage = is_dir($activePath) && ! is_link($activePath);
         $state = $this->readState();
         $marker = [
@@ -267,6 +391,7 @@ final class RuntimePluginStore
             }
 
             $this->ensureDirectory(dirname($activePath));
+            $this->assertSafeManagedPath(dirname($activePath));
             $this->renameOrFail($stagingPath, $activePath);
             $marker['phase'] = 'new_active';
             $this->writeRecoveryMarker($marker);
@@ -277,6 +402,7 @@ final class RuntimePluginStore
             $this->writeRecoveryMarker($marker);
 
             $this->deleteDirectory($backupPath);
+            $this->assertSafeManagedPath($this->root.'/.staging');
             $this->deleteDirectory($this->root.'/.staging');
             $this->removeRecoveryMarker();
         } catch (Throwable $exception) {
@@ -296,8 +422,9 @@ final class RuntimePluginStore
     public function setEnabled(string $id, bool $enabled): void
     {
         $this->assertValidId($id);
+        $path = $this->packagePath($id);
 
-        if (! is_dir($this->packagePath($id))) {
+        if (! is_dir($path) || is_link($path)) {
             throw new RuntimeException("Runtime plugin [{$id}] is not installed.");
         }
 
@@ -311,6 +438,7 @@ final class RuntimePluginStore
         $this->assertValidId($id);
 
         $activePath = $this->packagePath($id);
+        $this->assertSafeManagedPath($activePath);
         $state = $this->readState();
 
         if (! is_dir($activePath) || is_link($activePath)) {
@@ -322,6 +450,7 @@ final class RuntimePluginStore
         }
 
         $backupPath = $this->root.'/.backup/'.str_replace('/', '-', $id).'-remove-'.bin2hex(random_bytes(8));
+        $this->assertSafeManagedPath(dirname($backupPath));
         $marker = [
             'operation' => 'remove',
             'id' => $id,
@@ -356,42 +485,51 @@ final class RuntimePluginStore
     public function forceRemove(string $id, bool $allowPendingRecovery = false): void
     {
         $this->assertValidId($id);
+        $activePath = $this->packagePath($id);
+        $this->assertSafeManagedPath($activePath);
         $recoveryStatus = $this->recoveryStatus();
 
-        if ($recoveryStatus === 'pending') {
+        if (in_array($recoveryStatus, [self::RECOVERY_PENDING, self::RECOVERY_UNRECOVERABLE], true)) {
+            $this->assertRecoveryBelongsTo($id);
+        }
+
+        if ($recoveryStatus === self::RECOVERY_PENDING) {
             if (! $allowPendingRecovery) {
                 throw new RuntimeException('Runtime plugin recovery is still pending. Complete recovery before forcing removal.');
             }
 
-            $contents = file_get_contents($this->recoveryMarkerPath());
-            $marker = is_string($contents) ? json_decode($contents, true) : null;
-
-            $this->validateRecoveryMarker($marker);
-
-            if ($marker['id'] !== $id) {
-                throw new RuntimeException('Runtime plugin recovery belongs to a different package.');
+            try {
+                $this->recoverPendingOperation();
+                $recoveryStatus = $this->recoveryStatus();
+            } catch (Throwable) {
+                $recoveryStatus = self::RECOVERY_UNRECOVERABLE;
             }
+        }
 
-            $this->deleteDirectory($this->managedPath($marker['backup']));
-            $stagingPath = isset($marker['staging']) && is_string($marker['staging'])
-                ? $this->managedPath($marker['staging'])
-                : null;
-            $this->deleteDirectory($stagingPath);
+        if ($recoveryStatus === self::RECOVERY_UNRECOVERABLE) {
             $this->removeRecoveryMarker();
         }
 
-        $this->deleteDirectory($this->packagePath($id));
-
+        $stateWasCorrupt = false;
         try {
             $state = $this->readState();
-            unset($state[$id]);
-            $this->writeState($state);
         } catch (Throwable) {
-            // The managed package is still removable when lifecycle metadata is corrupt.
+            $this->resetState();
+            $state = [];
+            $stateWasCorrupt = true;
         }
 
-        if ($recoveryStatus === 'corrupt') {
-            $this->removeRecoveryMarker();
+        $this->deleteDirectory($activePath);
+
+        if (! $stateWasCorrupt) {
+            unset($state[$id]);
+            $this->writeState($state);
+        }
+
+        $this->cleanupRecoveryArtifacts();
+
+        if ($this->managedPackageEntries() === []) {
+            $this->forceCleanupOrphanedMetadata();
         }
     }
 
@@ -404,6 +542,10 @@ final class RuntimePluginStore
         }
 
         if (! is_file($path)) {
+            if (file_exists($path) || is_link($path)) {
+                throw new RuntimeException('Runtime plugin recovery marker is unsafe.');
+            }
+
             return;
         }
 
@@ -427,6 +569,9 @@ final class RuntimePluginStore
             ? $this->managedPath($marker['staging'])
             : null;
         $activePath = $this->packagePath($id);
+        $this->assertSafeManagedPath($backupPath);
+        $this->assertSafeManagedPath($stagingPath ?? $this->root);
+        $this->assertSafeManagedPath($activePath);
 
         if ($marker['phase'] === 'committed') {
             if (! is_dir($activePath)) {
@@ -511,6 +656,18 @@ final class RuntimePluginStore
         $this->writeState($state);
     }
 
+    private function resetState(): void
+    {
+        $path = $this->statePath();
+        $this->assertSafeManagedPath($path);
+
+        if (file_exists($path) && ! is_file($path)) {
+            $this->deleteDirectory($path);
+        }
+
+        $this->writeState([]);
+    }
+
     private function validateRecoveryMarker(mixed $marker): void
     {
         if (
@@ -527,6 +684,113 @@ final class RuntimePluginStore
         }
 
         $this->assertValidId($marker['id']);
+
+        if ($marker['operation'] === 'swap' && ! is_string($marker['staging'] ?? null)) {
+            throw new RuntimeException('Runtime plugin recovery marker is invalid.');
+        }
+
+        if (
+            $marker['operation'] === 'remove'
+            && (($marker['staging'] ?? null) !== null || $marker['had_active'] !== true)
+        ) {
+            throw new RuntimeException('Runtime plugin recovery marker is invalid.');
+        }
+
+        if (
+            $marker['operation'] === 'remove' && $marker['phase'] === 'new_active'
+        ) {
+            throw new RuntimeException('Runtime plugin recovery marker has an invalid phase transition.');
+        }
+
+        if (
+            $marker['operation'] === 'swap'
+            && $marker['phase'] === 'new_active'
+            && (! is_array($marker['next_entry'] ?? null) || ! is_bool($marker['next_entry']['enabled'] ?? null))
+        ) {
+            throw new RuntimeException('Runtime plugin recovery marker has invalid next state.');
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $marker
+     */
+    private function isRecoveryMarkerRecoverable(array $marker): bool
+    {
+        try {
+            $activePath = $this->packagePath($marker['id']);
+            $backupPath = $this->managedPath($marker['backup']);
+            $stagingPath = isset($marker['staging']) && is_string($marker['staging'])
+                ? $this->managedPath($marker['staging'])
+                : null;
+            $this->assertSafeManagedPath($activePath);
+            $this->assertSafeManagedPath($backupPath);
+            $this->assertSafeManagedPath($stagingPath ?? $this->root);
+        } catch (Throwable) {
+            return false;
+        }
+
+        $activeExists = is_dir($activePath) && ! is_link($activePath);
+        $backupExists = is_dir($backupPath) && ! is_link($backupPath);
+        $stagingExists = $stagingPath !== null && is_dir($stagingPath) && ! is_link($stagingPath);
+
+        if ($marker['operation'] === 'swap') {
+            return match ($marker['phase']) {
+                'prepared' => $stagingExists && ($marker['had_active']
+                    ? ($activeExists xor $backupExists)
+                    : ! $activeExists && ! $backupExists),
+                'old_preserved' => $backupExists && $stagingExists && ! $activeExists && $this->stateIsReadable(),
+                'new_active' => $activeExists
+                    && ($marker['had_active'] ? $backupExists : ! $backupExists)
+                    && $this->stateIsReadable(),
+                'committed' => $marker['had_active']
+                    ? ($activeExists || ($backupExists && $this->stateIsReadable()))
+                    : $activeExists,
+                default => false,
+            };
+        }
+
+        return match ($marker['phase']) {
+            'prepared' => $activeExists xor $backupExists,
+            'old_preserved' => $backupExists && ! $activeExists && $this->stateIsReadable(),
+            'committed' => $backupExists && ! $activeExists && $this->stateIsReadable(),
+            default => false,
+        };
+    }
+
+    private function stateIsReadable(): bool
+    {
+        try {
+            $this->readState();
+        } catch (Throwable) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function assertRecoveryBelongsTo(string $id): void
+    {
+        $path = $this->recoveryMarkerPath();
+
+        if (! is_file($path) || is_link($path)) {
+            return;
+        }
+
+        $contents = file_get_contents($path);
+
+        if ($contents === false) {
+            return;
+        }
+
+        try {
+            $marker = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+        } catch (Throwable) {
+            return;
+        }
+
+        if (is_array($marker) && is_string($marker['id'] ?? null) && $this->isValidId($marker['id']) && $marker['id'] !== $id) {
+            throw new RuntimeException('Runtime plugin recovery belongs to a different package.');
+        }
     }
 
     /**
@@ -534,14 +798,18 @@ final class RuntimePluginStore
      */
     private function writeRecoveryMarker(array $marker): void
     {
-        if (is_link($this->recoveryMarkerPath())) {
-            throw new RuntimeException('Could not persist runtime plugin recovery state through a symlink.');
+        $recoveryPath = $this->recoveryMarkerPath();
+        $this->assertSafeManagedPath($recoveryPath);
+
+        if (file_exists($recoveryPath) && ! is_file($recoveryPath)) {
+            throw new RuntimeException('Could not persist runtime plugin recovery state through a non-file path.');
         }
 
         $contents = json_encode($marker, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR).PHP_EOL;
-        $temporaryPath = $this->recoveryMarkerPath().'.tmp';
+        $temporaryPath = $recoveryPath.'.tmp';
+        $this->assertSafeManagedPath($temporaryPath);
 
-        if (file_put_contents($temporaryPath, $contents, LOCK_EX) === false || ! rename($temporaryPath, $this->recoveryMarkerPath())) {
+        if (file_put_contents($temporaryPath, $contents, LOCK_EX) === false || ! rename($temporaryPath, $recoveryPath)) {
             @unlink($temporaryPath);
 
             throw new RuntimeException('Could not persist runtime plugin recovery state.');
@@ -550,7 +818,25 @@ final class RuntimePluginStore
 
     private function removeRecoveryMarker(): void
     {
-        @unlink($this->recoveryMarkerPath());
+        $path = $this->recoveryMarkerPath();
+
+        if (! file_exists($path) && ! is_link($path)) {
+            return;
+        }
+
+        $this->assertSafeManagedPath($path);
+        $this->deleteDirectory($path);
+    }
+
+    /** @return array<int, string> */
+    private function recoveryArtifactPaths(): array
+    {
+        return [
+            $this->recoveryMarkerPath(),
+            $this->root.'/.staging',
+            $this->root.'/.backup',
+            $this->root.'/recovery.json.tmp',
+        ];
     }
 
     private function statePath(): string
@@ -591,6 +877,10 @@ final class RuntimePluginStore
 
     private function ensureDirectory(string $path): void
     {
+        if (is_link($path) || (file_exists($path) && ! is_dir($path))) {
+            throw new RuntimeException("Runtime plugin path is not a safe directory [{$path}].");
+        }
+
         if (is_dir($path)) {
             return;
         }
@@ -607,12 +897,23 @@ final class RuntimePluginStore
         }
 
         if (is_link($path) || is_file($path)) {
-            unlink($path);
+            if (! @unlink($path) || file_exists($path) || is_link($path)) {
+                throw new RuntimeException("Could not remove runtime plugin path [{$path}].");
+            }
 
             return;
         }
 
-        foreach (scandir($path) ?: [] as $entry) {
+        if (! is_dir($path)) {
+            throw new RuntimeException("Could not remove runtime plugin path [{$path}].");
+        }
+
+        $entries = @scandir($path);
+        if ($entries === false) {
+            throw new RuntimeException("Could not inspect runtime plugin path [{$path}].");
+        }
+
+        foreach ($entries as $entry) {
             if ($entry === '.' || $entry === '..') {
                 continue;
             }
@@ -620,7 +921,44 @@ final class RuntimePluginStore
             $this->deleteDirectory($path.DIRECTORY_SEPARATOR.$entry);
         }
 
-        rmdir($path);
+        if (! @rmdir($path) || file_exists($path) || is_link($path)) {
+            throw new RuntimeException("Could not remove runtime plugin path [{$path}].");
+        }
+    }
+
+    private function assertSafeManagedPath(string $path): void
+    {
+        if ($path !== $this->root && ! str_starts_with($path, $this->root.DIRECTORY_SEPARATOR)) {
+            throw new RuntimeException('Runtime plugin path is outside managed storage.');
+        }
+
+        $resolvedRoot = realpath($this->root);
+        if (! is_string($resolvedRoot) || $resolvedRoot !== $this->root) {
+            throw new RuntimeException('Runtime plugin storage path cannot be resolved.');
+        }
+
+        $current = $path;
+        while (! file_exists($current) && ! is_link($current)) {
+            $parent = dirname($current);
+
+            if ($parent === $current) {
+                throw new RuntimeException('Runtime plugin path cannot be resolved.');
+            }
+
+            $current = $parent;
+        }
+
+        if (is_link($current)) {
+            throw new RuntimeException("Runtime plugin path contains a symlink [{$current}].");
+        }
+
+        $resolved = realpath($current);
+        if (
+            ! is_string($resolved)
+            || ($resolved !== $resolvedRoot && ! str_starts_with($resolved, $resolvedRoot.DIRECTORY_SEPARATOR))
+        ) {
+            throw new RuntimeException('Runtime plugin path is outside managed storage.');
+        }
     }
 
     private function renameOrFail(string $from, string $to): void

--- a/app/Services/Platform/RuntimePluginStore.php
+++ b/app/Services/Platform/RuntimePluginStore.php
@@ -60,10 +60,10 @@ final class RuntimePluginStore
 
         try {
             if ($recover) {
-                $recoveryIdentity = $this->recoveryIdentity();
-
-                if ($pluginId === null || $recoveryIdentity === $pluginId) {
+                if ($pluginId === null) {
                     $this->recoverPendingOperation();
+                } elseif ($this->recoveryMarkerPathForId($pluginId) !== null) {
+                    $this->recoverPendingOperation($pluginId);
                 }
             }
 
@@ -76,71 +76,111 @@ final class RuntimePluginStore
 
     public function recoveryStatus(): string
     {
-        if (is_link($this->root) || (file_exists($this->root) && ! is_dir($this->root))) {
-            return self::RECOVERY_UNRECOVERABLE;
-        }
-
-        $path = $this->recoveryMarkerPath();
-
-        if (is_link($path) || (file_exists($path) && ! is_file($path))) {
-            return self::RECOVERY_UNRECOVERABLE;
-        }
-
-        if (! is_file($path)) {
-            return $this->orphanedRuntimeArtifactPaths() === []
-                ? self::RECOVERY_HEALTHY
-                : self::RECOVERY_ORPHANED_ARTIFACT;
-        }
-
-        $contents = file_get_contents($path);
-
-        if ($contents === false) {
-            return self::RECOVERY_UNRECOVERABLE;
-        }
-
         try {
-            $marker = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
-            $this->validateRecoveryMarker($marker);
+            $hasPending = false;
 
-            if (! $this->isRecoveryMarkerRecoverable($marker)) {
-                return self::RECOVERY_UNRECOVERABLE;
+            foreach ($this->recoveryMarkerPaths() as $path) {
+                $status = $this->recoveryStatusForPath($path);
+
+                if ($status === self::RECOVERY_UNRECOVERABLE) {
+                    return $status;
+                }
+
+                $hasPending = $hasPending || $status === self::RECOVERY_PENDING;
             }
         } catch (Throwable) {
             return self::RECOVERY_UNRECOVERABLE;
         }
 
-        return self::RECOVERY_PENDING;
+        if ($hasPending) {
+            return self::RECOVERY_PENDING;
+        }
+
+        return $this->orphanedRuntimeArtifactPaths() === []
+            ? self::RECOVERY_HEALTHY
+            : self::RECOVERY_ORPHANED_ARTIFACT;
     }
 
     public function recoveryIdentity(): ?string
     {
-        $path = $this->recoveryMarkerPath();
+        $identities = $this->recoveryIdentities();
+
+        return count($identities) === 1 ? $identities[0] : null;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function recoveryIdentities(): array
+    {
+        $identities = [];
+
+        foreach ($this->recoveryMarkerPaths() as $path) {
+            $contents = @file_get_contents($path);
+
+            if ($contents === false) {
+                continue;
+            }
+
+            try {
+                $marker = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+            } catch (Throwable) {
+                continue;
+            }
+
+            $id = $path === $this->recoveryMarkerPath()
+                ? (is_array($marker) ? $marker['id'] ?? null : null)
+                : $this->recoveryIdentityFromPath($path);
+
+            if (is_string($id) && $this->isValidId($id)) {
+                $identities[$id] = true;
+            }
+        }
+
+        return array_keys($identities);
+    }
+
+    public function hasRecoveryFor(string $id): bool
+    {
+        return $this->recoveryMarkerPathForId($id) !== null;
+    }
+
+    /**
+     * @return array<int, array{id: string|null, status: string, cleanup_key: string}>
+     */
+    public function recoveryRecords(): array
+    {
+        $records = [];
 
         try {
-            $this->assertSafeManagedPath($path);
+            $paths = $this->recoveryMarkerPaths();
         } catch (Throwable) {
-            return null;
+            return [[
+                'id' => null,
+                'status' => self::RECOVERY_UNRECOVERABLE,
+                'cleanup_key' => 'orphaned-recovery',
+            ]];
         }
 
-        if (! is_file($path) || is_link($path)) {
-            return null;
+        foreach ($paths as $path) {
+            $id = $path === $this->recoveryMarkerPath()
+                ? $this->markerIdentity($path)
+                : $this->recoveryIdentityFromPath($path);
+
+            try {
+                $status = $this->recoveryStatusForPath($path);
+            } catch (Throwable) {
+                $status = self::RECOVERY_UNRECOVERABLE;
+            }
+
+            $records[] = [
+                'id' => $id,
+                'status' => $status,
+                'cleanup_key' => $id === null ? 'orphaned-recovery' : 'recovery:'.$id,
+            ];
         }
 
-        $contents = file_get_contents($path);
-
-        if ($contents === false) {
-            return null;
-        }
-
-        try {
-            $marker = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
-        } catch (Throwable) {
-            return null;
-        }
-
-        $id = is_array($marker) ? $marker['id'] ?? null : null;
-
-        return is_string($id) && $this->isValidId($id) ? $id : null;
+        return $records;
     }
 
     /**
@@ -299,10 +339,18 @@ final class RuntimePluginStore
      */
     public function installedPackages(): array
     {
-        return array_filter(
-            $this->managedPackageEntries(),
-            fn (string $path): bool => is_dir($path) && ! is_link($path),
-        );
+        $packages = [];
+
+        foreach ($this->managedPackageEntries() as $id => $path) {
+            if (! $this->isRealDirectory($path)) {
+                continue;
+            }
+
+            $this->assertSafeManagedPath($path);
+            $packages[$id] = $path;
+        }
+
+        return $packages;
     }
 
     /**
@@ -328,7 +376,7 @@ final class RuntimePluginStore
         }
 
         $expectedFiles = ['.lock', 'state.json', 'recovery.json', 'recovery.json.tmp'];
-        $expectedDirectories = ['.staging', '.backup'];
+        $expectedDirectories = ['.staging', '.backup', '.recovery'];
 
         foreach ($vendors as $vendor) {
             if ($vendor === '.' || $vendor === '..') {
@@ -348,6 +396,34 @@ final class RuntimePluginStore
             if (in_array($vendor, $expectedDirectories, true)) {
                 if (! $this->isRealDirectory($vendorPath)) {
                     $anomalies['internal:'.$vendor] = $vendorPath;
+
+                    continue;
+                }
+
+                if ($vendor === '.recovery') {
+                    $recoveryEntries = @scandir($vendorPath);
+
+                    if ($recoveryEntries === false) {
+                        $anomalies['internal:.recovery'] = $vendorPath;
+
+                        continue;
+                    }
+
+                    foreach ($recoveryEntries as $recoveryEntry) {
+                        if ($recoveryEntry === '.' || $recoveryEntry === '..') {
+                            continue;
+                        }
+
+                        $recoveryEntryPath = $vendorPath.'/'.$recoveryEntry;
+
+                        if (
+                            ! str_ends_with($recoveryEntry, '.json')
+                            || ! $this->isRegularFile($recoveryEntryPath)
+                            || $this->recoveryIdentityFromPath($recoveryEntryPath) === null
+                        ) {
+                            $anomalies['internal:.recovery/'.$recoveryEntry] = $recoveryEntryPath;
+                        }
+                    }
                 }
 
                 continue;
@@ -455,13 +531,13 @@ final class RuntimePluginStore
         }
 
         $statePath = $this->statePath();
-        if (file_exists($statePath) || is_link($statePath)) {
+        if ($this->managedEntryExists($statePath)) {
             $this->deleteManagedPath($statePath);
         }
 
         $this->cleanupRecoveryArtifacts();
 
-        if (file_exists($statePath) || is_link($statePath)) {
+        if ($this->managedEntryExists($statePath)) {
             throw new RuntimeException("Could not clean runtime lifecycle path [{$statePath}].");
         }
     }
@@ -485,10 +561,17 @@ final class RuntimePluginStore
     public function forceCleanupRecovery(string $id): void
     {
         $this->assertValidId($id);
-        $markerPath = $this->recoveryMarkerPath();
+        $markerPath = $this->recoveryMarkerPathForId($id);
+
+        if ($markerPath === null) {
+            throw new RuntimeException('Runtime plugin recovery metadata is not available.');
+        }
 
         if (! is_file($markerPath) || is_link($markerPath)) {
-            throw new RuntimeException('Runtime plugin recovery metadata is not available.');
+            $this->deleteManagedPath($markerPath);
+            $this->removeEmptyRecoveryDirectory();
+
+            return;
         }
 
         $contents = file_get_contents($markerPath);
@@ -499,12 +582,20 @@ final class RuntimePluginStore
 
         try {
             $marker = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
-        } catch (Throwable $exception) {
-            throw new RuntimeException('Runtime plugin recovery marker is corrupted.', previous: $exception);
+        } catch (Throwable) {
+            $marker = [];
         }
 
-        if (! is_array($marker) || ($marker['id'] ?? null) !== $id) {
-            throw new RuntimeException('Runtime plugin recovery belongs to a different package.');
+        if (! is_array($marker)) {
+            $marker = [];
+        }
+
+        if ($marker !== [] && ($marker['id'] ?? null) !== $id) {
+            if ($this->recoveryIdentityFromPath($markerPath) !== $id) {
+                throw new RuntimeException('Runtime plugin recovery belongs to a different package.');
+            }
+
+            $marker = [];
         }
 
         try {
@@ -513,17 +604,11 @@ final class RuntimePluginStore
                 unset($state[$id]);
                 $this->writeState($state);
             }
-        } catch (Throwable) {
-            if ($this->managedPackageEntries() === []) {
-                $statePath = $this->statePath();
-
-                if (file_exists($statePath) || is_link($statePath)) {
-                    $this->deleteManagedPath($statePath);
-                }
-            }
+        } catch (Throwable $exception) {
+            report($exception);
         }
 
-        $paths = [$markerPath, $this->root.'/recovery.json.tmp'];
+        $paths = [$markerPath, $markerPath.'.tmp'];
 
         foreach (['backup', 'staging'] as $key) {
             if (! array_key_exists($key, $marker)) {
@@ -538,15 +623,17 @@ final class RuntimePluginStore
         }
 
         foreach (array_unique($paths) as $path) {
-            if (! file_exists($path) && ! is_link($path)) {
+            if (! $this->managedEntryExists($path)) {
                 continue;
             }
 
             $this->deleteManagedPath($path);
         }
 
+        $this->removeEmptyRecoveryDirectory();
+
         foreach (array_unique($paths) as $path) {
-            if (file_exists($path) || is_link($path)) {
+            if ($this->managedEntryExists($path)) {
                 throw new RuntimeException("Could not clean runtime lifecycle path [{$path}].");
             }
         }
@@ -571,7 +658,7 @@ final class RuntimePluginStore
 
     public function forceCleanupUnknownRecovery(): void
     {
-        if ($this->recoveryIdentity() !== null) {
+        if ($this->markerIdentity($this->recoveryMarkerPath()) !== null) {
             throw new RuntimeException('Runtime plugin recovery belongs to a known package.');
         }
 
@@ -604,7 +691,7 @@ final class RuntimePluginStore
         }
 
         foreach (array_unique($paths) as $path) {
-            if (! file_exists($path) && ! is_link($path)) {
+            if (! $this->managedEntryExists($path)) {
                 continue;
             }
 
@@ -612,7 +699,7 @@ final class RuntimePluginStore
         }
 
         foreach (array_unique($paths) as $path) {
-            if (file_exists($path) || is_link($path)) {
+            if ($this->managedEntryExists($path)) {
                 throw new RuntimeException("Could not clean runtime lifecycle path [{$path}].");
             }
         }
@@ -636,7 +723,7 @@ final class RuntimePluginStore
         if ($this->managedPackageEntries() === []) {
             $statePath = $this->statePath();
 
-            if (file_exists($statePath) || is_link($statePath)) {
+            if ($this->managedEntryExists($statePath)) {
                 $this->deleteManagedPath($statePath);
             }
         }
@@ -673,7 +760,7 @@ final class RuntimePluginStore
         $this->assertSafeManagedPath($this->root);
 
         foreach ($this->recoveryArtifactPaths() as $path) {
-            if (file_exists($path) || is_link($path)) {
+            if ($this->managedEntryExists($path)) {
                 $this->deleteManagedPath($path);
             }
         }
@@ -697,17 +784,17 @@ final class RuntimePluginStore
         }
 
         foreach ($this->recoveryArtifactPaths() as $path) {
-            if (file_exists($path) || is_link($path)) {
+            if ($this->managedEntryExists($path)) {
                 throw new RuntimeException("Could not clean runtime lifecycle path [{$path}].");
             }
         }
+
+        $this->removeEmptyRecoveryDirectory();
     }
 
     private function recoveryMarkerExists(): bool
     {
-        $path = $this->recoveryMarkerPath();
-
-        return file_exists($path) || is_link($path);
+        return $this->recoveryMarkerPaths() !== [];
     }
 
     public function packagePath(string $id): string
@@ -715,6 +802,18 @@ final class RuntimePluginStore
         $this->assertValidId($id);
 
         return $this->root.DIRECTORY_SEPARATOR.str_replace('/', DIRECTORY_SEPARATOR, $id);
+    }
+
+    public function installedPackagePath(string $id): string
+    {
+        $path = $this->packagePath($id);
+        $this->assertSafeManagedPath($path);
+
+        if (! $this->isRealDirectory($path)) {
+            throw new RuntimeException("Runtime plugin [{$id}] is not installed.");
+        }
+
+        return $path;
     }
 
     public function createStagingPath(string $id): string
@@ -804,12 +903,11 @@ final class RuntimePluginStore
             $this->writeRecoveryMarker($marker);
 
             $this->deleteDirectory($backupPath);
-            $this->assertSafeManagedPath($this->root.'/.staging');
-            $this->deleteDirectory($this->root.'/.staging');
-            $this->removeRecoveryMarker();
+            $this->discardStaging($stagingPath);
+            $this->removeRecoveryMarker($id);
         } catch (Throwable $exception) {
             try {
-                $this->recoverPendingOperation();
+                $this->recoverPendingOperation($id);
             } catch (Throwable $recoveryException) {
                 throw new RuntimeException(
                     'Runtime plugin installation failed and automatic recovery also failed.',
@@ -824,11 +922,7 @@ final class RuntimePluginStore
     public function setEnabled(string $id, bool $enabled): void
     {
         $this->assertValidId($id);
-        $path = $this->packagePath($id);
-
-        if (! is_dir($path) || is_link($path)) {
-            throw new RuntimeException("Runtime plugin [{$id}] is not installed.");
-        }
+        $this->installedPackagePath($id);
 
         $state = $this->readState();
         $state[$id] = ['enabled' => $enabled];
@@ -843,11 +937,10 @@ final class RuntimePluginStore
         $this->assertSafeManagedPath($activePath);
         $state = $this->readState();
         $recoveryStatus = $this->recoveryStatus();
-        $recoveryIdentity = $this->recoveryIdentity();
 
         if (
             in_array($recoveryStatus, [self::RECOVERY_PENDING, self::RECOVERY_UNRECOVERABLE], true)
-            && $recoveryIdentity !== $id
+            && ! $this->hasRecoveryFor($id)
         ) {
             $this->deleteDirectory($activePath);
             unset($state[$id]);
@@ -889,9 +982,9 @@ final class RuntimePluginStore
             $this->writeRecoveryMarker($marker);
 
             $this->deleteDirectory($backupPath);
-            $this->removeRecoveryMarker();
+            $this->removeRecoveryMarker($id);
         } catch (Throwable $exception) {
-            $this->recoverPendingOperation();
+            $this->recoverPendingOperation($id);
 
             throw $exception;
         }
@@ -903,12 +996,10 @@ final class RuntimePluginStore
         $activePath = $this->packagePath($id);
         $this->assertSafeManagedPath($activePath);
         $recoveryStatus = $this->recoveryStatus();
-        $recoveryIdentity = $this->recoveryIdentity();
-        $preserveUnrelatedRecovery = in_array(
-            $recoveryStatus,
-            [self::RECOVERY_PENDING, self::RECOVERY_UNRECOVERABLE],
-            true,
-        ) && $recoveryIdentity !== $id;
+        $recoveryPaths = $this->recoveryMarkerPaths();
+        $targetRecoveryPath = $this->recoveryMarkerPathForId($id);
+        $preserveUnrelatedRecovery = $recoveryPaths !== []
+            && ($targetRecoveryPath === null || count($recoveryPaths) > 1);
 
         if (
             in_array($recoveryStatus, [self::RECOVERY_PENDING, self::RECOVERY_UNRECOVERABLE], true)
@@ -924,16 +1015,12 @@ final class RuntimePluginStore
 
             if (! $preserveUnrelatedRecovery) {
                 try {
-                    $this->recoverPendingOperation();
+                    $this->recoverPendingOperation($id);
                     $recoveryStatus = $this->recoveryStatus();
                 } catch (Throwable) {
                     $recoveryStatus = self::RECOVERY_UNRECOVERABLE;
                 }
             }
-        }
-
-        if ($recoveryStatus === self::RECOVERY_UNRECOVERABLE && ! $preserveUnrelatedRecovery) {
-            $this->removeRecoveryMarker();
         }
 
         $stateWasCorrupt = false;
@@ -951,18 +1038,24 @@ final class RuntimePluginStore
             $this->writeState($state);
         }
 
-        if (! $preserveUnrelatedRecovery) {
-            $this->cleanupRecoveryArtifacts();
+        if ($this->recoveryMarkerPathForId($id) !== null) {
+            $this->forceCleanupRecovery($id);
         }
 
-        if ($this->managedPackageEntries() === []) {
+        if ($this->managedPackageEntries() === [] && $this->recoveryMarkerPaths() === []) {
             $this->forceCleanupOrphanedMetadata();
         }
     }
 
-    public function recoverPendingOperation(): void
+    public function recoverPendingOperation(?string $id = null): void
     {
-        $path = $this->recoveryMarkerPath();
+        $path = $id !== null
+            ? $this->recoveryMarkerPathForId($id)
+            : $this->singleRecoveryMarkerPath();
+
+        if ($path === null) {
+            return;
+        }
 
         if (is_link($path)) {
             throw new RuntimeException('Runtime plugin recovery marker is unsafe.');
@@ -990,6 +1083,11 @@ final class RuntimePluginStore
 
         $this->validateRecoveryMarker($marker);
 
+        $pathIdentity = $this->recoveryIdentityFromPath($path);
+        if (($pathIdentity !== null && $marker['id'] !== $pathIdentity) || ($id !== null && $marker['id'] !== $id)) {
+            throw new RuntimeException('Runtime plugin recovery belongs to a different package.');
+        }
+
         $id = $marker['id'];
         $backupPath = $this->managedPath($marker['backup']);
         $stagingPath = isset($marker['staging']) && is_string($marker['staging'])
@@ -1001,6 +1099,17 @@ final class RuntimePluginStore
         $this->assertSafeManagedPath($activePath);
 
         if ($marker['phase'] === 'committed') {
+            if ($marker['operation'] === 'remove') {
+                if ($this->managedEntryExists($activePath)) {
+                    throw new RuntimeException("Runtime plugin [{$id}] unexpectedly exists after removal was committed.");
+                }
+
+                $this->deleteDirectory($backupPath);
+                $this->removeRecoveryMarker($id, $path);
+
+                return;
+            }
+
             if (! is_dir($activePath)) {
                 if (! is_dir($backupPath)) {
                     throw new RuntimeException("Runtime plugin [{$id}] cannot be recovered: active package is missing.");
@@ -1013,7 +1122,7 @@ final class RuntimePluginStore
 
             $this->deleteDirectory($backupPath);
             $this->deleteDirectory($stagingPath);
-            $this->removeRecoveryMarker();
+            $this->removeRecoveryMarker($id, $path);
 
             return;
         }
@@ -1028,7 +1137,7 @@ final class RuntimePluginStore
 
             $this->deleteDirectory($stagingPath);
             $this->deleteDirectory($backupPath);
-            $this->removeRecoveryMarker();
+            $this->removeRecoveryMarker($id, $path);
 
             return;
         }
@@ -1045,7 +1154,7 @@ final class RuntimePluginStore
             $this->writeState($state);
             $this->deleteDirectory($backupPath);
             $this->deleteDirectory($stagingPath);
-            $this->removeRecoveryMarker();
+            $this->removeRecoveryMarker($id, $path);
 
             return;
         }
@@ -1062,7 +1171,7 @@ final class RuntimePluginStore
         $this->ensureDirectory(dirname($activePath));
         $this->renameOrFail($backupPath, $activePath);
         $this->deleteDirectory($stagingPath);
-        $this->removeRecoveryMarker();
+        $this->removeRecoveryMarker($id, $path);
     }
 
     /**
@@ -1167,7 +1276,7 @@ final class RuntimePluginStore
         return match ($marker['phase']) {
             'prepared' => $activeExists xor $backupExists,
             'old_preserved' => $backupExists && ! $activeExists && $this->stateIsReadable(),
-            'committed' => $backupExists && ! $activeExists && $this->stateIsReadable(),
+            'committed' => ! $activeExists && $backupExists && $this->stateIsReadable(),
             default => false,
         };
     }
@@ -1185,19 +1294,11 @@ final class RuntimePluginStore
 
     private function assertRecoveryBelongsTo(string $id): void
     {
-        $identity = $this->recoveryIdentity();
-
-        if ($identity !== null) {
-            if ($identity !== $id) {
-                throw new RuntimeException('Runtime plugin recovery belongs to a different package.');
-            }
-
+        if ($this->recoveryMarkerPathForId($id) !== null) {
             return;
         }
 
-        if (count($this->managedPackageEntries()) > 1) {
-            throw new RuntimeException('Runtime plugin recovery owner cannot be determined safely.');
-        }
+        throw new RuntimeException('Runtime plugin recovery belongs to a different package.');
     }
 
     /**
@@ -1205,7 +1306,7 @@ final class RuntimePluginStore
      */
     private function writeRecoveryMarker(array $marker): void
     {
-        $recoveryPath = $this->recoveryMarkerPath();
+        $recoveryPath = $this->recoveryMarkerPathForWrite($marker['id']);
         $this->assertSafeManagedPath($recoveryPath);
 
         if (file_exists($recoveryPath) && ! is_file($recoveryPath)) {
@@ -1226,22 +1327,28 @@ final class RuntimePluginStore
         }
     }
 
-    private function removeRecoveryMarker(): void
+    private function removeRecoveryMarker(?string $id = null, ?string $path = null): void
     {
-        $path = $this->recoveryMarkerPath();
+        $path ??= $id !== null
+            ? $this->recoveryMarkerPathForId($id)
+            : $this->recoveryMarkerPath();
 
-        if (! file_exists($path) && ! is_link($path)) {
+        if ($path === null || ! $this->managedEntryExists($path)) {
             return;
         }
 
         $this->deleteManagedPath($path);
+        $this->removeEmptyRecoveryDirectory();
     }
 
     /** @return array<int, string> */
     private function recoveryArtifactPaths(): array
     {
+        $markers = $this->recoveryMarkerPaths();
+
         return [
-            $this->recoveryMarkerPath(),
+            ...$markers,
+            ...array_map(fn (string $path): string => $path.'.tmp', $markers),
             $this->root.'/.staging',
             $this->root.'/.backup',
             $this->root.'/recovery.json.tmp',
@@ -1256,6 +1363,205 @@ final class RuntimePluginStore
     private function recoveryMarkerPath(): string
     {
         return $this->root.'/recovery.json';
+    }
+
+    private function recoveryMarkerPathForWrite(string $id): string
+    {
+        $rootPath = $this->recoveryMarkerPath();
+
+        if (! $this->managedEntryExists($rootPath) || $this->markerIdentity($rootPath) === $id) {
+            return $rootPath;
+        }
+
+        $directory = $this->root.'/.recovery';
+        $this->ensureDirectory($directory);
+
+        return $this->recoveryMarkerPathForId($id, false);
+    }
+
+    private function recoveryMarkerPathForId(string $id, bool $allowMissing = true): ?string
+    {
+        $this->assertValidId($id);
+        $sidecar = $this->root.'/.recovery/'.bin2hex($id).'.json';
+
+        if ($this->managedEntryExists($sidecar)) {
+            return $sidecar;
+        }
+
+        $directory = $this->root.'/.recovery';
+
+        if ($this->managedEntryExists($directory) && is_dir($directory) && ! is_link($directory)) {
+            $entries = scandir($directory);
+
+            if ($entries === false) {
+                throw new RuntimeException("Could not inspect runtime lifecycle path [{$directory}].");
+            }
+
+            foreach ($entries as $entry) {
+                if ($entry === '.' || $entry === '..' || ! str_ends_with($entry, '.json')) {
+                    continue;
+                }
+
+                $path = $directory.'/'.$entry;
+
+                if ($this->recoveryIdentityFromPath($path) === $id && $this->managedEntryExists($path)) {
+                    return $path;
+                }
+            }
+        }
+
+        $rootPath = $this->recoveryMarkerPath();
+
+        if ($this->managedEntryExists($rootPath) && $this->markerIdentity($rootPath) === $id) {
+            return $rootPath;
+        }
+
+        return $allowMissing ? null : $sidecar;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function recoveryMarkerPaths(): array
+    {
+        $paths = [];
+        $rootPath = $this->recoveryMarkerPath();
+
+        if ($this->managedEntryExists($rootPath)) {
+            $paths[] = $rootPath;
+        }
+
+        $directory = $this->root.'/.recovery';
+
+        if (! $this->managedEntryExists($directory)) {
+            return $paths;
+        }
+
+        if (is_link($directory) || ! is_dir($directory)) {
+            $paths[] = $directory;
+
+            return $paths;
+        }
+
+        $entries = scandir($directory);
+
+        if ($entries === false) {
+            $paths[] = $directory;
+
+            return $paths;
+        }
+
+        foreach ($entries as $entry) {
+            if ($entry === '.' || $entry === '..' || ! str_ends_with($entry, '.json')) {
+                continue;
+            }
+
+            $path = $directory.'/'.$entry;
+
+            if ($this->managedEntryExists($path)) {
+                $paths[] = $path;
+            }
+        }
+
+        sort($paths, SORT_STRING);
+
+        return $paths;
+    }
+
+    private function singleRecoveryMarkerPath(): ?string
+    {
+        $paths = $this->recoveryMarkerPaths();
+
+        if (count($paths) > 1) {
+            throw new RuntimeException('Multiple runtime plugin recovery records require a plugin identity.');
+        }
+
+        return $paths[0] ?? null;
+    }
+
+    private function recoveryStatusForPath(string $path): string
+    {
+        if (is_link($path) || ! is_file($path)) {
+            return self::RECOVERY_UNRECOVERABLE;
+        }
+
+        $contents = @file_get_contents($path);
+
+        if ($contents === false) {
+            return self::RECOVERY_UNRECOVERABLE;
+        }
+
+        try {
+            $marker = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+            $this->validateRecoveryMarker($marker);
+
+            $pathIdentity = $this->recoveryIdentityFromPath($path);
+            if ($pathIdentity !== null && $marker['id'] !== $pathIdentity) {
+                return self::RECOVERY_UNRECOVERABLE;
+            }
+        } catch (Throwable) {
+            return self::RECOVERY_UNRECOVERABLE;
+        }
+
+        return $this->isRecoveryMarkerRecoverable($marker)
+            ? self::RECOVERY_PENDING
+            : self::RECOVERY_UNRECOVERABLE;
+    }
+
+    private function markerIdentity(string $path): ?string
+    {
+        if (! is_file($path) || is_link($path)) {
+            return null;
+        }
+
+        $contents = @file_get_contents($path);
+
+        if ($contents === false) {
+            return null;
+        }
+
+        try {
+            $marker = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+        } catch (Throwable) {
+            return null;
+        }
+
+        $id = is_array($marker) ? $marker['id'] ?? null : null;
+
+        return is_string($id) && $this->isValidId($id) ? $id : null;
+    }
+
+    private function recoveryIdentityFromPath(string $path): ?string
+    {
+        $prefix = $this->root.'/.recovery/';
+
+        if (! str_starts_with($path, $prefix) || ! str_ends_with($path, '.json')) {
+            return null;
+        }
+
+        $encoded = substr($path, strlen($prefix), -5);
+        $decoded = ctype_xdigit($encoded) ? hex2bin($encoded) : false;
+
+        return is_string($decoded) && $this->isValidId($decoded) ? $decoded : null;
+    }
+
+    private function removeEmptyRecoveryDirectory(): void
+    {
+        $directory = $this->root.'/.recovery';
+
+        if (! $this->managedEntryExists($directory) || is_link($directory) || ! is_dir($directory)) {
+            return;
+        }
+
+        $entries = scandir($directory);
+
+        if ($entries === false) {
+            throw new RuntimeException("Could not inspect runtime lifecycle path [{$directory}].");
+        }
+
+        if ($entries === ['.', '..']) {
+            $this->deleteManagedPath($directory);
+        }
     }
 
     private function relativeManagedPath(string $path): string
@@ -1324,14 +1630,14 @@ final class RuntimePluginStore
 
     private function deleteDirectory(?string $path): void
     {
-        if ($path === null || (! file_exists($path) && ! is_link($path))) {
+        if ($path === null || ! $this->managedEntryExists($path)) {
             return;
         }
 
         if (is_link($path)) {
             $this->assertSafeManagedLink($path);
 
-            if (! @unlink($path) || file_exists($path) || is_link($path)) {
+            if (! @unlink($path) || $this->managedEntryExists($path)) {
                 throw new RuntimeException("Could not remove runtime plugin path [{$path}].");
             }
 
@@ -1341,7 +1647,7 @@ final class RuntimePluginStore
         if (! is_dir($path)) {
             $this->assertSafeManagedPath($path);
 
-            if (! @unlink($path) || file_exists($path) || is_link($path)) {
+            if (! @unlink($path) || $this->managedEntryExists($path)) {
                 throw new RuntimeException("Could not remove runtime plugin path [{$path}].");
             }
 
@@ -1367,8 +1673,49 @@ final class RuntimePluginStore
 
         $this->assertSafeManagedPath($path);
 
-        if (! @rmdir($path) || file_exists($path) || is_link($path)) {
+        if (! @rmdir($path) || $this->managedEntryExists($path)) {
             throw new RuntimeException("Could not remove runtime plugin path [{$path}].");
+        }
+    }
+
+    private function managedEntryExists(string $path): bool
+    {
+        if (@lstat($path) !== false) {
+            return true;
+        }
+
+        $current = dirname($path);
+        $missingEntry = basename($path);
+
+        while (true) {
+            $stat = @lstat($current);
+
+            if ($stat !== false) {
+                if (is_link($current) || ! is_dir($current)) {
+                    throw new RuntimeException("Could not inspect runtime plugin path [{$current}].");
+                }
+
+                $entries = @scandir($current);
+
+                if ($entries === false) {
+                    throw new RuntimeException("Could not inspect runtime plugin path [{$current}].");
+                }
+
+                if (! in_array($missingEntry, $entries, true)) {
+                    return false;
+                }
+
+                throw new RuntimeException("Could not inspect runtime plugin path [{$path}].");
+            }
+
+            $parent = dirname($current);
+
+            if ($parent === $current) {
+                throw new RuntimeException("Could not inspect runtime plugin path [{$path}].");
+            }
+
+            $missingEntry = basename($current);
+            $current = $parent;
         }
     }
 

--- a/app/Services/Platform/RuntimePluginStore.php
+++ b/app/Services/Platform/RuntimePluginStore.php
@@ -361,7 +361,15 @@ final class RuntimePluginStore
             }
         }
 
-        foreach (['state.json', 'recovery.json', 'recovery.json.tmp', '.staging', '.backup'] as $name) {
+        foreach (['.lock', 'state.json', 'recovery.json', 'recovery.json.tmp'] as $name) {
+            $path = $this->root.'/'.$name;
+
+            if (is_link($path) || (file_exists($path) && ! is_file($path))) {
+                $anomalies['internal:'.$name] = $path;
+            }
+        }
+
+        foreach (['.staging', '.backup'] as $name) {
             $path = $this->root.'/'.$name;
 
             if (is_link($path)) {
@@ -438,8 +446,7 @@ final class RuntimePluginStore
 
         $statePath = $this->statePath();
         if (file_exists($statePath) || is_link($statePath)) {
-            $this->assertSafeManagedPath($statePath);
-            $this->deleteDirectory($statePath);
+            $this->deleteManagedPath($statePath);
         }
 
         $this->cleanupRecoveryArtifacts();
@@ -552,6 +559,71 @@ final class RuntimePluginStore
         }
     }
 
+    public function forceCleanupUnknownRecovery(): void
+    {
+        if ($this->recoveryIdentity() !== null) {
+            throw new RuntimeException('Runtime plugin recovery belongs to a known package.');
+        }
+
+        $markerPath = $this->recoveryMarkerPath();
+
+        if (! is_file($markerPath) || is_link($markerPath)) {
+            throw new RuntimeException('Runtime plugin recovery metadata is not available.');
+        }
+
+        $contents = file_get_contents($markerPath);
+
+        $paths = [$markerPath, $this->root.'/recovery.json.tmp'];
+
+        if ($contents !== false) {
+            try {
+                $marker = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+
+                if (is_array($marker)) {
+                    foreach (['backup', 'staging'] as $key) {
+                        $path = $this->recoveryCleanupPath($key, $marker[$key] ?? null);
+
+                        if ($path !== null) {
+                            $paths[] = $path;
+                        }
+                    }
+                }
+            } catch (Throwable) {
+                // The marker itself is the only trustworthy cleanup target.
+            }
+        }
+
+        foreach (array_unique($paths) as $path) {
+            if (! file_exists($path) && ! is_link($path)) {
+                continue;
+            }
+
+            $this->deleteManagedPath($path);
+        }
+
+        foreach (array_unique($paths) as $path) {
+            if (file_exists($path) || is_link($path)) {
+                throw new RuntimeException("Could not clean runtime lifecycle path [{$path}].");
+            }
+        }
+
+        foreach ([$this->root.'/.staging', $this->root.'/.backup'] as $container) {
+            if (! is_dir($container) || is_link($container)) {
+                continue;
+            }
+
+            $entries = scandir($container);
+
+            if ($entries === false) {
+                throw new RuntimeException("Could not inspect runtime lifecycle path [{$container}].");
+            }
+
+            if ($entries === ['.', '..']) {
+                $this->deleteManagedPath($container);
+            }
+        }
+    }
+
     public function forceCleanupFilesystemAnomaly(string $key): void
     {
         $anomalies = $this->managedFilesystemAnomalies();
@@ -561,11 +633,7 @@ final class RuntimePluginStore
         }
 
         $path = $anomalies[$key];
-        $this->assertSafeManagedLink($path);
-
-        if (! @unlink($path) || file_exists($path) || is_link($path)) {
-            throw new RuntimeException("Could not remove runtime plugin path [{$path}].");
-        }
+        $this->deleteManagedPath($path);
 
         if (str_starts_with($key, 'package:')) {
             try {
@@ -655,6 +723,21 @@ final class RuntimePluginStore
         }
 
         $this->deleteManagedPath($path);
+
+        $container = $this->root.'/.staging';
+        if (! is_dir($container) || is_link($container)) {
+            return;
+        }
+
+        $entries = scandir($container);
+
+        if ($entries === false) {
+            throw new RuntimeException("Could not inspect runtime lifecycle path [{$container}].");
+        }
+
+        if ($entries === ['.', '..']) {
+            $this->deleteManagedPath($container);
+        }
     }
 
     public function promote(string $id, string $stagingPath, bool $enabled): void
@@ -812,11 +895,10 @@ final class RuntimePluginStore
         }
 
         $stateWasCorrupt = false;
+        $state = [];
         try {
             $state = $this->readState();
         } catch (Throwable) {
-            $this->resetState();
-            $state = [];
             $stateWasCorrupt = true;
         }
 
@@ -955,18 +1037,6 @@ final class RuntimePluginStore
         }
 
         $this->writeState($state);
-    }
-
-    private function resetState(): void
-    {
-        $path = $this->statePath();
-        $this->assertSafeManagedPath($path);
-
-        if (file_exists($path) && ! is_file($path)) {
-            $this->deleteDirectory($path);
-        }
-
-        $this->writeState([]);
     }
 
     private function validateRecoveryMarker(mixed $marker): void
@@ -1203,7 +1273,19 @@ final class RuntimePluginStore
             return;
         }
 
-        if (is_link($path) || is_file($path)) {
+        if (is_link($path)) {
+            $this->assertSafeManagedLink($path);
+
+            if (! @unlink($path) || file_exists($path) || is_link($path)) {
+                throw new RuntimeException("Could not remove runtime plugin path [{$path}].");
+            }
+
+            return;
+        }
+
+        if (is_file($path)) {
+            $this->assertSafeManagedPath($path);
+
             if (! @unlink($path) || file_exists($path) || is_link($path)) {
                 throw new RuntimeException("Could not remove runtime plugin path [{$path}].");
             }
@@ -1215,10 +1297,14 @@ final class RuntimePluginStore
             throw new RuntimeException("Could not remove runtime plugin path [{$path}].");
         }
 
+        $this->assertSafeManagedPath($path);
+
         $entries = @scandir($path);
         if ($entries === false) {
             throw new RuntimeException("Could not inspect runtime plugin path [{$path}].");
         }
+
+        $this->assertSafeManagedPath($path);
 
         foreach ($entries as $entry) {
             if ($entry === '.' || $entry === '..') {
@@ -1227,6 +1313,8 @@ final class RuntimePluginStore
 
             $this->deleteDirectory($path.DIRECTORY_SEPARATOR.$entry);
         }
+
+        $this->assertSafeManagedPath($path);
 
         if (! @rmdir($path) || file_exists($path) || is_link($path)) {
             throw new RuntimeException("Could not remove runtime plugin path [{$path}].");

--- a/composer.lock
+++ b/composer.lock
@@ -3317,16 +3317,16 @@
         },
         {
             "name": "openkos/platform",
-            "version": "0.2.3",
+            "version": "0.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/senatroxx/openkos-platform.git",
-                "reference": "e205d385b086a29db98441e961c271b54cd891fe"
+                "reference": "d2af88e90dcf86ee3cf68a5dbd72e21aa2b320de"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/senatroxx/openkos-platform/zipball/e205d385b086a29db98441e961c271b54cd891fe",
-                "reference": "e205d385b086a29db98441e961c271b54cd891fe",
+                "url": "https://api.github.com/repos/senatroxx/openkos-platform/zipball/d2af88e90dcf86ee3cf68a5dbd72e21aa2b320de",
+                "reference": "d2af88e90dcf86ee3cf68a5dbd72e21aa2b320de",
                 "shasum": ""
             },
             "require": {
@@ -3364,9 +3364,9 @@
             "description": "The OpenKOS platform and plugin SDK.",
             "support": {
                 "issues": "https://github.com/senatroxx/openkos-platform/issues",
-                "source": "https://github.com/senatroxx/openkos-platform/tree/v0.2.3"
+                "source": "https://github.com/senatroxx/openkos-platform/tree/v0.2.4"
             },
-            "time": "2026-08-24T04:26:34+00:00"
+            "time": "2026-08-28T08:07:02+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",

--- a/composer.lock
+++ b/composer.lock
@@ -3317,16 +3317,16 @@
         },
         {
             "name": "openkos/platform",
-            "version": "0.2.4",
+            "version": "0.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/senatroxx/openkos-platform.git",
-                "reference": "d2af88e90dcf86ee3cf68a5dbd72e21aa2b320de"
+                "reference": "b7862bffe119a9d1cf85488a7f588b785cd59761"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/senatroxx/openkos-platform/zipball/d2af88e90dcf86ee3cf68a5dbd72e21aa2b320de",
-                "reference": "d2af88e90dcf86ee3cf68a5dbd72e21aa2b320de",
+                "url": "https://api.github.com/repos/senatroxx/openkos-platform/zipball/b7862bffe119a9d1cf85488a7f588b785cd59761",
+                "reference": "b7862bffe119a9d1cf85488a7f588b785cd59761",
                 "shasum": ""
             },
             "require": {
@@ -3357,16 +3357,28 @@
                     "OpenKOS\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "pest --compact"
+                ],
+                "lint": [
+                    "pint"
+                ]
+            },
             "license": [
                 "Apache-2.0"
             ],
             "description": "The OpenKOS platform and plugin SDK.",
             "support": {
                 "issues": "https://github.com/senatroxx/openkos-platform/issues",
-                "source": "https://github.com/senatroxx/openkos-platform/tree/v0.2.4"
+                "source": "https://github.com/senatroxx/openkos-platform/tree/v0.2.5"
             },
-            "time": "2026-08-28T08:07:02+00:00"
+            "time": "2026-09-01T14:29:41+07:00"
         },
         {
             "name": "paragonie/constant_time_encoding",

--- a/resources/js/pages/settings/plugins.tsx
+++ b/resources/js/pages/settings/plugins.tsx
@@ -457,47 +457,43 @@ export default function Plugins({
                                                 </Button>
                                             )}
                                             {plugin.can_disable && (
-                                                <>
-                                                    <Button
-                                                        type="button"
-                                                        size="sm"
-                                                        variant="outline"
-                                                        disabled={
-                                                            processingPlugin ===
-                                                            pluginKey(plugin)
-                                                        }
-                                                        onClick={() =>
-                                                            runAction(
-                                                                plugin,
-                                                                'disable',
-                                                            )
-                                                        }
-                                                    >
-                                                        {t('Disable')}
-                                                    </Button>
-                                                    {plugin.can_force_recovery && (
-                                                        <Button
-                                                            type="button"
-                                                            size="sm"
-                                                            variant="destructive"
-                                                            disabled={
-                                                                processingPlugin ===
-                                                                pluginKey(
-                                                                    plugin,
-                                                                )
-                                                            }
-                                                            onClick={() =>
-                                                                runAction(
-                                                                    plugin,
-                                                                    'disable',
-                                                                    true,
-                                                                )
-                                                            }
-                                                        >
-                                                            {t('Force disable')}
-                                                        </Button>
-                                                    )}
-                                                </>
+                                                <Button
+                                                    type="button"
+                                                    size="sm"
+                                                    variant="outline"
+                                                    disabled={
+                                                        processingPlugin ===
+                                                        pluginKey(plugin)
+                                                    }
+                                                    onClick={() =>
+                                                        runAction(
+                                                            plugin,
+                                                            'disable',
+                                                        )
+                                                    }
+                                                >
+                                                    {t('Disable')}
+                                                </Button>
+                                            )}
+                                            {plugin.can_force_recovery && (
+                                                <Button
+                                                    type="button"
+                                                    size="sm"
+                                                    variant="destructive"
+                                                    disabled={
+                                                        processingPlugin ===
+                                                        pluginKey(plugin)
+                                                    }
+                                                    onClick={() =>
+                                                        runAction(
+                                                            plugin,
+                                                            'disable',
+                                                            true,
+                                                        )
+                                                    }
+                                                >
+                                                    {t('Force disable')}
+                                                </Button>
                                             )}
                                             {plugin.can_remove && (
                                                 <Button

--- a/resources/js/pages/settings/plugins.tsx
+++ b/resources/js/pages/settings/plugins.tsx
@@ -30,6 +30,7 @@ import {
     index,
     install,
 } from '@/routes/settings/plugins';
+import { cleanup as cleanupRecovery } from '@/routes/settings/plugins/recovery';
 import type { PlatformPlugin } from '@/types/platform';
 
 type Props = {
@@ -53,7 +54,10 @@ const statusVariants: Record<
     incompatible: 'destructive',
     broken: 'destructive',
     conflict: 'destructive',
-    missing: 'destructive',
+    missing_package: 'destructive',
+    pending_recovery: 'outline',
+    unrecoverable_recovery: 'destructive',
+    orphaned_state: 'destructive',
 };
 
 function formatBytes(bytes: number): string {
@@ -74,8 +78,15 @@ function statusLabel(status: PlatformPlugin['status']): string {
         incompatible: t('Incompatible'),
         broken: t('Broken'),
         conflict: t('Conflict'),
-        missing: t('Missing'),
+        missing_package: t('Missing package'),
+        pending_recovery: t('Pending recovery'),
+        unrecoverable_recovery: t('Unrecoverable recovery'),
+        orphaned_state: t('Orphaned state'),
     }[status];
+}
+
+function pluginKey(plugin: PlatformPlugin): string {
+    return plugin.managed_id ?? plugin.id;
 }
 
 export default function Plugins({
@@ -121,11 +132,15 @@ export default function Plugins({
         action: 'enable' | 'disable',
         force = false,
     ) {
+        if (plugin.managed_id === null) {
+            return;
+        }
+
         const parts = routeParts(plugin.managed_id);
         const route = action === 'enable' ? enable(parts) : disable(parts);
 
         setActionError(null);
-        setProcessingPlugin(plugin.managed_id);
+        setProcessingPlugin(pluginKey(plugin));
         router.post(route.url, force ? { force: true } : {}, {
             preserveScroll: true,
             onError: (errors) => setActionError(errors.plugin ?? null),
@@ -139,11 +154,28 @@ export default function Plugins({
         }
 
         const { plugin, force } = removeConfirmation;
+
+        if (plugin.managed_id === null) {
+            return;
+        }
+
         setRemoveConfirmation(null);
         setActionError(null);
-        setProcessingPlugin(plugin.managed_id);
+        setProcessingPlugin(pluginKey(plugin));
         router.delete(destroy(routeParts(plugin.managed_id)).url, {
             data: force ? { force: true } : {},
+            preserveScroll: true,
+            onError: (errors) => setActionError(errors.plugin ?? null),
+            onFinish: () => setProcessingPlugin(null),
+        });
+    }
+
+    function cleanupMetadata(plugin: PlatformPlugin) {
+        const key = pluginKey(plugin);
+
+        setActionError(null);
+        setProcessingPlugin(key);
+        router.delete(cleanupRecovery().url, {
             preserveScroll: true,
             onError: (errors) => setActionError(errors.plugin ?? null),
             onFinish: () => setProcessingPlugin(null),
@@ -255,13 +287,13 @@ export default function Plugins({
                 ) : (
                     <div className="grid gap-4 lg:grid-cols-2">
                         {plugins.map((plugin) => (
-                            <Card key={`${plugin.source}:${plugin.managed_id}`}>
+                            <Card key={`${plugin.source}:${pluginKey(plugin)}`}>
                                 <CardHeader>
                                     <div className="flex flex-wrap items-start justify-between gap-3">
                                         <div>
                                             <CardTitle>{plugin.name}</CardTitle>
                                             <CardDescription className="mt-1 font-mono">
-                                                {plugin.managed_id}
+                                                {plugin.managed_id ?? plugin.id}
                                             </CardDescription>
                                         </div>
                                         <Badge
@@ -372,6 +404,25 @@ export default function Plugins({
                                         </Alert>
                                     )}
 
+                                    {plugin.can_cleanup && (
+                                        <div className="flex flex-wrap gap-2">
+                                            <Button
+                                                type="button"
+                                                size="sm"
+                                                variant="destructive"
+                                                disabled={
+                                                    processingPlugin ===
+                                                    pluginKey(plugin)
+                                                }
+                                                onClick={() =>
+                                                    cleanupMetadata(plugin)
+                                                }
+                                            >
+                                                {t('Clean up metadata')}
+                                            </Button>
+                                        </div>
+                                    )}
+
                                     {(plugin.can_enable ||
                                         plugin.can_disable ||
                                         plugin.can_remove) && (
@@ -382,7 +433,7 @@ export default function Plugins({
                                                     size="sm"
                                                     disabled={
                                                         processingPlugin ===
-                                                        plugin.managed_id
+                                                        pluginKey(plugin)
                                                     }
                                                     onClick={() =>
                                                         runAction(
@@ -402,7 +453,7 @@ export default function Plugins({
                                                         variant="outline"
                                                         disabled={
                                                             processingPlugin ===
-                                                            plugin.managed_id
+                                                            pluginKey(plugin)
                                                         }
                                                         onClick={() =>
                                                             runAction(
@@ -420,7 +471,9 @@ export default function Plugins({
                                                             variant="destructive"
                                                             disabled={
                                                                 processingPlugin ===
-                                                                plugin.managed_id
+                                                                pluginKey(
+                                                                    plugin,
+                                                                )
                                                             }
                                                             onClick={() =>
                                                                 runAction(
@@ -443,7 +496,7 @@ export default function Plugins({
                                                         variant="destructive"
                                                         disabled={
                                                             processingPlugin ===
-                                                            plugin.managed_id
+                                                            pluginKey(plugin)
                                                         }
                                                         onClick={() =>
                                                             setRemoveConfirmation(
@@ -463,7 +516,9 @@ export default function Plugins({
                                                             variant="destructive"
                                                             disabled={
                                                                 processingPlugin ===
-                                                                plugin.managed_id
+                                                                pluginKey(
+                                                                    plugin,
+                                                                )
                                                             }
                                                             onClick={() =>
                                                                 setRemoveConfirmation(

--- a/resources/js/pages/settings/plugins.tsx
+++ b/resources/js/pages/settings/plugins.tsx
@@ -57,6 +57,7 @@ const statusVariants: Record<
     missing_package: 'destructive',
     pending_recovery: 'outline',
     unrecoverable_recovery: 'destructive',
+    load_failed: 'destructive',
     orphaned_state: 'destructive',
     orphaned_runtime_artifact: 'outline',
 };
@@ -82,6 +83,7 @@ function statusLabel(status: PlatformPlugin['status']): string {
         missing_package: t('Missing package'),
         pending_recovery: t('Pending recovery'),
         unrecoverable_recovery: t('Unrecoverable recovery'),
+        load_failed: t('Load failed'),
         orphaned_state: t('Orphaned state'),
         orphaned_runtime_artifact: t('Orphaned runtime artifact'),
     }[status];

--- a/resources/js/pages/settings/plugins.tsx
+++ b/resources/js/pages/settings/plugins.tsx
@@ -433,7 +433,8 @@ export default function Plugins({
 
                                     {(plugin.can_enable ||
                                         plugin.can_disable ||
-                                        plugin.can_remove) && (
+                                        plugin.can_remove ||
+                                        plugin.can_force_recovery) && (
                                         <div className="flex flex-wrap gap-2">
                                             {plugin.can_enable && (
                                                 <Button
@@ -497,50 +498,42 @@ export default function Plugins({
                                                 </>
                                             )}
                                             {plugin.can_remove && (
-                                                <>
-                                                    <Button
-                                                        type="button"
-                                                        size="sm"
-                                                        variant="destructive"
-                                                        disabled={
-                                                            processingPlugin ===
-                                                            pluginKey(plugin)
-                                                        }
-                                                        onClick={() =>
-                                                            setRemoveConfirmation(
-                                                                {
-                                                                    plugin,
-                                                                    force: false,
-                                                                },
-                                                            )
-                                                        }
-                                                    >
-                                                        {t('Remove')}
-                                                    </Button>
-                                                    {plugin.can_force_recovery && (
-                                                        <Button
-                                                            type="button"
-                                                            size="sm"
-                                                            variant="destructive"
-                                                            disabled={
-                                                                processingPlugin ===
-                                                                pluginKey(
-                                                                    plugin,
-                                                                )
-                                                            }
-                                                            onClick={() =>
-                                                                setRemoveConfirmation(
-                                                                    {
-                                                                        plugin,
-                                                                        force: true,
-                                                                    },
-                                                                )
-                                                            }
-                                                        >
-                                                            {t('Force remove')}
-                                                        </Button>
-                                                    )}
-                                                </>
+                                                <Button
+                                                    type="button"
+                                                    size="sm"
+                                                    variant="destructive"
+                                                    disabled={
+                                                        processingPlugin ===
+                                                        pluginKey(plugin)
+                                                    }
+                                                    onClick={() =>
+                                                        setRemoveConfirmation({
+                                                            plugin,
+                                                            force: false,
+                                                        })
+                                                    }
+                                                >
+                                                    {t('Remove')}
+                                                </Button>
+                                            )}
+                                            {plugin.can_force_recovery && (
+                                                <Button
+                                                    type="button"
+                                                    size="sm"
+                                                    variant="destructive"
+                                                    disabled={
+                                                        processingPlugin ===
+                                                        pluginKey(plugin)
+                                                    }
+                                                    onClick={() =>
+                                                        setRemoveConfirmation({
+                                                            plugin,
+                                                            force: true,
+                                                        })
+                                                    }
+                                                >
+                                                    {t('Force remove')}
+                                                </Button>
                                             )}
                                         </div>
                                     )}

--- a/resources/js/pages/settings/plugins.tsx
+++ b/resources/js/pages/settings/plugins.tsx
@@ -58,6 +58,7 @@ const statusVariants: Record<
     pending_recovery: 'outline',
     unrecoverable_recovery: 'destructive',
     orphaned_state: 'destructive',
+    orphaned_runtime_artifact: 'outline',
 };
 
 function formatBytes(bytes: number): string {
@@ -82,6 +83,7 @@ function statusLabel(status: PlatformPlugin['status']): string {
         pending_recovery: t('Pending recovery'),
         unrecoverable_recovery: t('Unrecoverable recovery'),
         orphaned_state: t('Orphaned state'),
+        orphaned_runtime_artifact: t('Orphaned runtime artifact'),
     }[status];
 }
 
@@ -172,10 +174,16 @@ export default function Plugins({
 
     function cleanupMetadata(plugin: PlatformPlugin) {
         const key = pluginKey(plugin);
+        const data = plugin.cleanup_key
+            ? { cleanup_key: plugin.cleanup_key }
+            : plugin.managed_id
+              ? { recovery_id: plugin.managed_id }
+              : {};
 
         setActionError(null);
         setProcessingPlugin(key);
         router.delete(cleanupRecovery().url, {
+            data,
             preserveScroll: true,
             onError: (errors) => setActionError(errors.plugin ?? null),
             onFinish: () => setProcessingPlugin(null),

--- a/resources/js/pages/settings/plugins.tsx
+++ b/resources/js/pages/settings/plugins.tsx
@@ -38,6 +38,11 @@ type Props = {
     max_upload_bytes: number;
 };
 
+type RemoveConfirmation = {
+    plugin: PlatformPlugin;
+    force: boolean;
+};
+
 const statusVariants: Record<
     PlatformPlugin['status'],
     'default' | 'secondary' | 'destructive' | 'outline'
@@ -81,7 +86,7 @@ export default function Plugins({
     const fileInput = useRef<HTMLInputElement>(null);
     const [uploadConfirmationOpen, setUploadConfirmationOpen] = useState(false);
     const [removeConfirmation, setRemoveConfirmation] =
-        useState<PlatformPlugin | null>(null);
+        useState<RemoveConfirmation | null>(null);
     const [processingPlugin, setProcessingPlugin] = useState<string | null>(
         null,
     );
@@ -111,21 +116,21 @@ export default function Plugins({
         });
     }
 
-    function runAction(plugin: PlatformPlugin, action: 'enable' | 'disable') {
+    function runAction(
+        plugin: PlatformPlugin,
+        action: 'enable' | 'disable',
+        force = false,
+    ) {
         const parts = routeParts(plugin.managed_id);
         const route = action === 'enable' ? enable(parts) : disable(parts);
 
         setActionError(null);
         setProcessingPlugin(plugin.managed_id);
-        router.post(
-            route.url,
-            {},
-            {
-                preserveScroll: true,
-                onError: (errors) => setActionError(errors.plugin ?? null),
-                onFinish: () => setProcessingPlugin(null),
-            },
-        );
+        router.post(route.url, force ? { force: true } : {}, {
+            preserveScroll: true,
+            onError: (errors) => setActionError(errors.plugin ?? null),
+            onFinish: () => setProcessingPlugin(null),
+        });
     }
 
     function confirmRemove() {
@@ -133,11 +138,12 @@ export default function Plugins({
             return;
         }
 
-        const plugin = removeConfirmation;
+        const { plugin, force } = removeConfirmation;
         setRemoveConfirmation(null);
         setActionError(null);
         setProcessingPlugin(plugin.managed_id);
         router.delete(destroy(routeParts(plugin.managed_id)).url, {
+            data: force ? { force: true } : {},
             preserveScroll: true,
             onError: (errors) => setActionError(errors.plugin ?? null),
             onFinish: () => setProcessingPlugin(null),
@@ -356,6 +362,16 @@ export default function Plugins({
                                         </Alert>
                                     )}
 
+                                    {plugin.can_force_recovery && (
+                                        <Alert variant="destructive">
+                                            <AlertDescription>
+                                                {t(
+                                                    'Recovery actions are available because this runtime package or its dependency graph is invalid. They may leave dependent plugins unavailable.',
+                                                )}
+                                            </AlertDescription>
+                                        </Alert>
+                                    )}
+
                                     {(plugin.can_enable ||
                                         plugin.can_disable ||
                                         plugin.can_remove) && (
@@ -379,41 +395,89 @@ export default function Plugins({
                                                 </Button>
                                             )}
                                             {plugin.can_disable && (
-                                                <Button
-                                                    type="button"
-                                                    size="sm"
-                                                    variant="outline"
-                                                    disabled={
-                                                        processingPlugin ===
-                                                        plugin.managed_id
-                                                    }
-                                                    onClick={() =>
-                                                        runAction(
-                                                            plugin,
-                                                            'disable',
-                                                        )
-                                                    }
-                                                >
-                                                    {t('Disable')}
-                                                </Button>
+                                                <>
+                                                    <Button
+                                                        type="button"
+                                                        size="sm"
+                                                        variant="outline"
+                                                        disabled={
+                                                            processingPlugin ===
+                                                            plugin.managed_id
+                                                        }
+                                                        onClick={() =>
+                                                            runAction(
+                                                                plugin,
+                                                                'disable',
+                                                            )
+                                                        }
+                                                    >
+                                                        {t('Disable')}
+                                                    </Button>
+                                                    {plugin.can_force_recovery && (
+                                                        <Button
+                                                            type="button"
+                                                            size="sm"
+                                                            variant="destructive"
+                                                            disabled={
+                                                                processingPlugin ===
+                                                                plugin.managed_id
+                                                            }
+                                                            onClick={() =>
+                                                                runAction(
+                                                                    plugin,
+                                                                    'disable',
+                                                                    true,
+                                                                )
+                                                            }
+                                                        >
+                                                            {t('Force disable')}
+                                                        </Button>
+                                                    )}
+                                                </>
                                             )}
                                             {plugin.can_remove && (
-                                                <Button
-                                                    type="button"
-                                                    size="sm"
-                                                    variant="destructive"
-                                                    disabled={
-                                                        processingPlugin ===
-                                                        plugin.managed_id
-                                                    }
-                                                    onClick={() =>
-                                                        setRemoveConfirmation(
-                                                            plugin,
-                                                        )
-                                                    }
-                                                >
-                                                    {t('Remove')}
-                                                </Button>
+                                                <>
+                                                    <Button
+                                                        type="button"
+                                                        size="sm"
+                                                        variant="destructive"
+                                                        disabled={
+                                                            processingPlugin ===
+                                                            plugin.managed_id
+                                                        }
+                                                        onClick={() =>
+                                                            setRemoveConfirmation(
+                                                                {
+                                                                    plugin,
+                                                                    force: false,
+                                                                },
+                                                            )
+                                                        }
+                                                    >
+                                                        {t('Remove')}
+                                                    </Button>
+                                                    {plugin.can_force_recovery && (
+                                                        <Button
+                                                            type="button"
+                                                            size="sm"
+                                                            variant="destructive"
+                                                            disabled={
+                                                                processingPlugin ===
+                                                                plugin.managed_id
+                                                            }
+                                                            onClick={() =>
+                                                                setRemoveConfirmation(
+                                                                    {
+                                                                        plugin,
+                                                                        force: true,
+                                                                    },
+                                                                )
+                                                            }
+                                                        >
+                                                            {t('Force remove')}
+                                                        </Button>
+                                                    )}
+                                                </>
                                             )}
                                         </div>
                                     )}
@@ -458,11 +522,19 @@ export default function Plugins({
             >
                 <DialogContent>
                     <DialogHeader>
-                        <DialogTitle>{t('Remove runtime plugin?')}</DialogTitle>
+                        <DialogTitle>
+                            {removeConfirmation?.force
+                                ? t('Force remove runtime plugin?')
+                                : t('Remove runtime plugin?')}
+                        </DialogTitle>
                         <DialogDescription>
-                            {t(
-                                'This removes only the runtime package and its activation state. Plugin-owned database data will not be deleted. A restart is required for changes to take effect.',
-                            )}
+                            {removeConfirmation?.force
+                                ? t(
+                                      'This recovery action removes the managed package directory even when lifecycle metadata is corrupt. Plugin-owned database data will not be deleted. A restart is required for changes to take effect.',
+                                  )
+                                : t(
+                                      'This removes only the runtime package and its activation state. Plugin-owned database data will not be deleted. A restart is required for changes to take effect.',
+                                  )}
                         </DialogDescription>
                     </DialogHeader>
                     <DialogFooter>
@@ -476,7 +548,9 @@ export default function Plugins({
                             variant="destructive"
                             onClick={confirmRemove}
                         >
-                            {t('Remove plugin')}
+                            {removeConfirmation?.force
+                                ? t('Force remove plugin')
+                                : t('Remove plugin')}
                         </Button>
                     </DialogFooter>
                 </DialogContent>

--- a/resources/js/types/platform.ts
+++ b/resources/js/types/platform.ts
@@ -47,7 +47,8 @@ export type PlatformPlugin = {
         | 'missing_package'
         | 'pending_recovery'
         | 'unrecoverable_recovery'
-        | 'orphaned_state';
+        | 'orphaned_state'
+        | 'orphaned_runtime_artifact';
     enabled: boolean;
     error: string | null;
     can_enable: boolean;
@@ -55,6 +56,7 @@ export type PlatformPlugin = {
     can_remove: boolean;
     can_force_recovery: boolean;
     can_cleanup: boolean;
+    cleanup_key: string | null;
 };
 
 export type Platform = {

--- a/resources/js/types/platform.ts
+++ b/resources/js/types/platform.ts
@@ -47,6 +47,7 @@ export type PlatformPlugin = {
         | 'missing_package'
         | 'pending_recovery'
         | 'unrecoverable_recovery'
+        | 'load_failed'
         | 'orphaned_state'
         | 'orphaned_runtime_artifact';
     enabled: boolean;

--- a/resources/js/types/platform.ts
+++ b/resources/js/types/platform.ts
@@ -50,6 +50,7 @@ export type PlatformPlugin = {
     can_enable: boolean;
     can_disable: boolean;
     can_remove: boolean;
+    can_force_recovery: boolean;
 };
 
 export type Platform = {

--- a/resources/js/types/platform.ts
+++ b/resources/js/types/platform.ts
@@ -27,7 +27,7 @@ export type PlatformPage = {
 
 export type PlatformPlugin = {
     id: string;
-    managed_id: string;
+    managed_id: string | null;
     declared_id: string | null;
     name: string;
     version: string | null;
@@ -44,13 +44,17 @@ export type PlatformPlugin = {
         | 'incompatible'
         | 'broken'
         | 'conflict'
-        | 'missing';
+        | 'missing_package'
+        | 'pending_recovery'
+        | 'unrecoverable_recovery'
+        | 'orphaned_state';
     enabled: boolean;
     error: string | null;
     can_enable: boolean;
     can_disable: boolean;
     can_remove: boolean;
     can_force_recovery: boolean;
+    can_cleanup: boolean;
 };
 
 export type Platform = {

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -73,6 +73,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
         Route::get('settings/plugins', [PluginController::class, 'index'])->name('settings.plugins.index');
         Route::post('settings/plugins', [PluginController::class, 'install'])->name('settings.plugins.install');
+        Route::delete('settings/plugins/recovery', [PluginController::class, 'cleanup'])->name('settings.plugins.recovery.cleanup');
         Route::post('settings/plugins/{vendor}/{package}/enable', [PluginController::class, 'enable'])
             ->where(['vendor' => '[a-z0-9][a-z0-9._-]*', 'package' => '[a-z0-9][a-z0-9._-]*'])
             ->name('settings.plugins.enable');

--- a/tests/Feature/Platform/ComposerPluginDiscoveryTest.php
+++ b/tests/Feature/Platform/ComposerPluginDiscoveryTest.php
@@ -3,6 +3,8 @@
 use App\Services\Platform\ComposerPluginDiscovery;
 use Composer\InstalledVersions;
 use OpenKOS\Core\Contracts\PluginDiscovery;
+use OpenKOS\Platform\PlatformServiceProvider;
+use OpenKOS\Platform\Plugin\PluginLifecycleFailureRegistry;
 use Tests\Support\Fixtures\ComposerDiscoveryFixturePlugin;
 use Tests\Support\Fixtures\ComposerDiscoverySecondFixturePlugin;
 
@@ -147,8 +149,10 @@ it('boots a Composer-discovered plugin through the normal lifecycle', function (
     expect(ComposerDiscoveryFixturePlugin::$registerCalls)->toBe(1);
 });
 
-it('does not run any plugin lifecycle when discovery finds an invalid class', function () {
+it('records an invalid discovered class and continues with healthy plugins', function () {
     ComposerDiscoveryFixturePlugin::$registerCalls = 0;
+    $this->bootPlatformWithIsolatedRegistries();
+
     app()->instance(PluginDiscovery::class, new class implements PluginDiscovery
     {
         public function discover(): array
@@ -159,10 +163,18 @@ it('does not run any plugin lifecycle when discovery finds an invalid class', fu
 
     config(['platform.plugins' => []]);
 
-    expect(fn () => $this->bootPlatformWithIsolatedRegistries())
-        ->toThrow(InvalidArgumentException::class, 'Plugin class [Acme\\MissingPlugin] does not exist.');
+    (new PlatformServiceProvider(app()))->boot();
 
-    expect(ComposerDiscoveryFixturePlugin::$registerCalls)->toBe(0);
+    expect(ComposerDiscoveryFixturePlugin::$registerCalls)->toBe(1)
+        ->and(app(PluginLifecycleFailureRegistry::class)->failures())->toMatchArray([
+            [
+                'id' => null,
+                'version' => null,
+                'entry_class' => 'Acme\\MissingPlugin',
+                'phase' => 'resolve',
+                'exception' => InvalidArgumentException::class,
+            ],
+        ]);
 });
 
 it('loads discovered plugins in deterministic package order', function () {

--- a/tests/Feature/Platform/RuntimePluginStoreTest.php
+++ b/tests/Feature/Platform/RuntimePluginStoreTest.php
@@ -14,6 +14,13 @@ afterEach(function (): void {
     config(['platform.runtime.path' => $this->originalRuntimePath]);
 });
 
+it('reads empty state without creating absent runtime storage', function (): void {
+    $store = app(RuntimePluginStore::class);
+
+    expect($store->readState())->toBe([])
+        ->and(is_dir($this->runtimePluginPath))->toBeFalse();
+});
+
 it('restores the previous package after an interrupted swap', function (): void {
     $store = app(RuntimePluginStore::class);
     $activePath = $this->runtimePluginPath.'/acme/recovery';
@@ -119,6 +126,148 @@ it('rejects recovery paths outside their managed directories', function (): void
 
     expect(fn (): mixed => $store->withLock(fn (): null => null))
         ->toThrow(RuntimeException::class, 'recovery marker is invalid');
+});
+
+it('classifies structurally valid but unrecoverable recovery metadata', function (): void {
+    $store = app(RuntimePluginStore::class);
+    mkdir($this->runtimePluginPath.'/.staging/incoming', 0750, true);
+    file_put_contents($this->runtimePluginPath.'/recovery.json', json_encode([
+        'operation' => 'swap',
+        'id' => 'acme/recovery',
+        'staging' => '.staging/incoming',
+        'backup' => '.backup/missing',
+        'had_active' => true,
+        'phase' => 'old_preserved',
+    ], JSON_THROW_ON_ERROR));
+
+    expect($store->recoveryStatus())->toBe(RuntimePluginStore::RECOVERY_UNRECOVERABLE);
+});
+
+it('classifies ambiguous prepared recovery metadata as unrecoverable', function (): void {
+    $store = app(RuntimePluginStore::class);
+    mkdir($this->runtimePluginPath.'/acme/recovery', 0750, true);
+    mkdir($this->runtimePluginPath.'/.staging/incoming', 0750, true);
+    file_put_contents($this->runtimePluginPath.'/recovery.json', json_encode([
+        'operation' => 'swap',
+        'id' => 'acme/recovery',
+        'staging' => '.staging/incoming',
+        'backup' => '.backup/missing',
+        'had_active' => false,
+        'phase' => 'prepared',
+    ], JSON_THROW_ON_ERROR));
+
+    expect($store->recoveryStatus())->toBe(RuntimePluginStore::RECOVERY_UNRECOVERABLE);
+});
+
+it('cleans orphaned lifecycle metadata while holding the store lock', function (): void {
+    $store = app(RuntimePluginStore::class);
+    mkdir($this->runtimePluginPath.'/.backup/stale', 0750, true);
+    mkdir($this->runtimePluginPath.'/.staging/stale', 0750, true);
+    file_put_contents($this->runtimePluginPath.'/state.json', '{broken');
+    file_put_contents($this->runtimePluginPath.'/recovery.json', '{broken');
+    file_put_contents($this->runtimePluginPath.'/recovery.json.tmp', 'stale');
+
+    $store->withLock(function (RuntimePluginStore $store): void {
+        $store->forceCleanupOrphanedMetadata();
+    }, false);
+
+    expect(is_file($this->runtimePluginPath.'/state.json'))->toBeFalse()
+        ->and(is_file($this->runtimePluginPath.'/recovery.json'))->toBeFalse()
+        ->and(is_file($this->runtimePluginPath.'/recovery.json.tmp'))->toBeFalse()
+        ->and(is_dir($this->runtimePluginPath.'/.backup'))->toBeFalse()
+        ->and(is_dir($this->runtimePluginPath.'/.staging'))->toBeFalse();
+});
+
+it('surfaces deletion failures instead of reporting force removal success', function (): void {
+    $store = app(RuntimePluginStore::class);
+    $packagePath = $this->runtimePluginPath.'/acme/failure';
+    mkdir(dirname($packagePath), 0750, true);
+    mkdir($packagePath, 0750);
+    file_put_contents($packagePath.'/locked.txt', 'locked');
+    chmod($packagePath, 0500);
+
+    try {
+        expect(fn (): mixed => $store->withLock(
+            fn (RuntimePluginStore $store): mixed => $store->forceRemove('acme/failure'),
+            false,
+        ))->toThrow(RuntimeException::class, 'Could not remove runtime plugin path');
+    } finally {
+        chmod($packagePath, 0700);
+    }
+});
+
+it('rejects symlinked internal staging paths', function (): void {
+    $store = app(RuntimePluginStore::class);
+    $outside = sys_get_temp_dir().'/openkos-runtime-outside-'.bin2hex(random_bytes(8));
+    mkdir($outside, 0750, true);
+    mkdir($this->runtimePluginPath, 0750, true);
+    symlink($outside, $this->runtimePluginPath.'/.staging');
+
+    try {
+        expect(fn (): mixed => $store->withLock(
+            fn (RuntimePluginStore $store): mixed => $store->createStagingPath('incoming'),
+            false,
+        ))->toThrow(RuntimeException::class, 'contains a symlink');
+    } finally {
+        unlink($this->runtimePluginPath.'/.staging');
+        File::deleteDirectory($outside);
+    }
+});
+
+it('does not remove a different package while forcing recovery', function (): void {
+    $store = app(RuntimePluginStore::class);
+    $targetPath = $this->runtimePluginPath.'/acme/target';
+    mkdir($targetPath, 0750, true);
+    file_put_contents($this->runtimePluginPath.'/recovery.json', json_encode([
+        'operation' => 'swap',
+        'id' => 'acme/other',
+        'staging' => '.staging/incoming',
+        'backup' => '.backup/missing',
+        'had_active' => true,
+        'phase' => 'old_preserved',
+    ], JSON_THROW_ON_ERROR));
+
+    expect(fn (): mixed => $store->withLock(
+        fn (RuntimePluginStore $store): mixed => $store->forceRemove('acme/target'),
+        false,
+    ))->toThrow(RuntimeException::class, 'belongs to a different package');
+
+    expect(is_dir($targetPath))->toBeTrue()
+        ->and(is_file($this->runtimePluginPath.'/recovery.json'))->toBeTrue();
+});
+
+it('clears recovery artifacts without touching another package', function (): void {
+    $store = app(RuntimePluginStore::class);
+    $targetPath = $this->runtimePluginPath.'/acme/target';
+    $otherPath = $this->runtimePluginPath.'/acme/other';
+    mkdir($targetPath, 0750, true);
+    mkdir($otherPath, 0750, true);
+    mkdir($this->runtimePluginPath.'/.backup/stale', 0750, true);
+    mkdir($this->runtimePluginPath.'/.staging/stale', 0750, true);
+    file_put_contents($this->runtimePluginPath.'/state.json', json_encode([
+        'acme/target' => ['enabled' => false],
+        'acme/other' => ['enabled' => true],
+    ], JSON_THROW_ON_ERROR));
+    file_put_contents($this->runtimePluginPath.'/recovery.json', json_encode([
+        'operation' => 'swap',
+        'id' => 'acme/target',
+        'staging' => '.staging/stale',
+        'backup' => '.backup/stale',
+        'had_active' => true,
+        'phase' => 'old_preserved',
+    ], JSON_THROW_ON_ERROR));
+
+    $store->withLock(
+        fn (RuntimePluginStore $store): mixed => $store->forceRemove('acme/target'),
+        false,
+    );
+
+    expect(is_dir($targetPath))->toBeFalse()
+        ->and(is_dir($otherPath))->toBeTrue()
+        ->and(is_dir($this->runtimePluginPath.'/.backup'))->toBeFalse()
+        ->and(is_dir($this->runtimePluginPath.'/.staging'))->toBeFalse()
+        ->and(json_decode(file_get_contents($this->runtimePluginPath.'/state.json'), true, 512, JSON_THROW_ON_ERROR))
+        ->toBe(['acme/other' => ['enabled' => true]]);
 });
 
 it('rejects the application root as runtime plugin storage', function (): void {

--- a/tests/Feature/Platform/RuntimePluginStoreTest.php
+++ b/tests/Feature/Platform/RuntimePluginStoreTest.php
@@ -112,6 +112,31 @@ it('never resurrects a package after a committed removal recovery', function ():
         ->and(is_file($this->runtimePluginPath.'/recovery.json'))->toBeFalse();
 });
 
+it('restores the previous state after an interrupted removal recovery', function (): void {
+    $store = app(RuntimePluginStore::class);
+    $activePath = $this->runtimePluginPath.'/acme/interrupted';
+    $backupPath = $this->runtimePluginPath.'/.backup/acme-interrupted-remove';
+
+    mkdir($backupPath, 0750, true);
+    file_put_contents($backupPath.'/version.txt', 'old');
+    $store->writeState(['acme/interrupted' => ['enabled' => true]]);
+    file_put_contents($this->runtimePluginPath.'/recovery.json', json_encode([
+        'operation' => 'remove',
+        'id' => 'acme/interrupted',
+        'staging' => null,
+        'backup' => '.backup/acme-interrupted-remove',
+        'had_active' => true,
+        'previous_entry' => ['enabled' => true],
+        'phase' => 'old_preserved',
+    ], JSON_THROW_ON_ERROR));
+
+    $store->withLock(fn (): null => null);
+
+    expect(file_get_contents($activePath.'/version.txt'))->toBe('old')
+        ->and($store->readState())->toMatchArray(['acme/interrupted' => ['enabled' => true]])
+        ->and(is_file($this->runtimePluginPath.'/recovery.json'))->toBeFalse();
+});
+
 it('recovers an identity-addressed sidecar without touching another marker', function (): void {
     $store = app(RuntimePluginStore::class);
     $id = 'acme/sidecar';
@@ -374,7 +399,7 @@ it('does not treat an inaccessible package parent as an absent package', functio
         ->toMatchArray(['acme/inaccessible' => ['enabled' => true]]);
 });
 
-it('does not erase another package state when removing with corrupt state', function (): void {
+it('repairs corrupt state while preserving another installed package', function (): void {
     $store = app(RuntimePluginStore::class);
     $firstPath = $this->runtimePluginPath.'/acme/first';
     $secondPath = $this->runtimePluginPath.'/acme/second';
@@ -393,7 +418,9 @@ it('does not erase another package state when removing with corrupt state', func
 
     expect(is_dir($firstPath))->toBeFalse()
         ->and(is_dir($secondPath))->toBeTrue()
-        ->and(file_get_contents($this->runtimePluginPath.'/state.json'))->toBe('{broken');
+        ->and($store->readState())->toBe([
+            'acme/second' => ['enabled' => false],
+        ]);
 });
 
 it('rejects symlinked internal staging paths', function (): void {

--- a/tests/Feature/Platform/RuntimePluginStoreTest.php
+++ b/tests/Feature/Platform/RuntimePluginStoreTest.php
@@ -21,6 +21,22 @@ it('reads empty state without creating absent runtime storage', function (): voi
         ->and(is_dir($this->runtimePluginPath))->toBeFalse();
 });
 
+it('rejects a symlinked configured runtime root', function (): void {
+    $target = sys_get_temp_dir().'/openkos-runtime-root-'.bin2hex(random_bytes(8));
+    mkdir($target, 0750, true);
+    symlink($target, $this->runtimePluginPath);
+    config(['platform.runtime.path' => $this->runtimePluginPath]);
+    app()->forgetInstance(RuntimePluginStore::class);
+
+    try {
+        expect(fn (): RuntimePluginStore => app(RuntimePluginStore::class))
+            ->toThrow(RuntimeException::class, 'symlinked path');
+    } finally {
+        unlink($this->runtimePluginPath);
+        File::deleteDirectory($target);
+    }
+});
+
 it('restores the previous package after an interrupted swap', function (): void {
     $store = app(RuntimePluginStore::class);
     $activePath = $this->runtimePluginPath.'/acme/recovery';
@@ -157,6 +173,72 @@ it('classifies ambiguous prepared recovery metadata as unrecoverable', function 
     ], JSON_THROW_ON_ERROR));
 
     expect($store->recoveryStatus())->toBe(RuntimePluginStore::RECOVERY_UNRECOVERABLE);
+});
+
+it('classifies stale runtime artifacts without a recovery marker', function (): void {
+    $store = app(RuntimePluginStore::class);
+    mkdir($this->runtimePluginPath.'/.staging/stale', 0750, true);
+    file_put_contents($this->runtimePluginPath.'/.state-stale.tmp', 'stale');
+
+    expect($store->recoveryStatus())->toBe(RuntimePluginStore::RECOVERY_ORPHANED_ARTIFACT);
+
+    $store->withLock(function (RuntimePluginStore $store): void {
+        $store->forceCleanupOrphanedArtifacts();
+    }, false);
+
+    expect(is_dir($this->runtimePluginPath.'/.staging'))->toBeFalse()
+        ->and(is_file($this->runtimePluginPath.'/.state-stale.tmp'))->toBeFalse();
+});
+
+it('cleans a recovery marker by its own identity', function (): void {
+    $store = app(RuntimePluginStore::class);
+    mkdir($this->runtimePluginPath.'/.staging/incoming', 0750, true);
+    mkdir($this->runtimePluginPath.'/acme/other', 0750, true);
+    $store->writeState([
+        'acme/missing' => ['enabled' => true],
+        'acme/other' => ['enabled' => true],
+    ]);
+    file_put_contents($this->runtimePluginPath.'/recovery.json', json_encode([
+        'operation' => 'swap',
+        'id' => 'acme/missing',
+        'staging' => '.staging/incoming',
+        'backup' => '.backup/missing',
+        'had_active' => true,
+        'phase' => 'old_preserved',
+    ], JSON_THROW_ON_ERROR));
+
+    $store->withLock(function (RuntimePluginStore $store): void {
+        $store->forceCleanupRecovery('acme/missing');
+    }, false);
+
+    expect(is_file($this->runtimePluginPath.'/recovery.json'))->toBeFalse()
+        ->and(is_dir($this->runtimePluginPath.'/.staging/incoming'))->toBeFalse()
+        ->and(is_dir($this->runtimePluginPath.'/acme/other'))->toBeTrue()
+        ->and(app(RuntimePluginStore::class)->readState())->toMatchArray([
+            'acme/other' => ['enabled' => true],
+        ]);
+});
+
+it('does not let malformed recovery paths delete lifecycle state', function (): void {
+    $store = app(RuntimePluginStore::class);
+    $store->writeState(['acme/other' => ['enabled' => true]]);
+    file_put_contents($this->runtimePluginPath.'/recovery.json', json_encode([
+        'operation' => 'swap',
+        'id' => 'acme/missing',
+        'staging' => '.staging/incoming',
+        'backup' => 'state.json',
+        'had_active' => true,
+        'phase' => 'old_preserved',
+    ], JSON_THROW_ON_ERROR));
+
+    $store->withLock(function (RuntimePluginStore $store): void {
+        $store->forceCleanupRecovery('acme/missing');
+    }, false);
+
+    expect(is_file($this->runtimePluginPath.'/recovery.json'))->toBeFalse()
+        ->and(app(RuntimePluginStore::class)->readState())->toBe([
+            'acme/other' => ['enabled' => true],
+        ]);
 });
 
 it('cleans orphaned lifecycle metadata while holding the store lock', function (): void {

--- a/tests/Feature/Platform/RuntimePluginStoreTest.php
+++ b/tests/Feature/Platform/RuntimePluginStoreTest.php
@@ -260,6 +260,20 @@ it('cleans orphaned lifecycle metadata while holding the store lock', function (
         ->and(is_dir($this->runtimePluginPath.'/.staging'))->toBeFalse();
 });
 
+it('cleans corrupt orphaned state with unknown recovery metadata', function (): void {
+    $store = app(RuntimePluginStore::class);
+    mkdir($this->runtimePluginPath, 0750, true);
+    file_put_contents($this->runtimePluginPath.'/state.json', '{broken');
+    file_put_contents($this->runtimePluginPath.'/recovery.json', '{broken');
+
+    $store->withLock(function (RuntimePluginStore $store): void {
+        $store->forceCleanupUnknownRecovery();
+    }, false);
+
+    expect(is_file($this->runtimePluginPath.'/state.json'))->toBeFalse()
+        ->and(is_file($this->runtimePluginPath.'/recovery.json'))->toBeFalse();
+});
+
 it('surfaces deletion failures instead of reporting force removal success', function (): void {
     $store = app(RuntimePluginStore::class);
     $packagePath = $this->runtimePluginPath.'/acme/failure';
@@ -350,10 +364,12 @@ it('surfaces and removes a non-file recovery marker', function (): void {
     expect(file_exists($this->runtimePluginPath.'/recovery.json'))->toBeFalse();
 });
 
-it('does not remove a different package while forcing recovery', function (): void {
+it('removes a different package without touching recovery for another package', function (): void {
     $store = app(RuntimePluginStore::class);
     $targetPath = $this->runtimePluginPath.'/acme/target';
+    $otherPath = $this->runtimePluginPath.'/acme/other';
     mkdir($targetPath, 0750, true);
+    mkdir($otherPath, 0750, true);
     file_put_contents($this->runtimePluginPath.'/recovery.json', json_encode([
         'operation' => 'swap',
         'id' => 'acme/other',
@@ -363,13 +379,73 @@ it('does not remove a different package while forcing recovery', function (): vo
         'phase' => 'old_preserved',
     ], JSON_THROW_ON_ERROR));
 
-    expect(fn (): mixed => $store->withLock(
+    $store->withLock(
         fn (RuntimePluginStore $store): mixed => $store->forceRemove('acme/target'),
         false,
-    ))->toThrow(RuntimeException::class, 'belongs to a different package');
+    );
 
-    expect(is_dir($targetPath))->toBeTrue()
+    expect(is_dir($targetPath))->toBeFalse()
+        ->and(is_dir($otherPath))->toBeTrue()
         ->and(is_file($this->runtimePluginPath.'/recovery.json'))->toBeTrue();
+});
+
+it('scopes normal lifecycle changes away from unknown recovery metadata', function (): void {
+    $store = app(RuntimePluginStore::class);
+    $firstPath = $this->runtimePluginPath.'/acme/first';
+    $secondPath = $this->runtimePluginPath.'/acme/second';
+    mkdir($firstPath, 0750, true);
+    mkdir($secondPath, 0750, true);
+    $store->writeState([
+        'acme/first' => ['enabled' => true],
+        'acme/second' => ['enabled' => true],
+    ]);
+    file_put_contents($this->runtimePluginPath.'/recovery.json', '{broken');
+
+    $store->withLock(
+        fn (RuntimePluginStore $store): mixed => $store->setEnabled('acme/second', false),
+        true,
+        'acme/second',
+    );
+    $store->withLock(
+        fn (RuntimePluginStore $store): mixed => $store->remove('acme/second'),
+        true,
+        'acme/second',
+    );
+
+    expect(is_dir($firstPath))->toBeTrue()
+        ->and(is_dir($secondPath))->toBeFalse()
+        ->and(is_file($this->runtimePluginPath.'/recovery.json'))->toBeTrue()
+        ->and($store->readState())->toBe(['acme/first' => ['enabled' => true]]);
+});
+
+it('surfaces and removes special runtime filesystem nodes', function (): void {
+    if (! function_exists('posix_mkfifo')) {
+        $this->markTestSkipped('The POSIX extension is required for FIFO coverage.');
+    }
+
+    $store = app(RuntimePluginStore::class);
+    mkdir($this->runtimePluginPath, 0750, true);
+    $path = $this->runtimePluginPath.'/acme';
+    posix_mkfifo($path, 0600);
+
+    expect($store->managedFilesystemAnomalies())->toHaveKey('vendor:acme');
+
+    $store->forceCleanupFilesystemAnomaly('vendor:acme');
+
+    expect(file_exists($path))->toBeFalse();
+});
+
+it('rejects a special lock path before opening it', function (): void {
+    if (! function_exists('posix_mkfifo')) {
+        $this->markTestSkipped('The POSIX extension is required for FIFO coverage.');
+    }
+
+    $store = app(RuntimePluginStore::class);
+    mkdir($this->runtimePluginPath, 0750, true);
+    posix_mkfifo($this->runtimePluginPath.'/.lock', 0600);
+
+    expect(fn (): mixed => $store->withLock(fn (): null => null, false))
+        ->toThrow(RuntimeException::class, 'lock path is not a regular file');
 });
 
 it('clears recovery artifacts without touching another package', function (): void {

--- a/tests/Feature/Platform/RuntimePluginStoreTest.php
+++ b/tests/Feature/Platform/RuntimePluginStoreTest.php
@@ -87,6 +87,61 @@ it('keeps the new package after a committed swap recovery', function (): void {
         ->and(is_file($this->runtimePluginPath.'/recovery.json'))->toBeFalse();
 });
 
+it('never resurrects a package after a committed removal recovery', function (): void {
+    $store = app(RuntimePluginStore::class);
+    $activePath = $this->runtimePluginPath.'/acme/removed';
+    $backupPath = $this->runtimePluginPath.'/.backup/acme-removed-test';
+
+    mkdir($backupPath, 0750, true);
+    file_put_contents($backupPath.'/version.txt', 'old');
+    $store->writeState([]);
+    file_put_contents($this->runtimePluginPath.'/recovery.json', json_encode([
+        'operation' => 'remove',
+        'id' => 'acme/removed',
+        'staging' => null,
+        'backup' => '.backup/acme-removed-test',
+        'had_active' => true,
+        'phase' => 'committed',
+    ], JSON_THROW_ON_ERROR));
+
+    $store->withLock(fn (): null => null);
+
+    expect(is_dir($activePath))->toBeFalse()
+        ->and(is_dir($backupPath))->toBeFalse()
+        ->and($store->readState())->toBe([])
+        ->and(is_file($this->runtimePluginPath.'/recovery.json'))->toBeFalse();
+});
+
+it('recovers an identity-addressed sidecar without touching another marker', function (): void {
+    $store = app(RuntimePluginStore::class);
+    $id = 'acme/sidecar';
+    $activePath = $this->runtimePluginPath.'/'.$id;
+    $backupPath = $this->runtimePluginPath.'/.backup/acme-sidecar-test';
+    $markerPath = $this->runtimePluginPath.'/.recovery/'.bin2hex($id).'.json';
+
+    mkdir($backupPath, 0750, true);
+    file_put_contents($backupPath.'/version.txt', 'old');
+    mkdir($this->runtimePluginPath.'/.staging/sidecar', 0750, true);
+    mkdir(dirname($markerPath), 0750, true);
+    $store->writeState([$id => ['enabled' => true]]);
+    file_put_contents($markerPath, json_encode([
+        'operation' => 'swap',
+        'id' => $id,
+        'staging' => '.staging/sidecar',
+        'backup' => '.backup/acme-sidecar-test',
+        'had_active' => true,
+        'previous_entry' => ['enabled' => false],
+        'next_entry' => ['enabled' => true],
+        'phase' => 'old_preserved',
+    ], JSON_THROW_ON_ERROR));
+
+    $store->withLock(fn (): null => null, true, $id);
+
+    expect(file_get_contents($activePath.'/version.txt'))->toBe('old')
+        ->and(is_file($markerPath))->toBeFalse()
+        ->and($store->readState())->toMatchArray([$id => ['enabled' => false]]);
+});
+
 it('finishes an active swap after the new package is promoted', function (): void {
     $store = app(RuntimePluginStore::class);
     $activePath = $this->runtimePluginPath.'/acme/recovery';
@@ -292,6 +347,33 @@ it('surfaces deletion failures instead of reporting force removal success', func
     }
 });
 
+it('does not treat an inaccessible package parent as an absent package', function (): void {
+    if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
+        $this->markTestSkipped('The permission test requires a non-root user.');
+    }
+
+    $store = app(RuntimePluginStore::class);
+    $vendorPath = $this->runtimePluginPath.'/acme';
+    $packagePath = $vendorPath.'/inaccessible';
+    mkdir($packagePath, 0750, true);
+    file_put_contents($packagePath.'/plugin.php', 'content');
+    $store->writeState(['acme/inaccessible' => ['enabled' => true]]);
+    chmod($vendorPath, 0000);
+
+    try {
+        expect(fn (): mixed => $store->withLock(
+            fn (RuntimePluginStore $store): mixed => $store->forceRemove('acme/inaccessible'),
+            false,
+        ))->toThrow(RuntimeException::class, 'Could not inspect runtime plugin path');
+    } finally {
+        chmod($vendorPath, 0700);
+    }
+
+    expect(is_dir($packagePath))->toBeTrue()
+        ->and(json_decode(file_get_contents($this->runtimePluginPath.'/state.json'), true, 512, JSON_THROW_ON_ERROR))
+        ->toMatchArray(['acme/inaccessible' => ['enabled' => true]]);
+});
+
 it('does not erase another package state when removing with corrupt state', function (): void {
     $store = app(RuntimePluginStore::class);
     $firstPath = $this->runtimePluginPath.'/acme/first';
@@ -387,6 +469,51 @@ it('removes a different package without touching recovery for another package', 
     expect(is_dir($targetPath))->toBeFalse()
         ->and(is_dir($otherPath))->toBeTrue()
         ->and(is_file($this->runtimePluginPath.'/recovery.json'))->toBeTrue();
+});
+
+it('preserves unrelated recovery when force removing the last package', function (): void {
+    $store = app(RuntimePluginStore::class);
+    $targetPath = $this->runtimePluginPath.'/acme/target';
+    mkdir($targetPath, 0750, true);
+    file_put_contents($this->runtimePluginPath.'/recovery.json', json_encode([
+        'operation' => 'swap',
+        'id' => 'acme/other',
+        'staging' => '.staging/incoming',
+        'backup' => '.backup/missing',
+        'had_active' => true,
+        'phase' => 'old_preserved',
+    ], JSON_THROW_ON_ERROR));
+
+    $store->withLock(
+        fn (RuntimePluginStore $store): mixed => $store->forceRemove('acme/target'),
+        false,
+    );
+
+    expect(is_dir($targetPath))->toBeFalse()
+        ->and(is_file($this->runtimePluginPath.'/recovery.json'))->toBeTrue();
+});
+
+it('finds identity-scoped recovery markers despite filename casing', function (): void {
+    $store = app(RuntimePluginStore::class);
+    $directory = $this->runtimePluginPath.'/.recovery';
+    mkdir($directory, 0750, true);
+    $markerPath = $directory.'/'.strtoupper(bin2hex('acme/recovery')).'.json';
+    file_put_contents($markerPath, json_encode([
+        'operation' => 'swap',
+        'id' => 'acme/recovery',
+        'staging' => '.staging/incoming',
+        'backup' => '.backup/missing',
+        'had_active' => true,
+        'phase' => 'old_preserved',
+    ], JSON_THROW_ON_ERROR));
+
+    expect($store->hasRecoveryFor('acme/recovery'))->toBeTrue();
+
+    $store->withLock(function (RuntimePluginStore $store): void {
+        $store->forceCleanupRecovery('acme/recovery');
+    }, false);
+
+    expect(is_file($markerPath))->toBeFalse();
 });
 
 it('scopes normal lifecycle changes away from unknown recovery metadata', function (): void {

--- a/tests/Feature/Platform/RuntimePluginStoreTest.php
+++ b/tests/Feature/Platform/RuntimePluginStoreTest.php
@@ -278,6 +278,28 @@ it('surfaces deletion failures instead of reporting force removal success', func
     }
 });
 
+it('does not erase another package state when removing with corrupt state', function (): void {
+    $store = app(RuntimePluginStore::class);
+    $firstPath = $this->runtimePluginPath.'/acme/first';
+    $secondPath = $this->runtimePluginPath.'/acme/second';
+    mkdir($firstPath, 0750, true);
+    mkdir($secondPath, 0750, true);
+    $store->writeState([
+        'acme/first' => ['enabled' => true],
+        'acme/second' => ['enabled' => false],
+    ]);
+    file_put_contents($this->runtimePluginPath.'/state.json', '{broken');
+
+    $store->withLock(
+        fn (RuntimePluginStore $store): mixed => $store->forceRemove('acme/first'),
+        false,
+    );
+
+    expect(is_dir($firstPath))->toBeFalse()
+        ->and(is_dir($secondPath))->toBeTrue()
+        ->and(file_get_contents($this->runtimePluginPath.'/state.json'))->toBe('{broken');
+});
+
 it('rejects symlinked internal staging paths', function (): void {
     $store = app(RuntimePluginStore::class);
     $outside = sys_get_temp_dir().'/openkos-runtime-outside-'.bin2hex(random_bytes(8));
@@ -294,6 +316,38 @@ it('rejects symlinked internal staging paths', function (): void {
         unlink($this->runtimePluginPath.'/.staging');
         File::deleteDirectory($outside);
     }
+});
+
+it('surfaces and removes an unsafe lock path without opening it', function (): void {
+    $store = app(RuntimePluginStore::class);
+    $outside = sys_get_temp_dir().'/openkos-runtime-lock-outside-'.bin2hex(random_bytes(8));
+    mkdir($outside, 0750, true);
+    mkdir($this->runtimePluginPath, 0750, true);
+    symlink($outside, $this->runtimePluginPath.'/.lock');
+
+    try {
+        expect($store->managedFilesystemAnomalies())->toHaveKey('internal:.lock');
+
+        $store->forceCleanupFilesystemAnomaly('internal:.lock');
+
+        expect(is_link($this->runtimePluginPath.'/.lock'))->toBeFalse()
+            ->and(is_dir($outside))->toBeTrue();
+    } finally {
+        File::deleteDirectory($outside);
+        File::delete($this->runtimePluginPath.'/.lock');
+    }
+});
+
+it('surfaces and removes a non-file recovery marker', function (): void {
+    $store = app(RuntimePluginStore::class);
+    mkdir($this->runtimePluginPath.'/recovery.json/nested', 0750, true);
+    file_put_contents($this->runtimePluginPath.'/recovery.json/nested/marker', 'keep');
+
+    expect($store->managedFilesystemAnomalies())->toHaveKey('internal:recovery.json');
+
+    $store->forceCleanupFilesystemAnomaly('internal:recovery.json');
+
+    expect(file_exists($this->runtimePluginPath.'/recovery.json'))->toBeFalse();
 });
 
 it('does not remove a different package while forcing recovery', function (): void {

--- a/tests/Feature/Platform/RuntimePluginTest.php
+++ b/tests/Feature/Platform/RuntimePluginTest.php
@@ -91,6 +91,47 @@ it('does not execute disabled runtime plugins while listing them', function (): 
     File::delete($marker);
 });
 
+it('does not execute enabled runtime plugins while listing them', function (): void {
+    $artifact = makeRuntimePluginArtifact();
+    $marker = sys_get_temp_dir().'/openkos-enabled-list-'.bin2hex(random_bytes(8));
+
+    $this->artisan('plugin:install', ['zip' => $artifact['zip']])->assertSuccessful();
+    $autoloadPath = $this->runtimePluginPath.'/'.$artifact['id'].'/vendor/autoload.php';
+    $autoload = file_get_contents($autoloadPath);
+    file_put_contents($autoloadPath, str_replace(
+        '<?php',
+        "<?php\nfile_put_contents(".var_export($marker, true).", 'loaded');",
+        $autoload,
+    ));
+
+    $this->artisan('plugin:list')
+        ->assertSuccessful()
+        ->expectsOutputToContain('Enabled');
+
+    expect(is_file($marker))->toBeFalse();
+    File::delete($marker);
+});
+
+it('reports a disabled package with an unsafe tree without executing it', function (): void {
+    $artifact = makeRuntimePluginArtifact();
+    $outside = sys_get_temp_dir().'/openkos-disabled-symlink-'.bin2hex(random_bytes(8));
+    file_put_contents($outside, "<?php\nfile_put_contents(".var_export($outside.'.loaded', true).", 'loaded');");
+
+    $this->artisan('plugin:install', ['zip' => $artifact['zip']])->assertSuccessful();
+    $this->artisan('plugin:disable', ['id' => $artifact['id']])->assertSuccessful();
+    File::delete($this->runtimePluginPath.'/'.$artifact['id'].'/vendor/autoload.php');
+    symlink($outside, $this->runtimePluginPath.'/'.$artifact['id'].'/vendor/autoload.php');
+
+    $this->artisan('plugin:list')
+        ->assertSuccessful()
+        ->expectsOutputToContain('Invalid (disabled)');
+
+    expect(is_file($outside.'.loaded'))->toBeFalse();
+
+    File::delete($outside);
+    File::delete($outside.'.loaded');
+});
+
 it('does not recover runtime state while listing plugins', function (): void {
     mkdir($this->runtimePluginPath.'/.backup/recover', 0750, true);
     mkdir($this->runtimePluginPath.'/.staging/incoming', 0750, true);
@@ -325,24 +366,78 @@ it('does not execute duplicate runtime entry classes during discovery', function
     File::delete($markers[1]);
 });
 
+it('rejects enabling a duplicate runtime entry class before loading it', function (): void {
+    $first = makeRuntimePluginArtifact(
+        ['id' => 'acme/duplicate-enable-a'],
+        classShort: 'SharedEnablePlugin',
+    );
+    $second = makeRuntimePluginArtifact(
+        ['id' => 'acme/duplicate-enable-b'],
+        classShort: 'SharedEnablePlugin',
+    );
+
+    $this->artisan('plugin:install', ['zip' => $first['zip']])->assertSuccessful();
+    $secondPath = $this->runtimePluginPath.'/'.$second['id'];
+    File::makeDirectory($secondPath, 0750, true);
+    $zip = new ZipArchive;
+    $zip->open($second['zip']);
+    $zip->extractTo($secondPath);
+    $zip->close();
+    app(RuntimePluginStore::class)->writeState([
+        $first['id'] => ['enabled' => true],
+        $second['id'] => ['enabled' => false],
+    ]);
+
+    $marker = sys_get_temp_dir().'/openkos-duplicate-enable-'.bin2hex(random_bytes(8));
+    $autoloadPath = $secondPath.'/vendor/autoload.php';
+    $autoload = file_get_contents($autoloadPath);
+    file_put_contents($autoloadPath, str_replace(
+        '<?php',
+        "<?php\nfile_put_contents(".var_export($marker, true).", 'loaded');",
+        $autoload,
+    ));
+
+    $this->artisan('plugin:enable', ['id' => $second['id']])
+        ->assertFailed()
+        ->expectsOutputToContain('conflicts');
+
+    expect(is_file($marker))->toBeFalse()
+        ->and(app(RuntimePluginStore::class)->readState()[$second['id']]['enabled'])->toBeFalse();
+
+    File::delete($marker);
+});
+
 it('rejects an entry-class conflict before activating a runtime plugin', function (): void {
     $artifact = makeRuntimePluginArtifact();
+    $marker = sys_get_temp_dir().'/openkos-static-conflict-'.bin2hex(random_bytes(8));
+    $zip = new ZipArchive;
+    $zip->open($artifact['zip']);
+    $autoload = $zip->getFromName('vendor/autoload.php');
+    $zip->addFromString('vendor/autoload.php', str_replace(
+        '<?php',
+        "<?php\nfile_put_contents(".var_export($marker, true).", 'loaded');",
+        $autoload,
+    ));
+    $zip->close();
     config(['platform.plugins' => [$artifact['class']]]);
 
     $this->artisan('plugin:install', ['zip' => $artifact['zip']])
         ->assertFailed()
         ->expectsOutputToContain('conflicts');
 
-    expect(is_dir($this->runtimePluginPath.'/'.$artifact['id']))->toBeFalse();
+    expect(is_dir($this->runtimePluginPath.'/'.$artifact['id']))->toBeFalse()
+        ->and(is_file($marker))->toBeFalse();
+
+    File::delete($marker);
 });
 
-it('fails on corrupted runtime state instead of treating it as disabled', function (): void {
+it('surfaces corrupted runtime state instead of treating it as disabled', function (): void {
     mkdir($this->runtimePluginPath, 0750, true);
     file_put_contents($this->runtimePluginPath.'/state.json', '{broken');
 
     $this->artisan('plugin:list')
-        ->assertFailed()
-        ->expectsOutputToContain('state is corrupted');
+        ->assertSuccessful()
+        ->expectsOutputToContain('Orphaned state');
 });
 
 /**

--- a/tests/Feature/Platform/RuntimePluginTest.php
+++ b/tests/Feature/Platform/RuntimePluginTest.php
@@ -1,8 +1,11 @@
 <?php
 
+use App\Services\Platform\PluginManagementService;
+use App\Services\Platform\RuntimePluginStore;
 use Illuminate\Support\Facades\File;
 use OpenKOS\Core\Contracts\PluginDiscovery;
 use OpenKOS\Platform\Permission\PermissionRegistry;
+use OpenKOS\Plugins\Mail\MailPlugin;
 
 beforeEach(function (): void {
     $this->runtimePluginPath = sys_get_temp_dir().'/openkos-runtime-'.bin2hex(random_bytes(8));
@@ -54,6 +57,38 @@ it('does not boot a disabled runtime plugin', function (): void {
     expect(app(PermissionRegistry::class)->all())
         ->not->toHaveKey('runtime-fixture.view')
         ->and(class_exists($artifact['class'], false))->toBeFalse();
+});
+
+it('does not execute disabled runtime plugins while listing them', function (): void {
+    $artifact = makeRuntimePluginArtifact();
+    $marker = sys_get_temp_dir().'/openkos-disabled-plugin-'.bin2hex(random_bytes(8));
+
+    $this->artisan('plugin:install', ['zip' => $artifact['zip']])->assertSuccessful();
+    $this->artisan('plugin:disable', ['id' => $artifact['id']])->assertSuccessful();
+
+    $autoloadPath = $this->runtimePluginPath.'/'.$artifact['id'].'/vendor/autoload.php';
+    $autoload = file_get_contents($autoloadPath);
+    $replacementCount = 0;
+    file_put_contents($autoloadPath, str_replace(
+        '<?php',
+        "<?php\nfile_put_contents(".var_export($marker, true).", 'loaded');",
+        $autoload,
+        $replacementCount,
+    ));
+
+    $this->artisan('plugin:list')
+        ->assertSuccessful()
+        ->expectsOutputToContain('Disabled');
+
+    $plugins = app(PluginManagementService::class)->catalog()['plugins'];
+
+    expect(collect($plugins)->firstWhere('id', $artifact['id']))->toMatchArray([
+        'status' => 'disabled',
+        'enabled' => false,
+    ]);
+
+    expect(is_file($marker))->toBeFalse();
+    File::delete($marker);
 });
 
 it('validates updates in a fresh process after the previous class was loaded', function (): void {
@@ -145,15 +180,34 @@ it('reports an enabled package with a malformed manifest without booting it', fu
 });
 
 it('skips a runtime plugin that conflicts with an explicit plugin', function (): void {
-    $artifact = makeRuntimePluginArtifact();
+    $artifact = makeRuntimePluginArtifact(id: 'openkos/mail');
+    $packagePath = $this->runtimePluginPath.'/'.$artifact['id'];
+    File::makeDirectory($packagePath, 0750, true);
+    $zip = new ZipArchive;
+    $zip->open($artifact['zip']);
+    $zip->extractTo($packagePath);
+    $zip->close();
+    app(RuntimePluginStore::class)->writeState([
+        $artifact['id'] => ['enabled' => true],
+    ]);
+    $marker = sys_get_temp_dir().'/openkos-conflicting-plugin-'.bin2hex(random_bytes(8));
+    $autoloadPath = $packagePath.'/vendor/autoload.php';
+    $autoload = file_get_contents($autoloadPath);
+    $replacementCount = 0;
+    file_put_contents($autoloadPath, str_replace(
+        '<?php',
+        "<?php\nfile_put_contents(".var_export($marker, true).", 'loaded');",
+        $autoload,
+        $replacementCount,
+    ));
 
-    $this->artisan('plugin:install', ['zip' => $artifact['zip']])->assertSuccessful();
-    require_once $this->runtimePluginPath.'/'.$artifact['id'].'/vendor/autoload.php';
-    config(['platform.plugins' => [$artifact['class']]]);
+    config(['platform.plugins' => [MailPlugin::class]]);
 
     expect(fn (): mixed => $this->bootPlatformWithIsolatedRegistries())
         ->not->toThrow(RuntimeException::class);
-    expect(app(PermissionRegistry::class)->all())->toHaveKey('runtime-fixture.view');
+    expect(app(PermissionRegistry::class)->all())->not->toHaveKey('runtime-fixture.view')
+        ->and(is_file($marker))->toBeFalse();
+    File::delete($marker);
 });
 
 it('rejects an entry-class conflict before activating a runtime plugin', function (): void {

--- a/tests/Feature/Platform/RuntimePluginTest.php
+++ b/tests/Feature/Platform/RuntimePluginTest.php
@@ -51,7 +51,9 @@ it('does not boot a disabled runtime plugin', function (): void {
 
     $this->bootPlatformWithIsolatedRegistries();
 
-    expect(app(PermissionRegistry::class)->all())->not->toHaveKey('runtime-fixture.view');
+    expect(app(PermissionRegistry::class)->all())
+        ->not->toHaveKey('runtime-fixture.view')
+        ->and(class_exists($artifact['class'], false))->toBeFalse();
 });
 
 it('validates updates in a fresh process after the previous class was loaded', function (): void {

--- a/tests/Feature/Platform/RuntimePluginTest.php
+++ b/tests/Feature/Platform/RuntimePluginTest.php
@@ -91,6 +91,28 @@ it('does not execute disabled runtime plugins while listing them', function (): 
     File::delete($marker);
 });
 
+it('does not recover runtime state while listing plugins', function (): void {
+    mkdir($this->runtimePluginPath.'/.backup/recover', 0750, true);
+    mkdir($this->runtimePluginPath.'/.staging/incoming', 0750, true);
+    file_put_contents($this->runtimePluginPath.'/.backup/recover/marker', 'keep');
+    file_put_contents($this->runtimePluginPath.'/state.json', json_encode([
+        'acme/recover' => ['enabled' => true],
+    ], JSON_THROW_ON_ERROR));
+    file_put_contents($this->runtimePluginPath.'/recovery.json', json_encode([
+        'operation' => 'swap',
+        'id' => 'acme/recover',
+        'staging' => '.staging/incoming',
+        'backup' => '.backup/recover',
+        'had_active' => true,
+        'phase' => 'old_preserved',
+    ], JSON_THROW_ON_ERROR));
+
+    $this->artisan('plugin:list')->assertSuccessful();
+
+    expect(is_file($this->runtimePluginPath.'/recovery.json'))->toBeTrue()
+        ->and(is_file($this->runtimePluginPath.'/.backup/recover/marker'))->toBeTrue();
+});
+
 it('validates updates in a fresh process after the previous class was loaded', function (): void {
     $first = makeRuntimePluginArtifact();
 
@@ -136,6 +158,19 @@ it('rejects artifacts that exceed the configured archive limit', function (): vo
 
     $this->artisan('plugin:install', ['zip' => $zip])
         ->assertFailed();
+});
+
+it('does not overwrite stale runtime artifacts during installation', function (): void {
+    $artifact = makeRuntimePluginArtifact();
+    File::makeDirectory($this->runtimePluginPath.'/.staging/stale', 0750, true);
+    file_put_contents($this->runtimePluginPath.'/.staging/stale/marker', 'keep');
+
+    $this->artisan('plugin:install', ['zip' => $artifact['zip']])
+        ->assertFailed()
+        ->expectsOutputToContain('Orphaned runtime artifacts');
+
+    expect(is_file($this->runtimePluginPath.'/.staging/stale/marker'))->toBeTrue()
+        ->and(is_dir($this->runtimePluginPath.'/'.$artifact['id']))->toBeFalse();
 });
 
 it('counts archive directories toward the entry limit', function (): void {
@@ -208,6 +243,86 @@ it('skips a runtime plugin that conflicts with an explicit plugin', function ():
     expect(app(PermissionRegistry::class)->all())->not->toHaveKey('runtime-fixture.view')
         ->and(is_file($marker))->toBeFalse();
     File::delete($marker);
+});
+
+it('does not execute a conflicting runtime plugin while listing it', function (): void {
+    $artifact = makeRuntimePluginArtifact(id: 'openkos/mail');
+    $packagePath = $this->runtimePluginPath.'/'.$artifact['id'];
+    File::makeDirectory($packagePath, 0750, true);
+    $zip = new ZipArchive;
+    $zip->open($artifact['zip']);
+    $zip->extractTo($packagePath);
+    $zip->close();
+    app(RuntimePluginStore::class)->writeState([
+        $artifact['id'] => ['enabled' => true],
+    ]);
+    $marker = sys_get_temp_dir().'/openkos-conflicting-list-'.bin2hex(random_bytes(8));
+    $autoloadPath = $packagePath.'/vendor/autoload.php';
+    $autoload = file_get_contents($autoloadPath);
+    $replacementCount = 0;
+    file_put_contents($autoloadPath, str_replace(
+        '<?php',
+        "<?php\nfile_put_contents(".var_export($marker, true).", 'loaded');",
+        $autoload,
+        $replacementCount,
+    ));
+
+    config(['platform.plugins' => [MailPlugin::class]]);
+
+    $this->artisan('plugin:list')
+        ->assertSuccessful()
+        ->expectsOutputToContain('Conflict');
+
+    expect(is_file($marker))->toBeFalse();
+    File::delete($marker);
+});
+
+it('does not execute duplicate runtime entry classes during discovery', function (): void {
+    $first = makeRuntimePluginArtifact(
+        ['id' => 'acme/duplicate-a'],
+        classShort: 'SharedDuplicatePlugin',
+    );
+    $second = makeRuntimePluginArtifact(
+        ['id' => 'acme/duplicate-b'],
+        classShort: 'SharedDuplicatePlugin',
+    );
+
+    $this->artisan('plugin:install', ['zip' => $first['zip']])->assertSuccessful();
+    $secondPath = $this->runtimePluginPath.'/'.$second['id'];
+    File::makeDirectory($secondPath, 0750, true);
+    $zip = new ZipArchive;
+    $zip->open($second['zip']);
+    $zip->extractTo($secondPath);
+    $zip->close();
+    app(RuntimePluginStore::class)->writeState([
+        $first['id'] => ['enabled' => true],
+        $second['id'] => ['enabled' => true],
+    ]);
+
+    $markers = [
+        sys_get_temp_dir().'/openkos-duplicate-a-'.bin2hex(random_bytes(8)),
+        sys_get_temp_dir().'/openkos-duplicate-b-'.bin2hex(random_bytes(8)),
+    ];
+
+    foreach ([$first, $second] as $index => $artifact) {
+        $autoloadPath = $this->runtimePluginPath.'/'.$artifact['id'].'/vendor/autoload.php';
+        $autoload = file_get_contents($autoloadPath);
+        $replacementCount = 0;
+        file_put_contents($autoloadPath, str_replace(
+            '<?php',
+            "<?php\nfile_put_contents(".var_export($markers[$index], true).", 'loaded');",
+            $autoload,
+            $replacementCount,
+        ));
+    }
+
+    $this->bootPlatformWithIsolatedRegistries();
+
+    expect(is_file($markers[0]))->toBeFalse()
+        ->and(is_file($markers[1]))->toBeFalse();
+
+    File::delete($markers[0]);
+    File::delete($markers[1]);
 });
 
 it('rejects an entry-class conflict before activating a runtime plugin', function (): void {

--- a/tests/Feature/Platform/RuntimePluginTest.php
+++ b/tests/Feature/Platform/RuntimePluginTest.php
@@ -244,7 +244,7 @@ it('surfaces a runtime lifecycle failure as load_failed in the catalog', functio
     $sourcePath = glob($this->runtimePluginPath.'/'.$artifact['id'].'/src/*.php')[0];
     file_put_contents($sourcePath, str_replace(
         '        $platform->permissions()->register(\'runtime-fixture.view\', \'Runtime Fixture\');',
-        "        throw new RuntimeException('register failed');",
+        "        throw new \\RuntimeException('register failed');",
         file_get_contents($sourcePath),
     ));
 

--- a/tests/Feature/Platform/RuntimePluginTest.php
+++ b/tests/Feature/Platform/RuntimePluginTest.php
@@ -154,6 +154,58 @@ it('does not recover runtime state while listing plugins', function (): void {
         ->and(is_file($this->runtimePluginPath.'/.backup/recover/marker'))->toBeTrue();
 });
 
+it('keeps healthy runtime plugins discoverable when another recovery is unrecoverable', function (): void {
+    $healthy = makeRuntimePluginArtifact();
+    $this->artisan('plugin:install', ['zip' => $healthy['zip']])->assertSuccessful();
+    File::makeDirectory($this->runtimePluginPath.'/.staging/incoming', 0750, true);
+    file_put_contents($this->runtimePluginPath.'/recovery.json', json_encode([
+        'operation' => 'swap',
+        'id' => 'acme/broken-recovery',
+        'staging' => '.staging/incoming',
+        'backup' => '.backup/missing',
+        'had_active' => true,
+        'phase' => 'old_preserved',
+    ], JSON_THROW_ON_ERROR));
+
+    $this->bootPlatformWithIsolatedRegistries();
+
+    expect(app(PermissionRegistry::class)->all())->toHaveKey('runtime-fixture.view');
+});
+
+it('does not load runtime code when its static dependency graph is invalid', function (): void {
+    $artifact = makeRuntimePluginArtifact();
+    $this->artisan('plugin:install', ['zip' => $artifact['zip']])->assertSuccessful();
+
+    $packagePath = $this->runtimePluginPath.'/'.$artifact['id'];
+    $sourcePath = glob($packagePath.'/src/*.php')[0];
+    file_put_contents($sourcePath, str_replace(
+        'dependencies: [],',
+        "dependencies: ['missing/plugin'],",
+        file_get_contents($sourcePath),
+    ));
+    $manifestPath = $packagePath.'/manifest.json';
+    $manifest = json_decode(file_get_contents($manifestPath), true, 512, JSON_THROW_ON_ERROR);
+    $manifest['dependencies'] = ['missing/plugin'];
+    file_put_contents($manifestPath, json_encode($manifest, JSON_THROW_ON_ERROR));
+
+    $marker = sys_get_temp_dir().'/openkos-invalid-graph-'.bin2hex(random_bytes(8));
+    $parentPid = getmypid();
+    $autoloadPath = $packagePath.'/vendor/autoload.php';
+    $autoload = file_get_contents($autoloadPath);
+    file_put_contents($autoloadPath, str_replace(
+        '<?php',
+        "<?php\nif (getmypid() === ".var_export($parentPid, true).') { file_put_contents('.var_export($marker, true).", 'loaded'); }",
+        $autoload,
+    ));
+
+    $this->bootPlatformWithIsolatedRegistries();
+
+    expect(is_file($marker))->toBeFalse()
+        ->and(app(PermissionRegistry::class)->all())->not->toHaveKey('runtime-fixture.view');
+
+    File::delete($marker);
+});
+
 it('validates updates in a fresh process after the previous class was loaded', function (): void {
     $first = makeRuntimePluginArtifact();
 
@@ -183,6 +235,28 @@ it('revalidates an installed plugin before enabling it', function (): void {
         ->toMatchArray([$artifact['id'] => ['enabled' => false]]);
 });
 
+it('rejects enabling a package whose vendor ancestor is a symlink', function (): void {
+    $artifact = makeRuntimePluginArtifact();
+    $outside = sys_get_temp_dir().'/openkos-runtime-vendor-'.bin2hex(random_bytes(8));
+    $packagePath = $this->runtimePluginPath.'/'.$artifact['id'];
+
+    $this->artisan('plugin:install', ['zip' => $artifact['zip']])->assertSuccessful();
+    $this->artisan('plugin:disable', ['id' => $artifact['id']])->assertSuccessful();
+    File::deleteDirectory($packagePath.'/vendor');
+    File::makeDirectory($outside, 0750, true);
+    symlink($outside, $packagePath.'/vendor');
+
+    try {
+        $this->artisan('plugin:enable', ['id' => $artifact['id']])->assertFailed();
+    } finally {
+        unlink($packagePath.'/vendor');
+        File::deleteDirectory($outside);
+    }
+
+    expect(json_decode(file_get_contents($this->runtimePluginPath.'/state.json'), true, 512, JSON_THROW_ON_ERROR))
+        ->toMatchArray([$artifact['id'] => ['enabled' => false]]);
+});
+
 it('rejects unsafe ZIP paths before extraction', function (): void {
     $zip = makeZip(['../outside.txt' => 'unsafe']);
 
@@ -207,11 +281,29 @@ it('does not overwrite stale runtime artifacts during installation', function ()
     file_put_contents($this->runtimePluginPath.'/.staging/stale/marker', 'keep');
 
     $this->artisan('plugin:install', ['zip' => $artifact['zip']])
-        ->assertFailed()
-        ->expectsOutputToContain('Orphaned runtime artifacts');
+        ->assertSuccessful();
 
     expect(is_file($this->runtimePluginPath.'/.staging/stale/marker'))->toBeTrue()
-        ->and(is_dir($this->runtimePluginPath.'/'.$artifact['id']))->toBeFalse();
+        ->and(is_dir($this->runtimePluginPath.'/'.$artifact['id']))->toBeTrue();
+});
+
+it('preserves recovery state for an unrelated plugin during installation', function (): void {
+    $artifact = makeRuntimePluginArtifact();
+    File::makeDirectory($this->runtimePluginPath.'/.staging/recovery-a', 0750, true);
+    file_put_contents($this->runtimePluginPath.'/recovery.json', json_encode([
+        'operation' => 'swap',
+        'id' => 'acme/recovery-a',
+        'staging' => '.staging/recovery-a',
+        'backup' => '.backup/missing',
+        'had_active' => true,
+        'phase' => 'old_preserved',
+    ], JSON_THROW_ON_ERROR));
+
+    $this->artisan('plugin:install', ['zip' => $artifact['zip']])->assertSuccessful();
+
+    expect(json_decode(file_get_contents($this->runtimePluginPath.'/recovery.json'), true, 512, JSON_THROW_ON_ERROR))
+        ->toMatchArray(['id' => 'acme/recovery-a'])
+        ->and(is_dir($this->runtimePluginPath.'/'.$artifact['id']))->toBeTrue();
 });
 
 it('counts archive directories toward the entry limit', function (): void {

--- a/tests/Feature/Platform/RuntimePluginTest.php
+++ b/tests/Feature/Platform/RuntimePluginTest.php
@@ -1,6 +1,10 @@
 <?php
 
+use App\Services\Platform\PluginInstaller;
 use App\Services\Platform\PluginManagementService;
+use App\Services\Platform\RuntimePluginArtifactValidator;
+use App\Services\Platform\RuntimePluginDiscovery;
+use App\Services\Platform\RuntimePluginGraphValidator;
 use App\Services\Platform\RuntimePluginStore;
 use Illuminate\Support\Facades\File;
 use OpenKOS\Core\Contracts\PluginDiscovery;
@@ -204,6 +208,58 @@ it('does not load runtime code when its static dependency graph is invalid', fun
         ->and(app(PermissionRegistry::class)->all())->not->toHaveKey('runtime-fixture.view');
 
     File::delete($marker);
+});
+
+it('suppresses runtime dependants when fresh validation fails', function (): void {
+    $dependency = makeRuntimePluginArtifact();
+    $dependent = makeRuntimePluginArtifact(['dependencies' => [$dependency['id']]]);
+
+    app(PluginInstaller::class)->install($dependency['zip']);
+    app(PluginInstaller::class)->install($dependent['zip']);
+
+    $manifestPath = $this->runtimePluginPath.'/'.$dependency['id'].'/manifest.json';
+    $manifest = json_decode(file_get_contents($manifestPath), true, 512, JSON_THROW_ON_ERROR);
+    $manifest['entry_class'] = 'RuntimeArtifact\\MissingPlugin';
+    file_put_contents($manifestPath, json_encode($manifest, JSON_THROW_ON_ERROR));
+    $composerPath = $this->runtimePluginPath.'/'.$dependency['id'].'/composer.json';
+    $composer = json_decode(file_get_contents($composerPath), true, 512, JSON_THROW_ON_ERROR);
+    $composer['extra']['openkos']['plugin'] = $manifest['entry_class'];
+    file_put_contents($composerPath, json_encode($composer, JSON_THROW_ON_ERROR));
+
+    $discovery = new RuntimePluginDiscovery(
+        new RuntimePluginStore,
+        app(RuntimePluginArtifactValidator::class),
+        app(RuntimePluginGraphValidator::class),
+    );
+
+    expect($discovery->discover())->toBe([])
+        ->and($discovery->failureFor($dependency['id']))
+        ->toMatchArray(['status' => 'broken']);
+});
+
+it('surfaces a runtime lifecycle failure as load_failed in the catalog', function (): void {
+    $artifact = makeRuntimePluginArtifact();
+    app(PluginInstaller::class)->install($artifact['zip']);
+
+    $sourcePath = glob($this->runtimePluginPath.'/'.$artifact['id'].'/src/*.php')[0];
+    file_put_contents($sourcePath, str_replace(
+        '        $platform->permissions()->register(\'runtime-fixture.view\', \'Runtime Fixture\');',
+        "        throw new RuntimeException('register failed');",
+        file_get_contents($sourcePath),
+    ));
+
+    $this->bootPlatformWithIsolatedRegistries();
+
+    $plugin = collect(app(PluginManagementService::class)->catalog()['plugins'])
+        ->firstWhere('managed_id', $artifact['id']);
+
+    expect($plugin)->toMatchArray([
+        'status' => 'load_failed',
+        'enabled' => true,
+        'can_enable' => false,
+        'can_disable' => true,
+        'can_remove' => true,
+    ])->and($plugin['error'])->toContain('register');
 });
 
 it('validates updates in a fresh process after the previous class was loaded', function (): void {
@@ -571,7 +627,9 @@ function makeRuntimePluginArtifact(
         'autoload' => ['psr-4' => ['RuntimeArtifact\\' => 'src/']],
         'extra' => ['openkos' => ['plugin' => $entryClass]],
     ];
+    $dependencies = var_export($manifest['dependencies'], true);
     $source = "<?php\n\nnamespace RuntimeArtifact;\n\nuse OpenKOS\\Platform\\OpenKOSManager;\nuse OpenKOS\\Platform\\Plugin\\Plugin;\nuse OpenKOS\\Platform\\Plugin\\PluginManifest;\n\nfinal class {$classShort} extends Plugin\n{\n    public function manifest(): PluginManifest\n    {\n        return new PluginManifest(\n            id: '{$manifest['id']}',\n            name: '{$manifest['name']}',\n            version: '{$manifest['version']}',\n            description: '{$manifest['description']}',\n            coreVersion: '{$manifest['core_version']}',\n            dependencies: [],\n        );\n    }\n\n    public function register(OpenKOSManager \$platform): void\n    {\n        \$platform->permissions()->register('runtime-fixture.view', 'Runtime Fixture');\n    }\n}\n";
+    $source = str_replace('dependencies: [],', "dependencies: {$dependencies},", $source);
 
     return makeZip([
         'manifest.json' => json_encode($manifest, JSON_THROW_ON_ERROR),

--- a/tests/Feature/PluginSettingsTest.php
+++ b/tests/Feature/PluginSettingsTest.php
@@ -217,6 +217,59 @@ it('rejects disabling or removing a runtime dependency of an enabled plugin', fu
         ->and(is_dir($this->runtimePluginPath.'/'.$dependency['id']))->toBeTrue();
 });
 
+it('allows explicit force recovery from an invalid dependency cycle', function (): void {
+    $first = makePluginSettingsArtifact([
+        'id' => 'settings/cycle-a',
+        'dependencies' => ['settings/cycle-b'],
+    ]);
+    $second = makePluginSettingsArtifact([
+        'id' => 'settings/cycle-b',
+        'dependencies' => [$first['id']],
+    ]);
+
+    foreach ([$first, $second] as $artifact) {
+        $path = $this->runtimePluginPath.'/'.$artifact['id'];
+        File::makeDirectory($path, 0750, true);
+        $zip = new ZipArchive;
+        $zip->open($artifact['zip']);
+        $zip->extractTo($path);
+        $zip->close();
+    }
+
+    app(RuntimePluginStore::class)->writeState([
+        $first['id'] => ['enabled' => true],
+        $second['id'] => ['enabled' => true],
+    ]);
+
+    $owner = User::factory()->owner()->create();
+    [$vendor, $package] = explode('/', $first['id']);
+
+    $this->actingAs($owner)
+        ->post(route('settings.plugins.disable', ['vendor' => $vendor, 'package' => $package]))
+        ->assertSessionHasErrors('plugin');
+
+    $this->actingAs($owner)
+        ->post(route('settings.plugins.disable', ['vendor' => $vendor, 'package' => $package]), ['force' => true])
+        ->assertRedirect(route('settings.plugins.index'));
+
+    expect(app(RuntimePluginStore::class)->readState())
+        ->toMatchArray([$first['id'] => ['enabled' => false]]);
+});
+
+it('does not let an unrelated broken runtime plugin block a candidate', function (): void {
+    $broken = makePluginSettingsArtifact();
+    app(PluginInstaller::class)->install($broken['zip']);
+    File::delete($this->runtimePluginPath.'/'.$broken['id'].'/manifest.json');
+
+    $candidate = makePluginSettingsArtifact();
+    app(PluginInstaller::class)->install($candidate['zip']);
+    app(PluginInstaller::class)->disable($candidate['id']);
+    app(PluginInstaller::class)->enable($candidate['id']);
+
+    expect(is_dir($this->runtimePluginPath.'/'.$candidate['id']))->toBeTrue()
+        ->and(app(RuntimePluginStore::class)->readState()[$candidate['id']]['enabled'])->toBeTrue();
+});
+
 it('marks enabled runtime dependency cycles as unavailable', function (): void {
     $report = app(RuntimePluginGraphValidator::class)->validate([
         'settings/cycle-a' => [
@@ -366,11 +419,81 @@ it('uses the managed package identity to recover a mismatched manifest', functio
     expect(is_dir($this->runtimePluginPath.'/'.$artifact['id']))->toBeFalse();
 });
 
+it('keeps a runtime package removable when state metadata is corrupt', function (): void {
+    $artifact = makePluginSettingsArtifact();
+    app(PluginInstaller::class)->install($artifact['zip']);
+    file_put_contents($this->runtimePluginPath.'/state.json', '{broken');
+    $owner = User::factory()->owner()->create();
+    [$vendor, $package] = explode('/', $artifact['id']);
+
+    $plugins = $this->actingAs($owner)
+        ->get(route('settings.plugins.index'))
+        ->assertSuccessful()
+        ->inertiaProps('plugins');
+
+    expect(collect($plugins)->firstWhere('managed_id', $artifact['id']))->toMatchArray([
+        'status' => 'broken',
+        'can_enable' => false,
+        'can_disable' => false,
+        'can_remove' => true,
+        'can_force_recovery' => true,
+    ]);
+
+    $this->actingAs($owner)
+        ->delete(route('settings.plugins.destroy', ['vendor' => $vendor, 'package' => $package]), ['force' => true])
+        ->assertRedirect(route('settings.plugins.index'));
+
+    expect(is_dir($this->runtimePluginPath.'/'.$artifact['id']))->toBeFalse();
+});
+
+it('keeps a runtime package removable when recovery metadata is corrupt', function (): void {
+    $artifact = makePluginSettingsArtifact();
+    app(PluginInstaller::class)->install($artifact['zip']);
+    file_put_contents($this->runtimePluginPath.'/recovery.json', '{broken');
+    $owner = User::factory()->owner()->create();
+    [$vendor, $package] = explode('/', $artifact['id']);
+
+    $plugins = $this->actingAs($owner)
+        ->get(route('settings.plugins.index'))
+        ->assertSuccessful()
+        ->inertiaProps('plugins');
+
+    expect(collect($plugins)->firstWhere('managed_id', $artifact['id']))->toMatchArray([
+        'status' => 'broken',
+        'can_disable' => false,
+        'can_remove' => true,
+        'can_force_recovery' => true,
+    ]);
+
+    $this->actingAs($owner)
+        ->delete(route('settings.plugins.destroy', ['vendor' => $vendor, 'package' => $package]), ['force' => true])
+        ->assertRedirect(route('settings.plugins.index'));
+
+    expect(is_dir($this->runtimePluginPath.'/'.$artifact['id']))->toBeFalse()
+        ->and(is_file($this->runtimePluginPath.'/recovery.json'))->toBeFalse();
+});
+
+it('does not offer disable for a package missing from the managed directory', function (): void {
+    $artifact = makePluginSettingsArtifact();
+    app(PluginInstaller::class)->install($artifact['zip']);
+    File::deleteDirectory($this->runtimePluginPath.'/'.$artifact['id']);
+
+    $plugins = $this->actingAs(User::factory()->owner()->create())
+        ->get(route('settings.plugins.index'))
+        ->inertiaProps('plugins');
+
+    expect(collect($plugins)->firstWhere('managed_id', $artifact['id']))->toMatchArray([
+        'status' => 'missing',
+        'can_disable' => false,
+        'can_remove' => true,
+    ]);
+});
+
 /** @return array{zip: string, id: string, class: string} */
 function makePluginSettingsArtifact(array $overrides = []): array
 {
     $suffix = (string) random_int(100000, 999999);
-    $id = "settings/runtime-{$suffix}";
+    $id = $overrides['id'] ?? "settings/runtime-{$suffix}";
     $classShort = "Runtime{$suffix}Plugin";
     $entryClass = "SettingsRuntime\\{$classShort}";
     $manifest = [

--- a/tests/Feature/PluginSettingsTest.php
+++ b/tests/Feature/PluginSettingsTest.php
@@ -568,6 +568,11 @@ it('offers cleanup for pending recovery without a package row', function (): voi
         ->and(is_dir($this->runtimePluginPath.'/.staging'))->toBeFalse();
 });
 
+it('rejects a recovery cleanup key without a package identity', function (): void {
+    expect(fn () => app(PluginInstaller::class)->cleanupOrphanedMetadata(null, 'recovery:'))
+        ->toThrow(RuntimeException::class, 'recovery identity is missing');
+});
+
 it('cleans an orphaned recovery marker by identity without touching another package', function (): void {
     $other = makePluginSettingsArtifact();
     app(PluginInstaller::class)->install($other['zip']);

--- a/tests/Feature/PluginSettingsTest.php
+++ b/tests/Feature/PluginSettingsTest.php
@@ -487,16 +487,154 @@ it('surfaces and cleans unrecoverable runtime recovery without a package row', f
         ->inertiaProps('plugins');
 
     expect(collect($plugins)->firstWhere('status', 'unrecoverable_recovery'))->toMatchArray([
+        'managed_id' => 'settings/missing-backup',
+        'can_cleanup' => true,
+        'cleanup_key' => 'recovery:settings/missing-backup',
+    ]);
+
+    $this->actingAs($owner)
+        ->delete(route('settings.plugins.recovery.cleanup'), [
+            'cleanup_key' => 'recovery:settings/missing-backup',
+        ])
+        ->assertRedirect(route('settings.plugins.index'));
+
+    expect(is_file($this->runtimePluginPath.'/recovery.json'))->toBeFalse()
+        ->and(is_dir($this->runtimePluginPath.'/.staging'))->toBeFalse();
+});
+
+it('cleans an orphaned recovery marker by identity without touching another package', function (): void {
+    $other = makePluginSettingsArtifact();
+    app(PluginInstaller::class)->install($other['zip']);
+    File::makeDirectory($this->runtimePluginPath.'/.staging/incoming', 0750, true);
+    file_put_contents($this->runtimePluginPath.'/recovery.json', json_encode([
+        'operation' => 'swap',
+        'id' => 'settings/missing-recovery',
+        'staging' => '.staging/incoming',
+        'backup' => '.backup/missing',
+        'had_active' => true,
+        'phase' => 'old_preserved',
+    ], JSON_THROW_ON_ERROR));
+    $owner = User::factory()->owner()->create();
+
+    $plugins = $this->actingAs($owner)
+        ->get(route('settings.plugins.index'))
+        ->assertSuccessful()
+        ->inertiaProps('plugins');
+
+    expect(collect($plugins)->firstWhere('managed_id', 'settings/missing-recovery'))->toMatchArray([
+        'status' => 'unrecoverable_recovery',
+        'can_cleanup' => true,
+    ]);
+
+    [$otherVendor, $otherPackage] = explode('/', $other['id']);
+
+    $this->actingAs($owner)
+        ->post(route('settings.plugins.disable', ['vendor' => $otherVendor, 'package' => $otherPackage]))
+        ->assertRedirect(route('settings.plugins.index'));
+
+    expect(app(RuntimePluginStore::class)->readState()[$other['id']]['enabled'])->toBeFalse();
+
+    $this->actingAs($owner)
+        ->delete(route('settings.plugins.recovery.cleanup'), [
+            'cleanup_key' => 'recovery:settings/missing-recovery',
+        ])
+        ->assertRedirect(route('settings.plugins.index'));
+
+    expect(is_dir($this->runtimePluginPath.'/'.$other['id']))->toBeTrue()
+        ->and(is_file($this->runtimePluginPath.'/recovery.json'))->toBeFalse()
+        ->and(is_dir($this->runtimePluginPath.'/.staging/incoming'))->toBeFalse();
+});
+
+it('surfaces and cleans stale runtime artifacts without touching a package', function (): void {
+    $artifact = makePluginSettingsArtifact();
+    app(PluginInstaller::class)->install($artifact['zip']);
+    File::makeDirectory($this->runtimePluginPath.'/.staging/stale', 0750, true);
+    file_put_contents($this->runtimePluginPath.'/.state-stale.tmp', 'stale');
+    $owner = User::factory()->owner()->create();
+
+    $plugins = $this->actingAs($owner)
+        ->get(route('settings.plugins.index'))
+        ->assertSuccessful()
+        ->inertiaProps('plugins');
+
+    expect(collect($plugins)->firstWhere('status', 'orphaned_runtime_artifact'))->toMatchArray([
         'managed_id' => null,
         'can_cleanup' => true,
     ]);
 
     $this->actingAs($owner)
-        ->delete(route('settings.plugins.recovery.cleanup'))
+        ->delete(route('settings.plugins.recovery.cleanup'), [
+            'cleanup_key' => 'orphaned-artifacts',
+        ])
         ->assertRedirect(route('settings.plugins.index'));
 
-    expect(is_file($this->runtimePluginPath.'/recovery.json'))->toBeFalse()
-        ->and(is_dir($this->runtimePluginPath.'/.staging'))->toBeFalse();
+    expect(is_dir($this->runtimePluginPath.'/'.$artifact['id']))->toBeTrue()
+        ->and(is_dir($this->runtimePluginPath.'/.staging'))->toBeFalse()
+        ->and(is_file($this->runtimePluginPath.'/.state-stale.tmp'))->toBeFalse();
+});
+
+it('surfaces and removes a symlinked runtime package without following it', function (): void {
+    $outside = sys_get_temp_dir().'/openkos-settings-outside-'.bin2hex(random_bytes(8));
+    File::makeDirectory($outside, 0750, true);
+    File::makeDirectory($this->runtimePluginPath.'/settings', 0750, true);
+    symlink($outside, $this->runtimePluginPath.'/settings/runtime');
+    $owner = User::factory()->owner()->create();
+
+    try {
+        $plugins = $this->actingAs($owner)
+            ->get(route('settings.plugins.index'))
+            ->assertSuccessful()
+            ->inertiaProps('plugins');
+
+        expect(collect($plugins)->firstWhere('managed_id', 'settings/runtime'))->toMatchArray([
+            'status' => 'broken',
+            'can_cleanup' => true,
+        ]);
+
+        $this->actingAs($owner)
+            ->delete(route('settings.plugins.recovery.cleanup'), [
+                'cleanup_key' => 'package:settings/runtime',
+            ])
+            ->assertRedirect(route('settings.plugins.index'));
+
+        expect(is_link($this->runtimePluginPath.'/settings/runtime'))->toBeFalse()
+            ->and(is_dir($outside))->toBeTrue();
+    } finally {
+        File::deleteDirectory($outside);
+        File::delete($this->runtimePluginPath.'/settings/runtime');
+    }
+});
+
+it('surfaces and removes a symlinked runtime vendor without following it', function (): void {
+    $outside = sys_get_temp_dir().'/openkos-settings-vendor-'.bin2hex(random_bytes(8));
+    File::makeDirectory($outside, 0750, true);
+    File::makeDirectory($this->runtimePluginPath, 0750, true);
+    symlink($outside, $this->runtimePluginPath.'/settings');
+    $owner = User::factory()->owner()->create();
+
+    try {
+        $plugins = $this->actingAs($owner)
+            ->get(route('settings.plugins.index'))
+            ->assertSuccessful()
+            ->inertiaProps('plugins');
+
+        expect(collect($plugins)->firstWhere('cleanup_key', 'vendor:settings'))->toMatchArray([
+            'status' => 'broken',
+            'can_cleanup' => true,
+        ]);
+
+        $this->actingAs($owner)
+            ->delete(route('settings.plugins.recovery.cleanup'), [
+                'cleanup_key' => 'vendor:settings',
+            ])
+            ->assertRedirect(route('settings.plugins.index'));
+
+        expect(is_link($this->runtimePluginPath.'/settings'))->toBeFalse()
+            ->and(is_dir($outside))->toBeTrue();
+    } finally {
+        File::deleteDirectory($outside);
+        File::delete($this->runtimePluginPath.'/settings');
+    }
 });
 
 it('keeps a runtime package removable when recovery metadata is corrupt', function (): void {

--- a/tests/Feature/PluginSettingsTest.php
+++ b/tests/Feature/PluginSettingsTest.php
@@ -435,7 +435,7 @@ it('keeps a runtime package removable when state metadata is corrupt', function 
         'status' => 'broken',
         'can_enable' => false,
         'can_disable' => false,
-        'can_remove' => true,
+        'can_remove' => false,
         'can_force_recovery' => true,
     ]);
 
@@ -525,6 +525,10 @@ it('cleans an orphaned recovery marker by identity without touching another pack
         'status' => 'unrecoverable_recovery',
         'can_cleanup' => true,
     ]);
+    expect(collect($plugins)->firstWhere('managed_id', $other['id']))->toMatchArray([
+        'can_remove' => false,
+        'can_force_recovery' => false,
+    ]);
 
     [$otherVendor, $otherPackage] = explode('/', $other['id']);
 
@@ -543,6 +547,44 @@ it('cleans an orphaned recovery marker by identity without touching another pack
     expect(is_dir($this->runtimePluginPath.'/'.$other['id']))->toBeTrue()
         ->and(is_file($this->runtimePluginPath.'/recovery.json'))->toBeFalse()
         ->and(is_dir($this->runtimePluginPath.'/.staging/incoming'))->toBeFalse();
+});
+
+it('surfaces unknown recovery metadata independently from installed packages', function (): void {
+    $first = makePluginSettingsArtifact();
+    $second = makePluginSettingsArtifact();
+    app(PluginInstaller::class)->install($first['zip']);
+    app(PluginInstaller::class)->install($second['zip']);
+    file_put_contents($this->runtimePluginPath.'/recovery.json', '{broken');
+    $owner = User::factory()->owner()->create();
+
+    $plugins = $this->actingAs($owner)
+        ->get(route('settings.plugins.index'))
+        ->assertSuccessful()
+        ->inertiaProps('plugins');
+
+    expect(collect($plugins)->firstWhere('cleanup_key', 'orphaned-recovery'))->toMatchArray([
+        'status' => 'unrecoverable_recovery',
+        'managed_id' => null,
+        'can_cleanup' => true,
+    ])
+        ->and(collect($plugins)->firstWhere('managed_id', $first['id']))->toMatchArray([
+            'can_remove' => false,
+            'can_force_recovery' => false,
+        ])
+        ->and(collect($plugins)->firstWhere('managed_id', $second['id']))->toMatchArray([
+            'can_remove' => false,
+            'can_force_recovery' => false,
+        ]);
+
+    $this->actingAs($owner)
+        ->delete(route('settings.plugins.recovery.cleanup'), [
+            'cleanup_key' => 'orphaned-recovery',
+        ])
+        ->assertRedirect(route('settings.plugins.index'));
+
+    expect(is_file($this->runtimePluginPath.'/recovery.json'))->toBeFalse()
+        ->and(is_dir($this->runtimePluginPath.'/'.$first['id']))->toBeTrue()
+        ->and(is_dir($this->runtimePluginPath.'/'.$second['id']))->toBeTrue();
 });
 
 it('surfaces and cleans stale runtime artifacts without touching a package', function (): void {
@@ -610,6 +652,7 @@ it('surfaces and removes a symlinked runtime vendor without following it', funct
     File::makeDirectory($outside, 0750, true);
     File::makeDirectory($this->runtimePluginPath, 0750, true);
     symlink($outside, $this->runtimePluginPath.'/settings');
+    app(RuntimePluginStore::class)->writeState(['settings/runtime' => ['enabled' => true]]);
     $owner = User::factory()->owner()->create();
 
     try {
@@ -621,7 +664,12 @@ it('surfaces and removes a symlinked runtime vendor without following it', funct
         expect(collect($plugins)->firstWhere('cleanup_key', 'vendor:settings'))->toMatchArray([
             'status' => 'broken',
             'can_cleanup' => true,
-        ]);
+        ])
+            ->and(collect($plugins)->firstWhere('managed_id', 'settings/runtime'))->toMatchArray([
+                'status' => 'missing_package',
+                'can_remove' => false,
+                'can_force_recovery' => false,
+            ]);
 
         $this->actingAs($owner)
             ->delete(route('settings.plugins.recovery.cleanup'), [
@@ -652,12 +700,22 @@ it('keeps a runtime package removable when recovery metadata is corrupt', functi
     expect(collect($plugins)->firstWhere('managed_id', $artifact['id']))->toMatchArray([
         'status' => 'unrecoverable_recovery',
         'can_disable' => false,
-        'can_remove' => true,
-        'can_force_recovery' => true,
+        'can_remove' => false,
+        'can_force_recovery' => false,
+    ]);
+
+    expect(collect($plugins)->firstWhere('cleanup_key', 'orphaned-recovery'))->toMatchArray([
+        'can_cleanup' => true,
     ]);
 
     $this->actingAs($owner)
-        ->delete(route('settings.plugins.destroy', ['vendor' => $vendor, 'package' => $package]), ['force' => true])
+        ->delete(route('settings.plugins.recovery.cleanup'), [
+            'cleanup_key' => 'orphaned-recovery',
+        ])
+        ->assertRedirect(route('settings.plugins.index'));
+
+    $this->actingAs($owner)
+        ->delete(route('settings.plugins.destroy', ['vendor' => $vendor, 'package' => $package]))
         ->assertRedirect(route('settings.plugins.index'));
 
     expect(is_dir($this->runtimePluginPath.'/'.$artifact['id']))->toBeFalse()

--- a/tests/Feature/PluginSettingsTest.php
+++ b/tests/Feature/PluginSettingsTest.php
@@ -241,6 +241,10 @@ it('allows explicit force recovery from an invalid dependency cycle', function (
         $second['id'] => ['enabled' => true],
     ]);
 
+    $this->artisan('plugin:list')
+        ->assertSuccessful()
+        ->expectsOutputToContain('Invalid (enabled)');
+
     $owner = User::factory()->owner()->create();
     [$vendor, $package] = explode('/', $first['id']);
 
@@ -526,7 +530,7 @@ it('cleans an orphaned recovery marker by identity without touching another pack
         'can_cleanup' => true,
     ]);
     expect(collect($plugins)->firstWhere('managed_id', $other['id']))->toMatchArray([
-        'can_remove' => false,
+        'can_remove' => true,
         'can_force_recovery' => false,
     ]);
 
@@ -568,11 +572,11 @@ it('surfaces unknown recovery metadata independently from installed packages', f
         'can_cleanup' => true,
     ])
         ->and(collect($plugins)->firstWhere('managed_id', $first['id']))->toMatchArray([
-            'can_remove' => false,
+            'can_remove' => true,
             'can_force_recovery' => false,
         ])
         ->and(collect($plugins)->firstWhere('managed_id', $second['id']))->toMatchArray([
-            'can_remove' => false,
+            'can_remove' => true,
             'can_force_recovery' => false,
         ]);
 
@@ -698,9 +702,9 @@ it('keeps a runtime package removable when recovery metadata is corrupt', functi
         ->inertiaProps('plugins');
 
     expect(collect($plugins)->firstWhere('managed_id', $artifact['id']))->toMatchArray([
-        'status' => 'unrecoverable_recovery',
-        'can_disable' => false,
-        'can_remove' => false,
+        'status' => 'enabled',
+        'can_disable' => true,
+        'can_remove' => true,
         'can_force_recovery' => false,
     ]);
 

--- a/tests/Feature/PluginSettingsTest.php
+++ b/tests/Feature/PluginSettingsTest.php
@@ -443,7 +443,60 @@ it('keeps a runtime package removable when state metadata is corrupt', function 
         ->delete(route('settings.plugins.destroy', ['vendor' => $vendor, 'package' => $package]), ['force' => true])
         ->assertRedirect(route('settings.plugins.index'));
 
-    expect(is_dir($this->runtimePluginPath.'/'.$artifact['id']))->toBeFalse();
+    expect(is_dir($this->runtimePluginPath.'/'.$artifact['id']))->toBeFalse()
+        ->and(is_file($this->runtimePluginPath.'/state.json'))->toBeFalse();
+});
+
+it('surfaces and cleans orphaned runtime state without a package row', function (): void {
+    File::makeDirectory($this->runtimePluginPath, 0750, true);
+    file_put_contents($this->runtimePluginPath.'/state.json', '{broken');
+    $owner = User::factory()->owner()->create();
+
+    $plugins = $this->actingAs($owner)
+        ->get(route('settings.plugins.index'))
+        ->assertSuccessful()
+        ->inertiaProps('plugins');
+
+    expect(collect($plugins)->firstWhere('status', 'orphaned_state'))->toMatchArray([
+        'managed_id' => null,
+        'can_cleanup' => true,
+    ]);
+
+    $this->actingAs($owner)
+        ->delete(route('settings.plugins.recovery.cleanup'))
+        ->assertRedirect(route('settings.plugins.index'));
+
+    expect(is_file($this->runtimePluginPath.'/state.json'))->toBeFalse();
+});
+
+it('surfaces and cleans unrecoverable runtime recovery without a package row', function (): void {
+    File::makeDirectory($this->runtimePluginPath.'/.staging/incoming', 0750, true);
+    file_put_contents($this->runtimePluginPath.'/recovery.json', json_encode([
+        'operation' => 'swap',
+        'id' => 'settings/missing-backup',
+        'staging' => '.staging/incoming',
+        'backup' => '.backup/missing',
+        'had_active' => true,
+        'phase' => 'old_preserved',
+    ], JSON_THROW_ON_ERROR));
+    $owner = User::factory()->owner()->create();
+
+    $plugins = $this->actingAs($owner)
+        ->get(route('settings.plugins.index'))
+        ->assertSuccessful()
+        ->inertiaProps('plugins');
+
+    expect(collect($plugins)->firstWhere('status', 'unrecoverable_recovery'))->toMatchArray([
+        'managed_id' => null,
+        'can_cleanup' => true,
+    ]);
+
+    $this->actingAs($owner)
+        ->delete(route('settings.plugins.recovery.cleanup'))
+        ->assertRedirect(route('settings.plugins.index'));
+
+    expect(is_file($this->runtimePluginPath.'/recovery.json'))->toBeFalse()
+        ->and(is_dir($this->runtimePluginPath.'/.staging'))->toBeFalse();
 });
 
 it('keeps a runtime package removable when recovery metadata is corrupt', function (): void {
@@ -459,7 +512,7 @@ it('keeps a runtime package removable when recovery metadata is corrupt', functi
         ->inertiaProps('plugins');
 
     expect(collect($plugins)->firstWhere('managed_id', $artifact['id']))->toMatchArray([
-        'status' => 'broken',
+        'status' => 'unrecoverable_recovery',
         'can_disable' => false,
         'can_remove' => true,
         'can_force_recovery' => true,
@@ -483,7 +536,7 @@ it('does not offer disable for a package missing from the managed directory', fu
         ->inertiaProps('plugins');
 
     expect(collect($plugins)->firstWhere('managed_id', $artifact['id']))->toMatchArray([
-        'status' => 'missing',
+        'status' => 'missing_package',
         'can_disable' => false,
         'can_remove' => true,
     ]);

--- a/tests/Feature/PluginSettingsTest.php
+++ b/tests/Feature/PluginSettingsTest.php
@@ -328,6 +328,32 @@ it('marks duplicate runtime entry classes as conflicts', function (): void {
         ]);
 });
 
+it('treats runtime entry class names as case-insensitive', function (): void {
+    $report = app(RuntimePluginGraphValidator::class)->validate([
+        'settings/case-a' => [
+            'metadata' => [
+                'id' => 'settings/case-a',
+                'entry_class' => 'SettingsRuntime\\CasePlugin',
+                'core_version' => '*',
+                'dependencies' => [],
+            ],
+            'enabled' => true,
+        ],
+        'settings/case-b' => [
+            'metadata' => [
+                'id' => 'settings/case-b',
+                'entry_class' => 'settingsruntime\\caseplugin',
+                'core_version' => '*',
+                'dependencies' => [],
+            ],
+            'enabled' => true,
+        ],
+    ], []);
+
+    expect($report['loadable'])->toBe([])
+        ->and($report['issues'])->toHaveKeys(['settings/case-a', 'settings/case-b']);
+});
+
 it('keeps the plugins page available when a runtime dependency is missing or disabled', function (): void {
     $dependency = makePluginSettingsArtifact();
     $dependent = makePluginSettingsArtifact(['dependencies' => [$dependency['id']]]);
@@ -503,6 +529,42 @@ it('surfaces and cleans unrecoverable runtime recovery without a package row', f
         ->assertRedirect(route('settings.plugins.index'));
 
     expect(is_file($this->runtimePluginPath.'/recovery.json'))->toBeFalse()
+        ->and(is_dir($this->runtimePluginPath.'/.staging'))->toBeFalse();
+});
+
+it('offers cleanup for pending recovery without a package row', function (): void {
+    File::makeDirectory($this->runtimePluginPath.'/.backup', 0750, true);
+    File::makeDirectory($this->runtimePluginPath.'/.backup/settings-pending', 0750, true);
+    File::makeDirectory($this->runtimePluginPath.'/.staging/incoming', 0750, true);
+    file_put_contents($this->runtimePluginPath.'/recovery.json', json_encode([
+        'operation' => 'swap',
+        'id' => 'settings/pending-recovery',
+        'staging' => '.staging/incoming',
+        'backup' => '.backup/settings-pending',
+        'had_active' => true,
+        'phase' => 'old_preserved',
+    ], JSON_THROW_ON_ERROR));
+    $owner = User::factory()->owner()->create();
+
+    $plugins = $this->actingAs($owner)
+        ->get(route('settings.plugins.index'))
+        ->assertSuccessful()
+        ->inertiaProps('plugins');
+
+    expect(collect($plugins)->firstWhere('managed_id', 'settings/pending-recovery'))->toMatchArray([
+        'status' => 'pending_recovery',
+        'can_cleanup' => true,
+        'cleanup_key' => 'recovery:settings/pending-recovery',
+    ]);
+
+    $this->actingAs($owner)
+        ->delete(route('settings.plugins.recovery.cleanup'), [
+            'cleanup_key' => 'recovery:settings/pending-recovery',
+        ])
+        ->assertRedirect(route('settings.plugins.index'));
+
+    expect(is_file($this->runtimePluginPath.'/recovery.json'))->toBeFalse()
+        ->and(is_dir($this->runtimePluginPath.'/.backup'))->toBeFalse()
         ->and(is_dir($this->runtimePluginPath.'/.staging'))->toBeFalse();
 });
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use App\Services\Platform\ComposerPluginDiscovery;
 use App\Services\Platform\RuntimePluginDiscovery;
 use App\Services\Platform\RuntimePluginStore;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
@@ -31,6 +32,8 @@ abstract class TestCase extends BaseTestCase
             PaymentRegistry::class,
             PermissionRegistry::class,
             OpenKOSManager::class,
+            PluginDiscovery::class,
+            ComposerPluginDiscovery::class,
             RuntimePluginDiscovery::class,
             RuntimePluginStore::class,
         ] as $singleton) {


### PR DESCRIPTION
## Summary

- Scope candidate graph validation to the affected plugin dependency closure.
- Add explicit force recovery for invalid graphs and corrupt lifecycle metadata.
- Skip disabled runtime packages during boot discovery.
- Keep managed package identity authoritative for catalog recovery actions.
- Expose recovery warnings and force actions in the Plugins UI.

## Testing

- PHP lint, Pint, route registration, TypeScript, ESLint, Prettier, and Vite build pass.
- Focused Pest suite is blocked in this environment because the PHP build lacks the SQLite PDO driver.

Refs OPE-170