### PR TITLE
docs: add GitHub contribution templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Report a reproducible problem in OpenKOS
+title: ''
+labels: ''
+assignees: ''
+---
+
+## Summary
+
+<!-- Briefly describe the problem. -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+<!-- What should have happened? -->
+
+## Actual behavior
+
+<!-- What happened instead? Include relevant error messages. -->
+
+## Environment
+
+- OpenKOS version or commit:
+- PHP version:
+- PostgreSQL version:
+- Browser and version (if applicable):
+
+## Additional context
+
+<!-- Add logs, screenshots, or other details that may help investigate. Remove sensitive data. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an improvement for OpenKOS
+title: ''
+labels: ''
+assignees: ''
+---
+
+## Problem
+
+<!-- What problem would this feature solve, and who would benefit? -->
+
+## Proposed solution
+
+<!-- Describe the behavior or outcome you would like. -->
+
+## Alternatives considered
+
+<!-- What other solutions or workarounds have you considered? -->
+
+## Additional context
+
+<!-- Add examples, screenshots, links, or related issues. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Summary
+
+<!-- What problem does this pull request solve? -->
+
+## Changes
+
+<!-- List the important changes. -->
+
+-
+
+## Related issue
+
+<!-- Link the issue, for example: Closes #123 -->
+
+## Verification
+
+<!-- List the checks you ran and any relevant manual testing. -->
+
+- [ ] `php artisan test --compact`
+- [ ] `npm run lint:check`
+- [ ] `npm run format:check`
+- [ ] `npm run types:check`
+- [ ] `vendor/bin/pint --dirty --format agent` (if PHP files changed)
+
+## Additional notes
+
+<!-- Mention migrations, configuration, deployment steps, or documentation/ADR updates. -->


### PR DESCRIPTION
## Summary

Adds GitHub templates for pull requests, bug reports, and feature requests.

## Verification

- Template files and required sections validated.
- Whitespace validation passed.
- Laravel test suite not run because this is Markdown-only.