### PR TITLE
OPE-173: support Composer-built plugin artifacts

### DIFF
--- a/app/Services/Platform/ComposerPluginDiscovery.php
+++ b/app/Services/Platform/ComposerPluginDiscovery.php
@@ -76,6 +76,10 @@ final class ComposerPluginDiscovery implements PluginDiscovery
                 continue;
             }
 
+            if ($this->isRuntimePackagePath($installPath)) {
+                continue;
+            }
+
             $composerFile = $installPath.'/composer.json';
 
             if (! is_file($composerFile)) {
@@ -134,5 +138,21 @@ final class ComposerPluginDiscovery implements PluginDiscovery
     private function canonicalClassName(string $class): string
     {
         return strtolower(ltrim(trim($class), '\\'));
+    }
+
+    private function isRuntimePackagePath(string $installPath): bool
+    {
+        $runtimePath = config('platform.runtime.path');
+
+        if (! is_string($runtimePath)) {
+            return false;
+        }
+
+        $runtimeRoot = realpath($runtimePath);
+        $packagePath = realpath($installPath);
+
+        return is_string($runtimeRoot)
+            && is_string($packagePath)
+            && ($packagePath === $runtimeRoot || str_starts_with($packagePath, $runtimeRoot.DIRECTORY_SEPARATOR));
     }
 }

--- a/app/Services/Platform/RuntimePluginArtifactValidator.php
+++ b/app/Services/Platform/RuntimePluginArtifactValidator.php
@@ -355,7 +355,7 @@ final class RuntimePluginArtifactValidator
                 }
 
                 $this->assertSatisfies(
-                    (string) InstalledVersions::getPrettyVersion($package),
+                    $this->installedPackageVersion($package),
                     $constraint,
                     "Host package [{$package}]",
                 );
@@ -379,7 +379,7 @@ final class RuntimePluginArtifactValidator
 
             if (InstalledVersions::isInstalled($package)) {
                 $this->assertSatisfies(
-                    (string) InstalledVersions::getPrettyVersion($package),
+                    $this->installedPackageVersion($package),
                     $constraint,
                     "Host package [{$package}]",
                 );
@@ -411,7 +411,15 @@ final class RuntimePluginArtifactValidator
 
         $packages = [];
         foreach ($versions as $package => $metadata) {
-            if (! is_string($package) || ! is_array($metadata) || ! is_string($metadata['pretty_version'] ?? null)) {
+            if (! is_string($package) || ! is_array($metadata)) {
+                throw new InvalidArgumentException('Runtime plugin vendor package metadata is malformed.');
+            }
+
+            if (! is_string($metadata['pretty_version'] ?? null)) {
+                if (isset($metadata['provided']) || isset($metadata['replaced'])) {
+                    continue;
+                }
+
                 throw new InvalidArgumentException('Runtime plugin vendor package metadata is malformed.');
             }
 
@@ -538,6 +546,25 @@ final class RuntimePluginArtifactValidator
         return in_array($package, config('platform.runtime.shared_packages', []), true)
             || collect(config('platform.runtime.shared_package_prefixes', []))
                 ->contains(fn (string $prefix): bool => str_starts_with($package, $prefix));
+    }
+
+    private function installedPackageVersion(string $package): string
+    {
+        $version = InstalledVersions::getPrettyVersion($package);
+
+        if (is_string($version) && trim($version) !== '') {
+            return $version;
+        }
+
+        if (str_starts_with($package, 'illuminate/')) {
+            $frameworkVersion = InstalledVersions::getPrettyVersion('laravel/framework');
+
+            if (is_string($frameworkVersion) && trim($frameworkVersion) !== '') {
+                return $frameworkVersion;
+            }
+        }
+
+        throw new InvalidArgumentException("Host package [{$package}] does not expose a concrete version.");
     }
 
     private function assertSatisfies(string $version, string $constraint, string $subject): void

--- a/app/Services/Platform/RuntimePluginArtifactValidator.php
+++ b/app/Services/Platform/RuntimePluginArtifactValidator.php
@@ -3,7 +3,7 @@
 namespace App\Services\Platform;
 
 use Composer\InstalledVersions;
-use Composer\Semver\Semver;
+use Composer\Semver\VersionParser;
 use InvalidArgumentException;
 use OpenKOS\Platform\Plugin\Plugin;
 use Symfony\Component\Process\Process;
@@ -131,6 +131,7 @@ final class RuntimePluginArtifactValidator
         }
 
         $this->validateTree($directory);
+        $this->assertNoBundledHostPackagePaths($directory);
         $metadata = $this->validateManifest($this->readJsonFile($directory.'/manifest.json', 'manifest.json'));
 
         if ($expectedId !== null && $metadata['id'] !== $expectedId) {
@@ -314,6 +315,8 @@ final class RuntimePluginArtifactValidator
             throw new InvalidArgumentException('Runtime plugin composer.lock must contain packages.');
         }
 
+        $this->assertNoBundledHostPackagePaths($directory);
+
         $requires = is_array($composer['require'] ?? null) ? $composer['require'] : [];
         $lockedPackages = [];
         foreach ([...$lock['packages'], ...(is_array($lock['packages-dev'] ?? null) ? $lock['packages-dev'] : [])] as $package) {
@@ -324,8 +327,8 @@ final class RuntimePluginArtifactValidator
 
         $bundledPackages = $this->bundledPackages($directory.'/vendor/composer/installed.php');
 
-        foreach (array_keys($bundledPackages) as $package) {
-            if ($this->isSharedPackage($package)) {
+        foreach ($bundledPackages as $package => $metadata) {
+            if ($metadata['version'] !== null && $this->isSharedPackage($package)) {
                 throw new InvalidArgumentException("Runtime plugin must not bundle host package [{$package}].");
             }
         }
@@ -354,16 +357,12 @@ final class RuntimePluginArtifactValidator
                     throw new InvalidArgumentException("Host package [{$package}] is not installed.");
                 }
 
-                $this->assertSatisfies(
-                    $this->installedPackageVersion($package),
-                    $constraint,
-                    "Host package [{$package}]",
-                );
+                $this->assertHostPackageSatisfies($package, $constraint);
 
                 continue;
             }
 
-            if (! isset($lockedPackages[$package]) && ! InstalledVersions::isInstalled($package)) {
+            if (! isset($lockedPackages[$package]) && ! InstalledVersions::isInstalled($package) && ! isset($bundledPackages[$package])) {
                 throw new InvalidArgumentException(
                     "Runtime plugin dependency [{$package}] is absent from composer.lock and the host.",
                 );
@@ -371,18 +370,14 @@ final class RuntimePluginArtifactValidator
 
             if (isset($bundledPackages[$package])) {
                 $this->assertSatisfies(
-                    $bundledPackages[$package],
+                    $bundledPackages[$package]['ranges'],
                     $constraint,
                     "Bundled package [{$package}]",
                 );
             }
 
             if (InstalledVersions::isInstalled($package)) {
-                $this->assertSatisfies(
-                    $this->installedPackageVersion($package),
-                    $constraint,
-                    "Host package [{$package}]",
-                );
+                $this->assertHostPackageSatisfies($package, $constraint);
             } elseif (! isset($bundledPackages[$package])) {
                 throw new InvalidArgumentException(
                     "Runtime plugin dependency [{$package}] is not bundled in vendor/.",
@@ -394,7 +389,7 @@ final class RuntimePluginArtifactValidator
     }
 
     /**
-     * @return array<string, string>
+     * @return array<string, array{version: string|null, ranges: array<int, string>}>
      */
     private function bundledPackages(string $installedPath): array
     {
@@ -415,15 +410,44 @@ final class RuntimePluginArtifactValidator
                 throw new InvalidArgumentException('Runtime plugin vendor package metadata is malformed.');
             }
 
-            if (! is_string($metadata['pretty_version'] ?? null)) {
-                if (isset($metadata['provided']) || isset($metadata['replaced'])) {
+            $ranges = [];
+            $version = null;
+
+            if (array_key_exists('pretty_version', $metadata)) {
+                if (! is_string($metadata['pretty_version']) || trim($metadata['pretty_version']) === '') {
+                    throw new InvalidArgumentException('Runtime plugin vendor package metadata is malformed.');
+                }
+
+                $version = $metadata['pretty_version'];
+                $ranges[] = $version;
+            }
+
+            foreach (['provided', 'replaced'] as $field) {
+                if (! array_key_exists($field, $metadata)) {
                     continue;
                 }
 
+                if (! is_array($metadata[$field]) || ! array_is_list($metadata[$field]) || $metadata[$field] === []) {
+                    throw new InvalidArgumentException('Runtime plugin vendor package metadata is malformed.');
+                }
+
+                foreach ($metadata[$field] as $range) {
+                    if (! is_string($range) || trim($range) === '') {
+                        throw new InvalidArgumentException('Runtime plugin vendor package metadata is malformed.');
+                    }
+
+                    $ranges[] = $range;
+                }
+            }
+
+            if ($ranges === []) {
                 throw new InvalidArgumentException('Runtime plugin vendor package metadata is malformed.');
             }
 
-            $packages[$package] = $metadata['pretty_version'];
+            $packages[$package] = [
+                'version' => $version,
+                'ranges' => array_values(array_unique($ranges)),
+            ];
         }
 
         return $packages;
@@ -548,35 +572,105 @@ final class RuntimePluginArtifactValidator
                 ->contains(fn (string $prefix): bool => str_starts_with($package, $prefix));
     }
 
-    private function installedPackageVersion(string $package): string
+    private function assertNoBundledHostPackagePaths(string $directory): void
     {
-        $version = InstalledVersions::getPrettyVersion($package);
+        $paths = [
+            ...array_map(
+                fn (string $package): string => $directory.'/vendor/'.$package,
+                array_filter(config('platform.runtime.shared_packages', []), 'is_string'),
+            ),
+            ...array_map(
+                fn (string $prefix): string => $directory.'/vendor/'.rtrim($prefix, '/'),
+                array_filter(config('platform.runtime.shared_package_prefixes', []), 'is_string'),
+            ),
+        ];
 
-        if (is_string($version) && trim($version) !== '') {
-            return $version;
+        foreach (array_unique($paths) as $path) {
+            $relative = str_replace($directory.'/vendor/', '', $path);
+
+            if ($this->managedPathExists($directory.'/vendor', $relative)) {
+                throw new InvalidArgumentException("Runtime plugin must not bundle host package [{$relative}].");
+            }
+        }
+    }
+
+    private function managedPathExists(string $root, string $relative): bool
+    {
+        if (! is_dir($root) || is_link($root)) {
+            return false;
         }
 
+        $current = $root;
+        $segments = explode('/', trim($relative, '/'));
+
+        foreach ($segments as $key => $segment) {
+            $entries = @scandir($current);
+
+            if ($entries === false) {
+                throw new InvalidArgumentException("Runtime plugin path [{$relative}] cannot be inspected.");
+            }
+
+            if (! in_array($segment, $entries, true)) {
+                return false;
+            }
+
+            $current .= DIRECTORY_SEPARATOR.$segment;
+            $stat = @lstat($current);
+
+            if ($stat === false || is_link($current)) {
+                throw new InvalidArgumentException("Runtime plugin path [{$relative}] is unsafe.");
+            }
+
+            if ($key < count($segments) - 1 && ! is_dir($current)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function assertHostPackageSatisfies(string $package, string $constraint): void
+    {
         if (str_starts_with($package, 'illuminate/')) {
             $frameworkVersion = InstalledVersions::getPrettyVersion('laravel/framework');
 
             if (is_string($frameworkVersion) && trim($frameworkVersion) !== '') {
-                return $frameworkVersion;
+                $this->assertSatisfies($frameworkVersion, $constraint, "Host package [{$package}]");
+
+                return;
             }
         }
 
-        throw new InvalidArgumentException("Host package [{$package}] does not expose a concrete version.");
+        try {
+            $ranges = InstalledVersions::getVersionRanges($package);
+        } catch (Throwable $exception) {
+            throw new InvalidArgumentException("Host package [{$package}] does not expose a usable version.", previous: $exception);
+        }
+
+        if (! is_string($ranges) || trim($ranges) === '') {
+            throw new InvalidArgumentException("Host package [{$package}] does not expose a usable version.");
+        }
+
+        $this->assertSatisfies($ranges, $constraint, "Host package [{$package}]");
     }
 
-    private function assertSatisfies(string $version, string $constraint, string $subject): void
+    /**
+     * @param  string|array<int, string>  $version
+     */
+    private function assertSatisfies(string|array $version, string $constraint, string $subject): void
     {
+        $versionRanges = is_array($version) ? implode(' || ', $version) : $version;
+
         try {
-            $satisfies = Semver::satisfies($version, $constraint);
+            $required = (new VersionParser)->parseConstraints($constraint);
+            $provided = (new VersionParser)->parseConstraints($versionRanges);
+            $satisfies = $provided->matches($required);
         } catch (Throwable $exception) {
             throw new InvalidArgumentException("{$subject} constraint [{$constraint}] is invalid.", previous: $exception);
         }
 
         if (! $satisfies) {
-            throw new InvalidArgumentException("{$subject} version [{$version}] does not satisfy [{$constraint}].");
+            throw new InvalidArgumentException("{$subject} version [{$versionRanges}] does not satisfy [{$constraint}].");
         }
     }
 }

--- a/app/Services/Platform/RuntimePluginArtifactValidator.php
+++ b/app/Services/Platform/RuntimePluginArtifactValidator.php
@@ -604,6 +604,10 @@ final class RuntimePluginArtifactValidator
         $segments = explode('/', trim($relative, '/'));
 
         foreach ($segments as $key => $segment) {
+            if ($segment === '' || $segment === '.' || $segment === '..') {
+                throw new InvalidArgumentException("Runtime plugin path [{$relative}] is unsafe.");
+            }
+
             $entries = @scandir($current);
 
             if ($entries === false) {

--- a/tests/Feature/Platform/ComposerPluginDiscoveryTest.php
+++ b/tests/Feature/Platform/ComposerPluginDiscoveryTest.php
@@ -108,6 +108,68 @@ it('skips disabled Composer packages', function () {
     expect($plugins)->not->toContain(ComposerDiscoveryFixturePlugin::class);
 });
 
+it('ignores Composer metadata installed inside the runtime plugin store', function () {
+    $original = require base_path('vendor/composer/installed.php');
+    $originalDisabledPackages = config('platform.discovery.disabled_packages', []);
+    $originalRuntimePath = config('platform.runtime.path');
+    $runtimeRoot = sys_get_temp_dir().'/openkos-runtime-'.bin2hex(random_bytes(8));
+    $packagePath = $runtimeRoot.'/openkos/payment-xendit';
+
+    mkdir($packagePath, 0755, true);
+    file_put_contents($packagePath.'/composer.json', json_encode([
+        'name' => 'openkos/payment-xendit',
+        'extra' => [
+            'openkos' => ['plugin' => ComposerDiscoveryFixturePlugin::class],
+        ],
+    ], JSON_THROW_ON_ERROR));
+
+    try {
+        config([
+            'platform.runtime.path' => $runtimeRoot,
+            'platform.discovery.disabled_packages' => array_values(array_unique([
+                ...$originalDisabledPackages,
+                ...array_diff(InstalledVersions::getInstalledPackages(), ['openkos/payment-xendit']),
+            ])),
+        ]);
+        InstalledVersions::reload([
+            'root' => [
+                'name' => 'openkos/openkos',
+                'pretty_version' => 'dev-test',
+                'version' => 'dev-test',
+                'reference' => null,
+                'type' => 'project',
+                'install_path' => base_path(),
+                'aliases' => [],
+                'dev' => true,
+            ],
+            'versions' => [
+                'openkos/payment-xendit' => [
+                    'pretty_version' => '0.1.6',
+                    'version' => '0.1.6.0',
+                    'reference' => null,
+                    'type' => 'library',
+                    'install_path' => $packagePath,
+                    'aliases' => [],
+                    'dev_requirement' => false,
+                ],
+            ],
+        ]);
+
+        expect(app(ComposerPluginDiscovery::class)->discoverComposerOnly())
+            ->not->toContain(ComposerDiscoveryFixturePlugin::class);
+    } finally {
+        InstalledVersions::reload($original);
+        config([
+            'platform.runtime.path' => $originalRuntimePath,
+            'platform.discovery.disabled_packages' => $originalDisabledPackages,
+        ]);
+        unlink($packagePath.'/composer.json');
+        rmdir($packagePath);
+        rmdir(dirname($packagePath));
+        rmdir($runtimeRoot);
+    }
+});
+
 it('rejects malformed OpenKOS plugin metadata', function () {
     withComposerDiscoveryFixtures([
         'acme/malformed-plugin' => [

--- a/tests/Feature/Platform/RuntimePluginTest.php
+++ b/tests/Feature/Platform/RuntimePluginTest.php
@@ -392,6 +392,32 @@ it('validates bundled dependency versions and rejects bundled host packages', fu
         ->expectsOutputToContain('must not bundle host package [laravel/framework]');
 });
 
+it('accepts Composer virtual packages and resolves host-provided Illuminate versions', function (): void {
+    $artifact = makeRuntimePluginArtifact(
+        additionalRequirements: ['illuminate/support' => '^13.0'],
+        additionalInstalledMetadata: [
+            'illuminate/support' => [
+                'dev_requirement' => false,
+                'replaced' => ['v13.25.0'],
+            ],
+        ],
+    );
+
+    $this->artisan('plugin:install', ['zip' => $artifact['zip']])->assertSuccessful();
+});
+
+it('rejects malformed concrete Composer vendor metadata', function (): void {
+    $artifact = makeRuntimePluginArtifact(
+        additionalInstalledMetadata: [
+            'acme/concrete' => ['dev_requirement' => false],
+        ],
+    );
+
+    $this->artisan('plugin:install', ['zip' => $artifact['zip']])
+        ->assertFailed()
+        ->expectsOutputToContain('Runtime plugin vendor package metadata is malformed.');
+});
+
 it('reports an enabled package with a malformed manifest without booting it', function (): void {
     $artifact = makeRuntimePluginArtifact();
 
@@ -592,6 +618,7 @@ it('surfaces corrupted runtime state instead of treating it as disabled', functi
  * @param  array<string, mixed>  $overrides
  * @param  array<string, string>  $bundledPackages
  * @param  array<string, string>  $additionalRequirements
+ * @param  array<string, array<string, mixed>>  $additionalInstalledMetadata
  * @return array{zip: string, id: string, class: string}
  */
 function makeRuntimePluginArtifact(
@@ -600,6 +627,7 @@ function makeRuntimePluginArtifact(
     ?string $classShort = null,
     array $bundledPackages = [],
     array $additionalRequirements = [],
+    array $additionalInstalledMetadata = [],
 ): array {
     $suffix = (string) random_int(100000, 999999);
     $id ??= "acme/runtime-{$suffix}";
@@ -631,6 +659,14 @@ function makeRuntimePluginArtifact(
     $source = "<?php\n\nnamespace RuntimeArtifact;\n\nuse OpenKOS\\Platform\\OpenKOSManager;\nuse OpenKOS\\Platform\\Plugin\\Plugin;\nuse OpenKOS\\Platform\\Plugin\\PluginManifest;\n\nfinal class {$classShort} extends Plugin\n{\n    public function manifest(): PluginManifest\n    {\n        return new PluginManifest(\n            id: '{$manifest['id']}',\n            name: '{$manifest['name']}',\n            version: '{$manifest['version']}',\n            description: '{$manifest['description']}',\n            coreVersion: '{$manifest['core_version']}',\n            dependencies: [],\n        );\n    }\n\n    public function register(OpenKOSManager \$platform): void\n    {\n        \$platform->permissions()->register('runtime-fixture.view', 'Runtime Fixture');\n    }\n}\n";
     $source = str_replace('dependencies: [],', "dependencies: {$dependencies},", $source);
 
+    $installedPackages = [
+        ...array_map(
+            fn (string $version): array => ['pretty_version' => $version],
+            $bundledPackages,
+        ),
+        ...$additionalInstalledMetadata,
+    ];
+
     return makeZip([
         'manifest.json' => json_encode($manifest, JSON_THROW_ON_ERROR),
         'composer.json' => json_encode($composer, JSON_THROW_ON_ERROR),
@@ -647,10 +683,7 @@ function makeRuntimePluginArtifact(
         ], JSON_THROW_ON_ERROR),
         'src/'.$classShort.'.php' => $source,
         'vendor/autoload.php' => "<?php\nspl_autoload_register(static function (string \$class): void {\n    if (\$class === '{$entryClass}') {\n        require_once __DIR__.'/../src/{$classShort}.php';\n    }\n});\n",
-        'vendor/composer/installed.php' => "<?php\nreturn ['versions' => ".var_export(array_map(
-            fn (string $version): array => ['pretty_version' => $version],
-            $bundledPackages,
-        ), true)."];\n",
+        'vendor/composer/installed.php' => "<?php\nreturn ['versions' => ".var_export($installedPackages, true)."];\n",
     ], $manifest['id'], $entryClass);
 }
 

--- a/tests/Feature/Platform/RuntimePluginTest.php
+++ b/tests/Feature/Platform/RuntimePluginTest.php
@@ -448,6 +448,19 @@ it('rejects physical host package trees even when metadata claims a virtual pack
         ->expectsOutputToContain('must not bundle host package [openkos/platform]');
 });
 
+it('rejects unsafe configured host package paths', function (): void {
+    $originalPrefixes = config('platform.runtime.shared_package_prefixes');
+    config(['platform.runtime.shared_package_prefixes' => ['../outside/']]);
+
+    try {
+        $this->artisan('plugin:install', ['zip' => makeRuntimePluginArtifact()['zip']])
+            ->assertFailed()
+            ->expectsOutputToContain('is unsafe');
+    } finally {
+        config(['platform.runtime.shared_package_prefixes' => $originalPrefixes]);
+    }
+});
+
 it('rejects malformed concrete Composer vendor metadata', function (): void {
     $artifact = makeRuntimePluginArtifact(
         additionalInstalledMetadata: [

--- a/tests/Feature/Platform/RuntimePluginTest.php
+++ b/tests/Feature/Platform/RuntimePluginTest.php
@@ -394,16 +394,58 @@ it('validates bundled dependency versions and rejects bundled host packages', fu
 
 it('accepts Composer virtual packages and resolves host-provided Illuminate versions', function (): void {
     $artifact = makeRuntimePluginArtifact(
-        additionalRequirements: ['illuminate/support' => '^13.0'],
+        additionalRequirements: [
+            'illuminate/support' => '^13.0',
+            'psr/log-implementation' => '^3.0',
+            'acme/implementation' => '^1.0',
+        ],
         additionalInstalledMetadata: [
             'illuminate/support' => [
                 'dev_requirement' => false,
                 'replaced' => ['v13.25.0'],
             ],
+            'acme/implementation' => [
+                'dev_requirement' => false,
+                'provided' => ['1.0'],
+            ],
         ],
     );
 
     $this->artisan('plugin:install', ['zip' => $artifact['zip']])->assertSuccessful();
+});
+
+it('rejects malformed Composer virtual vendor metadata', function (): void {
+    $artifact = makeRuntimePluginArtifact(
+        additionalRequirements: ['acme/implementation' => '^1.0'],
+        additionalInstalledMetadata: [
+            'acme/implementation' => [
+                'dev_requirement' => false,
+                'provided' => true,
+            ],
+        ],
+    );
+
+    $this->artisan('plugin:install', ['zip' => $artifact['zip']])
+        ->assertFailed()
+        ->expectsOutputToContain('Runtime plugin vendor package metadata is malformed.');
+});
+
+it('rejects physical host package trees even when metadata claims a virtual package', function (): void {
+    $artifact = makeRuntimePluginArtifact(
+        additionalInstalledMetadata: [
+            'openkos/platform' => [
+                'dev_requirement' => false,
+                'replaced' => ['*'],
+            ],
+        ],
+        additionalFiles: [
+            'vendor/openkos/platform/README.md' => 'forged host package',
+        ],
+    );
+
+    $this->artisan('plugin:install', ['zip' => $artifact['zip']])
+        ->assertFailed()
+        ->expectsOutputToContain('must not bundle host package [openkos/platform]');
 });
 
 it('rejects malformed concrete Composer vendor metadata', function (): void {
@@ -619,6 +661,7 @@ it('surfaces corrupted runtime state instead of treating it as disabled', functi
  * @param  array<string, string>  $bundledPackages
  * @param  array<string, string>  $additionalRequirements
  * @param  array<string, array<string, mixed>>  $additionalInstalledMetadata
+ * @param  array<string, string>  $additionalFiles
  * @return array{zip: string, id: string, class: string}
  */
 function makeRuntimePluginArtifact(
@@ -628,6 +671,7 @@ function makeRuntimePluginArtifact(
     array $bundledPackages = [],
     array $additionalRequirements = [],
     array $additionalInstalledMetadata = [],
+    array $additionalFiles = [],
 ): array {
     $suffix = (string) random_int(100000, 999999);
     $id ??= "acme/runtime-{$suffix}";
@@ -684,6 +728,7 @@ function makeRuntimePluginArtifact(
         'src/'.$classShort.'.php' => $source,
         'vendor/autoload.php' => "<?php\nspl_autoload_register(static function (string \$class): void {\n    if (\$class === '{$entryClass}') {\n        require_once __DIR__.'/../src/{$classShort}.php';\n    }\n});\n",
         'vendor/composer/installed.php' => "<?php\nreturn ['versions' => ".var_export($installedPackages, true)."];\n",
+        ...$additionalFiles,
     ], $manifest['id'], $entryClass);
 }
 


### PR DESCRIPTION
Implements the OPE-169 validator compatibility prerequisite for Composer virtual/replaced packages and resolves Illuminate host versions through laravel/framework. Also prevents nested runtime vendor packages from being rediscovered as host Composer plugins.