### PR TITLE
feat(expenses): add expense tracking

### DIFF
--- a/app/Business/Dashboard/OverviewStatsCalculator.php
+++ b/app/Business/Dashboard/OverviewStatsCalculator.php
@@ -4,6 +4,7 @@ namespace App\Business\Dashboard;
 
 use App\Enums\InvoiceStatus;
 use App\Enums\LeaseStatus;
+use App\Models\Expense;
 use App\Models\Invoice;
 use App\Models\Payment;
 use Brick\Math\BigDecimal;
@@ -80,6 +81,57 @@ class OverviewStatsCalculator
             'monthly_potential' => $monthlyPotential,
             'outstanding' => $outstanding,
             'collection_rate' => $collectionRate,
+        ];
+    }
+
+    /**
+     * @param  Collection<int, int>  $accessiblePropertyIds
+     * @return array{this_month: array<int, array{currency: string, amount: string}>, last_month: array<int, array{currency: string, amount: string}>, change_vs_last_month: array<int, array{currency: string, amount: string}>}
+     */
+    public function computeExpenses(Collection $accessiblePropertyIds): array
+    {
+        $thisMonthStart = now()->startOfMonth();
+        $lastMonthStart = $thisMonthStart->copy()->subMonthNoOverflow();
+        $expenses = Expense::query()
+            ->active()
+            ->whereIn('property_id', $accessiblePropertyIds)
+            ->whereBetween('expense_date', [
+                $lastMonthStart->toDateString(),
+                $thisMonthStart->copy()->endOfMonth()->toDateString(),
+            ])
+            ->get(['amount', 'currency', 'expense_date']);
+
+        $thisMonth = $this->aggregate(
+            $expenses->filter(fn (Expense $expense): bool => $expense->expense_date->betweenIncluded($thisMonthStart, $thisMonthStart->copy()->endOfMonth())
+            ),
+            fn (Expense $expense): string => (string) $expense->amount,
+        );
+        $lastMonth = $this->aggregate(
+            $expenses->filter(fn (Expense $expense): bool => $expense->expense_date->betweenIncluded($lastMonthStart, $thisMonthStart->copy()->subDay())
+            ),
+            fn (Expense $expense): string => (string) $expense->amount,
+        );
+
+        $currencies = collect([...$thisMonth, ...$lastMonth])
+            ->pluck('currency')
+            ->unique()
+            ->sort()
+            ->values();
+        $thisMonth = $this->completeAmountGroups($thisMonth, $currencies);
+        $lastMonth = $this->completeAmountGroups($lastMonth, $currencies);
+        $thisMonthByCurrency = collect($thisMonth)->keyBy('currency');
+        $lastMonthByCurrency = collect($lastMonth)->keyBy('currency');
+        $change = $currencies->map(fn (string $currency): array => [
+            'currency' => $currency,
+            'amount' => BigDecimal::of($thisMonthByCurrency->get($currency)['amount'])
+                ->minus($lastMonthByCurrency->get($currency)['amount'])
+                ->toString(),
+        ])->all();
+
+        return [
+            'this_month' => $thisMonth,
+            'last_month' => $lastMonth,
+            'change_vs_last_month' => $change,
         ];
     }
 

--- a/app/Enums/ExpenseStatus.php
+++ b/app/Enums/ExpenseStatus.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Enums;
+
+enum ExpenseStatus: string
+{
+    case Active = 'active';
+    case Voided = 'voided';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Active => 'Active',
+            self::Voided => 'Voided',
+        };
+    }
+
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+}

--- a/app/Enums/Permission.php
+++ b/app/Enums/Permission.php
@@ -52,6 +52,11 @@ enum Permission: string
     case FinancialsView = 'financials.view';
     case ReportsView = 'reports.view';
 
+    case ExpensesView = 'expenses.view';
+    case ExpensesCreate = 'expenses.create';
+    case ExpensesUpdate = 'expenses.update';
+    case ExpensesDelete = 'expenses.delete';
+
     case MaintenanceTicketsView = 'maintenance-tickets.view';
     case MaintenanceTicketsCreate = 'maintenance-tickets.create';
     case MaintenanceTicketsUpdate = 'maintenance-tickets.update';
@@ -130,6 +135,11 @@ enum Permission: string
             self::RemindersSend => 'Send rent reminders to tenants.',
             self::FinancialsView => 'View financial reports and payment data.',
             self::ReportsView => 'Access generated reports.',
+
+            self::ExpensesView => 'View operating expenses.',
+            self::ExpensesCreate => 'Record operating expenses.',
+            self::ExpensesUpdate => 'Edit operating expenses.',
+            self::ExpensesDelete => 'Void operating expenses.',
 
             self::MaintenanceTicketsView => 'View the maintenance ticket list.',
             self::MaintenanceTicketsCreate => 'Report new maintenance issues.',

--- a/app/Http/Controllers/Dashboard/OverviewController.php
+++ b/app/Http/Controllers/Dashboard/OverviewController.php
@@ -180,7 +180,10 @@ class OverviewController extends Controller
 
         $propertyTypes = PropertyType::active()->ordered()->get(['slug', 'label']);
 
-        $financeResult = $finance->computeFinance($accessibleLeases);
+        $financeResult = [
+            ...$finance->computeFinance($accessibleLeases),
+            'expenses' => $finance->computeExpenses($accessibleProperties),
+        ];
 
         return Inertia::render('dashboard/overview', [
             'attention' => $attention,

--- a/app/Http/Controllers/ExpenseController.php
+++ b/app/Http/Controllers/ExpenseController.php
@@ -16,8 +16,10 @@ use App\Services\Payments\MoneyConverter;
 use App\Tables\Column;
 use App\Tables\Filter;
 use App\Tables\Table;
+use Brick\Math\BigDecimal;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Inertia\Inertia;
@@ -62,6 +64,8 @@ class ExpenseController extends Controller
                 ),
                 Column::make('amount', 'Amount')->sortable(),
                 Column::make('status', 'Status')->sortable(),
+                Column::make('receipt', 'Receipt'),
+                Column::make('_actions', 'Actions'),
             ])
             ->filters([
                 Filter::select('property_id', 'Property', function () use ($request): array {
@@ -146,6 +150,7 @@ class ExpenseController extends Controller
 
         return Inertia::render('expenses/index', [
             ...$result,
+            'summary' => $this->expenseSummary($request),
             'properties' => $properties,
             'categories' => ExpenseCategory::ordered()->get(['id', 'slug', 'label', 'is_active']),
             'currencies' => array_keys($moneyConverter->scales()),
@@ -158,6 +163,67 @@ class ExpenseController extends Controller
                 'delete' => $request->user()->can('expenses.delete'),
             ],
         ]);
+    }
+
+    /**
+     * @return array{has_data: bool, this_month: array<int, array{currency: string, amount: string}>, last_month: array<int, array{currency: string, amount: string}>, this_month_count: int}
+     */
+    private function expenseSummary(IndexExpenseRequest $request): array
+    {
+        $scope = Expense::query()
+            ->where('status', ExpenseStatus::Active->value)
+            ->when(! $request->user()->isOwner(), fn (Builder $query) => $query->whereHas(
+                'property.users',
+                fn (Builder $userQuery) => $userQuery->whereKey($request->user()->id),
+            ));
+
+        if (! (clone $scope)->exists()) {
+            return [
+                'has_data' => false,
+                'this_month' => [],
+                'last_month' => [],
+                'this_month_count' => 0,
+            ];
+        }
+
+        $thisMonthStart = now()->startOfMonth();
+        $lastMonthStart = $thisMonthStart->copy()->subMonthNoOverflow();
+        $expenses = (clone $scope)
+            ->whereBetween('expense_date', [$lastMonthStart, $thisMonthStart->copy()->endOfMonth()])
+            ->get(['amount', 'currency', 'expense_date']);
+
+        $thisMonth = $expenses->filter(fn (Expense $expense): bool => $expense->expense_date->betweenIncluded($thisMonthStart, $thisMonthStart->copy()->endOfMonth())
+        );
+        $lastMonth = $expenses->filter(fn (Expense $expense): bool => $expense->expense_date->betweenIncluded($lastMonthStart, $thisMonthStart->copy()->subDay())
+        );
+
+        return [
+            'has_data' => true,
+            'this_month' => $this->aggregateExpenseAmounts($thisMonth),
+            'last_month' => $this->aggregateExpenseAmounts($lastMonth),
+            'this_month_count' => $thisMonth->count(),
+        ];
+    }
+
+    /**
+     * @param  Collection<int, Expense>  $expenses
+     * @return array<int, array{currency: string, amount: string}>
+     */
+    private function aggregateExpenseAmounts(Collection $expenses): array
+    {
+        return $expenses
+            ->groupBy('currency')
+            ->sortKeys()
+            ->map(function (Collection $currencyExpenses, string $currency): array {
+                $amount = $currencyExpenses->reduce(
+                    fn (BigDecimal $total, Expense $expense): BigDecimal => $total->plus((string) $expense->amount),
+                    BigDecimal::zero(),
+                );
+
+                return ['currency' => $currency, 'amount' => $amount->toString()];
+            })
+            ->values()
+            ->all();
     }
 
     public function store(StoreExpenseRequest $request, MediaManager $mediaManager): RedirectResponse

--- a/app/Http/Controllers/ExpenseController.php
+++ b/app/Http/Controllers/ExpenseController.php
@@ -1,0 +1,241 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Enums\ExpenseStatus;
+use App\Http\Requests\Expense\IndexExpenseRequest;
+use App\Http\Requests\Expense\StoreExpenseRequest;
+use App\Http\Requests\Expense\UpdateExpenseRequest;
+use App\Http\Requests\Expense\VoidExpenseRequest;
+use App\Models\Expense;
+use App\Models\ExpenseCategory;
+use App\Models\Media;
+use App\Models\Property;
+use App\Services\Media\MediaManager;
+use App\Services\Payments\MoneyConverter;
+use App\Tables\Column;
+use App\Tables\Filter;
+use App\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+use Inertia\Inertia;
+use Inertia\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class ExpenseController extends Controller
+{
+    public function index(IndexExpenseRequest $request, MoneyConverter $moneyConverter): Response
+    {
+        $table = Table::make()
+            ->columns([
+                Column::make('expense_date', 'Date')->sortable(),
+                Column::make('property_name', 'Property')
+                    ->sortable(fn (Builder $query, string $direction) => $query->orderBy(
+                        Property::select('name')->whereColumn('properties.id', 'expenses.property_id'),
+                        $direction,
+                    ))
+                    ->searchable(fn (Builder $query, string $search) => $query->orWhereHas(
+                        'property',
+                        fn (Builder $propertyQuery) => $propertyQuery->whereRaw(
+                            'lower(name) like ?',
+                            ['%'.mb_strtolower($search).'%'],
+                        ),
+                    )),
+                Column::make('category_name', 'Category')
+                    ->sortable(fn (Builder $query, string $direction) => $query->orderBy(
+                        ExpenseCategory::select('label')->whereColumn('expense_categories.id', 'expenses.expense_category_id'),
+                        $direction,
+                    ))
+                    ->searchable(fn (Builder $query, string $search) => $query->orWhereHas(
+                        'category',
+                        fn (Builder $categoryQuery) => $categoryQuery->whereRaw(
+                            'lower(label) like ?',
+                            ['%'.mb_strtolower($search).'%'],
+                        ),
+                    )),
+                Column::make('vendor', 'Vendor')->searchable(
+                    fn (Builder $query, string $search) => $query
+                        ->orWhereRaw('lower(vendor) like ?', ['%'.mb_strtolower($search).'%'])
+                        ->orWhereRaw('lower(reference) like ?', ['%'.mb_strtolower($search).'%']),
+                ),
+                Column::make('amount', 'Amount')->sortable(),
+                Column::make('status', 'Status')->sortable(),
+            ])
+            ->filters([
+                Filter::select('property_id', 'Property', function () use ($request): array {
+                    return Property::query()
+                        ->when(! $request->user()->isOwner(), fn (Builder $query) => $query->whereHas(
+                            'users',
+                            fn (Builder $userQuery) => $userQuery->whereKey($request->user()->id),
+                        ))
+                        ->orderBy('name')
+                        ->get(['id', 'name'])
+                        ->map(fn (Property $property): array => [
+                            'value' => (string) $property->id,
+                            'label' => $property->name,
+                        ])
+                        ->all();
+                })->query(fn (Builder $query, string $value) => $query->where('property_id', $value)),
+                Filter::select('category_id', 'Category', fn (): array => ExpenseCategory::ordered()
+                    ->get(['id', 'label'])
+                    ->map(fn (ExpenseCategory $category): array => [
+                        'value' => (string) $category->id,
+                        'label' => $category->label,
+                    ])
+                    ->all())->query(fn (Builder $query, string $value) => $query->where('expense_category_id', $value)),
+                Filter::select('currency', 'Currency', fn (): array => Expense::query()
+                    ->distinct()
+                    ->orderBy('currency')
+                    ->pluck('currency')
+                    ->all())->query(fn (Builder $query, string $value) => $query->where('currency', $value)),
+                Filter::select('status', 'Status', [
+                    ExpenseStatus::Active->value,
+                    ExpenseStatus::Voided->value,
+                ])->query(fn (Builder $query, string $value) => $query->where('status', $value)),
+            ])
+            ->defaultSort('-expense_date');
+
+        $statusValues = is_string($request->query('status'))
+            ? array_values(array_intersect(
+                explode(',', $request->query('status')),
+                ExpenseStatus::values(),
+            ))
+            : [];
+        $statusValues = $statusValues === [] ? [ExpenseStatus::Active->value] : $statusValues;
+        $status = implode(',', $statusValues);
+        $query = Expense::query()
+            ->with([
+                'property:id,name',
+                'category:id,slug,label,is_active',
+                'voidedByUser:id,name',
+                'media' => fn ($mediaQuery) => $mediaQuery
+                    ->where('collection', 'receipts')
+                    ->select(['id', 'mediable_type', 'mediable_id', 'collection', 'mime_type', 'size', 'original_name']),
+            ])
+            ->whereIn('status', $statusValues)
+            ->when(! $request->user()->isOwner(), fn (Builder $query) => $query->whereHas(
+                'property.users',
+                fn (Builder $userQuery) => $userQuery->whereKey($request->user()->id),
+            ))
+            ->when($request->filled('date_from'), fn (Builder $query) => $query->whereDate('expense_date', '>=', $request->string('date_from')->toString()))
+            ->when($request->filled('date_to'), fn (Builder $query) => $query->whereDate('expense_date', '<=', $request->string('date_to')->toString()));
+
+        $result = $table->paginate($query, $request, 'expenses');
+
+        foreach ($result['expenses'] as $expense) {
+            $receipt = $expense->media->first();
+            $expense->setAttribute('receipt', $receipt ? [
+                'id' => $receipt->id,
+                'original_name' => $receipt->original_name,
+                'mime_type' => $receipt->mime_type,
+                'size' => $receipt->size,
+                'download_url' => route('expenses.receipt', $expense),
+            ] : null);
+            $expense->makeHidden('media');
+        }
+
+        $properties = Property::query()
+            ->when(! $request->user()->isOwner(), fn (Builder $query) => $query->whereHas(
+                'users',
+                fn (Builder $userQuery) => $userQuery->whereKey($request->user()->id),
+            ))
+            ->orderBy('name')
+            ->get(['id', 'name']);
+
+        return Inertia::render('expenses/index', [
+            ...$result,
+            'properties' => $properties,
+            'categories' => ExpenseCategory::ordered()->get(['id', 'slug', 'label', 'is_active']),
+            'currencies' => array_keys($moneyConverter->scales()),
+            'status' => $status,
+            'date_from' => $request->query('date_from', ''),
+            'date_to' => $request->query('date_to', ''),
+            'can' => [
+                'create' => $request->user()->can('expenses.create'),
+                'update' => $request->user()->can('expenses.update'),
+                'delete' => $request->user()->can('expenses.delete'),
+            ],
+        ]);
+    }
+
+    public function store(StoreExpenseRequest $request, MediaManager $mediaManager): RedirectResponse
+    {
+        $data = $request->validated();
+        $receipt = $request->file('receipt');
+        unset($data['receipt']);
+
+        $expense = DB::transaction(function () use ($data, $receipt, $mediaManager): Expense {
+            $expense = Expense::create($data);
+
+            if ($receipt !== null) {
+                $mediaManager->store($expense, 'receipts', $receipt);
+            }
+
+            return $expense;
+        });
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Expense recorded.')]);
+
+        return back();
+    }
+
+    public function update(UpdateExpenseRequest $request, Expense $expense, MediaManager $mediaManager): RedirectResponse
+    {
+        abort_if($expense->isVoided(), 403);
+        $this->authorize('update', $expense);
+
+        $data = $request->validated();
+        $receipt = $request->file('receipt');
+        $removeReceipt = (bool) ($data['remove_receipt'] ?? false);
+        unset($data['receipt'], $data['remove_receipt']);
+
+        DB::transaction(function () use ($expense, $data, $receipt, $removeReceipt, $mediaManager): void {
+            $expense->update($data);
+            $currentReceipt = $expense->media()->where('collection', 'receipts')->first();
+
+            if ($receipt !== null && $currentReceipt instanceof Media) {
+                $mediaManager->replace($currentReceipt, $receipt);
+            } elseif ($receipt !== null) {
+                $mediaManager->store($expense, 'receipts', $receipt);
+            } elseif ($removeReceipt && $currentReceipt instanceof Media) {
+                $mediaManager->remove($currentReceipt);
+            }
+        });
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Expense updated.')]);
+
+        return back();
+    }
+
+    public function destroy(VoidExpenseRequest $request, Expense $expense): RedirectResponse
+    {
+        abort_if($expense->isVoided(), 403);
+        $this->authorize('delete', $expense);
+
+        $expense->update([
+            'status' => ExpenseStatus::Voided,
+            'voided_at' => now(),
+            'voided_by' => $request->user()->id,
+            'void_reason' => $request->validated('reason'),
+        ]);
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Expense voided.')]);
+
+        return back();
+    }
+
+    public function receipt(Expense $expense): StreamedResponse
+    {
+        $this->authorize('view', $expense);
+
+        $media = $expense->media()->where('collection', 'receipts')->firstOrFail();
+        $storage = Storage::disk($media->disk);
+        abort_unless($storage->exists($media->path), 404);
+
+        return $storage->response($media->path, $media->original_name, [
+            'Content-Type' => $media->mime_type,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Settings/ExpenseCategoryController.php
+++ b/app/Http/Controllers/Settings/ExpenseCategoryController.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Http\Controllers\Settings;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Settings\StoreExpenseCategoryRequest;
+use App\Http\Requests\Settings\UpdateExpenseCategoryRequest;
+use App\Models\ExpenseCategory;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Str;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class ExpenseCategoryController extends Controller
+{
+    public function index(): Response
+    {
+        return Inertia::render('settings/expense-categories', [
+            'categories' => ExpenseCategory::ordered()
+                ->withCount('expenses')
+                ->get(['id', 'slug', 'label', 'is_active', 'sort_order']),
+        ]);
+    }
+
+    public function store(StoreExpenseCategoryRequest $request): RedirectResponse
+    {
+        $data = $request->validated();
+
+        ExpenseCategory::create([
+            'slug' => $this->uniqueSlug($data['label']),
+            'label' => $data['label'],
+            'is_active' => $data['is_active'] ?? true,
+            'sort_order' => (int) ExpenseCategory::max('sort_order') + 1,
+        ]);
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Expense category added.')]);
+
+        return back();
+    }
+
+    public function update(UpdateExpenseCategoryRequest $request, ExpenseCategory $expenseCategory): RedirectResponse
+    {
+        $expenseCategory->update($request->validated());
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Expense category updated.')]);
+
+        return back();
+    }
+
+    public function destroy(ExpenseCategory $expenseCategory): RedirectResponse
+    {
+        if ($expenseCategory->expenses()->exists()) {
+            $expenseCategory->update(['is_active' => false]);
+            Inertia::flash('toast', ['type' => 'success', 'message' => __('Expense category archived.')]);
+
+            return back();
+        }
+
+        $expenseCategory->delete();
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Expense category deleted.')]);
+
+        return back();
+    }
+
+    private function uniqueSlug(string $label): string
+    {
+        $base = Str::slug($label, '_');
+        $slug = $base;
+        $counter = 1;
+
+        while (ExpenseCategory::where('slug', $slug)->exists()) {
+            $slug = $base.'_'.++$counter;
+        }
+
+        return $slug;
+    }
+}

--- a/app/Http/Requests/Expense/IndexExpenseRequest.php
+++ b/app/Http/Requests/Expense/IndexExpenseRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Expense;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class IndexExpenseRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('expenses.view') ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'date_from' => ['nullable', 'date'],
+            'date_to' => ['nullable', 'date', 'after_or_equal:date_from'],
+        ];
+    }
+}

--- a/app/Http/Requests/Expense/StoreExpenseRequest.php
+++ b/app/Http/Requests/Expense/StoreExpenseRequest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Http\Requests\Expense;
+
+use App\Models\Property;
+use App\Rules\MoneyAmount;
+use App\Services\Payments\MoneyConverter;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreExpenseRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('expenses.create') ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'property_id' => [
+                'required',
+                'integer',
+                Rule::exists('properties', 'id'),
+                function (string $attribute, mixed $value, \Closure $fail): void {
+                    if ($this->user()->isOwner()) {
+                        return;
+                    }
+
+                    if (! Property::query()
+                        ->whereKey($value)
+                        ->whereHas('users', fn ($query) => $query->whereKey($this->user()->id))
+                        ->exists()) {
+                        $fail(__('You do not have access to this property.'));
+                    }
+                },
+            ],
+            'expense_category_id' => [
+                'required',
+                'integer',
+                Rule::exists('expense_categories', 'id')->where('is_active', true),
+            ],
+            'amount' => [
+                'required',
+                new MoneyAmount($this->input('currency'), allowZero: false),
+            ],
+            'currency' => [
+                'required',
+                'string',
+                'size:3',
+                Rule::in(array_keys(app(MoneyConverter::class)->scales())),
+            ],
+            'expense_date' => ['required', 'date'],
+            'vendor' => ['nullable', 'string', 'max:255'],
+            'description' => ['nullable', 'string', 'max:65535'],
+            'notes' => ['nullable', 'string', 'max:65535'],
+            'reference' => ['nullable', 'string', 'max:255'],
+            'receipt' => ['nullable', 'file', 'max:10240', 'mimes:jpg,jpeg,png,pdf'],
+        ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        if ($this->filled('currency')) {
+            $this->merge(['currency' => strtoupper((string) $this->input('currency'))]);
+        }
+    }
+}

--- a/app/Http/Requests/Expense/UpdateExpenseRequest.php
+++ b/app/Http/Requests/Expense/UpdateExpenseRequest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Requests\Expense;
+
+use App\Models\Expense;
+use App\Models\Property;
+use App\Rules\MoneyAmount;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateExpenseRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $expense = $this->route('expense');
+
+        return $expense instanceof Expense
+            && ! $expense->isVoided()
+            && ($this->user()?->can('update', $expense) ?? false);
+    }
+
+    public function rules(): array
+    {
+        $expense = $this->route('expense');
+
+        return [
+            'property_id' => [
+                'required',
+                'integer',
+                Rule::exists('properties', 'id'),
+                function (string $attribute, mixed $value, \Closure $fail): void {
+                    if ($this->user()->isOwner()) {
+                        return;
+                    }
+
+                    if (! Property::query()
+                        ->whereKey($value)
+                        ->whereHas('users', fn ($query) => $query->whereKey($this->user()->id))
+                        ->exists()) {
+                        $fail(__('You do not have access to this property.'));
+                    }
+                },
+            ],
+            'expense_category_id' => ['required', 'integer', Rule::exists('expense_categories', 'id')],
+            'amount' => [
+                'required',
+                new MoneyAmount($expense instanceof Expense ? (string) $expense->currency : null, allowZero: false),
+            ],
+            'expense_date' => ['required', 'date'],
+            'vendor' => ['nullable', 'string', 'max:255'],
+            'description' => ['nullable', 'string', 'max:65535'],
+            'notes' => ['nullable', 'string', 'max:65535'],
+            'reference' => ['nullable', 'string', 'max:255'],
+            'receipt' => ['nullable', 'file', 'max:10240', 'mimes:jpg,jpeg,png,pdf'],
+            'remove_receipt' => ['nullable', 'boolean'],
+        ];
+    }
+}

--- a/app/Http/Requests/Expense/VoidExpenseRequest.php
+++ b/app/Http/Requests/Expense/VoidExpenseRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests\Expense;
+
+use App\Models\Expense;
+use Illuminate\Foundation\Http\FormRequest;
+
+class VoidExpenseRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $expense = $this->route('expense');
+
+        return $expense instanceof Expense
+            && ! $expense->isVoided()
+            && ($this->user()?->can('delete', $expense) ?? false);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'reason' => ['nullable', 'string', 'max:65535'],
+        ];
+    }
+}

--- a/app/Http/Requests/Settings/StoreExpenseCategoryRequest.php
+++ b/app/Http/Requests/Settings/StoreExpenseCategoryRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests\Settings;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreExpenseCategoryRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->isOwner() ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'label' => ['required', 'string', 'max:255', Rule::unique('expense_categories', 'label')],
+            'is_active' => ['nullable', 'boolean'],
+        ];
+    }
+}

--- a/app/Http/Requests/Settings/UpdateExpenseCategoryRequest.php
+++ b/app/Http/Requests/Settings/UpdateExpenseCategoryRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Requests\Settings;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateExpenseCategoryRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->isOwner() ?? false;
+    }
+
+    public function rules(): array
+    {
+        $category = $this->route('expenseCategory');
+
+        return [
+            'label' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique('expense_categories', 'label')->ignore($category?->id),
+            ],
+            'is_active' => ['nullable', 'boolean'],
+        ];
+    }
+}

--- a/app/Models/Expense.php
+++ b/app/Models/Expense.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\Auditable;
+use App\Concerns\HasMedia;
+use App\Concerns\SerializesDatesWithTimezone;
+use App\Enums\ExpenseStatus;
+use App\Services\Payments\MoneyConverter;
+use Database\Factories\ExpenseFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use LogicException;
+
+#[Fillable([
+    'property_id',
+    'expense_category_id',
+    'amount',
+    'currency',
+    'expense_date',
+    'vendor',
+    'description',
+    'notes',
+    'reference',
+    'status',
+    'voided_at',
+    'voided_by',
+    'void_reason',
+])]
+class Expense extends Model
+{
+    /** @use HasFactory<ExpenseFactory> */
+    use Auditable, HasFactory, HasMedia, SerializesDatesWithTimezone;
+
+    protected $attributes = [
+        'status' => ExpenseStatus::Active->value,
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'amount' => 'decimal:3',
+            'expense_date' => 'date:Y-m-d',
+            'status' => ExpenseStatus::class,
+            'voided_at' => 'datetime',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::creating(function (Expense $expense): void {
+            $converter = app(MoneyConverter::class);
+            $expense->currency = $converter->normalizeCurrency($expense->currency);
+            $expense->amount = $converter->normalizeAmount((string) $expense->amount, $expense->currency);
+        });
+
+        static::updating(function (Expense $expense): void {
+            if ($expense->getRawOriginal('status') === ExpenseStatus::Voided->value) {
+                throw new LogicException('Voided expenses are immutable.');
+            }
+
+            if ($expense->isDirty('currency')) {
+                throw new LogicException('Expense currency snapshots are immutable.');
+            }
+
+            if ($expense->isDirty('amount')) {
+                $expense->amount = app(MoneyConverter::class)->normalizeAmount(
+                    (string) $expense->amount,
+                    (string) $expense->currency,
+                );
+            }
+        });
+    }
+
+    public function property(): BelongsTo
+    {
+        return $this->belongsTo(Property::class);
+    }
+
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(ExpenseCategory::class, 'expense_category_id');
+    }
+
+    public function voidedByUser(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'voided_by');
+    }
+
+    public function scopeActive(Builder $query): void
+    {
+        $query->where('status', ExpenseStatus::Active->value);
+    }
+
+    public function scopeVoided(Builder $query): void
+    {
+        $query->where('status', ExpenseStatus::Voided->value);
+    }
+
+    public function isVoided(): bool
+    {
+        return $this->status === ExpenseStatus::Voided;
+    }
+}

--- a/app/Models/ExpenseCategory.php
+++ b/app/Models/ExpenseCategory.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\Auditable;
+use App\Concerns\SerializesDatesWithTimezone;
+use Database\Factories\ExpenseCategoryFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+#[Fillable([
+    'slug',
+    'label',
+    'is_active',
+    'sort_order',
+])]
+class ExpenseCategory extends Model
+{
+    /** @use HasFactory<ExpenseCategoryFactory> */
+    use Auditable, HasFactory, SerializesDatesWithTimezone;
+
+    protected function casts(): array
+    {
+        return [
+            'is_active' => 'boolean',
+        ];
+    }
+
+    public function getRouteKeyName(): string
+    {
+        return 'slug';
+    }
+
+    public function expenses(): HasMany
+    {
+        return $this->hasMany(Expense::class);
+    }
+
+    public function scopeActive(Builder $query): void
+    {
+        $query->where('is_active', true);
+    }
+
+    public function scopeOrdered(Builder $query): void
+    {
+        $query->orderBy('sort_order')->orderBy('label');
+    }
+}

--- a/app/Policies/ExpensePolicy.php
+++ b/app/Policies/ExpensePolicy.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Expense;
+use App\Models\User;
+
+class ExpensePolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return $user->can('expenses.view');
+    }
+
+    public function view(User $user, Expense $expense): bool
+    {
+        return $user->can('expenses.view')
+            && $user->canAccessProperty($expense->property_id);
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->can('expenses.create');
+    }
+
+    public function update(User $user, Expense $expense): bool
+    {
+        return ! $expense->isVoided()
+            && $user->can('expenses.update')
+            && $user->canAccessProperty($expense->property_id);
+    }
+
+    public function delete(User $user, Expense $expense): bool
+    {
+        return ! $expense->isVoided()
+            && $user->can('expenses.delete')
+            && $user->canAccessProperty($expense->property_id);
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Enums\Role;
+use App\Models\Expense;
 use App\Models\Invoice;
 use App\Models\Lease;
 use App\Models\MaintenanceTicket;
@@ -10,6 +11,7 @@ use App\Models\Payment;
 use App\Models\Property;
 use App\Models\Tenant;
 use App\Models\Unit;
+use App\Policies\ExpensePolicy;
 use App\Policies\InvoicePolicy;
 use App\Policies\LeasePolicy;
 use App\Policies\MaintenanceTicketPolicy;
@@ -29,6 +31,7 @@ class AuthServiceProvider extends ServiceProvider
         Lease::class => LeasePolicy::class,
         Invoice::class => InvoicePolicy::class,
         Payment::class => PaymentPolicy::class,
+        Expense::class => ExpensePolicy::class,
         MaintenanceTicket::class => MaintenanceTicketPolicy::class,
     ];
 

--- a/app/Support/RecommendedRoles.php
+++ b/app/Support/RecommendedRoles.php
@@ -39,6 +39,10 @@ class RecommendedRoles
                     Permission::LeasesMoveOut->value,
                     Permission::FinancialsView->value,
                     Permission::ReportsView->value,
+                    Permission::ExpensesView->value,
+                    Permission::ExpensesCreate->value,
+                    Permission::ExpensesUpdate->value,
+                    Permission::ExpensesDelete->value,
                     Permission::UsersView->value,
                     Permission::UsersUpdate->value,
                 ],
@@ -63,6 +67,7 @@ class RecommendedRoles
                 'permissions' => [
                     Permission::DashboardView->value,
                     Permission::FinancialsView->value,
+                    Permission::ExpensesView->value,
                     Permission::TenantsView->value,
                     Permission::TenantsExport->value,
                 ],

--- a/database/factories/ExpenseCategoryFactory.php
+++ b/database/factories/ExpenseCategoryFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ExpenseCategory;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ExpenseCategory>
+ */
+class ExpenseCategoryFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'slug' => fake()->unique()->slug(),
+            'label' => fake()->unique()->words(2, true),
+            'is_active' => true,
+            'sort_order' => 0,
+        ];
+    }
+}

--- a/database/factories/ExpenseFactory.php
+++ b/database/factories/ExpenseFactory.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\ExpenseStatus;
+use App\Models\Expense;
+use App\Models\ExpenseCategory;
+use App\Models\Property;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Expense>
+ */
+class ExpenseFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'property_id' => Property::factory(),
+            'expense_category_id' => ExpenseCategory::factory(),
+            'amount' => '100.00',
+            'currency' => 'IDR',
+            'expense_date' => now()->toDateString(),
+            'vendor' => fake()->company(),
+            'description' => fake()->sentence(),
+            'notes' => null,
+            'reference' => fake()->bothify('EXP-####'),
+            'status' => ExpenseStatus::Active,
+            'voided_at' => null,
+            'voided_by' => null,
+            'void_reason' => null,
+        ];
+    }
+
+    public function voided(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => ExpenseStatus::Voided,
+            'voided_at' => now(),
+            'void_reason' => 'Duplicate entry',
+        ]);
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -87,6 +87,10 @@ class UserFactory extends Factory
                 Permission::PaymentsCreate->value,
                 Permission::FinancialsView->value,
                 Permission::ReportsView->value,
+                Permission::ExpensesView->value,
+                Permission::ExpensesCreate->value,
+                Permission::ExpensesUpdate->value,
+                Permission::ExpensesDelete->value,
                 Permission::UsersView->value,
                 Permission::UsersUpdate->value,
             ]);

--- a/database/migrations/2026_09_09_034931_create_expense_categories_table.php
+++ b/database/migrations/2026_09_09_034931_create_expense_categories_table.php
@@ -1,0 +1,61 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('expense_categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('slug')->unique();
+            $table->string('label');
+            $table->boolean('is_active')->default(true);
+            $table->unsignedInteger('sort_order')->default(0);
+            $table->timestamps();
+
+            $table->index(['is_active', 'sort_order']);
+        });
+
+        $now = now();
+        $defaults = [
+            'maintenance' => 'Maintenance',
+            'utilities' => 'Utilities',
+            'repairs' => 'Repairs',
+            'supplies' => 'Supplies',
+            'insurance' => 'Insurance',
+            'taxes' => 'Taxes',
+            'cleaning' => 'Cleaning',
+            'other' => 'Other',
+        ];
+
+        $sortOrder = 0;
+
+        foreach ($defaults as $slug => $label) {
+            DB::table('expense_categories')->insertOrIgnore([
+                'slug' => $slug,
+                'label' => $label,
+                'is_active' => true,
+                'sort_order' => $sortOrder,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+
+            $sortOrder++;
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('expense_categories');
+    }
+};

--- a/database/migrations/2026_09_09_034932_create_expenses_table.php
+++ b/database/migrations/2026_09_09_034932_create_expenses_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('expenses', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('property_id')->constrained()->restrictOnDelete();
+            $table->foreignId('expense_category_id')->constrained()->restrictOnDelete();
+            $table->decimal('amount', 20, 3);
+            $table->char('currency', 3);
+            $table->date('expense_date');
+            $table->string('vendor')->nullable();
+            $table->text('description')->nullable();
+            $table->text('notes')->nullable();
+            $table->string('reference')->nullable();
+            $table->string('status')->default('active');
+            $table->timestamp('voided_at')->nullable();
+            $table->foreignId('voided_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->text('void_reason')->nullable();
+            $table->timestamps();
+
+            $table->index(['property_id', 'expense_date']);
+            $table->index(['expense_category_id', 'expense_date']);
+            $table->index(['status', 'expense_date']);
+            $table->index('currency');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('expenses');
+    }
+};

--- a/resources/js/components/data-table/filter-bar.tsx
+++ b/resources/js/components/data-table/filter-bar.tsx
@@ -26,6 +26,12 @@ type FilterBarProps = {
     onToggleOption: (key: string, value: string) => void;
     onClearAll: () => void;
     searchInput: ReactNode;
+    additionalFilters?: ReactNode;
+    additionalFilterChips?: Array<{
+        key: string;
+        display: string;
+        onRemove: () => void;
+    }>;
 };
 
 function optLabel(filter: TableFilterMeta, value: string): string | undefined {
@@ -127,6 +133,8 @@ export function FilterBar({
     onToggleOption,
     onClearAll,
     searchInput,
+    additionalFilters,
+    additionalFilterChips = [],
 }: FilterBarProps) {
     const [open, setOpen] = useState(false);
 
@@ -138,14 +146,14 @@ export function FilterBar({
 
             return values.map((v) => ({
                 key: `${key}-${v}`,
-                filterKey: key,
-                value: v,
                 display: filter
                     ? `${t(label)}: ${t(optLabel(filter, v) ?? v)}`
                     : `${label}: ${v}`,
+                onRemove: () => onToggleOption(key, v),
             }));
         },
     );
+    filterChips.push(...additionalFilterChips);
 
     const selectedValues = (key: string): string[] =>
         activeFilters[key] ? activeFilters[key].split(',') : [];
@@ -243,6 +251,7 @@ export function FilterBar({
 
                             return null;
                         })}
+                        {additionalFilters}
                     </div>
                 </div>
             )}
@@ -260,12 +269,7 @@ export function FilterBar({
                                 <button
                                     type="button"
                                     aria-label={`${t('Remove')} ${chip.display} ${t('filter')}`}
-                                    onClick={() =>
-                                        onToggleOption(
-                                            chip.filterKey,
-                                            chip.value,
-                                        )
-                                    }
+                                    onClick={chip.onRemove}
                                     className="ml-0.5 hover:text-foreground"
                                 >
                                     <X className="size-3" />

--- a/resources/js/components/features/app/app-sidebar.tsx
+++ b/resources/js/components/features/app/app-sidebar.tsx
@@ -6,6 +6,7 @@ import {
     Landmark,
     LayoutGrid,
     Receipt,
+    ReceiptText,
     Shield,
     Tags,
     UserCog,
@@ -28,6 +29,7 @@ import {
 import { platformNavItems, platformPageNavItems } from '@/lib/platform';
 import { dashboard } from '@/routes';
 import { rent as dashboardRent } from '@/routes/dashboard';
+import expenses from '@/routes/expenses';
 import leases from '@/routes/leases';
 import maintenanceTickets from '@/routes/maintenance-tickets';
 import { dashboard as portalDashboard } from '@/routes/portal';
@@ -35,6 +37,7 @@ import { index as portalBilling } from '@/routes/portal/billing';
 import { index as portalLease } from '@/routes/portal/lease';
 import properties from '@/routes/properties';
 import roles from '@/routes/roles';
+import expenseCategories from '@/routes/settings/expense-categories';
 import propertyTypes from '@/routes/settings/property-types';
 import tenants from '@/routes/tenants';
 import userRoutes from '@/routes/users';
@@ -126,7 +129,8 @@ export function AppSidebar() {
                   : []),
               ...(isOwner ||
               permissions.includes('dashboard.view') ||
-              permissions.includes('maintenance-tickets.view')
+              permissions.includes('maintenance-tickets.view') ||
+              permissions.includes('expenses.view')
                   ? [
                         {
                             title: 'DAILY OPERATIONS',
@@ -148,6 +152,31 @@ export function AppSidebar() {
                                               title: 'Maintenance',
                                               href: maintenanceTickets.index(),
                                               icon: Wrench,
+                                          },
+                                      ]
+                                    : []),
+                                ...(isOwner ||
+                                permissions.includes('expenses.view')
+                                    ? [
+                                          {
+                                              title: 'Expenses',
+                                              icon: ReceiptText,
+                                              children: [
+                                                  {
+                                                      title: 'All Expenses',
+                                                      href: expenses.index(),
+                                                      icon: ReceiptText,
+                                                  },
+                                                  ...(isOwner
+                                                      ? [
+                                                            {
+                                                                title: 'Expense Categories',
+                                                                href: expenseCategories.index(),
+                                                                icon: Tags,
+                                                            },
+                                                        ]
+                                                      : []),
+                                              ],
                                           },
                                       ]
                                     : []),

--- a/resources/js/components/features/app/app-sidebar.tsx
+++ b/resources/js/components/features/app/app-sidebar.tsx
@@ -11,6 +11,7 @@ import {
     Tags,
     UserCog,
     Users,
+    WalletCards,
     Wrench,
 } from 'lucide-react';
 import AppLogo from '@/components/features/app/app-logo';
@@ -160,7 +161,7 @@ export function AppSidebar() {
                                     ? [
                                           {
                                               title: 'Expenses',
-                                              icon: ReceiptText,
+                                              icon: WalletCards,
                                               children: [
                                                   {
                                                       title: 'All Expenses',

--- a/resources/js/components/features/dashboard/business-health-panel.tsx
+++ b/resources/js/components/features/dashboard/business-health-panel.tsx
@@ -90,7 +90,7 @@ export function BusinessHealthPanel({ finance }: { finance: Finance }) {
     return (
         <section className="mb-10 flex flex-col gap-3">
             <h2 className="text-xs font-semibold tracking-wider text-muted-foreground uppercase">
-                {t('Business Health')}
+                {t('Revenue & Collections')}
             </h2>
             <div className="rounded-xl border border-border bg-card p-6 shadow-xs">
                 <div className="grid gap-3 divide-y divide-border sm:grid-cols-2 sm:gap-4 sm:divide-x sm:divide-y-0 xl:grid-cols-4">

--- a/resources/js/components/features/dashboard/currency-amount-list.tsx
+++ b/resources/js/components/features/dashboard/currency-amount-list.tsx
@@ -6,18 +6,36 @@ type CurrencyAmountListProps = {
     groups: MoneyAggregate[];
     amountClassName?: string;
     className?: string;
+    compact?: boolean;
 };
+
+function formatCompactAmount(group: MoneyAggregate): string {
+    const formatted = formatPrice(group.amount, group.currency);
+
+    return formatted.replace(new RegExp(`^${group.currency}\\s*`), '');
+}
 
 export function CurrencyAmountList({
     groups,
     amountClassName,
     className,
+    compact = false,
 }: CurrencyAmountListProps) {
     if (groups.length === 0) {
-        return <span className={cn(className, amountClassName)}>—</span>;
+        return (
+            <span
+                className={cn(
+                    compact && 'text-sm font-semibold tabular-nums',
+                    className,
+                    amountClassName,
+                )}
+            >
+                —
+            </span>
+        );
     }
 
-    if (groups.length === 1) {
+    if (groups.length === 1 && !compact) {
         return (
             <span className={cn(className, amountClassName)}>
                 {formatPrice(groups[0].amount, groups[0].currency)}
@@ -37,11 +55,15 @@ export function CurrencyAmountList({
                     </span>
                     <span
                         className={cn(
-                            'min-w-0 text-right text-sm leading-tight font-bold break-words tabular-nums sm:text-base',
+                            compact
+                                ? 'ml-auto min-w-0 text-right text-xs leading-tight font-semibold whitespace-nowrap tabular-nums sm:text-sm'
+                                : 'min-w-0 text-right text-sm leading-tight font-bold break-words tabular-nums sm:text-base',
                             amountClassName,
                         )}
                     >
-                        {formatPrice(group.amount, group.currency)}
+                        {compact
+                            ? formatCompactAmount(group)
+                            : formatPrice(group.amount, group.currency)}
                     </span>
                 </span>
             ))}

--- a/resources/js/components/features/dashboard/expenses-summary-panel.tsx
+++ b/resources/js/components/features/dashboard/expenses-summary-panel.tsx
@@ -1,0 +1,139 @@
+import { formatPrice } from '@/lib/formatters';
+import { t } from '@/lib/i18n';
+import { cn } from '@/lib/utils';
+import type { Finance, MoneyAggregate } from '@/types';
+import { CurrencyAmountList } from './currency-amount-list';
+
+function amountSize(formattedAmount: string): string {
+    if (formattedAmount.length > 20) {
+        return 'text-lg sm:text-xl';
+    }
+
+    if (formattedAmount.length > 14) {
+        return 'text-xl sm:text-2xl';
+    }
+
+    return 'text-2xl sm:text-3xl';
+}
+
+function moneyAmountClass(groups: MoneyAggregate[]): string {
+    const size =
+        groups.length === 1
+            ? amountSize(formatPrice(groups[0].amount, groups[0].currency))
+            : 'text-sm sm:text-base';
+
+    return cn('font-bold tabular-nums', size);
+}
+
+function ExpenseChangeList({ groups }: { groups: MoneyAggregate[] }) {
+    const amountClassName = moneyAmountClass(groups);
+
+    if (groups.length === 0) {
+        return <span className={amountClassName}>—</span>;
+    }
+
+    if (groups.length === 1) {
+        const group = groups[0];
+        const isZero = /^-?0(?:\.0+)?$/.test(group.amount);
+        const prefix = group.amount.startsWith('-') || isZero ? '' : '+';
+
+        return (
+            <span
+                className={cn(
+                    amountClassName,
+                    group.amount.startsWith('-')
+                        ? 'text-surface-green-foreground'
+                        : isZero
+                          ? 'text-foreground'
+                          : 'text-surface-red-foreground',
+                )}
+            >
+                {prefix}
+                {formatPrice(group.amount, group.currency)}
+            </span>
+        );
+    }
+
+    return (
+        <span className="flex flex-col gap-0.5">
+            {groups.map((group) => {
+                const isZero = /^-?0(?:\.0+)?$/.test(group.amount);
+                const prefix =
+                    group.amount.startsWith('-') || isZero ? '' : '+';
+
+                return (
+                    <span
+                        key={group.currency}
+                        className="flex min-w-0 items-baseline gap-3 leading-none"
+                    >
+                        <span className="w-9 shrink-0 text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+                            {group.currency}
+                        </span>
+                        <span
+                            className={cn(
+                                'min-w-0 leading-tight break-words',
+                                amountClassName,
+                                group.amount.startsWith('-')
+                                    ? 'text-surface-green-foreground'
+                                    : isZero
+                                      ? 'text-foreground'
+                                      : 'text-surface-red-foreground',
+                            )}
+                        >
+                            {prefix}
+                            {formatPrice(group.amount, group.currency)}
+                        </span>
+                    </span>
+                );
+            })}
+        </span>
+    );
+}
+
+export function ExpensesSummaryPanel({
+    expenses,
+}: {
+    expenses: Finance['expenses'];
+}) {
+    return (
+        <section className="mb-10 flex flex-col gap-3">
+            <h2 className="text-xs font-semibold tracking-wider text-muted-foreground uppercase">
+                {t('Expenses')}
+            </h2>
+            <div className="rounded-xl border border-border bg-card p-4 shadow-xs sm:p-5">
+                <div className="grid gap-3 divide-y divide-border sm:grid-cols-3 sm:gap-4 sm:divide-x sm:divide-y-0">
+                    <div className="pb-3 sm:pr-4 sm:pb-0">
+                        <p className="mb-1.5 text-xs font-medium text-muted-foreground">
+                            {t('Expenses This Month')}
+                        </p>
+                        <CurrencyAmountList
+                            groups={expenses.this_month}
+                            amountClassName={moneyAmountClass(
+                                expenses.this_month,
+                            )}
+                        />
+                    </div>
+                    <div className="border-border pt-3 pb-3 sm:px-4 sm:pt-0 sm:pb-0">
+                        <p className="mb-1.5 text-xs font-medium text-muted-foreground">
+                            {t('Expenses Last Month')}
+                        </p>
+                        <CurrencyAmountList
+                            groups={expenses.last_month}
+                            amountClassName={moneyAmountClass(
+                                expenses.last_month,
+                            )}
+                        />
+                    </div>
+                    <div className="border-border pt-3 sm:pt-0 sm:pl-4">
+                        <p className="mb-1.5 text-xs font-medium text-muted-foreground">
+                            {t('Change vs Last Month')}
+                        </p>
+                        <ExpenseChangeList
+                            groups={expenses.change_vs_last_month}
+                        />
+                    </div>
+                </div>
+            </div>
+        </section>
+    );
+}

--- a/resources/js/components/features/dashboard/index.ts
+++ b/resources/js/components/features/dashboard/index.ts
@@ -1,5 +1,6 @@
 export * from './activity-feed-item';
 export * from './business-health-panel';
 export * from './currency-amount-list';
+export * from './expenses-summary-panel';
 export * from './operational-briefing-card';
 export * from './property-overview-card';

--- a/resources/js/components/features/expenses/expense-detail-sheet.tsx
+++ b/resources/js/components/features/expenses/expense-detail-sheet.tsx
@@ -1,0 +1,266 @@
+import { router } from '@inertiajs/react';
+import { Ban, ExternalLink, FileText, Pencil } from 'lucide-react';
+import { useState } from 'react';
+import { StatusBadge } from '@/components/shared/status-badge';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import {
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetHeader,
+    SheetTitle,
+} from '@/components/ui/sheet';
+import { formatDate, formatDateTime, formatPrice } from '@/lib/formatters';
+import { t } from '@/lib/i18n';
+import expenses from '@/routes/expenses';
+import type { Expense } from '@/types';
+
+export default function ExpenseDetailSheet({
+    expense,
+    open,
+    onOpenChange,
+    canUpdate,
+    canDelete,
+    onEdit,
+}: {
+    expense: Expense | null;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    canUpdate: boolean;
+    canDelete: boolean;
+    onEdit: () => void;
+}) {
+    const [voidConfirm, setVoidConfirm] = useState(false);
+    const [reason, setReason] = useState('');
+    const [voiding, setVoiding] = useState(false);
+
+    if (!expense) {
+        return null;
+    }
+
+    const isVoided = expense.status === 'voided';
+
+    function confirmVoid() {
+        if (voiding) {
+            return;
+        }
+
+        setVoiding(true);
+
+        router.delete(expenses.destroy.url(expense!), {
+            data: { reason: reason || undefined },
+            onSuccess: () => {
+                setVoidConfirm(false);
+                setReason('');
+                onOpenChange(false);
+            },
+            onFinish: () => setVoiding(false),
+        });
+    }
+
+    return (
+        <>
+            <Sheet open={open} onOpenChange={onOpenChange}>
+                <SheetContent className="sm:max-w-lg">
+                    <SheetHeader>
+                        <SheetTitle>
+                            {expense.category?.label ?? t('Expense')}
+                        </SheetTitle>
+                        <SheetDescription>
+                            {expense.property?.name ?? t('Property expense')}
+                        </SheetDescription>
+                    </SheetHeader>
+
+                    <div className="flex flex-1 flex-col justify-between gap-6 overflow-y-auto px-4 pt-4 pb-6">
+                        <div className="space-y-6">
+                            <div className="flex items-center gap-2">
+                                <StatusBadge
+                                    domain="expense"
+                                    value={expense.status}
+                                />
+                                {expense.reference && (
+                                    <Badge variant="outline">
+                                        {expense.reference}
+                                    </Badge>
+                                )}
+                            </div>
+
+                            <section className="space-y-3 rounded-lg border bg-muted/30 p-4">
+                                <DetailRow
+                                    label={t('Amount')}
+                                    value={formatPrice(
+                                        expense.amount,
+                                        expense.currency,
+                                    )}
+                                />
+                                <DetailRow
+                                    label={t('Date')}
+                                    value={formatDate(expense.expense_date)}
+                                />
+                                <DetailRow
+                                    label={t('Property')}
+                                    value={expense.property?.name ?? '—'}
+                                />
+                                <DetailRow
+                                    label={t('Category')}
+                                    value={expense.category?.label ?? '—'}
+                                />
+                                <DetailRow
+                                    label={t('Vendor / Payee')}
+                                    value={expense.vendor ?? '—'}
+                                />
+                            </section>
+
+                            {expense.description && (
+                                <section>
+                                    <h3 className="mb-2 text-xs font-medium tracking-wider text-muted-foreground uppercase">
+                                        {t('Description')}
+                                    </h3>
+                                    <p className="text-sm whitespace-pre-wrap">
+                                        {expense.description}
+                                    </p>
+                                </section>
+                            )}
+
+                            {expense.notes && (
+                                <section>
+                                    <h3 className="mb-2 text-xs font-medium tracking-wider text-muted-foreground uppercase">
+                                        {t('Notes')}
+                                    </h3>
+                                    <p className="text-sm whitespace-pre-wrap">
+                                        {expense.notes}
+                                    </p>
+                                </section>
+                            )}
+
+                            {expense.receipt && (
+                                <section>
+                                    <h3 className="mb-2 text-xs font-medium tracking-wider text-muted-foreground uppercase">
+                                        {t('Receipt')}
+                                    </h3>
+                                    <a
+                                        href={expense.receipt.download_url}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                        className="inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm hover:bg-accent"
+                                    >
+                                        <FileText className="size-4" />
+                                        {expense.receipt.original_name}
+                                        <ExternalLink className="size-3.5" />
+                                    </a>
+                                </section>
+                            )}
+
+                            {isVoided && (
+                                <section className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-sm">
+                                    <p className="font-medium">{t('Voided')}</p>
+                                    <p className="mt-1 text-muted-foreground">
+                                        {formatDateTime(expense.voided_at)}
+                                    </p>
+                                    {expense.void_reason && (
+                                        <p className="mt-2 whitespace-pre-wrap">
+                                            {expense.void_reason}
+                                        </p>
+                                    )}
+                                </section>
+                            )}
+                        </div>
+
+                        <div className="flex flex-wrap items-center justify-end gap-2 border-t pt-3">
+                            {!isVoided && canUpdate && (
+                                <Button
+                                    type="button"
+                                    variant="outline"
+                                    onClick={onEdit}
+                                >
+                                    <Pencil className="size-3.5" />
+                                    {t('Edit')}
+                                </Button>
+                            )}
+                            {!isVoided && canDelete && (
+                                <Button
+                                    type="button"
+                                    variant="destructive"
+                                    onClick={() => setVoidConfirm(true)}
+                                >
+                                    <Ban className="size-3.5" />
+                                    {t('Void')}
+                                </Button>
+                            )}
+                        </div>
+                    </div>
+                </SheetContent>
+            </Sheet>
+
+            <Dialog
+                open={voidConfirm}
+                onOpenChange={(next) => {
+                    setVoidConfirm(next);
+
+                    if (!next) {
+                        setReason('');
+                    }
+                }}
+            >
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>{t('Void expense')}</DialogTitle>
+                        <DialogDescription>
+                            {t(
+                                'Voided expenses become read-only and stay in the audit history.',
+                            )}
+                        </DialogDescription>
+                    </DialogHeader>
+                    <div className="grid gap-2">
+                        <label
+                            htmlFor="void_reason"
+                            className="text-sm font-medium"
+                        >
+                            {t('Reason (optional)')}
+                        </label>
+                        <Input
+                            id="void_reason"
+                            value={reason}
+                            onChange={(event) => setReason(event.target.value)}
+                        />
+                    </div>
+                    <DialogFooter>
+                        <Button
+                            variant="outline"
+                            onClick={() => setVoidConfirm(false)}
+                            disabled={voiding}
+                        >
+                            {t('Cancel')}
+                        </Button>
+                        <Button
+                            variant="destructive"
+                            onClick={confirmVoid}
+                            disabled={voiding}
+                        >
+                            {t(voiding ? 'Voiding...' : 'Void expense')}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        </>
+    );
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+    return (
+        <div className="flex items-center justify-between gap-4 text-sm">
+            <span className="text-muted-foreground">{label}</span>
+            <span className="text-right font-medium">{value}</span>
+        </div>
+    );
+}

--- a/resources/js/components/features/expenses/expense-form-sheet.tsx
+++ b/resources/js/components/features/expenses/expense-form-sheet.tsx
@@ -1,6 +1,6 @@
-import { useForm } from '@inertiajs/react';
+import { useForm, usePage } from '@inertiajs/react';
 import { useState } from 'react';
-import { InputError } from '@/components/shared';
+import { InputError, SearchableSelect } from '@/components/shared';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -23,6 +23,8 @@ import { todayISO } from '@/lib/formatters';
 import { t } from '@/lib/i18n';
 import expenses from '@/routes/expenses';
 import type { Expense, ExpenseCategory } from '@/types';
+
+const OTHER_CURRENCY = '__other__';
 
 type ExpenseFormData = {
     property_id: string;
@@ -53,7 +55,52 @@ export default function ExpenseFormSheet({
     open: boolean;
     onOpenChange: (open: boolean) => void;
 }) {
+    const { setting } = usePage<{
+        setting: { currency: string; supported_currencies: string[] };
+    }>().props;
     const isEdit = Boolean(expense);
+    const currentExpenseCurrency = expense?.currency?.toUpperCase();
+    const defaultCurrency = setting.currency.toUpperCase();
+    const allCurrencies = Array.from(
+        new Set(
+            [
+                ...currencies,
+                defaultCurrency,
+                ...(currentExpenseCurrency ? [currentExpenseCurrency] : []),
+            ].map((currency) => currency.toUpperCase()),
+        ),
+    );
+    const supportedCurrencies = Array.from(
+        new Set([
+            defaultCurrency,
+            ...setting.supported_currencies.map((currency) =>
+                currency.toUpperCase(),
+            ),
+        ]),
+    ).filter((currency) => allCurrencies.includes(currency));
+    const otherCurrencies = allCurrencies
+        .filter((currency) => !supportedCurrencies.includes(currency))
+        .sort();
+    const supportedCurrencyOptions = supportedCurrencies.map((currency) => ({
+        value: currency,
+        label: currency,
+    }));
+    const otherCurrencyOptions = otherCurrencies.map((currency) => ({
+        value: currency,
+        label: currency,
+    }));
+    const currencyOptions = [
+        ...supportedCurrencyOptions,
+        ...(otherCurrencyOptions.length > 0
+            ? [{ value: OTHER_CURRENCY, label: t('Other currency') }]
+            : []),
+    ];
+    const initialOtherCurrency = Boolean(
+        currentExpenseCurrency &&
+        !supportedCurrencies.includes(currentExpenseCurrency),
+    );
+    const [isOtherCurrency, setIsOtherCurrency] =
+        useState(initialOtherCurrency);
     const [receiptName, setReceiptName] = useState<string | null>(null);
     const { data, setData, submit, reset, processing, errors } =
         useForm<ExpenseFormData>({
@@ -68,7 +115,7 @@ export default function ExpenseFormSheet({
                       .find((category) => category.is_active)
                       ?.id.toString() ?? ''),
             amount: expense?.amount ?? '',
-            currency: expense?.currency ?? currencies[0] ?? '',
+            currency: currentExpenseCurrency ?? defaultCurrency,
             expense_date: expense?.expense_date ?? todayISO(),
             vendor: expense?.vendor ?? '',
             description: expense?.description ?? '',
@@ -83,6 +130,7 @@ export default function ExpenseFormSheet({
 
         if (!next) {
             reset();
+            setIsOtherCurrency(initialOtherCurrency);
             setReceiptName(null);
         }
     }
@@ -100,6 +148,10 @@ export default function ExpenseFormSheet({
         (category) =>
             category.is_active || category.id === expense?.expense_category_id,
     );
+    const propertyOptions = properties.map((property) => ({
+        value: String(property.id),
+        label: property.name,
+    }));
 
     return (
         <Sheet
@@ -123,37 +175,28 @@ export default function ExpenseFormSheet({
 
                 <form
                     onSubmit={handleSubmit}
-                    className="flex flex-1 flex-col justify-between gap-6 overflow-y-auto px-4 pt-4 pb-6"
+                    className="flex flex-1 flex-col justify-between gap-6 overflow-x-hidden overflow-y-auto px-4 pt-4 pb-6"
                 >
                     <div className="space-y-6">
                         <div className="grid gap-2">
-                            <Label htmlFor="property_id">{t('Property')}</Label>
-                            <Select
-                                value={data.property_id}
-                                onValueChange={(value) =>
-                                    setData('property_id', value)
+                            <Label>{t('Property')}</Label>
+                            <SearchableSelect
+                                options={propertyOptions}
+                                value={data.property_id || null}
+                                onChange={(value) =>
+                                    setData(
+                                        'property_id',
+                                        value === null ? '' : String(value),
+                                    )
                                 }
-                            >
-                                <SelectTrigger id="property_id">
-                                    <SelectValue
-                                        placeholder={t('Select property')}
-                                    />
-                                </SelectTrigger>
-                                <SelectContent>
-                                    {properties.map((property) => (
-                                        <SelectItem
-                                            key={property.id}
-                                            value={String(property.id)}
-                                        >
-                                            {property.name}
-                                        </SelectItem>
-                                    ))}
-                                </SelectContent>
-                            </Select>
+                                placeholder={t('Select property...')}
+                                searchPlaceholder={t('Search property...')}
+                                emptyText={t('No properties found.')}
+                            />
                             <InputError message={errors.property_id} />
                         </div>
 
-                        <div className="grid gap-2">
+                        <div className="grid w-full gap-2">
                             <Label htmlFor="expense_category_id">
                                 {t('Category')}
                             </Label>
@@ -163,7 +206,10 @@ export default function ExpenseFormSheet({
                                     setData('expense_category_id', value)
                                 }
                             >
-                                <SelectTrigger id="expense_category_id">
+                                <SelectTrigger
+                                    id="expense_category_id"
+                                    className="w-full"
+                                >
                                     <SelectValue
                                         placeholder={t('Select category')}
                                     />
@@ -184,8 +230,8 @@ export default function ExpenseFormSheet({
                             <InputError message={errors.expense_category_id} />
                         </div>
 
-                        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                            <div className="grid gap-2">
+                        <div className="grid w-full grid-cols-1 items-start gap-4 sm:grid-cols-[2fr_1fr]">
+                            <div className="grid min-w-0 gap-2">
                                 <Label htmlFor="amount">{t('Amount')}</Label>
                                 <Input
                                     id="amount"
@@ -202,31 +248,56 @@ export default function ExpenseFormSheet({
                                 <InputError message={errors.amount} />
                             </div>
 
-                            <div className="grid gap-2">
-                                <Label htmlFor="currency">
-                                    {t('Currency')}
-                                </Label>
-                                <Select
-                                    value={data.currency}
-                                    onValueChange={(value) =>
-                                        setData('currency', value)
+                            <div className="grid min-w-0 gap-2 overflow-hidden">
+                                <Label>{t('Currency')}</Label>
+                                <SearchableSelect
+                                    options={currencyOptions}
+                                    value={
+                                        isOtherCurrency
+                                            ? OTHER_CURRENCY
+                                            : data.currency || null
                                     }
+                                    onChange={(value) => {
+                                        if (value === OTHER_CURRENCY) {
+                                            setIsOtherCurrency(true);
+                                            setData('currency', '');
+
+                                            return;
+                                        }
+
+                                        setIsOtherCurrency(false);
+                                        setData(
+                                            'currency',
+                                            value === null ? '' : String(value),
+                                        );
+                                    }}
+                                    placeholder={t('Select currency...')}
+                                    searchPlaceholder={t('Search currency...')}
+                                    emptyText={t('No currencies found.')}
                                     disabled={isEdit}
-                                >
-                                    <SelectTrigger id="currency">
-                                        <SelectValue />
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        {currencies.map((currency) => (
-                                            <SelectItem
-                                                key={currency}
-                                                value={currency}
-                                            >
-                                                {currency}
-                                            </SelectItem>
-                                        ))}
-                                    </SelectContent>
-                                </Select>
+                                />
+                                {isOtherCurrency && (
+                                    <SearchableSelect
+                                        options={otherCurrencyOptions}
+                                        value={data.currency || null}
+                                        onChange={(value) =>
+                                            setData(
+                                                'currency',
+                                                value === null
+                                                    ? ''
+                                                    : String(value),
+                                            )
+                                        }
+                                        placeholder={t(
+                                            'Select other currency...',
+                                        )}
+                                        searchPlaceholder={t(
+                                            'Search other currencies...',
+                                        )}
+                                        emptyText={t('No currencies found.')}
+                                        disabled={isEdit}
+                                    />
+                                )}
                                 {isEdit && (
                                     <p className="text-xs text-muted-foreground">
                                         {t(
@@ -238,33 +309,40 @@ export default function ExpenseFormSheet({
                             </div>
                         </div>
 
-                        <div className="grid gap-2">
-                            <Label htmlFor="expense_date">{t('Date')}</Label>
-                            <Input
-                                id="expense_date"
-                                type="date"
-                                required
-                                value={data.expense_date}
-                                onChange={(event) =>
-                                    setData('expense_date', event.target.value)
-                                }
-                            />
-                            <InputError message={errors.expense_date} />
-                        </div>
+                        <div className="grid w-full grid-cols-1 gap-4 sm:grid-cols-2">
+                            <div className="grid min-w-0 gap-2">
+                                <Label htmlFor="expense_date">
+                                    {t('Date')}
+                                </Label>
+                                <Input
+                                    id="expense_date"
+                                    type="date"
+                                    required
+                                    value={data.expense_date}
+                                    onChange={(event) =>
+                                        setData(
+                                            'expense_date',
+                                            event.target.value,
+                                        )
+                                    }
+                                />
+                                <InputError message={errors.expense_date} />
+                            </div>
 
-                        <div className="grid gap-2">
-                            <Label htmlFor="vendor">
-                                {t('Vendor / Payee')}
-                            </Label>
-                            <Input
-                                id="vendor"
-                                value={data.vendor}
-                                onChange={(event) =>
-                                    setData('vendor', event.target.value)
-                                }
-                                placeholder={t('Optional')}
-                            />
-                            <InputError message={errors.vendor} />
+                            <div className="grid min-w-0 gap-2">
+                                <Label htmlFor="vendor">
+                                    {t('Vendor / Payee')}
+                                </Label>
+                                <Input
+                                    id="vendor"
+                                    value={data.vendor}
+                                    onChange={(event) =>
+                                        setData('vendor', event.target.value)
+                                    }
+                                    placeholder={t('Optional')}
+                                />
+                                <InputError message={errors.vendor} />
+                            </div>
                         </div>
 
                         <div className="grid gap-2">

--- a/resources/js/components/features/expenses/expense-form-sheet.tsx
+++ b/resources/js/components/features/expenses/expense-form-sheet.tsx
@@ -1,0 +1,368 @@
+import { useForm } from '@inertiajs/react';
+import { useState } from 'react';
+import { InputError } from '@/components/shared';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import {
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetHeader,
+    SheetTitle,
+} from '@/components/ui/sheet';
+import { Textarea } from '@/components/ui/textarea';
+import { todayISO } from '@/lib/formatters';
+import { t } from '@/lib/i18n';
+import expenses from '@/routes/expenses';
+import type { Expense, ExpenseCategory } from '@/types';
+
+type ExpenseFormData = {
+    property_id: string;
+    expense_category_id: string;
+    amount: string;
+    currency: string;
+    expense_date: string;
+    vendor: string;
+    description: string;
+    notes: string;
+    reference: string;
+    receipt: File | null;
+    remove_receipt: boolean;
+};
+
+export default function ExpenseFormSheet({
+    expense,
+    properties,
+    categories,
+    currencies,
+    open,
+    onOpenChange,
+}: {
+    expense?: Expense | null;
+    properties: { id: number; name: string }[];
+    categories: ExpenseCategory[];
+    currencies: string[];
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}) {
+    const isEdit = Boolean(expense);
+    const [receiptName, setReceiptName] = useState<string | null>(null);
+    const { data, setData, submit, reset, processing, errors } =
+        useForm<ExpenseFormData>({
+            property_id: expense?.property_id
+                ? String(expense.property_id)
+                : properties[0]
+                  ? String(properties[0].id)
+                  : '',
+            expense_category_id: expense?.expense_category_id
+                ? String(expense.expense_category_id)
+                : (categories
+                      .find((category) => category.is_active)
+                      ?.id.toString() ?? ''),
+            amount: expense?.amount ?? '',
+            currency: expense?.currency ?? currencies[0] ?? '',
+            expense_date: expense?.expense_date ?? todayISO(),
+            vendor: expense?.vendor ?? '',
+            description: expense?.description ?? '',
+            notes: expense?.notes ?? '',
+            reference: expense?.reference ?? '',
+            receipt: null,
+            remove_receipt: false,
+        });
+
+    function handleOpenChange(next: boolean) {
+        onOpenChange(next);
+
+        if (!next) {
+            reset();
+            setReceiptName(null);
+        }
+    }
+
+    function handleSubmit(event: React.FormEvent) {
+        event.preventDefault();
+
+        submit(isEdit ? expenses.update(expense!) : expenses.store(), {
+            forceFormData: true,
+            onSuccess: () => handleOpenChange(false),
+        });
+    }
+
+    const availableCategories = categories.filter(
+        (category) =>
+            category.is_active || category.id === expense?.expense_category_id,
+    );
+
+    return (
+        <Sheet
+            key={expense?.id ?? 'new'}
+            open={open}
+            onOpenChange={handleOpenChange}
+        >
+            <SheetContent className="sm:max-w-lg">
+                <SheetHeader>
+                    <SheetTitle>
+                        {t(isEdit ? 'Edit Expense' : 'New Expense')}
+                    </SheetTitle>
+                    <SheetDescription>
+                        {t(
+                            isEdit
+                                ? 'Update the expense details.'
+                                : 'Record an operating expense for a property.',
+                        )}
+                    </SheetDescription>
+                </SheetHeader>
+
+                <form
+                    onSubmit={handleSubmit}
+                    className="flex flex-1 flex-col justify-between gap-6 overflow-y-auto px-4 pt-4 pb-6"
+                >
+                    <div className="space-y-6">
+                        <div className="grid gap-2">
+                            <Label htmlFor="property_id">{t('Property')}</Label>
+                            <Select
+                                value={data.property_id}
+                                onValueChange={(value) =>
+                                    setData('property_id', value)
+                                }
+                            >
+                                <SelectTrigger id="property_id">
+                                    <SelectValue
+                                        placeholder={t('Select property')}
+                                    />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {properties.map((property) => (
+                                        <SelectItem
+                                            key={property.id}
+                                            value={String(property.id)}
+                                        >
+                                            {property.name}
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                            <InputError message={errors.property_id} />
+                        </div>
+
+                        <div className="grid gap-2">
+                            <Label htmlFor="expense_category_id">
+                                {t('Category')}
+                            </Label>
+                            <Select
+                                value={data.expense_category_id}
+                                onValueChange={(value) =>
+                                    setData('expense_category_id', value)
+                                }
+                            >
+                                <SelectTrigger id="expense_category_id">
+                                    <SelectValue
+                                        placeholder={t('Select category')}
+                                    />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {availableCategories.map((category) => (
+                                        <SelectItem
+                                            key={category.id}
+                                            value={String(category.id)}
+                                        >
+                                            {category.label}
+                                            {!category.is_active &&
+                                                ' (' + t('archived') + ')'}
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                            <InputError message={errors.expense_category_id} />
+                        </div>
+
+                        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                            <div className="grid gap-2">
+                                <Label htmlFor="amount">{t('Amount')}</Label>
+                                <Input
+                                    id="amount"
+                                    type="number"
+                                    min="0"
+                                    step="any"
+                                    inputMode="decimal"
+                                    required
+                                    value={data.amount}
+                                    onChange={(event) =>
+                                        setData('amount', event.target.value)
+                                    }
+                                />
+                                <InputError message={errors.amount} />
+                            </div>
+
+                            <div className="grid gap-2">
+                                <Label htmlFor="currency">
+                                    {t('Currency')}
+                                </Label>
+                                <Select
+                                    value={data.currency}
+                                    onValueChange={(value) =>
+                                        setData('currency', value)
+                                    }
+                                    disabled={isEdit}
+                                >
+                                    <SelectTrigger id="currency">
+                                        <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {currencies.map((currency) => (
+                                            <SelectItem
+                                                key={currency}
+                                                value={currency}
+                                            >
+                                                {currency}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                                {isEdit && (
+                                    <p className="text-xs text-muted-foreground">
+                                        {t(
+                                            'Currency is fixed after the expense is recorded.',
+                                        )}
+                                    </p>
+                                )}
+                                <InputError message={errors.currency} />
+                            </div>
+                        </div>
+
+                        <div className="grid gap-2">
+                            <Label htmlFor="expense_date">{t('Date')}</Label>
+                            <Input
+                                id="expense_date"
+                                type="date"
+                                required
+                                value={data.expense_date}
+                                onChange={(event) =>
+                                    setData('expense_date', event.target.value)
+                                }
+                            />
+                            <InputError message={errors.expense_date} />
+                        </div>
+
+                        <div className="grid gap-2">
+                            <Label htmlFor="vendor">
+                                {t('Vendor / Payee')}
+                            </Label>
+                            <Input
+                                id="vendor"
+                                value={data.vendor}
+                                onChange={(event) =>
+                                    setData('vendor', event.target.value)
+                                }
+                                placeholder={t('Optional')}
+                            />
+                            <InputError message={errors.vendor} />
+                        </div>
+
+                        <div className="grid gap-2">
+                            <Label htmlFor="reference">{t('Reference')}</Label>
+                            <Input
+                                id="reference"
+                                value={data.reference}
+                                onChange={(event) =>
+                                    setData('reference', event.target.value)
+                                }
+                                placeholder={t('Invoice or receipt number')}
+                            />
+                            <InputError message={errors.reference} />
+                        </div>
+
+                        <div className="grid gap-2">
+                            <Label htmlFor="description">
+                                {t('Description')}
+                            </Label>
+                            <Textarea
+                                id="description"
+                                value={data.description}
+                                onChange={(event) =>
+                                    setData('description', event.target.value)
+                                }
+                            />
+                            <InputError message={errors.description} />
+                        </div>
+
+                        <div className="grid gap-2">
+                            <Label htmlFor="notes">{t('Notes')}</Label>
+                            <Textarea
+                                id="notes"
+                                value={data.notes}
+                                onChange={(event) =>
+                                    setData('notes', event.target.value)
+                                }
+                            />
+                            <InputError message={errors.notes} />
+                        </div>
+
+                        <div className="grid gap-2">
+                            <Label htmlFor="receipt">{t('Receipt')}</Label>
+                            <Input
+                                id="receipt"
+                                type="file"
+                                accept=".jpg,.jpeg,.png,.pdf"
+                                onChange={(event) => {
+                                    const file =
+                                        event.target.files?.[0] ?? null;
+                                    setData('receipt', file);
+                                    setReceiptName(file?.name ?? null);
+                                }}
+                            />
+                            <p className="text-xs text-muted-foreground">
+                                {t(
+                                    'One optional JPG, PNG, or PDF receipt, up to 10 MB.',
+                                )}
+                            </p>
+                            {receiptName && (
+                                <p className="text-sm text-muted-foreground">
+                                    {t('Selected:')} {receiptName}
+                                </p>
+                            )}
+                            {isEdit && expense?.receipt && !receiptName && (
+                                <label className="flex items-center gap-2 text-sm">
+                                    <input
+                                        type="checkbox"
+                                        checked={data.remove_receipt}
+                                        onChange={(event) =>
+                                            setData(
+                                                'remove_receipt',
+                                                event.target.checked,
+                                            )
+                                        }
+                                    />
+                                    {t('Remove current receipt')}
+                                </label>
+                            )}
+                            <InputError message={errors.receipt} />
+                        </div>
+                    </div>
+
+                    <div className="flex flex-wrap items-center justify-end gap-4">
+                        <Button
+                            variant="outline"
+                            type="button"
+                            onClick={() => handleOpenChange(false)}
+                            disabled={processing}
+                        >
+                            {t('Cancel')}
+                        </Button>
+                        <Button disabled={processing}>
+                            {t(isEdit ? 'Save' : 'Record Expense')}
+                        </Button>
+                    </div>
+                </form>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/resources/js/components/features/expenses/index.ts
+++ b/resources/js/components/features/expenses/index.ts
@@ -1,0 +1,2 @@
+export { default as ExpenseDetailSheet } from './expense-detail-sheet';
+export { default as ExpenseFormSheet } from './expense-form-sheet';

--- a/resources/js/components/features/index.ts
+++ b/resources/js/components/features/index.ts
@@ -1,4 +1,5 @@
 export * from './app';
+export * from './expenses';
 export * from './auth';
 export * from './dashboard';
 export * from './leases';

--- a/resources/js/components/shared/metric-card.tsx
+++ b/resources/js/components/shared/metric-card.tsx
@@ -19,6 +19,7 @@ export interface MetricCardProps {
     variant?: MetricVariant;
     emphasis?: MetricEmphasis;
     icon?: React.ComponentType<{ className?: string }>;
+    subtextFullWidth?: boolean;
     progress?: number;
     onClick?: () => void;
     className?: string;
@@ -217,6 +218,7 @@ export function MetricCard({
     variant = 'neutral',
     emphasis = 'subtle',
     icon: Icon,
+    subtextFullWidth = false,
     progress,
     onClick,
     className,
@@ -252,7 +254,7 @@ export function MetricCard({
                     >
                         {value}
                     </p>
-                    {subtext && (
+                    {subtext && !subtextFullWidth && (
                         <div className="mt-1 text-xs font-medium text-muted-foreground">
                             {subtext}
                         </div>
@@ -270,6 +272,12 @@ export function MetricCard({
                     </div>
                 )}
             </div>
+
+            {subtext && subtextFullWidth && (
+                <div className="mt-3 border-t border-border pt-3 text-xs font-medium text-muted-foreground">
+                    {subtext}
+                </div>
+            )}
 
             {progress !== undefined && (
                 <div className="mt-3">

--- a/resources/js/components/shared/searchable-select/index.tsx
+++ b/resources/js/components/shared/searchable-select/index.tsx
@@ -58,15 +58,16 @@ export default function SearchableSelect({
                     role="combobox"
                     aria-expanded={open}
                     disabled={disabled}
-                    className="w-full justify-between font-normal"
+                    className="w-full max-w-full min-w-0 justify-between overflow-hidden font-normal"
                 >
-                    {selected ? (
-                        selected.label
-                    ) : (
-                        <span className="text-muted-foreground">
-                            {t(placeholder)}
-                        </span>
-                    )}
+                    <span
+                        className={cn(
+                            'min-w-0 flex-1 truncate text-left',
+                            !selected && 'text-muted-foreground',
+                        )}
+                    >
+                        {selected ? selected.label : t(placeholder)}
+                    </span>
                     <ChevronsUpDown
                         data-icon="inline-end"
                         className="shrink-0 opacity-50"
@@ -97,7 +98,7 @@ export default function SearchableSelect({
                                 key={option.value}
                                 type="button"
                                 className={cn(
-                                    'relative flex w-full cursor-default items-center gap-2 rounded-sm px-2 py-1.5 pr-8 text-sm outline-hidden select-none hover:bg-accent hover:text-accent-foreground',
+                                    'relative flex w-full min-w-0 cursor-default items-center gap-2 rounded-sm px-2 py-1.5 pr-8 text-sm outline-hidden select-none hover:bg-accent hover:text-accent-foreground',
                                     String(value) === String(option.value) &&
                                         'bg-accent text-accent-foreground',
                                 )}
@@ -118,7 +119,9 @@ export default function SearchableSelect({
                                             : 'opacity-0',
                                     )}
                                 />
-                                {option.label}
+                                <span className="min-w-0 truncate">
+                                    {option.label}
+                                </span>
                             </button>
                         ))
                     )}

--- a/resources/js/components/shared/status-badge.tsx
+++ b/resources/js/components/shared/status-badge.tsx
@@ -199,6 +199,14 @@ const STATUS_CONFIGS: Record<string, Record<string, StatusConfig>> = {
         },
         archived: { label: 'Archived', variant: 'secondary' },
     },
+    expense: {
+        active: {
+            label: 'Active',
+            className:
+                'bg-surface-green/70 text-surface-green-foreground border-surface-green-border/80',
+        },
+        voided: { label: 'Voided', variant: 'secondary' },
+    },
     role: {
         active: {
             label: 'Active',

--- a/resources/js/hooks/use-table.ts
+++ b/resources/js/hooks/use-table.ts
@@ -143,6 +143,7 @@ export function useTable({ routeFn, params, defaults = {} }: UseTableOptions) {
     }
 
     return {
+        navigate,
         searchValue,
         onSearchChange,
         clearSearch,

--- a/resources/js/pages/dashboard/overview.tsx
+++ b/resources/js/pages/dashboard/overview.tsx
@@ -16,6 +16,7 @@ import {
     ActivityFeedItem,
     BusinessHealthPanel,
     CurrencyAmountList,
+    ExpensesSummaryPanel,
     getActivitySummaryChips,
     OperationalBriefingCard,
     PropertyFormSheet,
@@ -156,6 +157,7 @@ export default function Overview({
                                         groups={
                                             attention.overdue_invoices.amounts
                                         }
+                                        compact
                                         amountClassName="text-surface-red-foreground"
                                     />
                                 ) : undefined
@@ -163,6 +165,7 @@ export default function Overview({
                             variant="red"
                             emphasis="attention"
                             icon={AlertTriangle}
+                            subtextFullWidth
                         />
                         <MetricCard
                             label={t('Due Today')}
@@ -195,10 +198,12 @@ export default function Overview({
                     </div>
                 </section>
 
-                {/* 4. Business Health Neutral Panel */}
+                {/* 4. Revenue & Collections Panel */}
                 <BusinessHealthPanel finance={finance} />
 
-                {/* 5. Lower Dashboard: Operational Workspace (Two-Column Layout) */}
+                <ExpensesSummaryPanel expenses={finance.expenses} />
+
+                {/* 6. Lower Dashboard: Operational Workspace (Two-Column Layout) */}
                 <div className="grid min-w-0 gap-8 lg:grid-cols-12">
                     {/* Left Column: Property Overview (~65% / lg:col-span-7) */}
                     <section className="flex min-w-0 flex-col gap-3 lg:col-span-7">

--- a/resources/js/pages/dashboard/rent.tsx
+++ b/resources/js/pages/dashboard/rent.tsx
@@ -455,17 +455,20 @@ export default function CollectionQueue({
                 <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                     <MetricCard
                         label={t('Outstanding Balance')}
-                        value={
-                            <CurrencyAmountList
-                                groups={outstanding.amounts}
-                                compact
-                                amountClassName="text-surface-amber-foreground"
-                            />
+                        value={outstanding.count}
+                        subtext={
+                            outstanding.amounts.length > 0 ? (
+                                <CurrencyAmountList
+                                    groups={outstanding.amounts}
+                                    compact
+                                    amountClassName="text-surface-amber-foreground"
+                                />
+                            ) : undefined
                         }
-                        subtext={`${outstanding.count} ${t(outstanding.count === 1 ? 'invoice unpaid' : 'invoices unpaid')}`}
                         variant="amber"
                         emphasis="subtle"
                         icon={Banknote}
+                        subtextFullWidth
                     />
                     <MetricCard
                         label={t('Last Payment Recorded')}

--- a/resources/js/pages/dashboard/rent.tsx
+++ b/resources/js/pages/dashboard/rent.tsx
@@ -458,6 +458,7 @@ export default function CollectionQueue({
                         value={
                             <CurrencyAmountList
                                 groups={outstanding.amounts}
+                                compact
                                 amountClassName="text-surface-amber-foreground"
                             />
                         }

--- a/resources/js/pages/expenses/index.tsx
+++ b/resources/js/pages/expenses/index.tsx
@@ -1,0 +1,313 @@
+import { Head } from '@inertiajs/react';
+import { Ban, EllipsisVertical, Eye, Pencil } from 'lucide-react';
+import { useState } from 'react';
+import { DataTable } from '@/components/data-table';
+import type { TableColumn } from '@/components/data-table';
+import { FilterBar } from '@/components/data-table/filter-bar';
+import { SearchInput } from '@/components/data-table/search-input';
+import { ExpenseDetailSheet, ExpenseFormSheet } from '@/components/features';
+import { Heading } from '@/components/shared';
+import { StatusBadge } from '@/components/shared/status-badge';
+import { Button } from '@/components/ui/button';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Input } from '@/components/ui/input';
+import { useTable } from '@/hooks/use-table';
+import { formatDate, formatPrice } from '@/lib/formatters';
+import { t } from '@/lib/i18n';
+import expenses from '@/routes/expenses';
+import type {
+    Expense,
+    ExpenseCategory,
+    PaginatedData,
+    TableMeta,
+} from '@/types';
+
+type PageProps = {
+    expenses: PaginatedData<Expense>;
+    properties: { id: number; name: string }[];
+    categories: ExpenseCategory[];
+    currencies: string[];
+    can: { create: boolean; update: boolean; delete: boolean };
+    table: TableMeta;
+    sort?: string;
+    search?: string;
+    per_page?: number | string;
+    property_id?: string;
+    category_id?: string;
+    currency?: string;
+    status?: string;
+    date_from?: string;
+    date_to?: string;
+};
+
+export default function Index({
+    expenses: data,
+    properties,
+    categories,
+    currencies,
+    can,
+    table: tableMeta,
+    sort: currentSort = '-expense_date',
+    search: currentSearch = '',
+    per_page: currentPerPage = 15,
+    property_id: currentPropertyId = '',
+    category_id: currentCategoryId = '',
+    currency: currentCurrency = '',
+    status: currentStatus = 'active',
+    date_from: currentDateFrom = '',
+    date_to: currentDateTo = '',
+}: PageProps) {
+    const [formOpen, setFormOpen] = useState(false);
+    const [editingExpense, setEditingExpense] = useState<Expense | null>(null);
+    const [detailOpen, setDetailOpen] = useState(false);
+    const [viewingExpense, setViewingExpense] = useState<Expense | null>(null);
+
+    const table = useTable({
+        routeFn: () => expenses.index(),
+        params: {
+            sort: currentSort,
+            search: currentSearch,
+            per_page: String(currentPerPage),
+            property_id: currentPropertyId,
+            category_id: currentCategoryId,
+            currency: currentCurrency,
+            status: currentStatus,
+            date_from: currentDateFrom,
+            date_to: currentDateTo,
+        },
+        defaults: {
+            sort: '-expense_date',
+            per_page: '15',
+            status: 'active',
+        },
+    });
+
+    function openCreate() {
+        setEditingExpense(null);
+        setFormOpen(true);
+    }
+
+    function openEdit(expense: Expense) {
+        setEditingExpense(expense);
+        setDetailOpen(false);
+        setFormOpen(true);
+    }
+
+    function openDetail(expense: Expense) {
+        setViewingExpense(expense);
+        setDetailOpen(true);
+    }
+
+    function editFromDetail() {
+        if (viewingExpense) {
+            openEdit(viewingExpense);
+        }
+    }
+
+    const columns: TableColumn<Expense>[] = [
+        {
+            key: 'expense_date',
+            label: t('Date'),
+            sortable: true,
+            render: (expense) => formatDate(expense.expense_date),
+        },
+        {
+            key: 'property_name',
+            label: t('Property'),
+            sortable: true,
+            render: (expense) => expense.property?.name ?? '—',
+        },
+        {
+            key: 'category_name',
+            label: t('Category'),
+            sortable: true,
+            render: (expense) => expense.category?.label ?? '—',
+        },
+        {
+            key: 'vendor',
+            label: t('Vendor / Payee'),
+            render: (expense) => expense.vendor ?? '—',
+        },
+        {
+            key: 'amount',
+            label: t('Amount'),
+            sortable: true,
+            className: 'text-right tabular-nums',
+            render: (expense) => formatPrice(expense.amount, expense.currency),
+        },
+        {
+            key: 'status',
+            label: t('Status'),
+            render: (expense) => (
+                <StatusBadge domain="expense" value={expense.status} />
+            ),
+        },
+        {
+            key: '_actions',
+            label: '',
+            render: (expense) => (
+                <DropdownMenu>
+                    <DropdownMenuTrigger
+                        asChild
+                        onClick={(event) => event.stopPropagation()}
+                    >
+                        <Button variant="ghost" size="icon" className="size-8">
+                            <EllipsisVertical className="size-4" />
+                        </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent
+                        align="end"
+                        onClick={(event) => event.stopPropagation()}
+                    >
+                        <DropdownMenuItem onClick={() => openDetail(expense)}>
+                            <Eye className="size-4" />
+                            {t('View')}
+                        </DropdownMenuItem>
+                        {expense.status !== 'voided' && can.update && (
+                            <DropdownMenuItem onClick={() => openEdit(expense)}>
+                                <Pencil className="size-4" />
+                                {t('Edit')}
+                            </DropdownMenuItem>
+                        )}
+                        {expense.status !== 'voided' && can.delete && (
+                            <DropdownMenuItem
+                                variant="destructive"
+                                onClick={() => openDetail(expense)}
+                            >
+                                <Ban className="size-4" />
+                                {t('Void')}
+                            </DropdownMenuItem>
+                        )}
+                    </DropdownMenuContent>
+                </DropdownMenu>
+            ),
+        },
+    ];
+
+    return (
+        <>
+            <Head title={t('Expenses')} />
+
+            <div className="flex h-full flex-1 flex-col gap-4 overflow-x-auto rounded-xl p-4">
+                <div className="flex flex-wrap items-center justify-between gap-4">
+                    <Heading
+                        title={t('Expenses')}
+                        description={t(
+                            'Track operating costs across your properties',
+                        )}
+                    />
+                    {can.create && (
+                        <Button onClick={openCreate}>{t('New Expense')}</Button>
+                    )}
+                </div>
+
+                <FilterBar
+                    filters={tableMeta.filters}
+                    activeFilters={table.activeFilters}
+                    activeFilterCount={table.activeFilterCount}
+                    onToggleOption={table.toggleFilterOption}
+                    onClearAll={table.clearAllFilters}
+                    searchInput={
+                        <SearchInput
+                            value={table.searchValue}
+                            onChange={table.onSearchChange}
+                            onClear={table.clearSearch}
+                            placeholder={t(
+                                'Search by vendor, property, category, or reference...',
+                            )}
+                        />
+                    }
+                />
+
+                <div className="flex flex-wrap items-end gap-3 rounded-lg border bg-card p-3">
+                    <div className="grid gap-1.5">
+                        <label
+                            htmlFor="date_from"
+                            className="text-xs font-medium text-muted-foreground"
+                        >
+                            {t('From')}
+                        </label>
+                        <Input
+                            id="date_from"
+                            type="date"
+                            value={currentDateFrom}
+                            onChange={(event) =>
+                                table.navigate({
+                                    date_from: event.target.value,
+                                    page: '',
+                                })
+                            }
+                        />
+                    </div>
+                    <div className="grid gap-1.5">
+                        <label
+                            htmlFor="date_to"
+                            className="text-xs font-medium text-muted-foreground"
+                        >
+                            {t('To')}
+                        </label>
+                        <Input
+                            id="date_to"
+                            type="date"
+                            value={currentDateTo}
+                            onChange={(event) =>
+                                table.navigate({
+                                    date_to: event.target.value,
+                                    page: '',
+                                })
+                            }
+                        />
+                    </div>
+                </div>
+
+                <DataTable
+                    columns={columns}
+                    rows={data.data}
+                    currentSort={currentSort}
+                    onSort={table.toggleSort}
+                    onRowClick={openDetail}
+                    paginator={data}
+                    perPage={Number(currentPerPage)}
+                    onPageChange={table.goToPage}
+                    onPerPageChange={table.setPerPage}
+                    noun={t('expenses')}
+                    empty={{
+                        message: t('No expenses yet.'),
+                        createLabel: can.create
+                            ? t('Record your first expense')
+                            : undefined,
+                        onCreate: can.create ? openCreate : undefined,
+                    }}
+                />
+            </div>
+
+            <ExpenseDetailSheet
+                expense={viewingExpense}
+                open={detailOpen}
+                onOpenChange={setDetailOpen}
+                canUpdate={can.update}
+                canDelete={can.delete}
+                onEdit={editFromDetail}
+            />
+
+            <ExpenseFormSheet
+                key={editingExpense?.id ?? 'new'}
+                expense={editingExpense}
+                properties={properties}
+                categories={categories}
+                currencies={currencies}
+                open={formOpen}
+                onOpenChange={setFormOpen}
+            />
+        </>
+    );
+}
+
+Index.layout = {
+    breadcrumbs: [{ title: 'Expenses', href: expenses.index() }],
+};

--- a/resources/js/pages/expenses/index.tsx
+++ b/resources/js/pages/expenses/index.tsx
@@ -1,5 +1,5 @@
 import { Head } from '@inertiajs/react';
-import { Ban, EllipsisVertical, Eye, Pencil } from 'lucide-react';
+import { Ban, EllipsisVertical, Eye, FileText, Pencil } from 'lucide-react';
 import { useState } from 'react';
 import { DataTable } from '@/components/data-table';
 import type { TableColumn } from '@/components/data-table';
@@ -23,6 +23,7 @@ import expenses from '@/routes/expenses';
 import type {
     Expense,
     ExpenseCategory,
+    MoneyAggregate,
     PaginatedData,
     TableMeta,
 } from '@/types';
@@ -43,7 +44,21 @@ type PageProps = {
     status?: string;
     date_from?: string;
     date_to?: string;
+    summary?: {
+        has_data: boolean;
+        this_month: MoneyAggregate[];
+        last_month: MoneyAggregate[];
+        this_month_count: number;
+    };
 };
+
+function formatMoneyGroups(groups: MoneyAggregate[]): string {
+    return (
+        groups
+            .map((group) => formatPrice(group.amount, group.currency))
+            .join(' · ') || '—'
+    );
+}
 
 export default function Index({
     expenses: data,
@@ -61,6 +76,7 @@ export default function Index({
     status: currentStatus = 'active',
     date_from: currentDateFrom = '',
     date_to: currentDateTo = '',
+    summary,
 }: PageProps) {
     const [formOpen, setFormOpen] = useState(false);
     const [editingExpense, setEditingExpense] = useState<Expense | null>(null);
@@ -130,7 +146,7 @@ export default function Index({
         },
         {
             key: 'vendor',
-            label: t('Vendor / Payee'),
+            label: t('Vendor'),
             render: (expense) => expense.vendor ?? '—',
         },
         {
@@ -146,6 +162,27 @@ export default function Index({
             render: (expense) => (
                 <StatusBadge domain="expense" value={expense.status} />
             ),
+        },
+        {
+            key: 'receipt',
+            label: t('Receipt'),
+            className: 'text-center',
+            render: (expense) =>
+                expense.receipt ? (
+                    <a
+                        href={expense.receipt.download_url}
+                        target="_blank"
+                        rel="noreferrer"
+                        onClick={(event) => event.stopPropagation()}
+                        className="inline-flex size-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+                        aria-label={t('View receipt')}
+                    >
+                        <FileText className="size-4" />
+                        <span className="sr-only">{t('View receipt')}</span>
+                    </a>
+                ) : (
+                    <span className="text-muted-foreground">—</span>
+                ),
         },
         {
             key: '_actions',
@@ -189,6 +226,78 @@ export default function Index({
         },
     ];
 
+    const dateFilters = (
+        <>
+            <div className="grid gap-1.5">
+                <label
+                    htmlFor="date_from"
+                    className="text-xs font-medium text-muted-foreground"
+                >
+                    {t('From')}
+                </label>
+                <Input
+                    id="date_from"
+                    type="date"
+                    className="w-36"
+                    value={currentDateFrom}
+                    onChange={(event) =>
+                        table.navigate({
+                            date_from: event.target.value,
+                            page: '',
+                        })
+                    }
+                />
+            </div>
+            <div className="grid gap-1.5">
+                <label
+                    htmlFor="date_to"
+                    className="text-xs font-medium text-muted-foreground"
+                >
+                    {t('To')}
+                </label>
+                <Input
+                    id="date_to"
+                    type="date"
+                    className="w-36"
+                    value={currentDateTo}
+                    onChange={(event) =>
+                        table.navigate({
+                            date_to: event.target.value,
+                            page: '',
+                        })
+                    }
+                />
+            </div>
+        </>
+    );
+
+    const dateFilterChips = [
+        ...(currentDateFrom
+            ? [
+                  {
+                      key: 'date_from',
+                      display: `${t('From')}: ${currentDateFrom}`,
+                      onRemove: () =>
+                          table.navigate({ date_from: '', page: '' }),
+                  },
+              ]
+            : []),
+        ...(currentDateTo
+            ? [
+                  {
+                      key: 'date_to',
+                      display: `${t('To')}: ${currentDateTo}`,
+                      onRemove: () => table.navigate({ date_to: '', page: '' }),
+                  },
+              ]
+            : []),
+    ];
+    const activeFilters = Object.fromEntries(
+        Object.entries(table.activeFilters).filter(
+            ([key]) => key !== 'date_from' && key !== 'date_to',
+        ),
+    );
+
     return (
         <>
             <Head title={t('Expenses')} />
@@ -206,12 +315,43 @@ export default function Index({
                     )}
                 </div>
 
+                {summary?.has_data && (
+                    <div className="grid gap-3 sm:grid-cols-3">
+                        <div className="min-w-0 rounded-lg border bg-card px-4 py-3">
+                            <p className="text-xs font-medium text-muted-foreground">
+                                {t('Expenses this month')}
+                            </p>
+                            <p className="mt-1 truncate text-lg font-semibold tabular-nums">
+                                {formatMoneyGroups(summary.this_month)}
+                            </p>
+                        </div>
+                        <div className="min-w-0 rounded-lg border bg-card px-4 py-3">
+                            <p className="text-xs font-medium text-muted-foreground">
+                                {t('Expenses last month')}
+                            </p>
+                            <p className="mt-1 truncate text-lg font-semibold tabular-nums">
+                                {formatMoneyGroups(summary.last_month)}
+                            </p>
+                        </div>
+                        <div className="min-w-0 rounded-lg border bg-card px-4 py-3">
+                            <p className="text-xs font-medium text-muted-foreground">
+                                {t('Expense count this month')}
+                            </p>
+                            <p className="mt-1 text-lg font-semibold tabular-nums">
+                                {summary.this_month_count}
+                            </p>
+                        </div>
+                    </div>
+                )}
+
                 <FilterBar
                     filters={tableMeta.filters}
-                    activeFilters={table.activeFilters}
+                    activeFilters={activeFilters}
                     activeFilterCount={table.activeFilterCount}
                     onToggleOption={table.toggleFilterOption}
                     onClearAll={table.clearAllFilters}
+                    additionalFilters={dateFilters}
+                    additionalFilterChips={dateFilterChips}
                     searchInput={
                         <SearchInput
                             value={table.searchValue}
@@ -223,47 +363,6 @@ export default function Index({
                         />
                     }
                 />
-
-                <div className="flex flex-wrap items-end gap-3 rounded-lg border bg-card p-3">
-                    <div className="grid gap-1.5">
-                        <label
-                            htmlFor="date_from"
-                            className="text-xs font-medium text-muted-foreground"
-                        >
-                            {t('From')}
-                        </label>
-                        <Input
-                            id="date_from"
-                            type="date"
-                            value={currentDateFrom}
-                            onChange={(event) =>
-                                table.navigate({
-                                    date_from: event.target.value,
-                                    page: '',
-                                })
-                            }
-                        />
-                    </div>
-                    <div className="grid gap-1.5">
-                        <label
-                            htmlFor="date_to"
-                            className="text-xs font-medium text-muted-foreground"
-                        >
-                            {t('To')}
-                        </label>
-                        <Input
-                            id="date_to"
-                            type="date"
-                            value={currentDateTo}
-                            onChange={(event) =>
-                                table.navigate({
-                                    date_to: event.target.value,
-                                    page: '',
-                                })
-                            }
-                        />
-                    </div>
-                </div>
 
                 <DataTable
                     columns={columns}

--- a/resources/js/pages/settings/expense-categories.tsx
+++ b/resources/js/pages/settings/expense-categories.tsx
@@ -1,0 +1,337 @@
+import { Head, router, useForm } from '@inertiajs/react';
+import { Archive, Pencil, Plus, Trash2 } from 'lucide-react';
+import { useState } from 'react';
+import { InputError } from '@/components/shared';
+import { Button } from '@/components/ui/button';
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from '@/components/ui/card';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetHeader,
+    SheetTitle,
+} from '@/components/ui/sheet';
+import { Switch } from '@/components/ui/switch';
+import { t } from '@/lib/i18n';
+import expenseCategories from '@/routes/settings/expense-categories';
+import type { ExpenseCategory } from '@/types';
+
+function CategoryFormSheet({
+    category,
+    open,
+    onOpenChange,
+}: {
+    category: ExpenseCategory | null;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}) {
+    const isEdit = Boolean(category);
+    const { data, setData, submit, reset, processing, errors } = useForm({
+        label: category?.label ?? '',
+        is_active: category?.is_active ?? true,
+    });
+
+    function close(next: boolean) {
+        onOpenChange(next);
+
+        if (!next) {
+            reset();
+        }
+    }
+
+    function handleSubmit(event: React.FormEvent) {
+        event.preventDefault();
+        submit(
+            isEdit
+                ? expenseCategories.update(category!)
+                : expenseCategories.store(),
+            {
+                onSuccess: () => close(false),
+            },
+        );
+    }
+
+    return (
+        <Sheet open={open} onOpenChange={close}>
+            <SheetContent className="sm:max-w-md">
+                <SheetHeader>
+                    <SheetTitle>
+                        {t(
+                            isEdit
+                                ? 'Edit expense category'
+                                : 'New expense category',
+                        )}
+                    </SheetTitle>
+                    <SheetDescription>
+                        {t('Categories are shared across all properties.')}
+                    </SheetDescription>
+                </SheetHeader>
+                <form
+                    onSubmit={handleSubmit}
+                    className="flex flex-1 flex-col justify-between gap-6 px-4 pt-4 pb-6"
+                >
+                    <div className="grid gap-2">
+                        <Label htmlFor="label">{t('Name')}</Label>
+                        <Input
+                            id="label"
+                            value={data.label}
+                            onChange={(event) =>
+                                setData('label', event.target.value)
+                            }
+                            placeholder={t('e.g. Landscaping')}
+                            required
+                        />
+                        <InputError message={errors.label} />
+                    </div>
+                    <div className="flex items-center justify-end gap-3">
+                        <Button
+                            type="button"
+                            variant="outline"
+                            onClick={() => close(false)}
+                            disabled={processing}
+                        >
+                            {t('Cancel')}
+                        </Button>
+                        <Button disabled={processing}>
+                            {t(isEdit ? 'Save' : 'Add')}
+                        </Button>
+                    </div>
+                </form>
+            </SheetContent>
+        </Sheet>
+    );
+}
+
+export default function ExpenseCategories({
+    categories,
+}: {
+    categories: ExpenseCategory[];
+}) {
+    const [formOpen, setFormOpen] = useState(false);
+    const [editing, setEditing] = useState<ExpenseCategory | null>(null);
+    const [pendingDelete, setPendingDelete] = useState<ExpenseCategory | null>(
+        null,
+    );
+
+    function openCreate() {
+        setEditing(null);
+        setFormOpen(true);
+    }
+
+    function openEdit(category: ExpenseCategory) {
+        setEditing(category);
+        setFormOpen(true);
+    }
+
+    function toggleActive(category: ExpenseCategory, isActive: boolean) {
+        router.patch(expenseCategories.update.url(category), {
+            label: category.label,
+            is_active: isActive,
+        });
+    }
+
+    function confirmDelete() {
+        if (!pendingDelete) {
+            return;
+        }
+
+        router.delete(expenseCategories.destroy.url(pendingDelete), {
+            onFinish: () => setPendingDelete(null),
+        });
+    }
+
+    return (
+        <>
+            <Head title={t('Expense Categories')} />
+
+            <div className="space-y-6">
+                <div className="flex flex-wrap items-start justify-between gap-4">
+                    <div>
+                        <h2 className="text-lg font-medium">
+                            {t('Expense Categories')}
+                        </h2>
+                        <p className="mt-1 text-sm text-muted-foreground">
+                            {t(
+                                'Manage the installation-wide categories available when recording expenses.',
+                            )}
+                        </p>
+                    </div>
+                    <Button onClick={openCreate}>
+                        <Plus className="size-4" />
+                        {t('Add category')}
+                    </Button>
+                </div>
+
+                <Card>
+                    <CardHeader>
+                        <CardTitle>{t('Categories')}</CardTitle>
+                        <CardDescription>
+                            {t(
+                                'Referenced categories are archived instead of deleted so historical expenses retain their category.',
+                            )}
+                        </CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                        <div className="overflow-x-auto rounded-lg border">
+                            <table className="w-full text-sm">
+                                <thead>
+                                    <tr className="border-b bg-muted/50 text-left text-muted-foreground">
+                                        <th className="px-4 py-3 font-medium">
+                                            {t('Label')}
+                                        </th>
+                                        <th className="px-4 py-3 font-medium">
+                                            {t('In use')}
+                                        </th>
+                                        <th className="px-4 py-3 font-medium">
+                                            {t('Active')}
+                                        </th>
+                                        <th className="px-4 py-3 font-medium" />
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {categories.map((category) => {
+                                        const inUse =
+                                            (category.expenses_count ?? 0) > 0;
+
+                                        return (
+                                            <tr
+                                                key={category.slug}
+                                                className="border-b last:border-0"
+                                            >
+                                                <td className="px-4 py-3 font-medium">
+                                                    {category.label}
+                                                </td>
+                                                <td className="px-4 py-3 text-muted-foreground tabular-nums">
+                                                    {category.expenses_count ??
+                                                        0}
+                                                </td>
+                                                <td className="px-4 py-3">
+                                                    <Switch
+                                                        checked={
+                                                            category.is_active
+                                                        }
+                                                        onCheckedChange={(
+                                                            value,
+                                                        ) =>
+                                                            toggleActive(
+                                                                category,
+                                                                value,
+                                                            )
+                                                        }
+                                                    />
+                                                </td>
+                                                <td className="px-4 py-3">
+                                                    <div className="flex items-center justify-end gap-1">
+                                                        <Button
+                                                            variant="ghost"
+                                                            size="icon"
+                                                            className="size-8"
+                                                            onClick={() =>
+                                                                openEdit(
+                                                                    category,
+                                                                )
+                                                            }
+                                                        >
+                                                            <Pencil className="size-4" />
+                                                        </Button>
+                                                        <Button
+                                                            variant="ghost"
+                                                            size="icon"
+                                                            className="size-8"
+                                                            onClick={() =>
+                                                                setPendingDelete(
+                                                                    category,
+                                                                )
+                                                            }
+                                                        >
+                                                            {inUse ? (
+                                                                <Archive className="size-4" />
+                                                            ) : (
+                                                                <Trash2 className="size-4" />
+                                                            )}
+                                                        </Button>
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                        );
+                                    })}
+                                </tbody>
+                            </table>
+                        </div>
+                    </CardContent>
+                </Card>
+            </div>
+
+            <CategoryFormSheet
+                key={editing?.id ?? 'new'}
+                category={editing}
+                open={formOpen}
+                onOpenChange={setFormOpen}
+            />
+
+            <Dialog
+                open={pendingDelete !== null}
+                onOpenChange={(next) => !next && setPendingDelete(null)}
+            >
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>
+                            {t(
+                                (pendingDelete?.expenses_count ?? 0) > 0
+                                    ? 'Archive expense category'
+                                    : 'Delete expense category',
+                            )}
+                        </DialogTitle>
+                        <DialogDescription>
+                            {(pendingDelete?.expenses_count ?? 0) > 0
+                                ? t(
+                                      'This category is referenced by historical expenses and will be archived.',
+                                  )
+                                : t('Delete this unused category?')}
+                        </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                        <Button
+                            variant="outline"
+                            onClick={() => setPendingDelete(null)}
+                        >
+                            {t('Cancel')}
+                        </Button>
+                        <Button variant="destructive" onClick={confirmDelete}>
+                            {t(
+                                (pendingDelete?.expenses_count ?? 0) > 0
+                                    ? 'Archive'
+                                    : 'Delete',
+                            )}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        </>
+    );
+}
+
+ExpenseCategories.layout = {
+    breadcrumbs: [
+        {
+            title: 'Expense Categories',
+            href: expenseCategories.index(),
+        },
+    ],
+};

--- a/resources/js/types/dashboard.ts
+++ b/resources/js/types/dashboard.ts
@@ -17,6 +17,11 @@ export type Finance = {
     monthly_potential: MoneyAggregate[];
     outstanding: MoneyAggregate[];
     collection_rate: Array<{ currency: string; rate: number }>;
+    expenses: {
+        this_month: MoneyAggregate[];
+        last_month: MoneyAggregate[];
+        change_vs_last_month: MoneyAggregate[];
+    };
 };
 
 export type MoneyAggregate = {

--- a/resources/js/types/models.ts
+++ b/resources/js/types/models.ts
@@ -55,6 +55,46 @@ export type PropertyTypeOption = {
     properties_count?: number;
 };
 
+export type ExpenseCategory = {
+    id: number;
+    slug: string;
+    label: string;
+    is_active: boolean;
+    sort_order?: number;
+    expenses_count?: number;
+};
+
+export type ExpenseReceipt = {
+    id: number;
+    original_name: string;
+    mime_type: string;
+    size: number;
+    download_url: string;
+};
+
+export type Expense = {
+    id: number;
+    property_id: number;
+    expense_category_id: number;
+    amount: string;
+    currency: string;
+    expense_date: string;
+    vendor: string | null;
+    description: string | null;
+    notes: string | null;
+    reference: string | null;
+    status: 'active' | 'voided' | string;
+    voided_at: string | null;
+    voided_by: number | null;
+    void_reason: string | null;
+    created_at: string;
+    updated_at: string;
+    property?: { id: number; name: string } | null;
+    category?: ExpenseCategory | null;
+    voided_by_user?: { id: number; name: string } | null;
+    receipt?: ExpenseReceipt | null;
+};
+
 export type Property = {
     id: number;
     name: string;

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\BrandingAssetController;
 use App\Http\Controllers\Settings\AboutController;
+use App\Http\Controllers\Settings\ExpenseCategoryController;
 use App\Http\Controllers\Settings\GeneralController;
 use App\Http\Controllers\Settings\MailController;
 use App\Http\Controllers\Settings\PaymentGatewayController;
@@ -70,6 +71,11 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::post('settings/property-types', [PropertyTypeController::class, 'store'])->name('settings.property-types.store');
         Route::patch('settings/property-types/{propertyType}', [PropertyTypeController::class, 'update'])->name('settings.property-types.update');
         Route::delete('settings/property-types/{propertyType}', [PropertyTypeController::class, 'destroy'])->name('settings.property-types.destroy');
+
+        Route::get('settings/expense-categories', [ExpenseCategoryController::class, 'index'])->name('settings.expense-categories.index');
+        Route::post('settings/expense-categories', [ExpenseCategoryController::class, 'store'])->name('settings.expense-categories.store');
+        Route::patch('settings/expense-categories/{expenseCategory}', [ExpenseCategoryController::class, 'update'])->name('settings.expense-categories.update');
+        Route::delete('settings/expense-categories/{expenseCategory}', [ExpenseCategoryController::class, 'destroy'])->name('settings.expense-categories.destroy');
 
         Route::get('settings/plugins', [PluginController::class, 'index'])->name('settings.plugins.index');
         Route::post('settings/plugins', [PluginController::class, 'install'])->name('settings.plugins.install');

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Dashboard\OverviewController;
 use App\Http\Controllers\Dashboard\RentController;
+use App\Http\Controllers\ExpenseController;
 use App\Http\Controllers\LeaseController;
 use App\Http\Controllers\LeaseInvoiceController;
 use App\Http\Controllers\LeaseRentScheduleController;
@@ -189,6 +190,17 @@ Route::middleware(['auth', 'verified', 'permission:dashboard.view'])->group(func
             Route::put('/', [MaintenanceTicketController::class, 'update'])->name('update')->middleware('permission:maintenance-tickets.update');
             Route::delete('/', [MaintenanceTicketController::class, 'destroy'])->name('destroy')->middleware('permission:maintenance-tickets.delete');
             Route::post('assign', [MaintenanceTicketController::class, 'assign'])->name('assign');
+        });
+    });
+
+    Route::prefix('expenses')->name('expenses.')->group(function () {
+        Route::get('/', [ExpenseController::class, 'index'])->name('index')->middleware('permission:expenses.view');
+        Route::post('/', [ExpenseController::class, 'store'])->name('store')->middleware('permission:expenses.create');
+
+        Route::prefix('{expense}')->whereNumber('expense')->group(function () {
+            Route::put('/', [ExpenseController::class, 'update'])->name('update')->middleware('permission:expenses.update');
+            Route::delete('/', [ExpenseController::class, 'destroy'])->name('destroy')->middleware('permission:expenses.delete');
+            Route::get('receipt', [ExpenseController::class, 'receipt'])->name('receipt')->middleware('permission:expenses.view');
         });
     });
 

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -5,6 +5,7 @@ use App\Data\Lease\MoveOutLeaseData;
 use App\Enums\InvoiceStatus;
 use App\Enums\LeaseStatus;
 use App\Enums\PaymentStatus;
+use App\Models\Expense;
 use App\Models\Invoice;
 use App\Models\Lease;
 use App\Models\MaintenanceTicket;
@@ -294,6 +295,61 @@ test('dashboard keeps every finance metric aligned to the same currencies', func
         );
 
     Carbon::setTestNow();
+});
+
+test('dashboard includes active expense summaries by currency', function () {
+    Carbon::setTestNow(Carbon::parse('2026-07-10'));
+
+    try {
+        $user = User::factory()->owner()->create();
+        Expense::factory()->create([
+            'amount' => '100000',
+            'currency' => 'IDR',
+            'expense_date' => '2026-07-05',
+        ]);
+        Expense::factory()->create([
+            'amount' => '70000',
+            'currency' => 'IDR',
+            'expense_date' => '2026-06-05',
+        ]);
+        Expense::factory()->create([
+            'amount' => '500',
+            'currency' => 'USD',
+            'expense_date' => '2026-06-05',
+        ]);
+        Expense::factory()->create([
+            'amount' => '2',
+            'currency' => 'EUR',
+            'expense_date' => '2026-07-05',
+        ]);
+        Expense::factory()->voided()->create([
+            'amount' => '900',
+            'currency' => 'USD',
+            'expense_date' => '2026-07-06',
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('dashboard'))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->where('finance.expenses.this_month', [
+                    ['currency' => 'EUR', 'amount' => '2.000'],
+                    ['currency' => 'IDR', 'amount' => '100000.000'],
+                    ['currency' => 'USD', 'amount' => '0'],
+                ])
+                ->where('finance.expenses.last_month', [
+                    ['currency' => 'EUR', 'amount' => '0'],
+                    ['currency' => 'IDR', 'amount' => '70000.000'],
+                    ['currency' => 'USD', 'amount' => '500.000'],
+                ])
+                ->where('finance.expenses.change_vs_last_month', [
+                    ['currency' => 'EUR', 'amount' => '2.000'],
+                    ['currency' => 'IDR', 'amount' => '30000.000'],
+                    ['currency' => 'USD', 'amount' => '-500.000'],
+                ]));
+    } finally {
+        Carbon::setTestNow();
+    }
 });
 
 test('dashboard preserves historical financial activity after lease termination', function () {

--- a/tests/Feature/ExpenseTest.php
+++ b/tests/Feature/ExpenseTest.php
@@ -8,6 +8,7 @@ use App\Models\Property;
 use App\Models\User;
 use Database\Seeders\RoleAndPermissionSeeder;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Storage;
 
 uses()->beforeEach(function (): void {
@@ -33,6 +34,7 @@ it('lists expenses for the owner with the configured table metadata', function (
             ->component('expenses/index')
             ->has('expenses.data', 1)
             ->where('expenses.data.0.id', $expense->id)
+            ->has('table.columns', 8)
             ->has('table.filters', 4)
             ->has('categories'));
 
@@ -41,6 +43,40 @@ it('lists expenses for the owner with the configured table metadata', function (
         ->assertInertia(fn ($page) => $page
             ->has('expenses.data', 1)
             ->where('expenses.data.0.id', $expense->id));
+});
+
+it('includes active expense summaries for the current and previous month', function (): void {
+    Carbon::setTestNow('2026-09-15');
+
+    try {
+        $owner = User::factory()->owner()->create();
+        Expense::factory()->create([
+            'amount' => '125.00',
+            'currency' => 'USD',
+            'expense_date' => '2026-09-05',
+        ]);
+        Expense::factory()->create([
+            'amount' => '75.00',
+            'currency' => 'USD',
+            'expense_date' => '2026-08-05',
+        ]);
+        Expense::factory()->voided()->create([
+            'amount' => '100.00',
+            'currency' => 'USD',
+            'expense_date' => '2026-09-06',
+        ]);
+
+        $this->actingAs($owner)
+            ->get(route('expenses.index'))
+            ->assertInertia(fn ($page) => $page
+                ->where('summary.has_data', true)
+                ->where('summary.this_month_count', 1)
+                ->where('summary.this_month.0.currency', 'USD')
+                ->where('summary.this_month.0.amount', '125.000')
+                ->where('summary.last_month.0.amount', '75.000'));
+    } finally {
+        Carbon::setTestNow();
+    }
 });
 
 it('creates an expense with a currency snapshot', function (): void {

--- a/tests/Feature/ExpenseTest.php
+++ b/tests/Feature/ExpenseTest.php
@@ -1,0 +1,201 @@
+<?php
+
+use App\Enums\ExpenseStatus;
+use App\Models\AuditLog;
+use App\Models\Expense;
+use App\Models\ExpenseCategory;
+use App\Models\Property;
+use App\Models\User;
+use Database\Seeders\RoleAndPermissionSeeder;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+uses()->beforeEach(function (): void {
+    $this->seed(RoleAndPermissionSeeder::class);
+});
+
+it('requires the expenses view permission', function (): void {
+    $staff = User::factory()->staff()->create();
+
+    $this->actingAs($staff)
+        ->get(route('expenses.index'))
+        ->assertForbidden();
+});
+
+it('lists expenses for the owner with the configured table metadata', function (): void {
+    $owner = User::factory()->owner()->create();
+    $expense = Expense::factory()->create();
+
+    $this->actingAs($owner)
+        ->get(route('expenses.index'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('expenses/index')
+            ->has('expenses.data', 1)
+            ->where('expenses.data.0.id', $expense->id)
+            ->has('table.filters', 4)
+            ->has('categories'));
+
+    $this->actingAs($owner)
+        ->get(route('expenses.index', ['search' => $expense->reference]))
+        ->assertInertia(fn ($page) => $page
+            ->has('expenses.data', 1)
+            ->where('expenses.data.0.id', $expense->id));
+});
+
+it('creates an expense with a currency snapshot', function (): void {
+    $owner = User::factory()->owner()->create();
+    $property = Property::factory()->create();
+    $category = ExpenseCategory::factory()->create();
+
+    $this->actingAs($owner)
+        ->post(route('expenses.store'), [
+            'property_id' => $property->id,
+            'expense_category_id' => $category->id,
+            'amount' => '125.50',
+            'currency' => 'USD',
+            'expense_date' => '2026-09-01',
+            'vendor' => 'Water Company',
+            'reference' => 'INV-123',
+        ])
+        ->assertRedirect();
+
+    $expense = Expense::query()->latest('id')->firstOrFail();
+
+    expect($expense->property_id)->toBe($property->id)
+        ->and($expense->expense_category_id)->toBe($category->id)
+        ->and($expense->amount)->toBe('125.500')
+        ->and($expense->currency)->toBe('USD')
+        ->and($expense->status)->toBe(ExpenseStatus::Active);
+});
+
+it('uses the existing currency minor-unit validation', function (): void {
+    $owner = User::factory()->owner()->create();
+
+    $this->actingAs($owner)
+        ->post(route('expenses.store'), [
+            'property_id' => Property::factory()->create()->id,
+            'expense_category_id' => ExpenseCategory::factory()->create()->id,
+            'amount' => '1.1',
+            'currency' => 'IDR',
+            'expense_date' => '2026-09-01',
+        ])
+        ->assertSessionHasErrors('amount');
+});
+
+it('limits non-owner expenses to assigned properties', function (): void {
+    $admin = User::factory()->admin()->create();
+    $assigned = Property::factory()->create();
+    $unassigned = Property::factory()->create();
+    $assigned->users()->attach($admin);
+
+    Expense::factory()->create(['property_id' => $assigned->id]);
+    Expense::factory()->create(['property_id' => $unassigned->id]);
+
+    $this->actingAs($admin)
+        ->get(route('expenses.index'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->has('expenses.data', 1)
+            ->where('expenses.data.0.property_id', $assigned->id));
+
+    $this->actingAs($admin)
+        ->post(route('expenses.store'), [
+            'property_id' => $unassigned->id,
+            'expense_category_id' => ExpenseCategory::factory()->create()->id,
+            'amount' => '10.00',
+            'currency' => 'USD',
+            'expense_date' => '2026-09-01',
+        ])
+        ->assertSessionHasErrors('property_id');
+});
+
+it('keeps the currency snapshot immutable', function (): void {
+    $expense = Expense::factory()->create(['currency' => 'USD']);
+
+    expect(fn () => $expense->update(['currency' => 'EUR']))
+        ->toThrow(LogicException::class);
+});
+
+it('voids an expense with an audited reason and makes it read-only', function (): void {
+    $owner = User::factory()->owner()->create();
+    $expense = Expense::factory()->create();
+    AuditLog::query()->delete();
+
+    $this->actingAs($owner)
+        ->delete(route('expenses.destroy', $expense), ['reason' => 'Duplicate entry'])
+        ->assertRedirect();
+
+    $expense->refresh();
+
+    expect($expense->status)->toBe(ExpenseStatus::Voided)
+        ->and($expense->voided_at)->not->toBeNull()
+        ->and($expense->voided_by)->toBe($owner->id)
+        ->and($expense->void_reason)->toBe('Duplicate entry');
+
+    expect(AuditLog::query()
+        ->where('auditable_type', $expense->getMorphClass())
+        ->where('auditable_id', $expense->id)
+        ->where('operation', 'update')
+        ->latest('id')
+        ->firstOrFail()
+        ->after)
+        ->toMatchArray([
+            'status' => ExpenseStatus::Voided->value,
+            'void_reason' => 'Duplicate entry',
+        ]);
+
+    $this->actingAs($owner)
+        ->put(route('expenses.update', $expense), [
+            'property_id' => $expense->property_id,
+            'expense_category_id' => $expense->expense_category_id,
+            'amount' => '20.00',
+            'expense_date' => '2026-09-01',
+        ])
+        ->assertForbidden();
+
+    expect(fn () => $expense->update(['notes' => 'Attempted change']))
+        ->toThrow(LogicException::class);
+});
+
+it('supports date range and status filters', function (): void {
+    $owner = User::factory()->owner()->create();
+    Expense::factory()->create(['expense_date' => '2026-01-01']);
+    Expense::factory()->voided()->create(['expense_date' => '2026-02-01']);
+
+    $this->actingAs($owner)
+        ->get(route('expenses.index', [
+            'date_from' => '2026-01-15',
+            'date_to' => '2026-02-15',
+            'status' => 'voided',
+        ]))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->has('expenses.data', 1)
+            ->where('expenses.data.0.status', ExpenseStatus::Voided->value));
+
+    $this->actingAs($owner)
+        ->get(route('expenses.index', ['status' => 'active,voided']))
+        ->assertInertia(fn ($page) => $page
+            ->has('expenses.data', 2)
+            ->where('status', 'active,voided'));
+});
+
+it('stores one optional receipt and exposes its download route', function (): void {
+    Storage::fake('local');
+    $owner = User::factory()->owner()->create();
+    $expense = Expense::factory()->create();
+
+    $this->actingAs($owner)
+        ->put(route('expenses.update', $expense), [
+            'property_id' => $expense->property_id,
+            'expense_category_id' => $expense->expense_category_id,
+            'amount' => '125.00',
+            'expense_date' => '2026-09-01',
+            'receipt' => UploadedFile::fake()->create('receipt.pdf', 100, 'application/pdf'),
+        ])
+        ->assertRedirect();
+
+    expect($expense->media()->where('collection', 'receipts')->count())->toBe(1);
+    expect(route('expenses.receipt', $expense))->toContain('/expenses/'.$expense->id.'/receipt');
+});

--- a/tests/Feature/Settings/ExpenseCategoryTest.php
+++ b/tests/Feature/Settings/ExpenseCategoryTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use App\Models\Expense;
+use App\Models\ExpenseCategory;
+use App\Models\User;
+use Database\Seeders\RoleAndPermissionSeeder;
+
+uses()->beforeEach(function (): void {
+    $this->seed(RoleAndPermissionSeeder::class);
+});
+
+it('is owner-only', function (): void {
+    $admin = User::factory()->admin()->create();
+
+    $this->actingAs($admin)
+        ->get(route('settings.expense-categories.index'))
+        ->assertForbidden();
+});
+
+it('lists the idempotent default categories', function (): void {
+    $owner = User::factory()->owner()->create();
+
+    $this->actingAs($owner)
+        ->get(route('settings.expense-categories.index'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('settings/expense-categories')
+            ->has('categories', 8));
+});
+
+it('creates a category with a generated slug', function (): void {
+    $owner = User::factory()->owner()->create();
+
+    $this->actingAs($owner)->post(route('settings.expense-categories.store'), [
+        'label' => 'Landscaping',
+    ]);
+
+    expect(ExpenseCategory::where('slug', 'landscaping')
+        ->where('label', 'Landscaping')
+        ->exists())->toBeTrue();
+});
+
+it('updates a category without changing its slug', function (): void {
+    $owner = User::factory()->owner()->create();
+    $category = ExpenseCategory::where('slug', 'other')->firstOrFail();
+
+    $this->actingAs($owner)->patch(route('settings.expense-categories.update', $category), [
+        'label' => 'Miscellaneous',
+        'is_active' => false,
+    ]);
+
+    $category->refresh();
+
+    expect($category->slug)->toBe('other')
+        ->and($category->label)->toBe('Miscellaneous')
+        ->and($category->is_active)->toBeFalse();
+});
+
+it('archives a category referenced by an expense', function (): void {
+    $owner = User::factory()->owner()->create();
+    $category = ExpenseCategory::factory()->create();
+    $expense = Expense::factory()->create(['expense_category_id' => $category->id]);
+
+    $this->actingAs($owner)
+        ->delete(route('settings.expense-categories.destroy', $category))
+        ->assertRedirect();
+
+    expect($category->refresh()->is_active)->toBeFalse()
+        ->and($expense->refresh()->expense_category_id)->toBe($category->id);
+});
+
+it('deletes an unused category', function (): void {
+    $owner = User::factory()->owner()->create();
+    $category = ExpenseCategory::factory()->create();
+
+    $this->actingAs($owner)
+        ->delete(route('settings.expense-categories.destroy', $category));
+
+    expect(ExpenseCategory::find($category->id))->toBeNull();
+});


### PR DESCRIPTION
## Summary
- add property-scoped expense CRUD with currency-aware amounts, filtering, receipts, and detail views
- add installation-wide expense categories with idempotent defaults and archive-on-reference behavior
- add audited voiding, immutable voided records, permissions, and focused Pest coverage

## Verification
- focused Pest: 15 passed, 102 assertions
- TypeScript, ESLint, Pint, and Vite build passed
- full suite: 1,105 passed; remaining failures are existing environment/plugin/branding issues (GD extension and runtime plugin artifact)

Refs OPE-187