### PR TITLE
OPE-184: refresh demo seed data

### DIFF
--- a/app/Models/PaymentAllocation.php
+++ b/app/Models/PaymentAllocation.php
@@ -3,12 +3,13 @@
 namespace App\Models;
 
 use App\Concerns\SerializesDatesWithTimezone;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class PaymentAllocation extends Model
 {
-    use SerializesDatesWithTimezone;
+    use HasFactory, SerializesDatesWithTimezone;
 
     protected $fillable = [
         'payment_id',

--- a/database/factories/LeaseFactory.php
+++ b/database/factories/LeaseFactory.php
@@ -45,11 +45,15 @@ class LeaseFactory extends Factory
 
     public function terminated(): static
     {
-        return $this->state(fn (array $attributes) => [
-            'end_date' => fake()->dateTimeBetween('-1 month', 'now'),
-            'status' => LeaseStatus::Terminated,
-            'termination_date' => fake()->dateTimeBetween('-1 month', 'now'),
-            'termination_reason' => fake()->sentence(),
-        ]);
+        return $this->state(function (array $attributes): array {
+            $endDate = fake()->dateTimeBetween('-1 month', 'now');
+
+            return [
+                'end_date' => $endDate,
+                'status' => LeaseStatus::Terminated,
+                'termination_date' => $endDate,
+                'termination_reason' => fake()->sentence(),
+            ];
+        });
     }
 }

--- a/database/factories/PaymentAllocationFactory.php
+++ b/database/factories/PaymentAllocationFactory.php
@@ -2,7 +2,6 @@
 
 namespace Database\Factories;
 
-use App\Models\Invoice;
 use App\Models\Payment;
 use App\Models\PaymentAllocation;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -15,8 +14,20 @@ class PaymentAllocationFactory extends Factory
     {
         return [
             'payment_id' => Payment::factory(),
-            'invoice_id' => Invoice::factory(),
-            'amount' => fake()->numberBetween(100_000, 1_000_000),
+            'invoice_id' => 0,
+            'amount' => '0',
         ];
+    }
+
+    public function configure(): static
+    {
+        return $this->afterMaking(function (PaymentAllocation $allocation): void {
+            $payment = Payment::query()->findOrFail($allocation->payment_id);
+
+            $allocation->forceFill([
+                'invoice_id' => $payment->invoice_id,
+                'amount' => $payment->amount,
+            ]);
+        });
     }
 }

--- a/database/factories/UnitFactory.php
+++ b/database/factories/UnitFactory.php
@@ -5,6 +5,7 @@ namespace Database\Factories;
 use App\Enums\UnitStatus;
 use App\Models\Property;
 use App\Models\Unit;
+use App\Services\Payments\MoneyConverter;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -35,6 +36,7 @@ class UnitFactory extends Factory
                     'billing_interval' => 1,
                     'billing_unit' => 'month',
                     'amount' => fake()->numberBetween(500_000, 3_000_000),
+                    'currency' => app(MoneyConverter::class)->normalizeCurrency(),
                     'is_active' => true,
                 ]);
             }
@@ -44,12 +46,22 @@ class UnitFactory extends Factory
     /**
      * Give the unit a specific monthly rate.
      */
-    public function withRate(int|string $amount): static
+    public function withRate(int|string $amount, ?string $currency = null): static
     {
-        return $this->afterCreating(function (Unit $unit) use ($amount) {
+        return $this->afterCreating(function (Unit $unit) use ($amount, $currency) {
+            $currency = app(MoneyConverter::class)->normalizeCurrency($currency);
+
             $unit->rates()->updateOrCreate(
-                ['billing_interval' => 1, 'billing_unit' => 'month'],
-                ['amount' => $amount, 'is_active' => true],
+                [
+                    'billing_interval' => 1,
+                    'billing_unit' => 'month',
+                    'currency' => $currency,
+                ],
+                [
+                    'amount' => $amount,
+                    'currency' => $currency,
+                    'is_active' => true,
+                ],
             );
         });
     }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -8,12 +8,16 @@ class DatabaseSeeder extends Seeder
 {
     public function run(): void
     {
-        $this->call(RoleAndPermissionSeeder::class);
-        $this->call(SettingSeeder::class);
-        $this->call(RegionAndCitySeeder::class);
-        $this->call(OwnerSeeder::class);
-        $this->call(TenantSeeder::class);
-        $this->call(PropertyAndUnitSeeder::class);
-        $this->call(LeaseSeeder::class);
+        $this->call([
+            RoleAndPermissionSeeder::class,
+            SettingSeeder::class,
+            RegionAndCitySeeder::class,
+            OwnerSeeder::class,
+            TenantSeeder::class,
+            PropertyAndUnitSeeder::class,
+            DemoUsersSeeder::class,
+            LeaseSeeder::class,
+            MaintenanceSeeder::class,
+        ]);
     }
 }

--- a/database/seeders/DemoUsersSeeder.php
+++ b/database/seeders/DemoUsersSeeder.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Property;
+use App\Models\Role as RoleModel;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Support\RecommendedRoles;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use RuntimeException;
+
+class DemoUsersSeeder extends Seeder
+{
+    private const STAFF_EMAIL = 'demo.staff@openkos.com';
+
+    private const TENANT_EMAIL = 'demo.tenant@openkos.com';
+
+    private const PASSWORD = 'password';
+
+    public function run(): void
+    {
+        DB::transaction(function (): void {
+            $staffRole = $this->ensureStaffRole();
+            $staff = $this->upsertUser('Demo Staff', self::STAFF_EMAIL);
+            $staff->syncRoles([$staffRole->name]);
+            $staff->properties()->syncWithoutDetaching(
+                Property::query()
+                    ->where('slug', 'like', 'ope-184-demo-%')
+                    ->pluck('id')
+                    ->all(),
+            );
+
+            $tenantUser = $this->upsertUser('Demo Tenant', self::TENANT_EMAIL);
+            $tenantUser->syncRoles([]);
+
+            $tenant = Tenant::query()
+                ->where('id_card_number', '3273010203040004')
+                ->firstOrFail();
+            $linkedTenant = Tenant::query()
+                ->where('user_id', $tenantUser->id)
+                ->whereKeyNot($tenant->id)
+                ->first();
+
+            if ($tenant->user_id !== null && $tenant->user_id !== $tenantUser->id) {
+                throw new RuntimeException('The demo tenant fixture is already linked to another user.');
+            }
+
+            $linkedTenant?->forceFill(['user_id' => null])->saveQuietly();
+            $tenant->forceFill(['user_id' => $tenantUser->id])->saveQuietly();
+        });
+    }
+
+    private function upsertUser(string $name, string $email): User
+    {
+        $user = User::query()->firstOrNew(['email' => $email]);
+        $user->forceFill([
+            'name' => $name,
+            'email' => $email,
+            'password' => Hash::make(self::PASSWORD),
+            'email_verified_at' => now(),
+            'is_active' => true,
+            'invited_at' => null,
+            'last_login_at' => null,
+            'two_factor_secret' => null,
+            'two_factor_recovery_codes' => null,
+            'two_factor_confirmed_at' => null,
+        ])->save();
+
+        return $user->refresh();
+    }
+
+    private function ensureStaffRole(): RoleModel
+    {
+        $definition = collect(RecommendedRoles::all())->firstWhere('name', 'staff');
+
+        if (! $definition) {
+            throw new RuntimeException('Missing recommended role definition for [staff].');
+        }
+
+        $role = RoleModel::query()->firstOrNew([
+            'name' => 'staff',
+            'guard_name' => 'web',
+        ]);
+        $role->forceFill([
+            'label' => $definition['label'],
+            'description' => $definition['description'],
+            'color' => $definition['color'],
+            'is_system' => false,
+            'is_active' => true,
+        ])->save();
+        $role->syncPermissions($definition['permissions']);
+
+        return $role->refresh();
+    }
+}

--- a/database/seeders/LeaseSeeder.php
+++ b/database/seeders/LeaseSeeder.php
@@ -2,219 +2,347 @@
 
 namespace Database\Seeders;
 
-use App\Actions\Invoices\GenerateInvoices;
+use App\Actions\Leases\CreateLease;
+use App\Actions\Payments\RecordPayment;
+use App\Data\Lease\CreateLeaseData;
+use App\Data\Payment\RecordPaymentData;
+use App\Enums\BillingStrategy;
 use App\Enums\LeaseStatus;
-use App\Enums\PaymentStatus;
-use App\Enums\UnitStatus;
+use App\Enums\PaymentMethod;
+use App\Models\Invoice;
 use App\Models\Lease;
 use App\Models\Property;
 use App\Models\Tenant;
 use App\Models\Unit;
-use Carbon\Carbon;
-use Illuminate\Database\Eloquent\Collection;
+use App\Models\UnitRate;
+use App\Models\User;
+use Carbon\CarbonInterface;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
 
 class LeaseSeeder extends Seeder
 {
+    private const NAMESPACE = 'ope-184-demo';
+
     private array $activeAssignments = [
-        ['property' => 'Kos Melati Indah', 'unit_name' => 'A1', 'tenant' => 'Budi Santoso'],
-        ['property' => 'Kos Melati Indah', 'unit_name' => 'A2', 'tenant' => 'Siti Nurhaliza'],
-        ['property' => 'Kos Melati Indah', 'unit_name' => 'A3', 'tenant' => 'Ahmad Rizki'],
-        ['property' => 'Kos Mawar Putih',  'unit_name' => 'A1', 'tenant' => 'Dewi Lestari'],
-        ['property' => 'Kos Mawar Putih',  'unit_name' => 'B1', 'tenant' => 'Rudi Hartono'],
-        ['property' => 'Kos Kenanga Asri', 'unit_name' => 'A1', 'tenant' => 'Rina Wijaya'],
-        ['property' => 'Kos Kenanga Asri', 'unit_name' => 'B2', 'tenant' => 'Agus Prasetyo'],
-        ['property' => 'Kos Dahlia Permai', 'unit_name' => 'A4', 'tenant' => 'Maya Anggraini'],
+        [
+            'reference' => 'ope-184-demo-lease-001',
+            'property' => 'ope-184-demo-kos-melati-indah',
+            'unit' => 'A1',
+            'tenants' => ['Budi Santoso'],
+            'currency' => 'IDR',
+            'start_months_ago' => 5,
+            'rent_due_day' => 1,
+            'payment' => null,
+        ],
+        [
+            'reference' => 'ope-184-demo-lease-002',
+            'property' => 'ope-184-demo-kos-melati-indah',
+            'unit' => 'A2',
+            'tenants' => ['Siti Nurhaliza'],
+            'currency' => 'IDR',
+            'start_months_ago' => 4,
+            'rent_due_day' => 28,
+            'payment' => null,
+        ],
+        [
+            'reference' => 'ope-184-demo-lease-003',
+            'property' => 'ope-184-demo-kos-melati-indah',
+            'unit' => 'A3',
+            'tenants' => ['Ahmad Rizki'],
+            'currency' => 'IDR',
+            'start_months_ago' => 3,
+            'rent_due_day' => 10,
+            'payment' => ['kind' => 'partial', 'amount' => '750000'],
+        ],
+        [
+            'reference' => 'ope-184-demo-lease-004',
+            'property' => 'ope-184-demo-kos-mawar-putih',
+            'unit' => 'A1',
+            'tenants' => ['Dewi Lestari'],
+            'currency' => 'USD',
+            'start_months_ago' => 2,
+            'rent_due_day' => 5,
+            'payment' => ['kind' => 'paid'],
+        ],
+        [
+            'reference' => 'ope-184-demo-lease-005',
+            'property' => 'ope-184-demo-kos-mawar-putih',
+            'unit' => 'B1',
+            'tenants' => ['Rudi Hartono'],
+            'currency' => 'IDR',
+            'start_months_ago' => 2,
+            'rent_due_day' => 15,
+            'payment' => ['kind' => 'pending'],
+        ],
+        [
+            'reference' => 'ope-184-demo-lease-006',
+            'property' => 'ope-184-demo-kos-kenanga-asri',
+            'unit' => 'A1',
+            'tenants' => ['Rina Wijaya'],
+            'currency' => 'IDR',
+            'start_months_ago' => 2,
+            'rent_due_day' => 12,
+            'payment' => ['kind' => 'paid'],
+        ],
+        [
+            'reference' => 'ope-184-demo-lease-007',
+            'property' => 'ope-184-demo-kos-kenanga-asri',
+            'unit' => 'B2',
+            'tenants' => ['Agus Prasetyo'],
+            'currency' => 'IDR',
+            'start_months_ago' => 1,
+            'rent_due_day' => 20,
+            'payment' => ['kind' => 'partial', 'amount' => '900000'],
+        ],
+        [
+            'reference' => 'ope-184-demo-lease-008',
+            'property' => 'ope-184-demo-kos-dahlia-permai',
+            'unit' => 'A4',
+            'tenants' => ['Maya Anggraini'],
+            'currency' => 'IDR',
+            'start_months_ago' => 2,
+            'rent_due_day' => 25,
+            'end_days_from_now' => 14,
+            'payment' => ['kind' => 'paid'],
+        ],
     ];
 
     private array $sharedAssignments = [
-        ['property' => 'Kos Melati Indah', 'unit_name' => 'B1', 'primary_tenant' => 'Eko Wahyudi', 'extra_tenants' => ['Dian Permata']],
-        ['property' => 'Kos Melati Indah', 'unit_name' => 'B2', 'primary_tenant' => 'Fajar Nugroho', 'extra_tenants' => ['Ratna Sari', 'Bayu Aji']],
+        [
+            'reference' => 'ope-184-demo-lease-009',
+            'property' => 'ope-184-demo-kos-melati-indah',
+            'unit' => 'B1',
+            'tenants' => ['Eko Wahyudi', 'Dian Permata'],
+            'currency' => 'IDR',
+            'start_months_ago' => 1,
+            'rent_due_day' => 7,
+            'payment' => ['kind' => 'paid'],
+        ],
+        [
+            'reference' => 'ope-184-demo-lease-010',
+            'property' => 'ope-184-demo-kos-melati-indah',
+            'unit' => 'B2',
+            'tenants' => ['Fajar Nugroho', 'Ratna Sari', 'Bayu Aji'],
+            'currency' => 'IDR',
+            'start_months_ago' => 1,
+            'rent_due_day' => 8,
+            'payment' => ['kind' => 'paid'],
+        ],
     ];
 
     private array $historicalAssignments = [
-        ['property' => 'Kos Melati Indah', 'unit_name' => 'A3', 'tenant' => 'Fitri Handayani', 'months_ago' => 7],
-        ['property' => 'Kos Mawar Putih',  'unit_name' => 'B3', 'tenant' => 'Hendra Gunawan', 'months_ago' => 5],
-        ['property' => 'Kos Kenanga Asri', 'unit_name' => 'C3', 'tenant' => 'Joko Susilo',    'months_ago' => 4],
-        ['property' => 'Kos Dahlia Permai', 'unit_name' => 'C4', 'tenant' => 'Kartika Sari',   'months_ago' => 3],
-        ['property' => 'Kos Melati Indah', 'unit_name' => 'A2', 'tenant' => 'Doni Firmansyah', 'months_ago' => 9],
-        ['property' => 'Kos Mawar Putih',  'unit_name' => 'B4', 'tenant' => 'Indah Permata',   'months_ago' => 6],
-        ['property' => 'Kos Kenanga Asri', 'unit_name' => 'A2', 'tenant' => 'Lukman Hakim',    'months_ago' => 8],
+        ['reference' => 'ope-184-demo-history-001', 'property' => 'ope-184-demo-kos-melati-indah', 'unit' => 'A3', 'tenant' => 'Fitri Handayani', 'months_ago' => 7, 'currency' => 'IDR', 'refund_amount' => null],
+        ['reference' => 'ope-184-demo-history-002', 'property' => 'ope-184-demo-kos-mawar-putih', 'unit' => 'B3', 'tenant' => 'Hendra Gunawan', 'months_ago' => 5, 'currency' => 'IDR', 'refund_amount' => '1500000'],
+        ['reference' => 'ope-184-demo-history-003', 'property' => 'ope-184-demo-kos-kenanga-asri', 'unit' => 'C3', 'tenant' => 'Joko Susilo', 'months_ago' => 4, 'currency' => 'IDR', 'refund_amount' => null],
+        ['reference' => 'ope-184-demo-history-004', 'property' => 'ope-184-demo-kos-dahlia-permai', 'unit' => 'C4', 'tenant' => 'Kartika Sari', 'months_ago' => 3, 'currency' => 'IDR', 'refund_amount' => '1500000'],
+        ['reference' => 'ope-184-demo-history-005', 'property' => 'ope-184-demo-kos-melati-indah', 'unit' => 'A2', 'tenant' => 'Doni Firmansyah', 'months_ago' => 9, 'currency' => 'IDR', 'refund_amount' => null],
+        ['reference' => 'ope-184-demo-history-006', 'property' => 'ope-184-demo-kos-mawar-putih', 'unit' => 'B4', 'tenant' => 'Indah Permata', 'months_ago' => 6, 'currency' => 'IDR', 'refund_amount' => '1500000'],
+        ['reference' => 'ope-184-demo-history-007', 'property' => 'ope-184-demo-kos-kenanga-asri', 'unit' => 'A2', 'tenant' => 'Lukman Hakim', 'months_ago' => 8, 'currency' => 'IDR', 'refund_amount' => null],
     ];
 
     public function run(): void
     {
-        /** @var Collection<int, Property> */
-        $properties = Property::with('units.activeRates')->get()->keyBy('name');
-        $tenants = Tenant::pluck('id', 'name');
+        $now = now();
+        $this->activeAssignments[0]['rent_due_day'] = $now->day;
+        $this->activeAssignments[1]['rent_due_day'] = min($now->day + 3, $now->daysInMonth);
 
-        $now = Carbon::now();
+        DB::transaction(function () use ($now): void {
+            $this->clearOwnedLeases();
 
-        foreach ($this->activeAssignments as $assignment) {
-            $property = $properties->get($assignment['property']);
-            $tenantId = $tenants->get($assignment['tenant']);
+            foreach ($this->activeAssignments as $assignment) {
+                $this->createActiveLease($assignment, $now);
+            }
 
-            if (! $property || ! $tenantId) {
+            foreach ($this->sharedAssignments as $assignment) {
+                $this->createActiveLease($assignment, $now);
+            }
+
+            foreach ($this->historicalAssignments as $assignment) {
+                $this->createHistoricalLease($assignment, $now);
+            }
+
+            $this->seedPayments($now);
+        });
+    }
+
+    private function clearOwnedLeases(): void
+    {
+        $leaseIds = Lease::withTrashed()
+            ->where(fn ($query) => $query
+                ->where('reference', 'like', self::NAMESPACE.'-lease-%')
+                ->orWhere('reference', 'like', self::NAMESPACE.'-history-%'))
+            ->pluck('id');
+
+        if ($leaseIds->isEmpty()) {
+            return;
+        }
+
+        Invoice::query()->whereIn('lease_id', $leaseIds)->delete();
+        DB::table('lease_tenant')->whereIn('lease_id', $leaseIds)->delete();
+        DB::table('lease_unit_histories')->whereIn('lease_id', $leaseIds)->delete();
+        DB::table('reminder_logs')->whereIn('lease_id', $leaseIds)->delete();
+        Lease::withTrashed()->whereKey($leaseIds)->forceDelete();
+    }
+
+    /**
+     * @param  array{reference: string, property: string, unit: string, tenants: array<int, string>, currency: string, start_months_ago: int, rent_due_day: int, end_days_from_now?: int, payment?: array{kind: string, amount?: string}|null}  $assignment
+     */
+    private function createActiveLease(array $assignment, CarbonInterface $now): Lease
+    {
+        $unit = $this->resolveUnit($assignment['property'], $assignment['unit']);
+        $tenantIds = array_map(fn (string $name): int => $this->resolveTenantId($name), $assignment['tenants']);
+        $rate = $this->resolveRate($unit, $assignment['currency']);
+        $startDate = $now->copy()->subMonthsNoOverflow($assignment['start_months_ago'])->startOfMonth();
+        $endDate = isset($assignment['end_days_from_now'])
+            ? $now->copy()->addDays($assignment['end_days_from_now'])->toDateString()
+            : null;
+
+        /** @var Lease $lease */
+        $lease = app(CreateLease::class)->execute($unit, new CreateLeaseData(
+            tenantIds: $tenantIds,
+            startDate: $startDate->toDateString(),
+            endDate: $endDate,
+            rentAmount: null,
+            billingInterval: null,
+            billingUnit: null,
+            billingStrategy: BillingStrategy::Advance->value,
+            unitRateId: $rate->id,
+            depositAmount: $assignment['currency'] === 'USD' ? '450.00' : '1500000',
+            depositPaidAt: $startDate->toDateString(),
+            depositRefundAmount: null,
+            depositRefundedAt: null,
+            rentDueDay: $assignment['rent_due_day'],
+            notes: 'OpenKOS demonstration lease.',
+        ));
+
+        $lease->forceFill(['reference' => $assignment['reference']])->saveQuietly();
+
+        return $lease->refresh();
+    }
+
+    /**
+     * @param  array{reference: string, property: string, unit: string, tenant: string, months_ago: int, currency: string, refund_amount: string|null}  $assignment
+     */
+    private function createHistoricalLease(array $assignment, CarbonInterface $now): Lease
+    {
+        $unit = $this->resolveUnit($assignment['property'], $assignment['unit']);
+        $tenantId = $this->resolveTenantId($assignment['tenant']);
+        $rate = $this->resolveRate($unit, $assignment['currency']);
+        $endDate = $now->copy()->subMonthsNoOverflow($assignment['months_ago'])->startOfMonth()->addDays(10);
+        $startDate = $endDate->copy()->subMonthsNoOverflow(6)->startOfMonth();
+        $depositAmount = $assignment['currency'] === 'USD' ? '450.00' : '1500000';
+
+        $lease = Lease::create([
+            'reference' => $assignment['reference'],
+            'primary_tenant_id' => $tenantId,
+            'unit_id' => $unit->id,
+            'start_date' => $startDate->toDateString(),
+            'end_date' => $endDate->toDateString(),
+            'rent_amount' => $rate->amount,
+            'currency' => $rate->currency,
+            'billing_interval' => $rate->billing_interval,
+            'billing_unit' => $rate->billing_unit,
+            'billing_strategy' => BillingStrategy::Advance,
+            'is_custom_price' => false,
+            'unit_rate_id' => $rate->id,
+            'deposit_amount' => $depositAmount,
+            'deposit_paid_at' => $startDate,
+            'deposit_refund_amount' => $assignment['refund_amount'],
+            'deposit_refunded_at' => $assignment['refund_amount'] === null ? null : $endDate,
+            'rent_due_day' => 5,
+            'status' => LeaseStatus::Terminated,
+            'termination_date' => $endDate,
+            'termination_reason' => 'contract_ended',
+            'notes' => 'OpenKOS demonstration historical lease.',
+        ]);
+
+        $lease->tenants()->sync([$tenantId => ['is_primary' => true]]);
+
+        return $lease;
+    }
+
+    private function seedPayments(CarbonInterface $now): void
+    {
+        $owner = User::query()->where('email', 'budi@openkos.com')->firstOrFail();
+        $assignments = [...$this->activeAssignments, ...$this->sharedAssignments];
+
+        foreach ($assignments as $assignment) {
+            $payment = $assignment['payment'] ?? null;
+
+            if ($payment === null) {
                 continue;
             }
 
-            $unit = $property->units->firstWhere('name');
+            $lease = Lease::query()->where('reference', $assignment['reference'])->firstOrFail();
+            $invoice = $lease->invoices()
+                ->whereDate('period_start', '<=', $now->toDateString())
+                ->orderByDesc('period_start')
+                ->firstOrFail();
+            $amount = $payment['kind'] === 'paid'
+                ? (string) $invoice->outstanding
+                : ($payment['amount'] ?? (string) $invoice->outstanding);
+            $forcePending = $payment['kind'] === 'pending';
 
-            if (! $unit) {
-                continue;
+            $result = app(RecordPayment::class)->execute($invoice, new RecordPaymentData(
+                amount: $amount,
+                paymentDate: $now->copy()->subDay()->toDateString(),
+                paymentMethod: PaymentMethod::Transfer->value,
+                notes: 'OpenKOS demonstration payment.',
+            ), $owner, $forcePending);
+
+            if ($result->failed() || $result->payment === null) {
+                throw new RuntimeException('Unable to record demonstration payment.');
             }
 
-            $rate = $unit->activeRates->first();
-            $startDate = $now->copy()->subMonths(fake()->numberBetween(1, 6));
+            $result->payment->forceFill([
+                'reference_number' => self::NAMESPACE.'-payment-'.substr($assignment['reference'], -3),
+            ])->saveQuietly();
+        }
+    }
 
-            $lease = Lease::create([
-                'primary_tenant_id' => $tenantId,
-                'unit_id' => $unit->id,
-                'start_date' => $startDate,
-                'end_date' => null,
-                'rent_amount' => $rate?->amount ?? 1_500_000,
-                'billing_interval' => $rate?->billing_interval ?? 1,
-                'billing_unit' => $rate?->billing_unit ?? 'month',
-                'is_custom_price' => false,
-                'unit_rate_id' => $rate?->id ?? null,
-                'deposit_amount' => fake()->randomElement([500_000, 1_000_000, 1_500_000]),
-                'deposit_paid_at' => $startDate,
-                'rent_due_day' => fake()->randomElement([1, 5, 10, 15, 20, 25]),
-                'status' => LeaseStatus::Active,
-                'notes' => null,
-            ]);
+    private function resolveUnit(string $propertySlug, string $name): Unit
+    {
+        $property = Property::query()->where('slug', $propertySlug)->first();
 
-            $lease->tenants()->attach($tenantId, ['is_primary' => true]);
+        if (! $property) {
+            throw new RuntimeException("Missing demonstration property [{$propertySlug}].");
         }
 
-        foreach ($this->sharedAssignments as $assignment) {
-            $property = $properties->get($assignment['property']);
-            $tenantIds = collect($assignment['extra_tenants'])
-                ->push($assignment['primary_tenant'])
-                ->map(fn (string $name) => $tenants->get($name));
+        $unit = $property->units()->where('name', $name)->first();
 
-            if (! $property || $tenantIds->contains(null)) {
-                continue;
-            }
-
-            $unit = $property->units->firstWhere('name');
-
-            if (! $unit) {
-                continue;
-            }
-
-            $rate = $unit->activeRates->first();
-            $startDate = $now->copy()->subMonths(fake()->numberBetween(1, 6));
-            $primaryId = $tenantIds->pop();
-
-            $lease = Lease::create([
-                'primary_tenant_id' => $primaryId,
-                'unit_id' => $unit->id,
-                'start_date' => $startDate,
-                'end_date' => null,
-                'rent_amount' => $rate?->amount ?? 1_500_000,
-                'billing_interval' => $rate?->billing_interval ?? 1,
-                'billing_unit' => $rate?->billing_unit ?? 'month',
-                'is_custom_price' => false,
-                'unit_rate_id' => $rate?->id ?? null,
-                'deposit_amount' => fake()->randomElement([500_000, 1_000_000, 1_500_000]),
-                'deposit_paid_at' => $startDate,
-                'rent_due_day' => fake()->randomElement([1, 5, 10, 15, 20, 25]),
-                'status' => LeaseStatus::Active,
-                'notes' => null,
-            ]);
-
-            $lease->tenants()->attach($primaryId, ['is_primary' => true]);
-
-            foreach ($tenantIds as $extraId) {
-                $lease->tenants()->attach($extraId, ['is_primary' => false]);
-            }
+        if (! $unit) {
+            throw new RuntimeException("Missing demonstration unit [{$propertySlug}/{$name}].");
         }
 
-        foreach ($this->historicalAssignments as $assignment) {
-            $property = $properties->get($assignment['property']);
-            $tenantId = $tenants->get($assignment['tenant']);
+        return $unit;
+    }
 
-            if (! $property || ! $tenantId) {
-                continue;
-            }
+    private function resolveTenantId(string $name): int
+    {
+        $tenant = Tenant::query()->where('name', $name)->first();
 
-            $unit = $property->units->firstWhere('name');
-
-            if (! $unit) {
-                continue;
-            }
-
-            $rate = $unit->activeRates->first();
-            $monthsAgo = $assignment['months_ago'];
-            $startDate = $now->copy()->subMonths($monthsAgo + random_int(1, 4));
-            $endDate = $now->copy()->subMonths($monthsAgo);
-
-            $lease = Lease::create([
-                'primary_tenant_id' => $tenantId,
-                'unit_id' => $unit->id,
-                'start_date' => $startDate,
-                'end_date' => $endDate,
-                'rent_amount' => $rate?->amount ?? 1_500_000,
-                'billing_interval' => $rate?->billing_interval ?? 1,
-                'billing_unit' => $rate?->billing_unit ?? 'month',
-                'is_custom_price' => false,
-                'unit_rate_id' => $rate?->id ?? null,
-                'deposit_amount' => fake()->randomElement([500_000, 1_000_000]),
-                'deposit_paid_at' => $startDate,
-                'deposit_refund_amount' => fake()->randomElement([null, 500_000, 1_000_000]),
-                'deposit_refunded_at' => fake()->randomElement([null, $endDate]),
-                'rent_due_day' => fake()->randomElement([1, 5, 10]),
-                'status' => LeaseStatus::Terminated,
-                'termination_date' => $endDate,
-                'termination_reason' => fake()->randomElement([
-                    'move_out', 'contract_ended', 'mutual_agreement',
-                ]),
-                'notes' => null,
-            ]);
-
-            $lease->tenants()->attach($tenantId, ['is_primary' => true]);
+        if (! $tenant) {
+            throw new RuntimeException("Missing demonstration tenant [{$name}].");
         }
 
-        // Ensure dashboard rent status coverage, then create payments for the rest
-        $activeLeases = Lease::where('status', LeaseStatus::Active->value)->get();
-        $today = (int) $now->day;
+        return $tenant->id;
+    }
 
-        if ($activeLeases->isNotEmpty()) {
-            $activeLeases->first()->update(['rent_due_day' => $today]); // Due Today
+    private function resolveRate(Unit $unit, string $currency): UnitRate
+    {
+        $rate = $unit->rates()
+            ->where('billing_interval', 1)
+            ->where('billing_unit', 'month')
+            ->where('currency', $currency)
+            ->where('is_active', true)
+            ->first();
+
+        if (! $rate) {
+            throw new RuntimeException("Missing active {$currency} monthly rate for demonstration unit [{$unit->name}].");
         }
 
-        if ($activeLeases->count() > 1) {
-            $activeLeases->get(1)->update(['rent_due_day' => min($today + 3, 28)]); // Due Soon
-        }
-
-        // Generate invoices, then pay this month's invoice for ~half the
-        // active leases (makes them "Paid"), skip the first 2
-        $generateInvoices = app(GenerateInvoices::class);
-
-        foreach ($activeLeases as $i => $lease) {
-            $generateInvoices->execute($lease);
-
-            if ($i > 1 && $i % 2 !== 0) {
-                $invoice = $lease->invoices()
-                    ->whereBetween('period_start', [$now->copy()->startOfMonth(), $now->copy()->endOfMonth()])
-                    ->first();
-
-                if ($invoice) {
-                    $invoice->payments()->create([
-                        'amount' => $invoice->total,
-                        'payment_date' => $now->copy()->setDay(min((int) $lease->rent_due_day, $now->daysInMonth)),
-                        'payment_method' => 'cash',
-                        'status' => PaymentStatus::Confirmed,
-                    ]);
-
-                    $invoice->recalculateStatus();
-                }
-            }
-        }
-
-        Unit::query()
-            ->whereIn('id', Lease::where('status', LeaseStatus::Active->value)->pluck('unit_id'))
-            ->update(['status' => UnitStatus::Occupied->value]);
+        return $rate;
     }
 }

--- a/database/seeders/MaintenanceSeeder.php
+++ b/database/seeders/MaintenanceSeeder.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\MaintenancePriority;
+use App\Enums\MaintenanceStatus;
+use App\Enums\UnitStatus;
+use App\Models\MaintenanceTicket;
+use App\Models\Property;
+use App\Models\Unit;
+use App\Models\User;
+use Carbon\CarbonInterface;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class MaintenanceSeeder extends Seeder
+{
+    private const PROPERTY_SLUG = 'ope-184-demo-kos-anggrek-residence';
+
+    public function run(): void
+    {
+        $now = now();
+        DB::transaction(function () use ($now): void {
+            $property = Property::query()->where('slug', self::PROPERTY_SLUG)->firstOrFail();
+            $staff = User::query()->where('email', 'demo.staff@openkos.com')->firstOrFail();
+            $tenant = User::query()->where('email', 'demo.tenant@openkos.com')->firstOrFail();
+            $owner = User::query()->where('email', 'budi@openkos.com')->firstOrFail();
+            $maintenanceUnit = $this->unit($property, 'C1');
+            $maintenanceUnit->forceFill(['status' => UnitStatus::Maintenance])->saveQuietly();
+
+            $this->upsertTicket([
+                'reference' => 'ope-184-demo-ticket-001',
+                'property_id' => $property->id,
+                'unit_id' => null,
+                'location' => 'Lobby',
+                'title' => 'Lobby light needs replacement',
+                'description' => 'The main lobby light flickers after rain.',
+                'status' => MaintenanceStatus::Reported,
+                'priority' => MaintenancePriority::Medium,
+                'assigned_to' => null,
+                'created_by' => $tenant->id,
+                'cost' => null,
+                'resolved_at' => null,
+                'resolution_notes' => null,
+            ], $now);
+
+            $this->upsertTicket([
+                'reference' => 'ope-184-demo-ticket-002',
+                'property_id' => $property->id,
+                'unit_id' => $maintenanceUnit->id,
+                'location' => 'Unit C1',
+                'title' => 'Bathroom tap is leaking',
+                'description' => 'The bathroom tap has a steady leak and needs a washer replacement.',
+                'status' => MaintenanceStatus::InProgress,
+                'priority' => MaintenancePriority::High,
+                'assigned_to' => $staff->id,
+                'created_by' => $tenant->id,
+                'cost' => null,
+                'resolved_at' => null,
+                'resolution_notes' => null,
+            ], $now);
+
+            $this->upsertTicket([
+                'reference' => 'ope-184-demo-ticket-003',
+                'property_id' => $property->id,
+                'unit_id' => $this->unit($property, 'C2')->id,
+                'location' => 'Unit C2',
+                'title' => 'Air conditioner filter replaced',
+                'description' => 'Routine filter replacement completed before the next move-in.',
+                'status' => MaintenanceStatus::Resolved,
+                'priority' => MaintenancePriority::Low,
+                'assigned_to' => $staff->id,
+                'created_by' => $owner->id,
+                'cost' => '250000',
+                'resolved_at' => $now->copy()->subDays(2),
+                'resolution_notes' => 'Filter cleaned and replaced.',
+            ], $now);
+        });
+    }
+
+    /**
+     * @param  array{reference: string, property_id: int, unit_id: int|null, location: string, title: string, description: string, status: MaintenanceStatus, priority: MaintenancePriority, assigned_to: int|null, created_by: int, cost: string|null, resolved_at: CarbonInterface|null, resolution_notes: string|null}  $data
+     */
+    private function upsertTicket(array $data, CarbonInterface $now): void
+    {
+        $ticket = MaintenanceTicket::query()->firstOrNew(['reference' => $data['reference']]);
+        $ticket->forceFill([
+            ...$data,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ])->saveQuietly();
+    }
+
+    private function unit(Property $property, string $name): Unit
+    {
+        return $property->units()->where('name', $name)->firstOrFail();
+    }
+}

--- a/database/seeders/PropertyAndUnitSeeder.php
+++ b/database/seeders/PropertyAndUnitSeeder.php
@@ -2,16 +2,21 @@
 
 namespace Database\Seeders;
 
+use App\Enums\LeaseStatus;
 use App\Enums\UnitStatus;
 use App\Models\City;
 use App\Models\Property;
 use App\Models\Region;
 use App\Models\Unit;
+use App\Models\UnitRate;
+use Carbon\CarbonInterface;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 
 class PropertyAndUnitSeeder extends Seeder
 {
+    private const NAMESPACE = 'ope-184-demo';
+
     private array $properties = [
         [
             'name' => 'Kos Melati Indah',
@@ -106,72 +111,153 @@ class PropertyAndUnitSeeder extends Seeder
     ];
 
     private array $unitTemplates = [
-        ['prefix' => 'A', 'count' => 4, 'floor' => 1, 'rates' => [
-            ['billing_interval' => 1, 'billing_unit' => 'month', 'amount' => 1_500_000],
-            ['billing_interval' => 1, 'billing_unit' => 'year', 'amount' => 15_000_000],
-        ]],
-        ['prefix' => 'B', 'count' => 4, 'floor' => 2, 'rates' => [
-            ['billing_interval' => 1, 'billing_unit' => 'month', 'amount' => 1_800_000],
-            ['billing_interval' => 3, 'billing_unit' => 'month', 'amount' => 5_000_000],
-        ]],
-        ['prefix' => 'C', 'count' => 4, 'floor' => 3, 'rates' => [
-            ['billing_interval' => 1, 'billing_unit' => 'month', 'amount' => 2_200_000],
-            ['billing_interval' => 1, 'billing_unit' => 'week', 'amount' => 600_000],
-        ]],
+        [
+            'prefix' => 'A',
+            'count' => 4,
+            'floor' => 1,
+            'capacity' => 1,
+            'rates' => [
+                ['billing_interval' => 1, 'billing_unit' => 'month', 'amount' => '1500000', 'currency' => 'IDR'],
+                ['billing_interval' => 1, 'billing_unit' => 'year', 'amount' => '15000000', 'currency' => 'IDR'],
+                ['billing_interval' => 1, 'billing_unit' => 'month', 'amount' => '450.00', 'currency' => 'USD'],
+            ],
+        ],
+        [
+            'prefix' => 'B',
+            'count' => 4,
+            'floor' => 2,
+            'capacity' => 3,
+            'rates' => [
+                ['billing_interval' => 1, 'billing_unit' => 'month', 'amount' => '1800000', 'currency' => 'IDR'],
+                ['billing_interval' => 3, 'billing_unit' => 'month', 'amount' => '5000000', 'currency' => 'IDR'],
+            ],
+        ],
+        [
+            'prefix' => 'C',
+            'count' => 4,
+            'floor' => 3,
+            'capacity' => 1,
+            'rates' => [
+                ['billing_interval' => 1, 'billing_unit' => 'month', 'amount' => '2200000', 'currency' => 'IDR'],
+                ['billing_interval' => 1, 'billing_unit' => 'week', 'amount' => '600000', 'currency' => 'IDR'],
+            ],
+        ],
     ];
 
     public function run(): void
     {
-        DB::statement('TRUNCATE TABLE properties CASCADE');
+        $now = now();
 
-        $regions = Region::pluck('id', 'name');
-        $cities = City::all()->groupBy('region_id');
+        DB::transaction(function () use ($now): void {
+            foreach ($this->properties as $data) {
+                $region = Region::query()
+                    ->where('country_code', 'ID')
+                    ->where('name', $data['region_name'])
+                    ->firstOrFail();
+                $city = City::query()
+                    ->where('region_id', $region->id)
+                    ->where('name', $data['city_name'])
+                    ->firstOrFail();
 
-        foreach ($this->properties as $data) {
-            $regionId = $regions->get($data['region_name']);
-            if ($regionId === null) {
-                continue;
-            }
+                $property = $this->upsertProperty($data, $region->id, $city->id);
 
-            $city = $cities[$regionId]->firstWhere('name', $data['city_name']);
-            if ($city === null) {
-                $city = $cities[$regionId]->first();
-            }
+                foreach ($this->unitTemplates as $template) {
+                    for ($index = 1; $index <= $template['count']; $index++) {
+                        $unit = $this->upsertUnit($property, $template, $index);
 
-            $property = Property::create([
-                'name' => $data['name'],
-                'address' => $data['address'],
-                'region_id' => $regionId,
-                'city_id' => $city->id,
-                'postal_code' => $data['postal_code'],
-                'phone' => $data['phone'],
-                'description' => $data['description'],
-            ]);
-
-            DB::statement('UPDATE properties SET is_active = true WHERE id = ?', [$property->id]);
-
-            foreach ($this->unitTemplates as $template) {
-                for ($i = 1; $i <= $template['count']; $i++) {
-                    $unit = Unit::create([
-                        'property_id' => $property->id,
-                        'name' => $template['prefix'].$i,
-                        'floor' => (string) $template['floor'],
-                        'size_sqm' => fake()->randomFloat(2, 14, 28),
-                        'capacity' => fake()->randomElement([1, 2]),
-                        'status' => UnitStatus::Available,
-                        'notes' => null,
-                    ]);
-
-                    foreach ($template['rates'] as $rate) {
-                        $unit->rates()->create([
-                            'billing_interval' => $rate['billing_interval'],
-                            'billing_unit' => $rate['billing_unit'],
-                            'amount' => $rate['amount'],
-                            'is_active' => true,
-                        ]);
+                        foreach ($template['rates'] as $rate) {
+                            $this->upsertRate($unit, $rate, $now);
+                        }
                     }
                 }
             }
+        });
+    }
+
+    /**
+     * @param  array{name: string, address: string, region_name: string, city_name: string, postal_code: string, phone: string, description: string}  $data
+     */
+    private function upsertProperty(array $data, int $regionId, int $cityId): Property
+    {
+        $slug = self::NAMESPACE.'-'.str($data['name'])->slug();
+        $property = Property::withTrashed()->firstOrNew(['slug' => $slug]);
+
+        if ($property->trashed()) {
+            $property->restoreQuietly();
         }
+
+        $property->forceFill([
+            'name' => $data['name'],
+            'type' => 'boarding_house',
+            'slug' => $slug,
+            'address' => $data['address'],
+            'region_id' => $regionId,
+            'city_id' => $cityId,
+            'postal_code' => $data['postal_code'],
+            'phone' => $data['phone'],
+            'description' => $data['description'],
+            'is_active' => true,
+        ])->saveQuietly();
+
+        return $property->refresh();
+    }
+
+    /**
+     * @param  array{prefix: string, count: int, floor: int, capacity: int, rates: array<int, array{billing_interval: int, billing_unit: string, amount: string, currency: string}>}  $template
+     */
+    private function upsertUnit(Property $property, array $template, int $index): Unit
+    {
+        $name = $template['prefix'].$index;
+        $unit = Unit::withTrashed()->firstOrNew([
+            'property_id' => $property->id,
+            'name' => $name,
+        ]);
+
+        if ($unit->trashed()) {
+            $unit->restoreQuietly();
+        }
+
+        $status = $unit->leases()->where('status', LeaseStatus::Active->value)->exists()
+            ? UnitStatus::Occupied
+            : UnitStatus::Available;
+
+        $unit->forceFill([
+            'property_id' => $property->id,
+            'name' => $name,
+            'slug' => self::NAMESPACE.'-'.str($property->slug.'-'.$name)->slug(),
+            'floor' => (string) $template['floor'],
+            'size_sqm' => 16 + ($index * 2),
+            'capacity' => $template['capacity'],
+            'status' => $status,
+            'notes' => 'OpenKOS demonstration unit.',
+        ])->saveQuietly();
+
+        return $unit->refresh();
+    }
+
+    /**
+     * @param  array{billing_interval: int, billing_unit: string, amount: string, currency: string}  $rateData
+     */
+    private function upsertRate(Unit $unit, array $rateData, CarbonInterface $now): UnitRate
+    {
+        $rate = UnitRate::query()->firstOrNew([
+            'unit_id' => $unit->id,
+            'billing_interval' => $rateData['billing_interval'],
+            'billing_unit' => $rateData['billing_unit'],
+            'currency' => $rateData['currency'],
+        ]);
+
+        $rate->forceFill([
+            'unit_id' => $unit->id,
+            'billing_interval' => $rateData['billing_interval'],
+            'billing_unit' => $rateData['billing_unit'],
+            'amount' => $rateData['amount'],
+            'currency' => $rateData['currency'],
+            'is_active' => true,
+            'effective_from' => $now->copy()->startOfMonth()->toDateString(),
+            'effective_until' => null,
+        ])->saveQuietly();
+
+        return $rate->refresh();
     }
 }

--- a/database/seeders/RegionAndCitySeeder.php
+++ b/database/seeders/RegionAndCitySeeder.php
@@ -11,9 +11,6 @@ class RegionAndCitySeeder extends Seeder
 {
     public function run(): void
     {
-        City::query()->delete();
-        Region::query()->delete();
-
         $provinces = json_decode(
             File::get(database_path('data/provinces.json')),
             true,
@@ -35,7 +32,7 @@ class RegionAndCitySeeder extends Seeder
         }
 
         foreach ($provinces as $province) {
-            $region = Region::create([
+            $region = Region::firstOrCreate([
                 'country_code' => 'ID',
                 'name' => $province['province'],
             ]);
@@ -43,7 +40,7 @@ class RegionAndCitySeeder extends Seeder
             $cities = $regenciesByProvinceId[$province['id']] ?? [];
 
             foreach ($cities as $city) {
-                City::create([
+                City::firstOrCreate([
                     'region_id' => $region->id,
                     'name' => trim(($city['type'] ?? '').' '.$city['regency']),
                 ]);

--- a/database/seeders/SettingSeeder.php
+++ b/database/seeders/SettingSeeder.php
@@ -13,6 +13,7 @@ class SettingSeeder extends Seeder
         Setting::set('country_code', 'ID');
         Setting::set('locale', 'id');
         Setting::set('currency', 'IDR');
+        Setting::set('supported_currencies', ['IDR', 'USD']);
         Setting::set('timezone', 'Asia/Jakarta');
         Setting::set('lease_id_prefix', 'LSX');
         Setting::set('invoice_id_prefix', 'INV');

--- a/tests/Feature/Ope184DemoSeederTest.php
+++ b/tests/Feature/Ope184DemoSeederTest.php
@@ -1,0 +1,147 @@
+<?php
+
+use App\Enums\InvoiceStatus;
+use App\Enums\LeaseStatus;
+use App\Enums\MaintenanceStatus;
+use App\Enums\PaymentStatus;
+use App\Enums\UnitStatus;
+use App\Models\City;
+use App\Models\Invoice;
+use App\Models\Lease;
+use App\Models\MaintenanceTicket;
+use App\Models\Payment;
+use App\Models\PaymentAllocation;
+use App\Models\Property;
+use App\Models\Region;
+use App\Models\Tenant;
+use App\Models\Unit;
+use App\Models\UnitRate;
+use App\Models\User;
+use Database\Seeders\DatabaseSeeder;
+use Database\Seeders\LoadTestDatasetSeeder;
+use Database\Seeders\LoadTestSeeder;
+
+it('seeds a complete currency-aware demo graph and can be rerun', function () {
+    $this->travelTo('2026-09-15 10:00:00');
+
+    $this->seed(DatabaseSeeder::class);
+
+    $demoProperties = Property::query()->where('slug', 'like', 'ope-184-demo-%');
+    $demoLeases = Lease::query()->where('reference', 'like', 'ope-184-demo-lease-%');
+    $demoHistory = Lease::query()->where('reference', 'like', 'ope-184-demo-history-%');
+    $demoInvoices = Invoice::query()->whereHas('lease', fn ($query) => $query->where('reference', 'like', 'ope-184-demo-%'));
+
+    expect($demoProperties->count())->toBe(10)
+        ->and(Unit::query()->whereHas('property', fn ($query) => $query->where('slug', 'like', 'ope-184-demo-%'))->count())->toBe(120)
+        ->and(UnitRate::query()
+            ->whereHas('unit.property', fn ($query) => $query->where('slug', 'like', 'ope-184-demo-%'))
+            ->select(['unit_id', 'billing_interval', 'billing_unit', 'currency'])
+            ->groupBy(['unit_id', 'billing_interval', 'billing_unit', 'currency'])
+            ->havingRaw('COUNT(*) > 1')
+            ->get()->count())->toBe(0)
+        ->and($demoLeases->count())->toBe(10)
+        ->and($demoLeases->where('status', LeaseStatus::Active)->count())->toBe(10)
+        ->and($demoHistory->count())->toBe(7)
+        ->and($demoInvoices->count())->toBeGreaterThan(0)
+        ->and(MaintenanceTicket::query()->where('reference', 'like', 'ope-184-demo-ticket-%')->count())->toBe(3)
+        ->and(User::query()->whereIn('email', ['demo.staff@openkos.com', 'demo.tenant@openkos.com'])->count())->toBe(2);
+
+    $usdLease = Lease::query()->where('reference', 'ope-184-demo-lease-004')->firstOrFail();
+    $usdInvoice = $usdLease->invoices()->where('currency', 'USD')->where('period_start', '<=', today())->latest('period_start')->firstOrFail();
+    $usdPayment = $usdInvoice->payments()->where('status', PaymentStatus::Confirmed)->firstOrFail();
+    $idLease = Lease::query()->where('reference', 'ope-184-demo-lease-006')->firstOrFail();
+    $idInvoice = $idLease->invoices()->where('currency', 'IDR')->where('period_start', '<=', today())->latest('period_start')->firstOrFail();
+    $idPayment = $idInvoice->payments()->where('status', PaymentStatus::Confirmed)->firstOrFail();
+
+    expect($usdLease->currency)->toBe('USD')
+        ->and($usdInvoice->currency)->toBe('USD')
+        ->and($usdPayment->currency)->toBe('USD')
+        ->and($usdPayment->allocations()->where('invoice_id', $usdInvoice->id)->exists())->toBeTrue()
+        ->and($idLease->currency)->toBe('IDR')
+        ->and($idInvoice->currency)->toBe('IDR')
+        ->and($idPayment->currency)->toBe('IDR')
+        ->and($idPayment->allocations()->where('invoice_id', $idInvoice->id)->exists())->toBeTrue()
+        ->and(UnitRate::query()->where('currency', 'USD')->where('billing_interval', 1)->where('billing_unit', 'month')->exists())->toBeTrue()
+        ->and(Invoice::query()->where('status', InvoiceStatus::Partial)->whereHas('lease', fn ($query) => $query->where('reference', 'like', 'ope-184-demo-%'))->exists())->toBeTrue()
+        ->and(Invoice::query()->where('status', InvoiceStatus::Paid)->whereHas('lease', fn ($query) => $query->where('reference', 'like', 'ope-184-demo-%'))->exists())->toBeTrue()
+        ->and(Payment::query()->where('status', PaymentStatus::Pending)->where('reference_number', 'like', 'ope-184-demo-%')->exists())->toBeTrue()
+        ->and(Unit::query()->where('status', UnitStatus::Maintenance)->whereHas('property', fn ($query) => $query->where('slug', 'like', 'ope-184-demo-%'))->exists())->toBeTrue()
+        ->and(MaintenanceTicket::query()->where('status', MaintenanceStatus::Reported)->where('reference', 'ope-184-demo-ticket-001')->exists())->toBeTrue()
+        ->and(Tenant::query()->whereHas('user', fn ($query) => $query->where('email', 'demo.tenant@openkos.com'))->exists())->toBeTrue();
+
+    foreach ($demoHistory->with('unitRate')->get() as $historyLease) {
+        expect($historyLease->currency)->toBe($historyLease->unitRate->currency)
+            ->and((float) $historyLease->deposit_refund_amount)->toBeLessThanOrEqual((float) $historyLease->deposit_amount)
+            ->and($historyLease->termination_date->toDateString())->toBe($historyLease->end_date->toDateString())
+            ->and($historyLease->status)->toBe(LeaseStatus::Terminated);
+    }
+
+    $counts = [
+        'properties' => $demoProperties->count(),
+        'units' => Unit::query()->whereHas('property', fn ($query) => $query->where('slug', 'like', 'ope-184-demo-%'))->count(),
+        'leases' => $demoLeases->count(),
+        'history' => $demoHistory->count(),
+        'invoices' => $demoInvoices->count(),
+        'payments' => Payment::query()->where('reference_number', 'like', 'ope-184-demo-%')->count(),
+        'tickets' => MaintenanceTicket::query()->where('reference', 'like', 'ope-184-demo-ticket-%')->count(),
+    ];
+
+    $this->seed(DatabaseSeeder::class);
+
+    expect([
+        'properties' => Property::query()->where('slug', 'like', 'ope-184-demo-%')->count(),
+        'units' => Unit::query()->whereHas('property', fn ($query) => $query->where('slug', 'like', 'ope-184-demo-%'))->count(),
+        'leases' => Lease::query()->where('reference', 'like', 'ope-184-demo-lease-%')->count(),
+        'history' => Lease::query()->where('reference', 'like', 'ope-184-demo-history-%')->count(),
+        'invoices' => Invoice::query()->whereHas('lease', fn ($query) => $query->where('reference', 'like', 'ope-184-demo-%'))->count(),
+        'payments' => Payment::query()->where('reference_number', 'like', 'ope-184-demo-%')->count(),
+        'tickets' => MaintenanceTicket::query()->where('reference', 'like', 'ope-184-demo-ticket-%')->count(),
+    ])->toBe($counts);
+});
+
+it('preserves the OPE-177 dataset when the normal demo seed runs', function () {
+    $loadTestConfig = [
+        'enabled' => true,
+        'users' => [
+            'owner' => ['name' => 'Load Test Owner', 'email' => 'owner.load-test@example.com', 'password' => 'owner-secret'],
+            'admin' => ['name' => 'Load Test Manager', 'email' => 'manager.load-test@example.com', 'password' => 'manager-secret'],
+            'staff' => ['name' => 'Load Test Staff', 'email' => 'staff.load-test@example.com', 'password' => 'staff-secret'],
+            'tenant' => ['name' => 'Load Test Tenant', 'email' => 'tenant.load-test@example.com', 'password' => 'tenant-secret'],
+        ],
+    ];
+    config([
+        'load-test.fixtures' => $loadTestConfig,
+        'load-test.dataset.enabled' => true,
+    ]);
+
+    $this->seed(LoadTestSeeder::class);
+    $region = Region::factory()->create(['country_code' => 'ID', 'name' => 'OPE-177 Test Region']);
+    $city = City::factory()->for($region)->create(['name' => 'OPE-177 Test City']);
+    $this->seed(LoadTestDatasetSeeder::class);
+
+    $property = Property::query()->where('slug', 'ope-177-load-test-property-01')->firstOrFail();
+    $unit = $property->units()->where('name', 'OPE-177 Unit 01')->firstOrFail();
+    $before = [
+        'property' => [$property->name, $property->region_id, $property->city_id],
+        'unit' => [$unit->name, $unit->status->value],
+    ];
+
+    $this->seed(DatabaseSeeder::class);
+
+    $property->refresh();
+    $unit->refresh();
+
+    expect([$property->name, $property->region_id, $property->city_id])->toBe($before['property'])
+        ->and([$unit->name, $unit->status->value])->toBe($before['unit'])
+        ->and(Region::query()->findOrFail($region->id)->name)->toBe('OPE-177 Test Region')
+        ->and(City::query()->findOrFail($city->id)->name)->toBe('OPE-177 Test City')
+        ->and(Property::query()->where('slug', 'ope-177-load-test-property-01')->count())->toBe(1)
+        ->and(Unit::query()->where('property_id', $property->id)->where('name', 'OPE-177 Unit 01')->count())->toBe(1);
+});
+
+it('keeps payment allocation factories aligned with their payment', function () {
+    $allocation = PaymentAllocation::factory()->create();
+
+    expect($allocation->invoice_id)->toBe($allocation->payment->invoice_id)
+        ->and((string) $allocation->amount)->toBe((string) $allocation->payment->amount);
+});


### PR DESCRIPTION
## Summary

- refresh demo seed data for current lease, invoice, payment, and maintenance flows
- add deterministic IDR/USD fixtures and fixed demo accounts
- preserve OPE-177 load-test data and make seeding rerunnable
- add regression coverage for currency snapshots, reruns, and factory alignment

## Verification

- `vendor/bin/pint --dirty --format agent`
- `php artisan test --compact tests/Feature/Ope184DemoSeederTest.php tests/Feature/LoadTestDatasetSeederTest.php tests/Feature/CurrencySnapshotTest.php tests/Feature/LeaseTest.php tests/Feature/PaymentAllocationTest.php`
- 59 tests passed, 270 assertions

Refs OPE-184