### PR TITLE
fix: align marketplace core compatibility

### DIFF
--- a/app/Services/Marketplace/MarketplaceClient.php
+++ b/app/Services/Marketplace/MarketplaceClient.php
@@ -55,7 +55,7 @@ final class MarketplaceClient
     /** @return array<string, mixed>|null */
     public function resolveVersion(
         string $pluginId,
-        string $openkosVersion,
+        string $coreVersion,
         string $platformVersion,
         string $phpVersion,
     ): ?array {
@@ -63,7 +63,7 @@ final class MarketplaceClient
             $data = $this->getJson(
                 'plugins/'.rawurlencode($this->pluginId($pluginId)).'/versions/resolve',
                 [
-                    'openkos_version' => $openkosVersion,
+                    'core_version' => $coreVersion,
                     'platform_version' => $platformVersion,
                     'php_version' => $phpVersion,
                 ],
@@ -350,7 +350,13 @@ final class MarketplaceClient
             throw new MarketplaceException('Marketplace returned malformed plugin version metadata.');
         }
 
-        foreach (['openkos', 'platform', 'php'] as $key) {
+        $coreCompatibility = $data['compatibility']['core'] ?? $data['compatibility']['openkos'] ?? null;
+
+        if (! is_string($coreCompatibility) || trim($coreCompatibility) === '') {
+            throw new MarketplaceException('Marketplace returned malformed compatibility metadata.');
+        }
+
+        foreach (['platform', 'php'] as $key) {
             if (! is_string($data['compatibility'][$key] ?? null) || trim($data['compatibility'][$key]) === '') {
                 throw new MarketplaceException('Marketplace returned malformed compatibility metadata.');
             }
@@ -360,7 +366,7 @@ final class MarketplaceClient
             'version' => $data['version'],
             'entry_class' => $data['entry_class'],
             'compatibility' => [
-                'openkos' => $data['compatibility']['openkos'],
+                'core' => $coreCompatibility,
                 'platform' => $data['compatibility']['platform'],
                 'php' => $data['compatibility']['php'],
             ],
@@ -387,7 +393,7 @@ final class MarketplaceClient
         }
 
         $dependencies = $this->validateDependencies($data['dependencies']);
-        $manifest = $this->validateManifest($data['manifest'], $pluginId, $data['version'], $data['entry_class'], $data['compatibility']);
+        $manifest = $this->validateManifest($data['manifest'], $pluginId, $data['version'], $data['entry_class'], $normalized['compatibility']);
 
         if ($dependencies !== $manifest['dependencies']) {
             throw new MarketplaceException('Marketplace version dependencies do not match its manifest.');
@@ -420,7 +426,7 @@ final class MarketplaceClient
             $manifest['id'] !== $pluginId
             || $manifest['version'] !== $version
             || $manifest['entry_class'] !== $entryClass
-            || $manifest['core_version'] !== $compatibility['openkos']
+            || $manifest['core_version'] !== $compatibility['core']
             || $manifest['php'] !== $compatibility['php']
         ) {
             throw new MarketplaceException('Marketplace version metadata does not match its manifest.');

--- a/app/Services/Platform/PluginManagementService.php
+++ b/app/Services/Platform/PluginManagementService.php
@@ -22,7 +22,6 @@ class PluginManagementService
         private PluginInstaller $installer,
         private RuntimePluginGraphValidator $graph,
         private MarketplaceClient $marketplace,
-        private BuildInfo $buildInfo,
     ) {}
 
     /**
@@ -105,7 +104,7 @@ class PluginManagementService
                 'plugins' => [],
                 'updates' => [],
                 'pagination' => $pagination,
-                'error' => __('Marketplace browsing requires a semantic OpenKOS build version.'),
+                'error' => __('Marketplace browsing requires a semantic OpenKOS platform version.'),
             ];
         }
 
@@ -318,13 +317,9 @@ class PluginManagementService
     /** @return array{0: string, 1: string, 2: string}|null */
     private function marketplaceHostVersions(): ?array
     {
-        $versions = [
-            $this->buildInfo->toArray()['version'] ?? null,
-            config('platform.version'),
-            PHP_VERSION,
-        ];
+        $versions = [config('platform.version'), PHP_VERSION];
 
-        if (! is_string($versions[0]) || ! is_string($versions[1]) || ! is_string($versions[2])) {
+        if (! is_string($versions[0]) || ! is_string($versions[1])) {
             return null;
         }
 
@@ -334,7 +329,7 @@ class PluginManagementService
             }
         }
 
-        return [$versions[0], $versions[1], $versions[2]];
+        return [$versions[0], $versions[0], $versions[1]];
     }
 
     /** @param array<string, mixed> $record @param array<string, mixed>|null $compatible @param array<string, mixed>|null $local @return array<string, mixed> */
@@ -384,7 +379,7 @@ class PluginManagementService
             || ! is_string($versionMetadata['entry_class'] ?? null)
             || ! is_array($versionMetadata['dependencies'] ?? null)
             || ! is_array($versionMetadata['manifest'] ?? null)
-            || ! is_string($compatibility['openkos'] ?? null)
+            || ! is_string($compatibility['core'] ?? null)
             || ! is_string($compatibility['platform'] ?? null)
             || ! is_string($compatibility['php'] ?? null)
         ) {
@@ -413,7 +408,7 @@ class PluginManagementService
                 expectedCurrentState: $expectedCurrentState,
                 expectedMetadata: [
                     'entry_class' => $versionMetadata['entry_class'],
-                    'core_version' => $compatibility['openkos'],
+                    'core_version' => $compatibility['core'],
                     'platform_constraint' => $compatibility['platform'],
                     'php' => $compatibility['php'],
                     'dependencies' => $versionMetadata['dependencies'],

--- a/resources/js/types/platform.ts
+++ b/resources/js/types/platform.ts
@@ -69,7 +69,7 @@ export type MarketplaceVersion = {
     version: string;
     entry_class: string;
     compatibility: {
-        openkos: string;
+        core: string;
         platform: string;
         php: string;
     };

--- a/tests/Feature/PluginSettingsTest.php
+++ b/tests/Feature/PluginSettingsTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use App\Models\User;
-use App\Services\Platform\BuildInfo;
 use App\Services\Platform\PluginInstaller;
 use App\Services\Platform\RuntimePluginDiscovery;
 use App\Services\Platform\RuntimePluginGraphValidator;
@@ -39,7 +38,6 @@ afterEach(function (): void {
         'app.build.version' => $this->originalBuildVersion,
         'platform.version' => $this->originalPlatformVersion,
     ]);
-    app()->forgetInstance(BuildInfo::class);
 });
 
 it('redirects guests and forbids non-owners from plugin management', function (): void {
@@ -856,6 +854,32 @@ it('lists marketplace plugins with the latest compatible version', function (): 
         ->assertJsonPath('plugins.0.latest_compatible_version.version', '1.0.0')
         ->assertJsonPath('plugins.0.compatible', true);
     Http::assertSentCount(2);
+    Http::assertSent(function (Request $request): bool {
+        if (! str_ends_with((string) parse_url($request->url(), PHP_URL_PATH), '/versions/resolve')) {
+            return false;
+        }
+
+        parse_str((string) parse_url($request->url(), PHP_URL_QUERY), $query);
+
+        return ($query['core_version'] ?? null) === '0.2.5'
+            && ($query['platform_version'] ?? null) === '0.2.5';
+    });
+});
+
+it('accepts legacy marketplace compatibility metadata', function (): void {
+    configureMarketplaceForTests();
+    $artifact = makePluginSettingsArtifact(['version' => '1.0.0']);
+    $metadata = marketplaceVersionMetadata($artifact, '1.0.0');
+    $metadata['compatibility']['openkos'] = $metadata['compatibility']['core'];
+    unset($metadata['compatibility']['core']);
+    fakeMarketplace($artifact, ['1.0.0' => $metadata], '1.0.0');
+
+    $this->actingAs(User::factory()->owner()->create())
+        ->post(route('settings.plugins.marketplace.install'), [
+            'plugin_id' => $artifact['id'],
+            'version' => '1.0.0',
+        ])
+        ->assertRedirect(route('settings.plugins.index'));
 });
 
 it('installs an exact marketplace artifact with verified provenance', function (): void {
@@ -1274,11 +1298,10 @@ function makePluginSettingsArtifact(array $overrides = []): array
 function configureMarketplaceForTests(): void
 {
     config([
-        'app.build.version' => '0.2.3',
-        'platform.version' => '0.2.3',
+        'app.build.version' => '0.1.0-alpha.6',
+        'platform.version' => '0.2.5',
         'services.marketplace.url' => 'https://marketplace.test',
     ]);
-    app()->forgetInstance(BuildInfo::class);
 }
 
 /** @return array<string, mixed> */
@@ -1303,7 +1326,7 @@ function marketplaceVersionMetadata(array $artifact, string $version): array
         'version' => $version,
         'entry_class' => $artifact['class'],
         'compatibility' => [
-            'openkos' => '^0.2',
+            'core' => '^0.2',
             'platform' => '^0.2',
             'php' => '^8.3',
         ],


### PR DESCRIPTION
## Summary

This fixes Marketplace compatibility resolution for OpenKOS releases where the product version and platform version follow different version lines.

## Changes

- Resolve plugin core compatibility against `openkos/platform`, not the product build version.
- Send canonical `core_version` compatibility data to the Marketplace API.
- Accept the legacy `openkos_version` Marketplace response field during migration.
- Keep the product build version independent from plugin runtime compatibility.
- Add regression coverage for OpenKOS `0.1.0-alpha.6` with platform `0.2.5`.

## Related issue

OPE-172

Companion Marketplace API PR: https://github.com/senatroxx/openkos-marketplace-api/pull/1

## Verification

- [ ] `php artisan test --compact` (full suite)
- [ ] `npm run lint:check`
- [ ] `npm run format:check`
- [x] `npm run types:check`
- [x] `vendor/bin/pint --dirty --format agent`
- [x] `php artisan test --compact tests/Feature/PluginSettingsTest.php` (45 tests, 485 assertions)

## Additional notes

- No database migrations or plugin artifact republishing are required.
- Existing Marketplace compatibility metadata remains readable through the legacy field fallback.
- The Marketplace API companion change should be deployed with or before this OpenKOS change.