### PR TITLE
feat: add unit utility metering

### DIFF
--- a/app/Actions/Invoices/GenerateInvoices.php
+++ b/app/Actions/Invoices/GenerateInvoices.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Invoices;
 
+use App\Actions\Utility\BillUtilityReadings;
 use App\Enums\InvoiceStatus;
 use App\Events\Invoice\InvoiceGenerated;
 use App\Models\Invoice;
@@ -17,7 +18,10 @@ class GenerateInvoices
 {
     private const MAX_UNIQUE_RETRIES = 3;
 
-    public function __construct(private MoneyConverter $money) {}
+    public function __construct(
+        private MoneyConverter $money,
+        private BillUtilityReadings $billUtilityReadings,
+    ) {}
 
     /**
      * Materialize invoices for upcoming billing periods.
@@ -85,10 +89,8 @@ class GenerateInvoices
         $existingKeys = Invoice::query()
             ->whereIn('lease_id', $leaseIds)
             ->whereBetween('period_start', [$minimumPeriod, $horizon])
-            ->get(['lease_id', 'period_start'])
-            ->mapWithKeys(fn (Invoice $invoice): array => [
-                $this->periodKey($invoice->lease_id, $invoice->period_start) => true,
-            ]);
+            ->get(['id', 'lease_id', 'period_start'])
+            ->keyBy(fn (Invoice $invoice): string => $this->periodKey($invoice->lease_id, $invoice->period_start));
 
         $newCandidates = collect($candidates)
             ->reject(fn (array $candidate): bool => $existingKeys->has(
@@ -96,62 +98,75 @@ class GenerateInvoices
             ))
             ->values();
 
-        if ($newCandidates->isEmpty()) {
-            return 0;
-        }
+        $createdInvoices = collect();
 
-        $references = Invoice::nextReferences($newCandidates->count());
-        $timestamp = now();
-        $invoiceRows = $newCandidates->map(fn (array $candidate, int $index): array => [
-            'lease_id' => $candidate['lease_id'],
-            'reference' => $references[$index],
-            'period_start' => $candidate['period_start']->toDateString(),
-            'period_end' => $candidate['period_end']->toDateString(),
-            'due_date' => $candidate['due_date']->toDateString(),
-            'status' => InvoiceStatus::Pending->value,
-            'total' => $candidate['amount'],
-            'amount_paid' => 0,
-            'currency' => $candidate['currency'],
-            'created_at' => $timestamp,
-            'updated_at' => $timestamp,
-        ])->all();
-
-        Invoice::query()->insert($invoiceRows);
-
-        $candidateKeys = $newCandidates->mapWithKeys(fn (array $candidate): array => [
-            $this->periodKey($candidate['lease_id'], $candidate['period_start']) => $candidate,
-        ]);
-        $persistedInvoices = Invoice::query()
-            ->whereIn('lease_id', $newCandidates->pluck('lease_id')->unique()->values())
-            ->whereBetween('period_start', [$minimumPeriod, $horizon])
-            ->get()
-            ->keyBy(fn (Invoice $invoice): string => $this->periodKey($invoice->lease_id, $invoice->period_start));
-
-        $createdInvoices = $newCandidates
-            ->map(fn (array $candidate): ?Invoice => $persistedInvoices->get(
-                $this->periodKey($candidate['lease_id'], $candidate['period_start'])
-            ))
-            ->filter()
-            ->values();
-
-        if ($createdInvoices->count() !== $newCandidates->count()) {
-            throw new \LogicException('Invoice batch did not persist all generated periods.');
-        }
-
-        $lineItemRows = $createdInvoices->map(function (Invoice $invoice) use ($candidateKeys, $timestamp): array {
-            $candidate = $candidateKeys->get($this->periodKey($invoice->lease_id, $invoice->period_start));
-
-            return [
-                'invoice_id' => $invoice->getKey(),
-                'type' => 'rent',
-                'description' => 'Rent '.$invoice->period_start->format('F Y'),
-                'amount' => $candidate['amount'],
+        if ($newCandidates->isNotEmpty()) {
+            $references = Invoice::nextReferences($newCandidates->count());
+            $timestamp = now();
+            $invoiceRows = $newCandidates->map(fn (array $candidate, int $index): array => [
+                'lease_id' => $candidate['lease_id'],
+                'reference' => $references[$index],
+                'period_start' => $candidate['period_start']->toDateString(),
+                'period_end' => $candidate['period_end']->toDateString(),
+                'due_date' => $candidate['due_date']->toDateString(),
+                'status' => InvoiceStatus::Pending->value,
+                'total' => $candidate['amount'],
+                'amount_paid' => 0,
+                'currency' => $candidate['currency'],
                 'created_at' => $timestamp,
                 'updated_at' => $timestamp,
-            ];
-        })->all();
+            ])->all();
 
-        InvoiceLineItem::query()->insert($lineItemRows);
+            Invoice::query()->insert($invoiceRows);
+
+            $candidateKeys = $newCandidates->mapWithKeys(fn (array $candidate): array => [
+                $this->periodKey($candidate['lease_id'], $candidate['period_start']) => $candidate,
+            ]);
+            $persistedInvoices = Invoice::query()
+                ->whereIn('lease_id', $newCandidates->pluck('lease_id')->unique()->values())
+                ->whereBetween('period_start', [$minimumPeriod, $horizon])
+                ->get()
+                ->keyBy(fn (Invoice $invoice): string => $this->periodKey($invoice->lease_id, $invoice->period_start));
+
+            $createdInvoices = $newCandidates
+                ->map(fn (array $candidate): ?Invoice => $persistedInvoices->get(
+                    $this->periodKey($candidate['lease_id'], $candidate['period_start'])
+                ))
+                ->filter()
+                ->values();
+
+            if ($createdInvoices->count() !== $newCandidates->count()) {
+                throw new \LogicException('Invoice batch did not persist all generated periods.');
+            }
+
+            InvoiceLineItem::query()->insert($createdInvoices->map(function (Invoice $invoice) use ($candidateKeys, $timestamp): array {
+                $candidate = $candidateKeys->get($this->periodKey($invoice->lease_id, $invoice->period_start));
+
+                return [
+                    'invoice_id' => $invoice->getKey(),
+                    'type' => 'rent',
+                    'description' => 'Rent '.$invoice->period_start->format('F Y'),
+                    'amount' => $candidate['amount'],
+                    'created_at' => $timestamp,
+                    'updated_at' => $timestamp,
+                ];
+            })->all());
+        }
+
+        $invoicesToBill = $existingKeys->values()
+            ->merge($createdInvoices)
+            ->unique('id')
+            ->values();
+
+        foreach ($invoicesToBill as $invoice) {
+            $this->billUtilityReadings->execute($invoice);
+        }
+
+        $createdInvoices->each->refresh();
+
+        if ($createdInvoices->isEmpty()) {
+            return 0;
+        }
 
         foreach ($createdInvoices as $invoice) {
             $invoice->recordAudit('create');
@@ -190,6 +205,7 @@ class GenerateInvoices
         return str_contains($message, 'invoices_lease_id_period_start_unique')
             || str_contains($message, 'invoices.lease_id, invoices.period_start')
             || str_contains($message, 'invoices_reference_unique')
-            || str_contains($message, 'invoices.reference');
+            || str_contains($message, 'invoices.reference')
+            || str_contains($message, 'invoice_line_items_utility_reading_id_unique');
     }
 }

--- a/app/Actions/Utility/BillUtilityReadings.php
+++ b/app/Actions/Utility/BillUtilityReadings.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace App\Actions\Utility;
+
+use App\Enums\InvoiceStatus;
+use App\Enums\UtilityReadingKind;
+use App\Models\Invoice;
+use App\Models\InvoiceLineItem;
+use App\Models\UtilityReading;
+use App\Services\Payments\MoneyConverter;
+use Brick\Math\BigDecimal;
+use Brick\Math\RoundingMode;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+class BillUtilityReadings
+{
+    public function __construct(private MoneyConverter $money) {}
+
+    public function execute(Invoice $invoice): int
+    {
+        return DB::transaction(function () use ($invoice): int {
+            $lockedInvoice = Invoice::query()
+                ->with(['lease.unit'])
+                ->lockForUpdate()
+                ->findOrFail($invoice->id);
+
+            if (in_array($lockedInvoice->status, [InvoiceStatus::Cancelled, InvoiceStatus::Void], true)) {
+                return 0;
+            }
+
+            $readings = UtilityReading::query()
+                ->with(['meter', 'previousReading', 'correctsReading.invoiceLineItem'])
+                ->whereHas('meter', fn ($query) => $query->where('unit_id', $lockedInvoice->lease->unit_id))
+                ->whereDoesntHave('invoiceLineItem')
+                ->orderBy('id')
+                ->lockForUpdate()
+                ->get();
+
+            $billed = 0;
+
+            foreach ($readings as $reading) {
+                if ($reading->reading_kind === UtilityReadingKind::Correction) {
+                    if ($reading->correctsReading?->invoiceLineItem?->invoice_id !== $lockedInvoice->id) {
+                        continue;
+                    }
+
+                    if ($reading->currency !== $lockedInvoice->currency) {
+                        continue;
+                    }
+
+                    $amount = $this->correctionAmount($reading);
+                    $metadata = $this->correctionMetadata($reading);
+                    $type = 'utility_adjustment';
+                    $description = 'Utility correction · '.$reading->meter->identifier.' · '.$reading->period_start->format('F Y');
+                } else {
+                    if (! $this->eligibleForInvoice($reading, $lockedInvoice)) {
+                        continue;
+                    }
+
+                    if ($reading->currency !== $lockedInvoice->currency) {
+                        continue;
+                    }
+
+                    $amount = $this->chargeAmount((string) $reading->consumption, (string) $reading->rate, $reading->currency);
+                    $metadata = $this->readingMetadata($reading);
+                    $type = 'utility';
+                    $description = $reading->meter->utility_type->value.' · '.$reading->consumption.' '.$reading->meter->measurement_unit.' · '.$reading->period_start->format('F Y');
+                }
+
+                $this->appendLineItem($lockedInvoice, $reading, $type, $description, $amount, $metadata);
+                $billed++;
+            }
+
+            return $billed;
+        });
+    }
+
+    private function eligibleForInvoice(UtilityReading $reading, Invoice $invoice): bool
+    {
+        /**
+         * MVP eligibility is whole-period containment: the reading must be
+         * inside both the invoice period and lease ownership window. A
+         * previous reading from before the lease makes the consumption
+         * unattributable, so it remains unbilled instead of being prorated.
+         */
+        $lease = $invoice->lease;
+        $invoiceStart = CarbonImmutable::instance($invoice->period_start);
+        $invoiceEnd = CarbonImmutable::instance($invoice->period_end);
+        $leaseStart = CarbonImmutable::instance($lease->start_date);
+        $leaseEnd = $lease->end_date
+            ? CarbonImmutable::instance($lease->end_date)
+            : null;
+        $periodStart = CarbonImmutable::instance($reading->period_start);
+        $periodEnd = CarbonImmutable::instance($reading->period_end);
+
+        if ($periodStart->lt($invoiceStart) || $periodEnd->gt($invoiceEnd)) {
+            return false;
+        }
+
+        if ($periodStart->lt($leaseStart) || ($leaseEnd !== null && $periodEnd->gt($leaseEnd))) {
+            return false;
+        }
+
+        $previous = $reading->previousReading;
+
+        return $previous === null
+            || (
+                CarbonImmutable::instance($previous->period_start)->gte($leaseStart)
+                && ($leaseEnd === null || CarbonImmutable::instance($previous->period_end)->lte($leaseEnd))
+            );
+    }
+
+    private function appendLineItem(
+        Invoice $invoice,
+        UtilityReading $reading,
+        string $type,
+        string $description,
+        string $amount,
+        array $metadata,
+    ): void {
+        InvoiceLineItem::query()->create([
+            'invoice_id' => $invoice->id,
+            'type' => $type,
+            'description' => $description,
+            'amount' => $amount,
+            'utility_reading_id' => $reading->id,
+            'metadata' => $metadata,
+        ]);
+
+        $total = BigDecimal::of((string) $invoice->total)
+            ->plus($amount)
+            ->toScale($this->money->scale($invoice->currency), RoundingMode::Unnecessary)
+            ->toString();
+
+        if (BigDecimal::of($total)->isNegative()) {
+            throw ValidationException::withMessages([
+                'reading' => __('This correction would make the invoice total negative.'),
+            ]);
+        }
+
+        $invoice->update(['total' => $total]);
+        $invoice->recalculateStatus();
+    }
+
+    private function chargeAmount(string $consumption, string $rate, string $currency): string
+    {
+        return $this->money->normalizeAmount(
+            BigDecimal::of($consumption)->multipliedBy($rate)->toString(),
+            $currency,
+        );
+    }
+
+    private function correctionAmount(UtilityReading $reading): string
+    {
+        $original = $reading->correctsReading;
+
+        return BigDecimal::of((string) $reading->adjustment_consumption)
+            ->multipliedBy((string) $original->rate)
+            ->toScale($this->money->scale($reading->currency), RoundingMode::HalfEven)
+            ->toString();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readingMetadata(UtilityReading $reading): array
+    {
+        return [
+            'meter_id' => $reading->meter->id,
+            'meter_identifier' => $reading->meter->identifier,
+            'utility_type' => $reading->meter->utility_type->value,
+            'measurement_unit' => $reading->meter->measurement_unit,
+            'reading_id' => $reading->id,
+            'reading_kind' => $reading->reading_kind->value,
+            'previous_reading' => (string) $reading->previous_reading,
+            'current_reading' => (string) $reading->current_reading,
+            'consumption' => (string) $reading->consumption,
+            'rate' => (string) $reading->rate,
+            'currency' => $reading->currency,
+            'period_start' => $reading->period_start->toDateString(),
+            'period_end' => $reading->period_end->toDateString(),
+            'reading_reference' => $reading->reference,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function correctionMetadata(UtilityReading $reading): array
+    {
+        $metadata = $this->readingMetadata($reading);
+        $original = $reading->correctsReading;
+
+        return [
+            ...$metadata,
+            'adjustment_consumption' => (string) $reading->adjustment_consumption,
+            'corrects_reading_id' => $original->id,
+            'original_invoice_line_item_id' => $original->invoiceLineItem?->id,
+            'original_consumption' => (string) $original->consumption,
+            'original_amount' => (string) $original->invoiceLineItem?->amount,
+        ];
+    }
+}

--- a/app/Actions/Utility/BillUtilityReadings.php
+++ b/app/Actions/Utility/BillUtilityReadings.php
@@ -53,7 +53,7 @@ class BillUtilityReadings
                     $amount = $this->correctionAmount($reading);
                     $metadata = $this->correctionMetadata($reading);
                     $type = 'utility_adjustment';
-                    $description = 'Utility correction · '.$reading->meter->identifier.' · '.$reading->period_start->format('F Y');
+                    $description = 'Utility correction · '.$this->utilityLabel($reading).' · '.$reading->period_start->format('F Y');
                 } else {
                     if (! $this->eligibleForInvoice($reading, $lockedInvoice)) {
                         continue;
@@ -66,7 +66,7 @@ class BillUtilityReadings
                     $amount = $this->chargeAmount((string) $reading->consumption, (string) $reading->rate, $reading->currency);
                     $metadata = $this->readingMetadata($reading);
                     $type = 'utility';
-                    $description = $reading->meter->utility_type->value.' · '.$reading->consumption.' '.$reading->meter->measurement_unit.' · '.$reading->period_start->format('F Y');
+                    $description = $this->utilityLabel($reading).' · '.$reading->consumption.' '.$reading->meter->measurement_unit.' · '.$reading->period_start->format('F Y');
                 }
 
                 $this->appendLineItem($lockedInvoice, $reading, $type, $description, $amount, $metadata);
@@ -171,6 +171,7 @@ class BillUtilityReadings
             'meter_id' => $reading->meter->id,
             'meter_identifier' => $reading->meter->identifier,
             'utility_type' => $reading->meter->utility_type->value,
+            'utility_name' => $reading->meter->utility_name,
             'measurement_unit' => $reading->meter->measurement_unit,
             'reading_id' => $reading->id,
             'reading_kind' => $reading->reading_kind->value,
@@ -201,5 +202,10 @@ class BillUtilityReadings
             'original_consumption' => (string) $original->consumption,
             'original_amount' => (string) $original->invoiceLineItem?->amount,
         ];
+    }
+
+    private function utilityLabel(UtilityReading $reading): string
+    {
+        return $reading->meter->utility_name ?? $reading->meter->utility_type->value;
     }
 }

--- a/app/Actions/Utility/CreateUtilityReadingCorrection.php
+++ b/app/Actions/Utility/CreateUtilityReadingCorrection.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Actions\Utility;
+
+use App\Enums\UtilityReadingKind;
+use App\Models\UtilityReading;
+use Brick\Math\BigDecimal;
+use Brick\Math\RoundingMode;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+class CreateUtilityReadingCorrection
+{
+    /**
+     * Corrections store the corrected non-negative consumption plus a signed
+     * delta from the billed reading for invoice adjustment purposes.
+     *
+     * @param  array{current_reading: string, reference?: string|null}  $data
+     */
+    public function execute(UtilityReading $reading, array $data): UtilityReading
+    {
+        try {
+            return DB::transaction(function () use ($reading, $data): UtilityReading {
+                $original = UtilityReading::query()->lockForUpdate()->findOrFail($reading->id);
+
+                if ($original->reading_kind !== UtilityReadingKind::Reading || ! $original->isBilled()) {
+                    throw ValidationException::withMessages([
+                        'reading' => __('Only billed readings can be corrected.'),
+                    ]);
+                }
+
+                if ($original->corrections()->exists()) {
+                    throw ValidationException::withMessages([
+                        'reading' => __('This reading already has a correction.'),
+                    ]);
+                }
+
+                if (BigDecimal::of($data['current_reading'])->compareTo((string) $original->previous_reading) < 0) {
+                    throw ValidationException::withMessages([
+                        'current_reading' => __('The corrected reading cannot be lower than the previous effective reading.'),
+                    ]);
+                }
+
+                $correctedConsumption = BigDecimal::of($data['current_reading'])
+                    ->minus((string) $original->previous_reading)
+                    ->toScale(3, RoundingMode::Unnecessary)
+                    ->toString();
+                $adjustmentConsumption = BigDecimal::of($correctedConsumption)
+                    ->minus((string) $original->consumption)
+                    ->toScale(3, RoundingMode::Unnecessary)
+                    ->toString();
+
+                return $original->meter()->firstOrFail()->readings()->create([
+                    'reading_kind' => UtilityReadingKind::Correction,
+                    'reading_date' => $original->reading_date,
+                    'period_start' => $original->period_start,
+                    'period_end' => $original->period_end,
+                    'previous_reading_id' => null,
+                    'previous_reading' => $original->previous_reading,
+                    'current_reading' => $data['current_reading'],
+                    'consumption' => $correctedConsumption,
+                    'adjustment_consumption' => $adjustmentConsumption,
+                    'rate' => $original->rate,
+                    'currency' => $original->currency,
+                    'reference' => $data['reference'] ?? null,
+                    'corrects_reading_id' => $original->id,
+                ]);
+            });
+        } catch (QueryException $exception) {
+            if (! str_contains($exception->getMessage(), 'utility_readings_meter_period_kind_unique')) {
+                throw $exception;
+            }
+
+            throw ValidationException::withMessages([
+                'reading' => __('This reading already has a correction.'),
+            ]);
+        }
+    }
+}

--- a/app/Actions/Utility/RecordUtilityReading.php
+++ b/app/Actions/Utility/RecordUtilityReading.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Actions\Utility;
+
+use App\Enums\UtilityReadingKind;
+use App\Models\UtilityMeter;
+use App\Models\UtilityReading;
+use Brick\Math\BigDecimal;
+use Brick\Math\RoundingMode;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+class RecordUtilityReading
+{
+    /**
+     * @param  array{reading_date: string, period_start: string, period_end: string, previous_reading: string, current_reading: string, reference?: string|null}  $data
+     */
+    public function execute(UtilityMeter $meter, array $data): UtilityReading
+    {
+        try {
+            return DB::transaction(function () use ($meter, $data): UtilityReading {
+                $lockedMeter = UtilityMeter::query()->lockForUpdate()->findOrFail($meter->id);
+                $periodStart = CarbonImmutable::parse($data['period_start'])->startOfDay();
+                $periodEnd = CarbonImmutable::parse($data['period_end'])->startOfDay();
+                $readingDate = CarbonImmutable::parse($data['reading_date'])->startOfDay();
+
+                if ($periodEnd->lt($periodStart) || $readingDate->lt($periodStart) || $readingDate->gt($periodEnd)) {
+                    throw ValidationException::withMessages([
+                        'period_start' => __('The reading date must fall within its utility period.'),
+                    ]);
+                }
+
+                $overlapping = $lockedMeter->readings()
+                    ->where('reading_kind', UtilityReadingKind::Reading->value)
+                    ->whereDate('period_start', '<=', $periodEnd)
+                    ->whereDate('period_end', '>=', $periodStart)
+                    ->exists();
+
+                if ($overlapping) {
+                    throw ValidationException::withMessages([
+                        'period_start' => __('This meter already has a reading covering that utility period.'),
+                    ]);
+                }
+
+                $previous = $lockedMeter->readings()
+                    ->where('reading_kind', UtilityReadingKind::Reading->value)
+                    ->whereDate('period_end', '<', $periodStart)
+                    ->latest('period_end')
+                    ->latest('id')
+                    ->first();
+                $previousValue = (string) ($previous?->current_reading ?? $data['previous_reading']);
+
+                if ($previous !== null && $this->compare($data['previous_reading'], $previousValue) !== 0) {
+                    throw ValidationException::withMessages([
+                        'previous_reading' => __('The previous reading must match the meter’s latest effective reading.'),
+                    ]);
+                }
+
+                if ($previous !== null && CarbonImmutable::instance($previous->period_end)->addDay()->gt($periodStart)) {
+                    throw ValidationException::withMessages([
+                        'period_start' => __('The utility period overlaps the previous reading.'),
+                    ]);
+                }
+
+                if ($this->compare($data['current_reading'], $previousValue) < 0) {
+                    throw ValidationException::withMessages([
+                        'current_reading' => __('The current reading cannot be lower than the previous effective reading.'),
+                    ]);
+                }
+
+                $consumption = BigDecimal::of($data['current_reading'])
+                    ->minus($previousValue)
+                    ->toScale(3, RoundingMode::Unnecessary)
+                    ->toString();
+
+                return $lockedMeter->readings()->create([
+                    'reading_kind' => UtilityReadingKind::Reading,
+                    'reading_date' => $readingDate,
+                    'period_start' => $periodStart,
+                    'period_end' => $periodEnd,
+                    'previous_reading_id' => $previous?->id,
+                    'previous_reading' => $previousValue,
+                    'current_reading' => $data['current_reading'],
+                    'consumption' => $consumption,
+                    'adjustment_consumption' => null,
+                    'rate' => $lockedMeter->rate,
+                    'currency' => $lockedMeter->currency,
+                    'reference' => $data['reference'] ?? null,
+                ]);
+            });
+        } catch (QueryException $exception) {
+            if (! str_contains($exception->getMessage(), 'utility_readings_meter_period_kind_unique')) {
+                throw $exception;
+            }
+
+            throw ValidationException::withMessages([
+                'period_start' => __('This meter already has a reading for that utility period.'),
+            ]);
+        }
+    }
+
+    private function compare(string $left, string $right): int
+    {
+        return BigDecimal::of($left)->compareTo(BigDecimal::of($right));
+    }
+}

--- a/app/Actions/Utility/UpdateUtilityReading.php
+++ b/app/Actions/Utility/UpdateUtilityReading.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace App\Actions\Utility;
+
+use App\Enums\UtilityReadingKind;
+use App\Models\UtilityMeter;
+use App\Models\UtilityReading;
+use Brick\Math\BigDecimal;
+use Brick\Math\RoundingMode;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+class UpdateUtilityReading
+{
+    /**
+     * @param  array<string, string|null>  $data
+     */
+    public function execute(UtilityReading $reading, array $data): UtilityReading
+    {
+        try {
+            return DB::transaction(function () use ($reading, $data): UtilityReading {
+                $lockedReading = UtilityReading::query()->findOrFail($reading->id);
+                $meter = UtilityMeter::query()->lockForUpdate()->findOrFail($lockedReading->utility_meter_id);
+                $lockedReading->setRelation('meter', $meter);
+
+                if ($lockedReading->isBilled()) {
+                    throw ValidationException::withMessages([
+                        'reading' => __('Billed utility readings cannot be changed.'),
+                    ]);
+                }
+
+                if ($lockedReading->hasDependents()) {
+                    throw ValidationException::withMessages([
+                        'reading' => __('This reading is used by a later reading and cannot be changed.'),
+                    ]);
+                }
+
+                if ($lockedReading->reading_kind === UtilityReadingKind::Correction) {
+                    return $this->updateCorrection($lockedReading, $data);
+                }
+
+                return $this->updateReading($lockedReading, $data);
+            });
+        } catch (QueryException $exception) {
+            if (! str_contains($exception->getMessage(), 'utility_readings_meter_period_kind_unique')) {
+                throw $exception;
+            }
+
+            throw ValidationException::withMessages([
+                'period_start' => __('This meter already has a reading for that utility period.'),
+            ]);
+        }
+    }
+
+    /**
+     * @param  array<string, string|null>  $data
+     */
+    private function updateReading(UtilityReading $reading, array $data): UtilityReading
+    {
+        $periodStart = CarbonImmutable::parse($data['period_start'] ?? $reading->period_start)->startOfDay();
+        $periodEnd = CarbonImmutable::parse($data['period_end'] ?? $reading->period_end)->startOfDay();
+        $readingDate = CarbonImmutable::parse($data['reading_date'] ?? $reading->reading_date)->startOfDay();
+
+        if ($periodEnd->lt($periodStart) || $readingDate->lt($periodStart) || $readingDate->gt($periodEnd)) {
+            throw ValidationException::withMessages([
+                'period_start' => __('The reading date must fall within its utility period.'),
+            ]);
+        }
+
+        $overlapping = $reading->meter->readings()
+            ->where($reading->getQualifiedKeyName(), '!=', $reading->id)
+            ->where('reading_kind', UtilityReadingKind::Reading->value)
+            ->whereDate('period_start', '<=', $periodEnd)
+            ->whereDate('period_end', '>=', $periodStart)
+            ->exists();
+
+        if ($overlapping) {
+            throw ValidationException::withMessages([
+                'period_start' => __('This meter already has a reading covering that utility period.'),
+            ]);
+        }
+
+        $previous = $reading->meter->readings()
+            ->where($reading->getQualifiedKeyName(), '!=', $reading->id)
+            ->where('reading_kind', UtilityReadingKind::Reading->value)
+            ->whereDate('period_end', '<', $periodStart)
+            ->latest('period_end')
+            ->latest('id')
+            ->first();
+        $previousValue = (string) ($previous?->current_reading ?? $data['previous_reading'] ?? $reading->previous_reading);
+
+        if ($previous !== null && isset($data['previous_reading']) && $this->compare($data['previous_reading'], $previousValue) !== 0) {
+            throw ValidationException::withMessages([
+                'previous_reading' => __('The previous reading must match the meter’s latest effective reading.'),
+            ]);
+        }
+
+        if ($this->compare((string) $data['current_reading'], $previousValue) < 0) {
+            throw ValidationException::withMessages([
+                'current_reading' => __('The current reading cannot be lower than the previous effective reading.'),
+            ]);
+        }
+
+        $consumption = BigDecimal::of((string) $data['current_reading'])
+            ->minus($previousValue)
+            ->toScale(3, RoundingMode::Unnecessary)
+            ->toString();
+
+        $reading->update([
+            'reading_date' => $readingDate,
+            'period_start' => $periodStart,
+            'period_end' => $periodEnd,
+            'previous_reading_id' => $previous?->id,
+            'previous_reading' => $previousValue,
+            'current_reading' => $data['current_reading'],
+            'consumption' => $consumption,
+            'adjustment_consumption' => null,
+            'reference' => $data['reference'] ?? null,
+        ]);
+
+        return $reading->refresh();
+    }
+
+    /**
+     * @param  array<string, string|null>  $data
+     */
+    private function updateCorrection(UtilityReading $reading, array $data): UtilityReading
+    {
+        $original = $reading->correctsReading;
+
+        if ($original === null) {
+            throw ValidationException::withMessages([
+                'reading' => __('This correction is missing its original reading.'),
+            ]);
+        }
+
+        if ($this->compare((string) $data['current_reading'], (string) $original->previous_reading) < 0) {
+            throw ValidationException::withMessages([
+                'current_reading' => __('The corrected reading cannot be lower than the previous effective reading.'),
+            ]);
+        }
+
+        $consumption = BigDecimal::of((string) $data['current_reading'])
+            ->minus((string) $original->previous_reading)
+            ->toScale(3, RoundingMode::Unnecessary)
+            ->toString();
+        $adjustmentConsumption = BigDecimal::of($consumption)
+            ->minus((string) $original->consumption)
+            ->toScale(3, RoundingMode::Unnecessary)
+            ->toString();
+
+        $reading->update([
+            'current_reading' => $data['current_reading'],
+            'consumption' => $consumption,
+            'adjustment_consumption' => $adjustmentConsumption,
+            'reference' => $data['reference'] ?? null,
+        ]);
+
+        return $reading->refresh();
+    }
+
+    private function compare(string $left, string $right): int
+    {
+        return BigDecimal::of($left)->compareTo(BigDecimal::of($right));
+    }
+}

--- a/app/Enums/UtilityMeterType.php
+++ b/app/Enums/UtilityMeterType.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Enums;
+
+enum UtilityMeterType: string
+{
+    case Electricity = 'electricity';
+    case Water = 'water';
+    case Custom = 'custom';
+
+    /**
+     * @return array<int, string>
+     */
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+}

--- a/app/Enums/UtilityReadingKind.php
+++ b/app/Enums/UtilityReadingKind.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Enums;
+
+enum UtilityReadingKind: string
+{
+    case Reading = 'reading';
+    case Correction = 'correction';
+
+    /**
+     * @return array<int, string>
+     */
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+}

--- a/app/Http/Controllers/UnitUtilityController.php
+++ b/app/Http/Controllers/UnitUtilityController.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Actions\Utility\CreateUtilityReadingCorrection;
+use App\Actions\Utility\RecordUtilityReading;
+use App\Actions\Utility\UpdateUtilityReading;
+use App\Http\Requests\Utility\StoreUtilityMeterRequest;
+use App\Http\Requests\Utility\StoreUtilityReadingCorrectionRequest;
+use App\Http\Requests\Utility\StoreUtilityReadingRequest;
+use App\Http\Requests\Utility\UpdateUtilityMeterRequest;
+use App\Http\Requests\Utility\UpdateUtilityReadingRequest;
+use App\Models\Property;
+use App\Models\Unit;
+use App\Models\UtilityMeter;
+use App\Models\UtilityReading;
+use App\Services\Payments\MoneyConverter;
+use Brick\Math\BigDecimal;
+use Brick\Math\RoundingMode;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class UnitUtilityController extends Controller
+{
+    public function __construct(
+        private RecordUtilityReading $recordReading,
+        private UpdateUtilityReading $updateReading,
+        private CreateUtilityReadingCorrection $createCorrection,
+        private MoneyConverter $money,
+    ) {}
+
+    public function index(Property $property, Unit $unit): Response
+    {
+        $this->authorizeUnit($property, $unit, 'view');
+
+        $unit->load([
+            'property.city',
+            'utilityMeters' => fn ($query) => $query
+                ->orderBy('utility_type')
+                ->orderBy('identifier')
+                ->with([
+                    'readings' => fn ($query) => $query
+                        ->with(['invoiceLineItem.invoice', 'correctsReading.invoiceLineItem'])
+                        ->withCount('dependentReadings')
+                        ->latest('period_end')
+                        ->latest('id'),
+                ]),
+        ]);
+
+        return Inertia::render('properties/units/utilities', [
+            'property' => $property,
+            'unit' => $unit->only('id', 'slug', 'name', 'floor'),
+            'meters' => $unit->utilityMeters->map(fn (UtilityMeter $meter): array => [
+                'id' => $meter->id,
+                'utility_type' => $meter->utility_type->value,
+                'identifier' => $meter->identifier,
+                'measurement_unit' => $meter->measurement_unit,
+                'rate' => (string) $meter->rate,
+                'currency' => $meter->currency,
+                'is_active' => $meter->is_active,
+                'readings' => $meter->readings->map(fn (UtilityReading $reading): array => $this->readingPayload($reading))->values()->all(),
+            ])->values()->all(),
+        ]);
+    }
+
+    public function storeMeter(StoreUtilityMeterRequest $request, Property $property, Unit $unit): RedirectResponse
+    {
+        $this->authorizeUnit($property, $unit, 'update');
+        $unit->utilityMeters()->create($request->validated());
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Utility meter added.')]);
+
+        return back();
+    }
+
+    public function updateMeter(UpdateUtilityMeterRequest $request, Property $property, Unit $unit, UtilityMeter $meter): RedirectResponse
+    {
+        $this->authorizeUnit($property, $unit, 'update');
+        $this->assertMeterBelongsToUnit($meter, $unit);
+        $meter->update($request->validated());
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Utility meter updated.')]);
+
+        return back();
+    }
+
+    public function storeReading(StoreUtilityReadingRequest $request, Property $property, Unit $unit, UtilityMeter $meter): RedirectResponse
+    {
+        $this->authorizeUnit($property, $unit, 'update');
+        $this->assertMeterBelongsToUnit($meter, $unit);
+        $this->recordReading->execute($meter, $request->validated());
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Utility reading recorded.')]);
+
+        return back();
+    }
+
+    public function updateReading(UpdateUtilityReadingRequest $request, Property $property, Unit $unit, UtilityMeter $meter, UtilityReading $reading): RedirectResponse
+    {
+        $this->authorizeUnit($property, $unit, 'update');
+        $this->assertReadingBelongsToMeter($meter, $reading);
+        $this->updateReading->execute($reading, $request->validated());
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Utility reading updated.')]);
+
+        return back();
+    }
+
+    public function destroyReading(Property $property, Unit $unit, UtilityMeter $meter, UtilityReading $reading): RedirectResponse
+    {
+        $this->authorizeUnit($property, $unit, 'update');
+        $this->assertReadingBelongsToMeter($meter, $reading);
+
+        DB::transaction(function () use ($reading): void {
+            $lockedReading = UtilityReading::query()->lockForUpdate()->findOrFail($reading->id);
+
+            if ($lockedReading->isBilled()) {
+                throw ValidationException::withMessages([
+                    'reading' => __('Billed utility readings cannot be deleted.'),
+                ]);
+            }
+
+            if ($lockedReading->hasDependents()) {
+                throw ValidationException::withMessages([
+                    'reading' => __('This reading is used by a later reading and cannot be deleted.'),
+                ]);
+            }
+
+            $lockedReading->delete();
+        });
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Utility reading deleted.')]);
+
+        return back();
+    }
+
+    public function storeCorrection(StoreUtilityReadingCorrectionRequest $request, Property $property, Unit $unit, UtilityMeter $meter, UtilityReading $reading): RedirectResponse
+    {
+        $this->authorizeUnit($property, $unit, 'update');
+        $this->assertReadingBelongsToMeter($meter, $reading);
+        $this->createCorrection->execute($reading, $request->validated());
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Utility correction recorded.')]);
+
+        return back();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readingPayload(UtilityReading $reading): array
+    {
+        $lineItem = $reading->invoiceLineItem;
+        $charge = $reading->reading_kind->value === 'correction'
+            ? BigDecimal::of((string) $reading->adjustment_consumption)
+                ->multipliedBy((string) $reading->rate)
+                ->toScale($this->money->scale($reading->currency), RoundingMode::HalfEven)
+                ->toString()
+            : $this->money->normalizeAmount(
+                BigDecimal::of((string) $reading->consumption)->multipliedBy((string) $reading->rate)->toString(),
+                $reading->currency,
+            );
+
+        return [
+            'id' => $reading->id,
+            'reading_kind' => $reading->reading_kind->value,
+            'reading_date' => $reading->reading_date->toDateString(),
+            'period_start' => $reading->period_start->toDateString(),
+            'period_end' => $reading->period_end->toDateString(),
+            'previous_reading' => (string) $reading->previous_reading,
+            'current_reading' => (string) $reading->current_reading,
+            'consumption' => (string) $reading->consumption,
+            'adjustment_consumption' => $reading->adjustment_consumption === null ? null : (string) $reading->adjustment_consumption,
+            'rate' => (string) $reading->rate,
+            'currency' => $reading->currency,
+            'reference' => $reading->reference,
+            'corrects_reading_id' => $reading->corrects_reading_id,
+            'charge_preview' => $charge,
+            'billed' => $lineItem !== null,
+            'invoice_reference' => $lineItem?->invoice?->reference,
+            'can_edit' => $lineItem === null && $reading->dependent_readings_count === 0,
+            'can_delete' => $lineItem === null && $reading->dependent_readings_count === 0,
+        ];
+    }
+
+    private function authorizeUnit(Property $property, Unit $unit, string $ability): void
+    {
+        abort_if($unit->property_id !== $property->id, 404);
+        $this->authorize($ability, $unit);
+    }
+
+    private function assertMeterBelongsToUnit(UtilityMeter $meter, Unit $unit): void
+    {
+        abort_if($meter->unit_id !== $unit->id, 404);
+    }
+
+    private function assertReadingBelongsToMeter(UtilityMeter $meter, UtilityReading $reading): void
+    {
+        abort_if($reading->utility_meter_id !== $meter->id, 404);
+    }
+}

--- a/app/Http/Controllers/UnitUtilityController.php
+++ b/app/Http/Controllers/UnitUtilityController.php
@@ -44,7 +44,7 @@ class UnitUtilityController extends Controller
                 ->with([
                     'readings' => fn ($query) => $query
                         ->with(['invoiceLineItem.invoice', 'correctsReading.invoiceLineItem'])
-                        ->withCount('dependentReadings')
+                        ->withCount(['dependentReadings', 'corrections'])
                         ->latest('period_end')
                         ->latest('id'),
                 ]),
@@ -177,6 +177,7 @@ class UnitUtilityController extends Controller
             'invoice_reference' => $lineItem?->invoice?->reference,
             'can_edit' => $lineItem === null && $reading->dependent_readings_count === 0,
             'can_delete' => $lineItem === null && $reading->dependent_readings_count === 0,
+            'correction_exists' => $reading->corrections_count > 0,
         ];
     }
 

--- a/app/Http/Controllers/UnitUtilityController.php
+++ b/app/Http/Controllers/UnitUtilityController.php
@@ -56,6 +56,7 @@ class UnitUtilityController extends Controller
             'meters' => $unit->utilityMeters->map(fn (UtilityMeter $meter): array => [
                 'id' => $meter->id,
                 'utility_type' => $meter->utility_type->value,
+                'utility_name' => $meter->utility_name,
                 'identifier' => $meter->identifier,
                 'measurement_unit' => $meter->measurement_unit,
                 'rate' => (string) $meter->rate,

--- a/app/Http/Requests/Utility/StoreUtilityMeterRequest.php
+++ b/app/Http/Requests/Utility/StoreUtilityMeterRequest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Http\Requests\Utility;
+
+use App\Enums\UtilityMeterType;
+use App\Rules\MoneyAmount;
+use App\Services\Payments\MoneyConverter;
+use App\Services\Settings\InstallationCurrencySettings;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Enum;
+use Illuminate\Validation\Validator;
+
+class StoreUtilityMeterRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'utility_type' => ['required', new Enum(UtilityMeterType::class)],
+            'identifier' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique('utility_meters', 'identifier')
+                    ->where(fn ($query) => $query->where('unit_id', $this->route('unit')->id)),
+            ],
+            'measurement_unit' => ['required', 'string', 'max:50'],
+            'rate' => ['required', new MoneyAmount($this->input('currency'), allowZero: false)],
+            'currency' => [
+                'required',
+                'string',
+                'size:3',
+                Rule::in(array_keys(app(MoneyConverter::class)->scales())),
+            ],
+            'is_active' => ['sometimes', 'boolean'],
+        ];
+    }
+
+    /**
+     * @return array<int, callable(Validator): void>
+     */
+    public function after(): array
+    {
+        return [function (Validator $validator): void {
+            $currency = $this->input('currency');
+
+            if (is_string($currency) && ! app(InstallationCurrencySettings::class)->supports($currency)) {
+                $validator->errors()->add('currency', __('This currency is not enabled for utility rates.'));
+            }
+        }];
+    }
+}

--- a/app/Http/Requests/Utility/StoreUtilityMeterRequest.php
+++ b/app/Http/Requests/Utility/StoreUtilityMeterRequest.php
@@ -28,6 +28,7 @@ class StoreUtilityMeterRequest extends FormRequest
     {
         return [
             'utility_type' => ['required', new Enum(UtilityMeterType::class)],
+            'utility_name' => ['nullable', 'string', 'max:255', 'required_if:utility_type,custom'],
             'identifier' => [
                 'required',
                 'string',

--- a/app/Http/Requests/Utility/StoreUtilityReadingCorrectionRequest.php
+++ b/app/Http/Requests/Utility/StoreUtilityReadingCorrectionRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests\Utility;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreUtilityReadingCorrectionRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'current_reading' => ['required', 'regex:/\A(?:0|[1-9]\d*)(?:\.\d{1,3})?\z/D'],
+            'reference' => ['nullable', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Http/Requests/Utility/StoreUtilityReadingRequest.php
+++ b/app/Http/Requests/Utility/StoreUtilityReadingRequest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Requests\Utility;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Validator;
+
+class StoreUtilityReadingRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'reading_date' => ['required', 'date'],
+            'period_start' => ['required', 'date'],
+            'period_end' => ['required', 'date', 'after_or_equal:period_start'],
+            'previous_reading' => ['required', 'regex:/\A(?:0|[1-9]\d*)(?:\.\d{1,3})?\z/D'],
+            'current_reading' => ['required', 'regex:/\A(?:0|[1-9]\d*)(?:\.\d{1,3})?\z/D'],
+            'reference' => ['nullable', 'string', 'max:255'],
+        ];
+    }
+
+    /**
+     * @return array<int, callable(Validator): void>
+     */
+    public function after(): array
+    {
+        return [function (Validator $validator): void {
+            if (! $this->date('reading_date') || ! $this->date('period_start') || ! $this->date('period_end')) {
+                return;
+            }
+
+            if ($this->date('reading_date')->lt($this->date('period_start')) || $this->date('reading_date')->gt($this->date('period_end'))) {
+                $validator->errors()->add('reading_date', __('The reading date must fall within its utility period.'));
+            }
+        }];
+    }
+}

--- a/app/Http/Requests/Utility/UpdateUtilityMeterRequest.php
+++ b/app/Http/Requests/Utility/UpdateUtilityMeterRequest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Http\Requests\Utility;
+
+use App\Enums\UtilityMeterType;
+use App\Rules\MoneyAmount;
+use App\Services\Payments\MoneyConverter;
+use App\Services\Settings\InstallationCurrencySettings;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Enum;
+use Illuminate\Validation\Validator;
+
+class UpdateUtilityMeterRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        $meter = $this->route('meter');
+
+        return [
+            'utility_type' => ['required', new Enum(UtilityMeterType::class)],
+            'identifier' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique('utility_meters', 'identifier')
+                    ->ignore($meter->id)
+                    ->where(fn ($query) => $query->where('unit_id', $this->route('unit')->id)),
+            ],
+            'measurement_unit' => ['required', 'string', 'max:50'],
+            'rate' => ['required', new MoneyAmount($this->input('currency'), allowZero: false)],
+            'currency' => [
+                'required',
+                'string',
+                'size:3',
+                Rule::in(array_keys(app(MoneyConverter::class)->scales())),
+            ],
+            'is_active' => ['required', 'boolean'],
+        ];
+    }
+
+    /**
+     * @return array<int, callable(Validator): void>
+     */
+    public function after(): array
+    {
+        return [function (Validator $validator): void {
+            $currency = $this->input('currency');
+
+            if (is_string($currency) && ! app(InstallationCurrencySettings::class)->supports($currency)) {
+                $validator->errors()->add('currency', __('This currency is not enabled for utility rates.'));
+            }
+        }];
+    }
+}

--- a/app/Http/Requests/Utility/UpdateUtilityMeterRequest.php
+++ b/app/Http/Requests/Utility/UpdateUtilityMeterRequest.php
@@ -30,6 +30,7 @@ class UpdateUtilityMeterRequest extends FormRequest
 
         return [
             'utility_type' => ['required', new Enum(UtilityMeterType::class)],
+            'utility_name' => ['nullable', 'string', 'max:255', 'required_if:utility_type,custom'],
             'identifier' => [
                 'required',
                 'string',

--- a/app/Http/Requests/Utility/UpdateUtilityReadingRequest.php
+++ b/app/Http/Requests/Utility/UpdateUtilityReadingRequest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Requests\Utility;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Validator;
+
+class UpdateUtilityReadingRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'reading_date' => ['sometimes', 'date'],
+            'period_start' => ['sometimes', 'date'],
+            'period_end' => ['sometimes', 'date', 'after_or_equal:period_start'],
+            'previous_reading' => ['sometimes', 'regex:/\A(?:0|[1-9]\d*)(?:\.\d{1,3})?\z/D'],
+            'current_reading' => ['required', 'regex:/\A(?:0|[1-9]\d*)(?:\.\d{1,3})?\z/D'],
+            'reference' => ['nullable', 'string', 'max:255'],
+        ];
+    }
+
+    /**
+     * @return array<int, callable(Validator): void>
+     */
+    public function after(): array
+    {
+        return [function (Validator $validator): void {
+            if (! $this->date('reading_date') || ! $this->date('period_start') || ! $this->date('period_end')) {
+                return;
+            }
+
+            if ($this->date('reading_date')->lt($this->date('period_start')) || $this->date('reading_date')->gt($this->date('period_end'))) {
+                $validator->errors()->add('reading_date', __('The reading date must fall within its utility period.'));
+            }
+        }];
+    }
+}

--- a/app/Models/InvoiceLineItem.php
+++ b/app/Models/InvoiceLineItem.php
@@ -13,6 +13,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
     'type',
     'description',
     'amount',
+    'utility_reading_id',
+    'metadata',
 ])]
 class InvoiceLineItem extends Model
 {
@@ -22,11 +24,17 @@ class InvoiceLineItem extends Model
     {
         return [
             'amount' => 'decimal:3',
+            'metadata' => 'array',
         ];
     }
 
     public function invoice(): BelongsTo
     {
         return $this->belongsTo(Invoice::class);
+    }
+
+    public function utilityReading(): BelongsTo
+    {
+        return $this->belongsTo(UtilityReading::class);
     }
 }

--- a/app/Models/Unit.php
+++ b/app/Models/Unit.php
@@ -79,6 +79,16 @@ class Unit extends Model
         return $this->hasMany(UnitRate::class);
     }
 
+    public function utilityMeters(): HasMany
+    {
+        return $this->hasMany(UtilityMeter::class);
+    }
+
+    public function meters(): HasMany
+    {
+        return $this->utilityMeters();
+    }
+
     public function activeRates(): HasMany
     {
         // Deterministic, meaningful order: shortest billing period first

--- a/app/Models/UtilityMeter.php
+++ b/app/Models/UtilityMeter.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 #[Fillable([
     'unit_id',
     'utility_type',
+    'utility_name',
     'identifier',
     'measurement_unit',
     'rate',
@@ -32,6 +33,12 @@ class UtilityMeter extends Model
 
     protected static function booted(): void
     {
+        static::saving(function (UtilityMeter $meter): void {
+            if ($meter->utility_type !== UtilityMeterType::Custom) {
+                $meter->utility_name = null;
+            }
+        });
+
         static::creating(function (UtilityMeter $meter): void {
             $meter->currency = app(MoneyConverter::class)->normalizeCurrency(
                 $meter->getAttributeFromArray('currency'),

--- a/app/Models/UtilityMeter.php
+++ b/app/Models/UtilityMeter.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\Auditable;
+use App\Concerns\SerializesDatesWithTimezone;
+use App\Enums\UtilityMeterType;
+use App\Services\Payments\MoneyConverter;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+#[Fillable([
+    'unit_id',
+    'utility_type',
+    'identifier',
+    'measurement_unit',
+    'rate',
+    'currency',
+    'is_active',
+])]
+class UtilityMeter extends Model
+{
+    use Auditable, HasFactory, SerializesDatesWithTimezone;
+
+    protected $attributes = [
+        'is_active' => true,
+    ];
+
+    protected static function booted(): void
+    {
+        static::creating(function (UtilityMeter $meter): void {
+            $meter->currency = app(MoneyConverter::class)->normalizeCurrency(
+                $meter->getAttributeFromArray('currency'),
+            );
+            $meter->rate = app(MoneyConverter::class)->normalizeAmount(
+                (string) $meter->rate,
+                $meter->currency,
+            );
+        });
+
+        static::updating(function (UtilityMeter $meter): void {
+            if (! $meter->isDirty(['rate', 'currency'])) {
+                return;
+            }
+
+            $meter->currency = app(MoneyConverter::class)->normalizeCurrency($meter->currency);
+            $meter->rate = app(MoneyConverter::class)->normalizeAmount(
+                (string) $meter->rate,
+                $meter->currency,
+            );
+        });
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'utility_type' => UtilityMeterType::class,
+            'rate' => 'decimal:3',
+            'is_active' => 'boolean',
+        ];
+    }
+
+    public function unit(): BelongsTo
+    {
+        return $this->belongsTo(Unit::class);
+    }
+
+    public function readings(): HasMany
+    {
+        return $this->hasMany(UtilityReading::class);
+    }
+
+    public function scopeActive(Builder $query): void
+    {
+        $query->where('is_active', true);
+    }
+
+    public function getCurrencyAttribute(?string $value): string
+    {
+        return app(MoneyConverter::class)->normalizeCurrency($value);
+    }
+}

--- a/app/Models/UtilityReading.php
+++ b/app/Models/UtilityReading.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\Auditable;
+use App\Concerns\SerializesDatesWithTimezone;
+use App\Enums\UtilityReadingKind;
+use App\Services\Payments\MoneyConverter;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use LogicException;
+
+#[Fillable([
+    'utility_meter_id',
+    'reading_kind',
+    'reading_date',
+    'period_start',
+    'period_end',
+    'previous_reading_id',
+    'previous_reading',
+    'current_reading',
+    'consumption',
+    'adjustment_consumption',
+    'rate',
+    'currency',
+    'reference',
+    'corrects_reading_id',
+])]
+class UtilityReading extends Model
+{
+    use Auditable, HasFactory, SerializesDatesWithTimezone;
+
+    protected $attributes = [
+        'reading_kind' => UtilityReadingKind::Reading,
+    ];
+
+    protected static function booted(): void
+    {
+        static::creating(function (UtilityReading $reading): void {
+            $reading->currency = app(MoneyConverter::class)->normalizeCurrency($reading->currency);
+            $reading->rate = app(MoneyConverter::class)->normalizeAmount(
+                (string) $reading->rate,
+                $reading->currency,
+            );
+        });
+
+        static::updating(function (UtilityReading $reading): void {
+            $reading->guardMutable();
+
+            if ($reading->isDirty(['utility_meter_id', 'reading_kind', 'rate', 'currency'])) {
+                throw new LogicException('Utility reading identity and rate snapshots cannot be changed.');
+            }
+        });
+
+        static::deleting(function (UtilityReading $reading): void {
+            $reading->guardMutable();
+        });
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'reading_kind' => UtilityReadingKind::class,
+            'reading_date' => 'date:Y-m-d',
+            'period_start' => 'date:Y-m-d',
+            'period_end' => 'date:Y-m-d',
+            'previous_reading' => 'decimal:3',
+            'current_reading' => 'decimal:3',
+            'consumption' => 'decimal:3',
+            'adjustment_consumption' => 'decimal:3',
+            'rate' => 'decimal:3',
+        ];
+    }
+
+    public function meter(): BelongsTo
+    {
+        return $this->belongsTo(UtilityMeter::class, 'utility_meter_id');
+    }
+
+    public function previousReading(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'previous_reading_id');
+    }
+
+    public function dependentReadings(): HasMany
+    {
+        return $this->hasMany(self::class, 'previous_reading_id');
+    }
+
+    public function correctsReading(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'corrects_reading_id');
+    }
+
+    public function corrections(): HasMany
+    {
+        return $this->hasMany(self::class, 'corrects_reading_id');
+    }
+
+    public function invoiceLineItem(): HasOne
+    {
+        return $this->hasOne(InvoiceLineItem::class);
+    }
+
+    public function isBilled(): bool
+    {
+        return $this->invoiceLineItem()->exists();
+    }
+
+    public function hasDependents(): bool
+    {
+        return $this->dependentReadings()->exists();
+    }
+
+    public function getCurrencyAttribute(?string $value): string
+    {
+        return app(MoneyConverter::class)->normalizeCurrency($value);
+    }
+
+    private function guardMutable(): void
+    {
+        if ($this->isBilled()) {
+            throw new LogicException('Billed utility readings cannot be changed.');
+        }
+
+        if ($this->hasDependents()) {
+            throw new LogicException('Utility readings used by later readings cannot be changed.');
+        }
+    }
+}

--- a/database/factories/UtilityMeterFactory.php
+++ b/database/factories/UtilityMeterFactory.php
@@ -22,6 +22,7 @@ class UtilityMeterFactory extends Factory
         return [
             'unit_id' => Unit::factory(),
             'utility_type' => UtilityMeterType::Electricity,
+            'utility_name' => null,
             'identifier' => fake()->unique()->bothify('MTR-####'),
             'measurement_unit' => 'kWh',
             'rate' => '1000',

--- a/database/factories/UtilityMeterFactory.php
+++ b/database/factories/UtilityMeterFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\UtilityMeterType;
+use App\Models\Unit;
+use App\Models\UtilityMeter;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<UtilityMeter>
+ */
+class UtilityMeterFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'unit_id' => Unit::factory(),
+            'utility_type' => UtilityMeterType::Electricity,
+            'identifier' => fake()->unique()->bothify('MTR-####'),
+            'measurement_unit' => 'kWh',
+            'rate' => '1000',
+            'currency' => 'IDR',
+            'is_active' => true,
+        ];
+    }
+
+    public function inactive(): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'is_active' => false,
+        ]);
+    }
+}

--- a/database/factories/UtilityReadingFactory.php
+++ b/database/factories/UtilityReadingFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\UtilityReadingKind;
+use App\Models\UtilityMeter;
+use App\Models\UtilityReading;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<UtilityReading>
+ */
+class UtilityReadingFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $periodStart = CarbonImmutable::now()->startOfMonth();
+        $periodEnd = $periodStart->endOfMonth();
+
+        return [
+            'utility_meter_id' => UtilityMeter::factory(),
+            'reading_kind' => UtilityReadingKind::Reading,
+            'reading_date' => $periodEnd,
+            'period_start' => $periodStart,
+            'period_end' => $periodEnd,
+            'previous_reading_id' => null,
+            'previous_reading' => '0',
+            'current_reading' => '100',
+            'consumption' => '100',
+            'adjustment_consumption' => null,
+            'rate' => '1000',
+            'currency' => 'IDR',
+            'reference' => null,
+            'corrects_reading_id' => null,
+        ];
+    }
+}

--- a/database/migrations/2026_09_09_094616_create_utility_meters_table.php
+++ b/database/migrations/2026_09_09_094616_create_utility_meters_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('utility_meters', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('unit_id')->constrained()->restrictOnDelete();
+            $table->string('utility_type');
+            $table->string('identifier');
+            $table->string('measurement_unit');
+            $table->decimal('rate', 20, 3);
+            $table->char('currency', 3);
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+            $table->unique(['unit_id', 'identifier']);
+            $table->index(['unit_id', 'is_active'], 'idx_utility_meters_unit_active');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('utility_meters');
+    }
+};

--- a/database/migrations/2026_09_09_094617_create_utility_readings_table.php
+++ b/database/migrations/2026_09_09_094617_create_utility_readings_table.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('utility_readings', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('utility_meter_id')->constrained('utility_meters')->restrictOnDelete();
+            $table->string('reading_kind')->default('reading');
+            $table->date('reading_date');
+            $table->date('period_start');
+            $table->date('period_end');
+            $table->foreignId('previous_reading_id')->nullable()->constrained('utility_readings')->restrictOnDelete();
+            $table->decimal('previous_reading', 20, 3);
+            $table->decimal('current_reading', 20, 3);
+            $table->decimal('consumption', 20, 3);
+            $table->decimal('adjustment_consumption', 20, 3)->nullable();
+            $table->decimal('rate', 20, 3);
+            $table->char('currency', 3);
+            $table->string('reference')->nullable();
+            $table->foreignId('corrects_reading_id')->nullable()->constrained('utility_readings')->restrictOnDelete();
+            $table->timestamps();
+            $table->unique(
+                ['utility_meter_id', 'period_start', 'period_end', 'reading_kind'],
+                'utility_readings_meter_period_kind_unique',
+            );
+            $table->index(
+                ['utility_meter_id', 'period_start', 'period_end'],
+                'idx_utility_readings_meter_period',
+            );
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('utility_readings');
+    }
+};

--- a/database/migrations/2026_09_09_094618_add_utility_source_to_invoice_line_items_table.php
+++ b/database/migrations/2026_09_09_094618_add_utility_source_to_invoice_line_items_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('invoice_line_items', function (Blueprint $table) {
+            $table->foreignId('utility_reading_id')
+                ->nullable()
+                ->after('amount')
+                ->unique()
+                ->constrained('utility_readings')
+                ->restrictOnDelete();
+            $table->json('metadata')->nullable()->after('utility_reading_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('invoice_line_items', function (Blueprint $table) {
+            $table->dropForeign(['utility_reading_id']);
+            $table->dropUnique('invoice_line_items_utility_reading_id_unique');
+            $table->dropColumn(['utility_reading_id', 'metadata']);
+        });
+    }
+};

--- a/database/migrations/2026_09_10_035433_add_utility_name_to_utility_meters_table.php
+++ b/database/migrations/2026_09_10_035433_add_utility_name_to_utility_meters_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('utility_meters', function (Blueprint $table) {
+            $table->string('utility_name')->nullable()->after('utility_type');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('utility_meters', function (Blueprint $table) {
+            $table->dropColumn('utility_name');
+        });
+    }
+};

--- a/resources/js/pages/properties/units/layout.tsx
+++ b/resources/js/pages/properties/units/layout.tsx
@@ -39,6 +39,11 @@ export function UnitLayout({
                         href: `${base}/rates`,
                     },
                     {
+                        key: 'utilities',
+                        label: 'Utilities',
+                        href: `${base}/utilities`,
+                    },
+                    {
                         key: 'maintenance',
                         label: 'Maintenance',
                         href: `${base}/maintenance-history`,

--- a/resources/js/pages/properties/units/utilities.tsx
+++ b/resources/js/pages/properties/units/utilities.tsx
@@ -611,7 +611,8 @@ export default function UnitUtilities({
                                                                         )}
                                                                         {reading.billed &&
                                                                             reading.reading_kind ===
-                                                                                'reading' && (
+                                                                                'reading' &&
+                                                                            !reading.correction_exists && (
                                                                                 <DropdownMenuItem
                                                                                     onSelect={() =>
                                                                                         openCorrectionDialog(

--- a/resources/js/pages/properties/units/utilities.tsx
+++ b/resources/js/pages/properties/units/utilities.tsx
@@ -36,6 +36,7 @@ import { UnitLayout } from './layout';
 
 type MeterFormData = {
     utility_type: UtilityMeter['utility_type'];
+    utility_name: string;
     identifier: string;
     measurement_unit: string;
     rate: string;
@@ -78,6 +79,16 @@ function periodEnd(periodStart: string): string {
     date.setMonth(date.getMonth() + 1, 0);
 
     return date.toISOString().slice(0, 10);
+}
+
+function defaultMeasurementUnit(
+    utilityType: UtilityMeter['utility_type'],
+): string {
+    return utilityType === 'electricity'
+        ? 'kWh'
+        : utilityType === 'water'
+          ? 'm³'
+          : '';
 }
 
 function previewCharge(
@@ -125,8 +136,9 @@ export default function UnitUtilities({
         useState<UtilityReading | null>(null);
     const meterForm = useForm<MeterFormData>({
         utility_type: 'electricity',
+        utility_name: '',
         identifier: '',
-        measurement_unit: 'kWh',
+        measurement_unit: defaultMeasurementUnit('electricity'),
         rate: '',
         currency: defaultCurrency,
         is_active: true,
@@ -150,6 +162,7 @@ export default function UnitUtilities({
             meter
                 ? {
                       utility_type: meter.utility_type,
+                      utility_name: meter.utility_name ?? '',
                       identifier: meter.identifier,
                       measurement_unit: meter.measurement_unit,
                       rate: meter.rate,
@@ -158,14 +171,29 @@ export default function UnitUtilities({
                   }
                 : {
                       utility_type: 'electricity',
+                      utility_name: '',
                       identifier: '',
-                      measurement_unit: 'kWh',
+                      measurement_unit: defaultMeasurementUnit('electricity'),
                       rate: '',
                       currency: defaultCurrency,
                       is_active: true,
                   },
         );
         setMeterDialogOpen(true);
+    }
+
+    function handleUtilityTypeChange(value: string) {
+        const utilityType = value as UtilityMeter['utility_type'];
+
+        meterForm.setData('utility_type', utilityType);
+        meterForm.setData(
+            'measurement_unit',
+            defaultMeasurementUnit(utilityType),
+        );
+
+        if (utilityType !== 'custom') {
+            meterForm.setData('utility_name', '');
+        }
     }
 
     function closeMeterDialog(open: boolean) {
@@ -360,11 +388,15 @@ export default function UnitUtilities({
                                                 {meter.identifier}
                                             </h3>
                                             <Badge variant="outline">
-                                                {t(
-                                                    utilityLabels[
-                                                        meter.utility_type
-                                                    ],
-                                                )}
+                                                {meter.utility_type ===
+                                                    'custom' &&
+                                                meter.utility_name
+                                                    ? meter.utility_name
+                                                    : t(
+                                                          utilityLabels[
+                                                              meter.utility_type
+                                                          ],
+                                                      )}
                                             </Badge>
                                             <Badge
                                                 variant="outline"
@@ -387,7 +419,7 @@ export default function UnitUtilities({
                                                 meter.rate,
                                                 meter.currency,
                                             )}{' '}
-                                            {t('per unit')}
+                                            / {meter.measurement_unit}
                                         </p>
                                     </div>
                                     <div className="flex items-center gap-2">
@@ -677,12 +709,7 @@ export default function UnitUtilities({
                             </Label>
                             <Select
                                 value={meterForm.data.utility_type}
-                                onValueChange={(value) =>
-                                    meterForm.setData(
-                                        'utility_type',
-                                        value as UtilityMeter['utility_type'],
-                                    )
-                                }
+                                onValueChange={handleUtilityTypeChange}
                             >
                                 <SelectTrigger id="utility-type">
                                     <SelectValue />
@@ -704,6 +731,28 @@ export default function UnitUtilities({
                                 message={meterForm.errors.utility_type}
                             />
                         </div>
+                        {meterForm.data.utility_type === 'custom' && (
+                            <div className="grid gap-2">
+                                <Label htmlFor="utility-name">
+                                    {t('Utility name')}
+                                </Label>
+                                <Input
+                                    id="utility-name"
+                                    required
+                                    value={meterForm.data.utility_name}
+                                    onChange={(event) =>
+                                        meterForm.setData(
+                                            'utility_name',
+                                            event.target.value,
+                                        )
+                                    }
+                                    placeholder={t('e.g. Gas')}
+                                />
+                                <InputError
+                                    message={meterForm.errors.utility_name}
+                                />
+                            </div>
+                        )}
                         <div className="grid gap-2">
                             <Label htmlFor="meter-identifier">
                                 {t('Meter identifier')}
@@ -735,7 +784,13 @@ export default function UnitUtilities({
                                         event.target.value,
                                     )
                                 }
-                                placeholder="kWh"
+                                placeholder={
+                                    meterForm.data.utility_type === 'custom'
+                                        ? t('e.g. kg')
+                                        : defaultMeasurementUnit(
+                                              meterForm.data.utility_type,
+                                          )
+                                }
                             />
                             <InputError
                                 message={meterForm.errors.measurement_unit}
@@ -743,7 +798,13 @@ export default function UnitUtilities({
                         </div>
                         <div className="grid grid-cols-2 gap-3">
                             <div className="grid gap-2">
-                                <Label htmlFor="meter-rate">{t('Rate')}</Label>
+                                <Label htmlFor="meter-rate">
+                                    {t('Rate per :unit', {
+                                        unit:
+                                            meterForm.data.measurement_unit.trim() ||
+                                            'unit',
+                                    })}
+                                </Label>
                                 <Input
                                     id="meter-rate"
                                     type="number"
@@ -836,7 +897,7 @@ export default function UnitUtilities({
                         </DialogTitle>
                         <DialogDescription>
                             {selectedMeter &&
-                                `${selectedMeter.identifier} · ${selectedMeter.measurement_unit} · ${formatPrice(selectedMeter.rate, selectedMeter.currency)} ${t('per unit')}`}
+                                `${selectedMeter.identifier} · ${selectedMeter.measurement_unit} · ${formatPrice(selectedMeter.rate, selectedMeter.currency)} / ${selectedMeter.measurement_unit}`}
                         </DialogDescription>
                     </DialogHeader>
                     <form onSubmit={submitReading} className="grid gap-4">

--- a/resources/js/pages/properties/units/utilities.tsx
+++ b/resources/js/pages/properties/units/utilities.tsx
@@ -1,0 +1,1111 @@
+import { router, useForm, usePage } from '@inertiajs/react';
+import { Ellipsis, Pencil, Plus, RotateCcw, Trash2, X } from 'lucide-react';
+import { useState } from 'react';
+import { InputError } from '@/components/shared';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import { formatDate, formatPrice } from '@/lib/formatters';
+import { t } from '@/lib/i18n';
+import properties from '@/routes/properties';
+import type { Property, Unit, UtilityMeter, UtilityReading } from '@/types';
+import { UnitLayout } from './layout';
+
+type MeterFormData = {
+    utility_type: UtilityMeter['utility_type'];
+    identifier: string;
+    measurement_unit: string;
+    rate: string;
+    currency: string;
+    is_active: boolean;
+};
+
+type ReadingFormData = {
+    reading_date: string;
+    period_start: string;
+    period_end: string;
+    previous_reading: string;
+    current_reading: string;
+    reference: string;
+    reading?: string;
+};
+
+type CorrectionFormData = {
+    current_reading: string;
+    reference: string;
+    reading?: string;
+};
+
+const utilityLabels: Record<UtilityMeter['utility_type'], string> = {
+    electricity: 'Electricity',
+    water: 'Water',
+    custom: 'Custom',
+};
+
+function today(): string {
+    return new Date().toISOString().slice(0, 10);
+}
+
+function periodEnd(periodStart: string): string {
+    if (!periodStart) {
+        return '';
+    }
+
+    const date = new Date(`${periodStart}T00:00:00`);
+    date.setMonth(date.getMonth() + 1, 0);
+
+    return date.toISOString().slice(0, 10);
+}
+
+function previewCharge(
+    previous: string,
+    current: string,
+    rate: string,
+    currency: string,
+): string {
+    const consumption = Number(current) - Number(previous);
+
+    if (!Number.isFinite(consumption) || consumption < 0) {
+        return '—';
+    }
+
+    return formatPrice(String(consumption * Number(rate)), currency);
+}
+
+export default function UnitUtilities({
+    property,
+    unit,
+    meters,
+}: {
+    property: Property;
+    unit: Unit;
+    meters: UtilityMeter[];
+}) {
+    const { setting } = usePage<{
+        setting: { currency: string; supported_currencies: string[] };
+    }>().props;
+    const defaultCurrency = setting.currency.toUpperCase();
+    const supportedCurrencies = Array.from(
+        new Set([defaultCurrency, ...setting.supported_currencies]),
+    ).sort();
+    const [meterDialogOpen, setMeterDialogOpen] = useState(false);
+    const [readingDialogOpen, setReadingDialogOpen] = useState(false);
+    const [correctionDialogOpen, setCorrectionDialogOpen] = useState(false);
+    const [editingMeter, setEditingMeter] = useState<UtilityMeter | null>(null);
+    const [selectedMeter, setSelectedMeter] = useState<UtilityMeter | null>(
+        null,
+    );
+    const [editingReading, setEditingReading] = useState<UtilityReading | null>(
+        null,
+    );
+    const [correctionReading, setCorrectionReading] =
+        useState<UtilityReading | null>(null);
+    const meterForm = useForm<MeterFormData>({
+        utility_type: 'electricity',
+        identifier: '',
+        measurement_unit: 'kWh',
+        rate: '',
+        currency: defaultCurrency,
+        is_active: true,
+    });
+    const readingForm = useForm<ReadingFormData>({
+        reading_date: today(),
+        period_start: today().slice(0, 7) + '-01',
+        period_end: periodEnd(today().slice(0, 7) + '-01'),
+        previous_reading: '',
+        current_reading: '',
+        reference: '',
+    });
+    const correctionForm = useForm<CorrectionFormData>({
+        current_reading: '',
+        reference: '',
+    });
+
+    function openMeterDialog(meter?: UtilityMeter) {
+        setEditingMeter(meter ?? null);
+        meterForm.setData(
+            meter
+                ? {
+                      utility_type: meter.utility_type,
+                      identifier: meter.identifier,
+                      measurement_unit: meter.measurement_unit,
+                      rate: meter.rate,
+                      currency: meter.currency,
+                      is_active: meter.is_active,
+                  }
+                : {
+                      utility_type: 'electricity',
+                      identifier: '',
+                      measurement_unit: 'kWh',
+                      rate: '',
+                      currency: defaultCurrency,
+                      is_active: true,
+                  },
+        );
+        setMeterDialogOpen(true);
+    }
+
+    function closeMeterDialog(open: boolean) {
+        setMeterDialogOpen(open);
+
+        if (!open) {
+            meterForm.reset();
+            setEditingMeter(null);
+        }
+    }
+
+    function submitMeter(event: React.FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        const route = editingMeter
+            ? properties.units.utilities.meters.update({
+                  property: property.slug,
+                  unit: unit.slug,
+                  meter: editingMeter.id,
+              })
+            : properties.units.utilities.meters.store({
+                  property: property.slug,
+                  unit: unit.slug,
+              });
+
+        meterForm.submit(editingMeter ? 'put' : 'post', route.url, {
+            onSuccess: () => closeMeterDialog(false),
+        });
+    }
+
+    function openReadingDialog(meter: UtilityMeter, reading?: UtilityReading) {
+        const previous =
+            reading?.previous_reading ??
+            meter.readings.find((item) => item.reading_kind === 'reading')
+                ?.current_reading ??
+            '';
+        const start = reading?.period_start ?? today().slice(0, 7) + '-01';
+
+        setSelectedMeter(meter);
+        setEditingReading(reading ?? null);
+        readingForm.setData({
+            reading_date: reading?.reading_date ?? today(),
+            period_start: start,
+            period_end: reading?.period_end ?? periodEnd(start),
+            previous_reading: previous,
+            current_reading: reading?.current_reading ?? '',
+            reference: reading?.reference ?? '',
+        });
+        setReadingDialogOpen(true);
+    }
+
+    function closeReadingDialog(open: boolean) {
+        setReadingDialogOpen(open);
+
+        if (!open) {
+            readingForm.reset();
+            setSelectedMeter(null);
+            setEditingReading(null);
+        }
+    }
+
+    function submitReading(event: React.FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+
+        if (!selectedMeter) {
+            return;
+        }
+
+        const route = editingReading
+            ? properties.units.utilities.readings.update({
+                  property: property.slug,
+                  unit: unit.slug,
+                  meter: selectedMeter.id,
+                  reading: editingReading.id,
+              })
+            : properties.units.utilities.readings.store({
+                  property: property.slug,
+                  unit: unit.slug,
+                  meter: selectedMeter.id,
+              });
+
+        readingForm.submit(editingReading ? 'put' : 'post', route.url, {
+            onSuccess: () => closeReadingDialog(false),
+        });
+    }
+
+    function openCorrectionDialog(
+        meter: UtilityMeter,
+        reading: UtilityReading,
+    ) {
+        setSelectedMeter(meter);
+        setCorrectionReading(reading);
+        correctionForm.setData({
+            current_reading: reading.current_reading,
+            reference: '',
+        });
+        setCorrectionDialogOpen(true);
+    }
+
+    function closeCorrectionDialog(open: boolean) {
+        setCorrectionDialogOpen(open);
+
+        if (!open) {
+            correctionForm.reset();
+            setSelectedMeter(null);
+            setCorrectionReading(null);
+        }
+    }
+
+    function submitCorrection(event: React.FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+
+        if (!selectedMeter || !correctionReading) {
+            return;
+        }
+
+        correctionForm.post(
+            properties.units.utilities.readings.corrections.store.url({
+                property: property.slug,
+                unit: unit.slug,
+                meter: selectedMeter.id,
+                reading: correctionReading.id,
+            }),
+            { onSuccess: () => closeCorrectionDialog(false) },
+        );
+    }
+
+    function deleteReading(meter: UtilityMeter, reading: UtilityReading) {
+        if (!reading.can_delete || !window.confirm(t('Delete this reading?'))) {
+            return;
+        }
+
+        router.delete(
+            properties.units.utilities.readings.destroy.url({
+                property: property.slug,
+                unit: unit.slug,
+                meter: meter.id,
+                reading: reading.id,
+            }),
+        );
+    }
+
+    return (
+        <UnitLayout property={property} unit={unit} activeTab="utilities">
+            <div className="w-full space-y-6">
+                <div className="flex flex-wrap items-start justify-between gap-4">
+                    <div>
+                        <h2 className="text-lg font-semibold">
+                            {t('Utility meters')}
+                        </h2>
+                        <p className="text-sm text-muted-foreground">
+                            {t(
+                                'Record unit utility usage for the next invoice.',
+                            )}
+                        </p>
+                    </div>
+                    <Button type="button" onClick={() => openMeterDialog()}>
+                        <Plus />
+                        {t('Add meter')}
+                    </Button>
+                </div>
+
+                {meters.length === 0 ? (
+                    <div className="rounded-lg border border-dashed px-6 py-12 text-center">
+                        <h3 className="font-semibold">
+                            {t('No utility meters')}
+                        </h3>
+                        <p className="mx-auto mt-1 max-w-md text-sm text-muted-foreground">
+                            {t(
+                                'Add a unit meter to start recording readings and billing usage.',
+                            )}
+                        </p>
+                        <Button
+                            className="mt-4"
+                            type="button"
+                            onClick={() => openMeterDialog()}
+                        >
+                            <Plus />
+                            {t('Add first meter')}
+                        </Button>
+                    </div>
+                ) : (
+                    <div className="space-y-4">
+                        {meters.map((meter) => (
+                            <section
+                                key={meter.id}
+                                className="overflow-hidden rounded-lg border bg-card"
+                            >
+                                <div className="flex flex-wrap items-start justify-between gap-4 border-b px-4 py-4">
+                                    <div className="min-w-0">
+                                        <div className="flex flex-wrap items-center gap-2">
+                                            <h3 className="font-semibold">
+                                                {meter.identifier}
+                                            </h3>
+                                            <Badge variant="outline">
+                                                {t(
+                                                    utilityLabels[
+                                                        meter.utility_type
+                                                    ],
+                                                )}
+                                            </Badge>
+                                            <Badge
+                                                variant="outline"
+                                                className={
+                                                    meter.is_active
+                                                        ? 'border-surface-green-border/80 bg-surface-green/70 text-surface-green-foreground'
+                                                        : 'text-muted-foreground'
+                                                }
+                                            >
+                                                {t(
+                                                    meter.is_active
+                                                        ? 'Active'
+                                                        : 'Inactive',
+                                                )}
+                                            </Badge>
+                                        </div>
+                                        <p className="mt-1 text-sm text-muted-foreground">
+                                            {meter.measurement_unit} ·{' '}
+                                            {formatPrice(
+                                                meter.rate,
+                                                meter.currency,
+                                            )}{' '}
+                                            {t('per unit')}
+                                        </p>
+                                    </div>
+                                    <div className="flex items-center gap-2">
+                                        <Button
+                                            type="button"
+                                            size="sm"
+                                            onClick={() =>
+                                                openReadingDialog(meter)
+                                            }
+                                            disabled={!meter.is_active}
+                                        >
+                                            <Plus />
+                                            {t('Record reading')}
+                                        </Button>
+                                        <DropdownMenu>
+                                            <DropdownMenuTrigger asChild>
+                                                <Button
+                                                    type="button"
+                                                    variant="ghost"
+                                                    size="icon-sm"
+                                                    aria-label={`${t('Actions for')} ${meter.identifier}`}
+                                                >
+                                                    <Ellipsis />
+                                                </Button>
+                                            </DropdownMenuTrigger>
+                                            <DropdownMenuContent align="end">
+                                                <DropdownMenuItem
+                                                    onSelect={() =>
+                                                        openMeterDialog(meter)
+                                                    }
+                                                >
+                                                    <Pencil />
+                                                    {t('Edit meter')}
+                                                </DropdownMenuItem>
+                                                <DropdownMenuItem
+                                                    onSelect={() => {
+                                                        router.put(
+                                                            properties.units.utilities.meters.update.url(
+                                                                {
+                                                                    property:
+                                                                        property.slug,
+                                                                    unit: unit.slug,
+                                                                    meter: meter.id,
+                                                                },
+                                                            ),
+                                                            {
+                                                                utility_type:
+                                                                    meter.utility_type,
+                                                                identifier:
+                                                                    meter.identifier,
+                                                                measurement_unit:
+                                                                    meter.measurement_unit,
+                                                                rate: meter.rate,
+                                                                currency:
+                                                                    meter.currency,
+                                                                is_active:
+                                                                    !meter.is_active,
+                                                            },
+                                                        );
+                                                    }}
+                                                >
+                                                    {meter.is_active ? (
+                                                        <X />
+                                                    ) : (
+                                                        <RotateCcw />
+                                                    )}
+                                                    {t(
+                                                        meter.is_active
+                                                            ? 'Deactivate'
+                                                            : 'Reactivate',
+                                                    )}
+                                                </DropdownMenuItem>
+                                            </DropdownMenuContent>
+                                        </DropdownMenu>
+                                    </div>
+                                </div>
+
+                                <div className="overflow-x-auto">
+                                    <table className="w-full min-w-[48rem] text-sm">
+                                        <thead className="border-b bg-muted/40 text-left text-muted-foreground">
+                                            <tr>
+                                                <th className="px-4 py-3 font-medium">
+                                                    {t('Period')}
+                                                </th>
+                                                <th className="px-4 py-3 font-medium">
+                                                    {t('Reading')}
+                                                </th>
+                                                <th className="px-4 py-3 text-right font-medium">
+                                                    {t('Consumption')}
+                                                </th>
+                                                <th className="px-4 py-3 text-right font-medium">
+                                                    {t('Charge')}
+                                                </th>
+                                                <th className="px-4 py-3 font-medium">
+                                                    {t('Status')}
+                                                </th>
+                                                <th className="px-4 py-3 text-right font-medium">
+                                                    <span className="sr-only">
+                                                        {t('Actions')}
+                                                    </span>
+                                                </th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {meter.readings.length > 0 ? (
+                                                meter.readings.map(
+                                                    (reading) => (
+                                                        <tr
+                                                            key={reading.id}
+                                                            className="border-b last:border-b-0"
+                                                        >
+                                                            <td className="px-4 py-3">
+                                                                <div>
+                                                                    {formatDate(
+                                                                        reading.period_start,
+                                                                    )}{' '}
+                                                                    —{' '}
+                                                                    {formatDate(
+                                                                        reading.period_end,
+                                                                    )}
+                                                                </div>
+                                                                <div className="text-xs text-muted-foreground">
+                                                                    {formatDate(
+                                                                        reading.reading_date,
+                                                                    )}
+                                                                </div>
+                                                            </td>
+                                                            <td className="px-4 py-3 tabular-nums">
+                                                                {
+                                                                    reading.previous_reading
+                                                                }{' '}
+                                                                →{' '}
+                                                                {
+                                                                    reading.current_reading
+                                                                }
+                                                            </td>
+                                                            <td className="px-4 py-3 text-right tabular-nums">
+                                                                {reading.reading_kind ===
+                                                                    'correction' &&
+                                                                reading.adjustment_consumption !==
+                                                                    null
+                                                                    ? `${reading.consumption} (${reading.adjustment_consumption})`
+                                                                    : reading.consumption}{' '}
+                                                                {
+                                                                    meter.measurement_unit
+                                                                }
+                                                            </td>
+                                                            <td className="px-4 py-3 text-right font-medium tabular-nums">
+                                                                {formatPrice(
+                                                                    reading.charge_preview,
+                                                                    reading.currency,
+                                                                )}
+                                                            </td>
+                                                            <td className="px-4 py-3">
+                                                                <Badge
+                                                                    variant="outline"
+                                                                    className={
+                                                                        reading.billed
+                                                                            ? 'border-surface-blue-border/80 bg-surface-blue/70 text-surface-blue-foreground'
+                                                                            : 'border-surface-amber-border/80 bg-surface-amber/30 text-surface-amber-foreground'
+                                                                    }
+                                                                >
+                                                                    {t(
+                                                                        reading.billed
+                                                                            ? 'Billed'
+                                                                            : 'Unbilled',
+                                                                    )}
+                                                                </Badge>
+                                                                {reading.invoice_reference && (
+                                                                    <div className="mt-1 text-xs text-muted-foreground">
+                                                                        {
+                                                                            reading.invoice_reference
+                                                                        }
+                                                                    </div>
+                                                                )}
+                                                            </td>
+                                                            <td className="px-4 py-3 text-right">
+                                                                <DropdownMenu>
+                                                                    <DropdownMenuTrigger
+                                                                        asChild
+                                                                    >
+                                                                        <Button
+                                                                            type="button"
+                                                                            variant="ghost"
+                                                                            size="icon-sm"
+                                                                            aria-label={`${t('Actions for')} ${formatDate(reading.period_start)}`}
+                                                                        >
+                                                                            <Ellipsis />
+                                                                        </Button>
+                                                                    </DropdownMenuTrigger>
+                                                                    <DropdownMenuContent align="end">
+                                                                        {reading.can_edit && (
+                                                                            <DropdownMenuItem
+                                                                                onSelect={() =>
+                                                                                    openReadingDialog(
+                                                                                        meter,
+                                                                                        reading,
+                                                                                    )
+                                                                                }
+                                                                            >
+                                                                                <Pencil />
+                                                                                {t(
+                                                                                    'Edit reading',
+                                                                                )}
+                                                                            </DropdownMenuItem>
+                                                                        )}
+                                                                        {reading.can_delete && (
+                                                                            <DropdownMenuItem
+                                                                                onSelect={() =>
+                                                                                    deleteReading(
+                                                                                        meter,
+                                                                                        reading,
+                                                                                    )
+                                                                                }
+                                                                            >
+                                                                                <Trash2 />
+                                                                                {t(
+                                                                                    'Delete reading',
+                                                                                )}
+                                                                            </DropdownMenuItem>
+                                                                        )}
+                                                                        {reading.billed &&
+                                                                            reading.reading_kind ===
+                                                                                'reading' && (
+                                                                                <DropdownMenuItem
+                                                                                    onSelect={() =>
+                                                                                        openCorrectionDialog(
+                                                                                            meter,
+                                                                                            reading,
+                                                                                        )
+                                                                                    }
+                                                                                >
+                                                                                    <Pencil />
+                                                                                    {t(
+                                                                                        'Create correction',
+                                                                                    )}
+                                                                                </DropdownMenuItem>
+                                                                            )}
+                                                                    </DropdownMenuContent>
+                                                                </DropdownMenu>
+                                                            </td>
+                                                        </tr>
+                                                    ),
+                                                )
+                                            ) : (
+                                                <tr>
+                                                    <td
+                                                        colSpan={6}
+                                                        className="px-4 py-8 text-center text-muted-foreground"
+                                                    >
+                                                        {t(
+                                                            'No readings recorded yet.',
+                                                        )}
+                                                    </td>
+                                                </tr>
+                                            )}
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </section>
+                        ))}
+                    </div>
+                )}
+            </div>
+
+            <Dialog open={meterDialogOpen} onOpenChange={closeMeterDialog}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>
+                            {t(
+                                editingMeter
+                                    ? 'Edit utility meter'
+                                    : 'Add utility meter',
+                            )}
+                        </DialogTitle>
+                        <DialogDescription>
+                            {t(
+                                'The rate is snapshotted on each reading and will not change billed history.',
+                            )}
+                        </DialogDescription>
+                    </DialogHeader>
+                    <form onSubmit={submitMeter} className="grid gap-4">
+                        <div className="grid gap-2">
+                            <Label htmlFor="utility-type">
+                                {t('Utility type')}
+                            </Label>
+                            <Select
+                                value={meterForm.data.utility_type}
+                                onValueChange={(value) =>
+                                    meterForm.setData(
+                                        'utility_type',
+                                        value as UtilityMeter['utility_type'],
+                                    )
+                                }
+                            >
+                                <SelectTrigger id="utility-type">
+                                    <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {Object.entries(utilityLabels).map(
+                                        ([value, label]) => (
+                                            <SelectItem
+                                                key={value}
+                                                value={value}
+                                            >
+                                                {t(label)}
+                                            </SelectItem>
+                                        ),
+                                    )}
+                                </SelectContent>
+                            </Select>
+                            <InputError
+                                message={meterForm.errors.utility_type}
+                            />
+                        </div>
+                        <div className="grid gap-2">
+                            <Label htmlFor="meter-identifier">
+                                {t('Meter identifier')}
+                            </Label>
+                            <Input
+                                id="meter-identifier"
+                                required
+                                value={meterForm.data.identifier}
+                                onChange={(event) =>
+                                    meterForm.setData(
+                                        'identifier',
+                                        event.target.value,
+                                    )
+                                }
+                            />
+                            <InputError message={meterForm.errors.identifier} />
+                        </div>
+                        <div className="grid gap-2">
+                            <Label htmlFor="measurement-unit">
+                                {t('Unit of measure')}
+                            </Label>
+                            <Input
+                                id="measurement-unit"
+                                required
+                                value={meterForm.data.measurement_unit}
+                                onChange={(event) =>
+                                    meterForm.setData(
+                                        'measurement_unit',
+                                        event.target.value,
+                                    )
+                                }
+                                placeholder="kWh"
+                            />
+                            <InputError
+                                message={meterForm.errors.measurement_unit}
+                            />
+                        </div>
+                        <div className="grid grid-cols-2 gap-3">
+                            <div className="grid gap-2">
+                                <Label htmlFor="meter-rate">{t('Rate')}</Label>
+                                <Input
+                                    id="meter-rate"
+                                    type="number"
+                                    min={0}
+                                    step="any"
+                                    inputMode="decimal"
+                                    required
+                                    value={meterForm.data.rate}
+                                    onChange={(event) =>
+                                        meterForm.setData(
+                                            'rate',
+                                            event.target.value,
+                                        )
+                                    }
+                                />
+                                <InputError message={meterForm.errors.rate} />
+                            </div>
+                            <div className="grid gap-2">
+                                <Label htmlFor="meter-currency">
+                                    {t('Currency')}
+                                </Label>
+                                <Select
+                                    value={meterForm.data.currency}
+                                    onValueChange={(value) =>
+                                        meterForm.setData('currency', value)
+                                    }
+                                >
+                                    <SelectTrigger id="meter-currency">
+                                        <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {supportedCurrencies.map((currency) => (
+                                            <SelectItem
+                                                key={currency}
+                                                value={currency}
+                                            >
+                                                {currency}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                                <InputError
+                                    message={meterForm.errors.currency}
+                                />
+                            </div>
+                        </div>
+                        <div className="flex items-center gap-2">
+                            <Checkbox
+                                id="meter-active"
+                                checked={meterForm.data.is_active}
+                                onCheckedChange={(checked) =>
+                                    meterForm.setData(
+                                        'is_active',
+                                        checked === true,
+                                    )
+                                }
+                            />
+                            <Label htmlFor="meter-active">{t('Active')}</Label>
+                        </div>
+                        <DialogFooter>
+                            <Button
+                                type="button"
+                                variant="outline"
+                                onClick={() => closeMeterDialog(false)}
+                            >
+                                {t('Cancel')}
+                            </Button>
+                            <Button
+                                type="submit"
+                                disabled={meterForm.processing}
+                            >
+                                {meterForm.processing
+                                    ? t('Saving...')
+                                    : t('Save meter')}
+                            </Button>
+                        </DialogFooter>
+                    </form>
+                </DialogContent>
+            </Dialog>
+
+            <Dialog open={readingDialogOpen} onOpenChange={closeReadingDialog}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>
+                            {t(
+                                editingReading
+                                    ? 'Edit utility reading'
+                                    : 'Record utility reading',
+                            )}
+                        </DialogTitle>
+                        <DialogDescription>
+                            {selectedMeter &&
+                                `${selectedMeter.identifier} · ${selectedMeter.measurement_unit} · ${formatPrice(selectedMeter.rate, selectedMeter.currency)} ${t('per unit')}`}
+                        </DialogDescription>
+                    </DialogHeader>
+                    <form onSubmit={submitReading} className="grid gap-4">
+                        <div className="grid grid-cols-2 gap-3">
+                            <div className="grid gap-2">
+                                <Label htmlFor="reading-period-start">
+                                    {t('Period start')}
+                                </Label>
+                                <Input
+                                    id="reading-period-start"
+                                    type="date"
+                                    required
+                                    value={readingForm.data.period_start}
+                                    onChange={(event) => {
+                                        readingForm.setData(
+                                            'period_start',
+                                            event.target.value,
+                                        );
+                                        readingForm.setData(
+                                            'period_end',
+                                            periodEnd(event.target.value),
+                                        );
+                                    }}
+                                />
+                                <InputError
+                                    message={readingForm.errors.period_start}
+                                />
+                            </div>
+                            <div className="grid gap-2">
+                                <Label htmlFor="reading-period-end">
+                                    {t('Period end')}
+                                </Label>
+                                <Input
+                                    id="reading-period-end"
+                                    type="date"
+                                    required
+                                    value={readingForm.data.period_end}
+                                    onChange={(event) =>
+                                        readingForm.setData(
+                                            'period_end',
+                                            event.target.value,
+                                        )
+                                    }
+                                />
+                                <InputError
+                                    message={readingForm.errors.period_end}
+                                />
+                            </div>
+                        </div>
+                        <div className="grid gap-2">
+                            <Label htmlFor="reading-date">
+                                {t('Reading date')}
+                            </Label>
+                            <Input
+                                id="reading-date"
+                                type="date"
+                                required
+                                value={readingForm.data.reading_date}
+                                onChange={(event) =>
+                                    readingForm.setData(
+                                        'reading_date',
+                                        event.target.value,
+                                    )
+                                }
+                            />
+                            <InputError
+                                message={readingForm.errors.reading_date}
+                            />
+                        </div>
+                        <div className="grid grid-cols-2 gap-3">
+                            <div className="grid gap-2">
+                                <Label htmlFor="previous-reading">
+                                    {t('Previous reading')}
+                                </Label>
+                                <Input
+                                    id="previous-reading"
+                                    type="number"
+                                    min={0}
+                                    step="any"
+                                    required
+                                    value={readingForm.data.previous_reading}
+                                    onChange={(event) =>
+                                        readingForm.setData(
+                                            'previous_reading',
+                                            event.target.value,
+                                        )
+                                    }
+                                />
+                                <InputError
+                                    message={
+                                        readingForm.errors.previous_reading
+                                    }
+                                />
+                            </div>
+                            <div className="grid gap-2">
+                                <Label htmlFor="current-reading">
+                                    {t('Current reading')}
+                                </Label>
+                                <Input
+                                    id="current-reading"
+                                    type="number"
+                                    min={0}
+                                    step="any"
+                                    required
+                                    value={readingForm.data.current_reading}
+                                    onChange={(event) =>
+                                        readingForm.setData(
+                                            'current_reading',
+                                            event.target.value,
+                                        )
+                                    }
+                                />
+                                <InputError
+                                    message={readingForm.errors.current_reading}
+                                />
+                            </div>
+                        </div>
+                        {selectedMeter && (
+                            <div className="rounded-md border bg-muted/30 px-3 py-2 text-sm">
+                                <div className="flex justify-between gap-4">
+                                    <span className="text-muted-foreground">
+                                        {t('Consumption')}
+                                    </span>
+                                    <span className="font-medium tabular-nums">
+                                        {readingForm.data.current_reading &&
+                                        readingForm.data.previous_reading
+                                            ? `${Math.max(0, Number(readingForm.data.current_reading) - Number(readingForm.data.previous_reading))} ${selectedMeter.measurement_unit}`
+                                            : '—'}
+                                    </span>
+                                </div>
+                                <div className="mt-1 flex justify-between gap-4">
+                                    <span className="text-muted-foreground">
+                                        {t('Charge preview')}
+                                    </span>
+                                    <span className="font-medium tabular-nums">
+                                        {previewCharge(
+                                            readingForm.data.previous_reading,
+                                            readingForm.data.current_reading,
+                                            selectedMeter.rate,
+                                            selectedMeter.currency,
+                                        )}
+                                    </span>
+                                </div>
+                            </div>
+                        )}
+                        <div className="grid gap-2">
+                            <Label htmlFor="reading-reference">
+                                {t('Reference')}
+                            </Label>
+                            <Input
+                                id="reading-reference"
+                                value={readingForm.data.reference}
+                                onChange={(event) =>
+                                    readingForm.setData(
+                                        'reference',
+                                        event.target.value,
+                                    )
+                                }
+                                placeholder={t(
+                                    'Optional note or source reference',
+                                )}
+                            />
+                            <InputError
+                                message={readingForm.errors.reference}
+                            />
+                        </div>
+                        <InputError message={readingForm.errors.reading} />
+                        <DialogFooter>
+                            <Button
+                                type="button"
+                                variant="outline"
+                                onClick={() => closeReadingDialog(false)}
+                            >
+                                {t('Cancel')}
+                            </Button>
+                            <Button
+                                type="submit"
+                                disabled={readingForm.processing}
+                            >
+                                {readingForm.processing
+                                    ? t('Saving...')
+                                    : t(
+                                          editingReading
+                                              ? 'Save reading'
+                                              : 'Record reading',
+                                      )}
+                            </Button>
+                        </DialogFooter>
+                    </form>
+                </DialogContent>
+            </Dialog>
+
+            <Dialog
+                open={correctionDialogOpen}
+                onOpenChange={closeCorrectionDialog}
+            >
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>
+                            {t('Create reading correction')}
+                        </DialogTitle>
+                        <DialogDescription>
+                            {t(
+                                'This creates a signed adjustment against the billed reading; the original remains unchanged.',
+                            )}
+                        </DialogDescription>
+                    </DialogHeader>
+                    <form onSubmit={submitCorrection} className="grid gap-4">
+                        <div className="grid gap-2">
+                            <Label htmlFor="correction-current-reading">
+                                {t('Corrected current reading')}
+                            </Label>
+                            <Input
+                                id="correction-current-reading"
+                                type="number"
+                                min={0}
+                                step="any"
+                                required
+                                value={correctionForm.data.current_reading}
+                                onChange={(event) =>
+                                    correctionForm.setData(
+                                        'current_reading',
+                                        event.target.value,
+                                    )
+                                }
+                            />
+                            <InputError
+                                message={correctionForm.errors.current_reading}
+                            />
+                        </div>
+                        <div className="grid gap-2">
+                            <Label htmlFor="correction-reference">
+                                {t('Correction reference')}
+                            </Label>
+                            <Input
+                                id="correction-reference"
+                                required
+                                value={correctionForm.data.reference}
+                                onChange={(event) =>
+                                    correctionForm.setData(
+                                        'reference',
+                                        event.target.value,
+                                    )
+                                }
+                            />
+                            <InputError
+                                message={correctionForm.errors.reference}
+                            />
+                        </div>
+                        <InputError message={correctionForm.errors.reading} />
+                        <DialogFooter>
+                            <Button
+                                type="button"
+                                variant="outline"
+                                onClick={() => closeCorrectionDialog(false)}
+                            >
+                                {t('Cancel')}
+                            </Button>
+                            <Button
+                                type="submit"
+                                disabled={correctionForm.processing}
+                            >
+                                {correctionForm.processing
+                                    ? t('Saving...')
+                                    : t('Save correction')}
+                            </Button>
+                        </DialogFooter>
+                    </form>
+                </DialogContent>
+            </Dialog>
+        </UnitLayout>
+    );
+}

--- a/resources/js/types/models.ts
+++ b/resources/js/types/models.ts
@@ -123,6 +123,38 @@ export type UnitRate = {
     is_active?: boolean;
 };
 
+export type UtilityReading = {
+    id: number;
+    reading_kind: 'reading' | 'correction';
+    reading_date: string;
+    period_start: string;
+    period_end: string;
+    previous_reading: string;
+    current_reading: string;
+    consumption: string;
+    adjustment_consumption: string | null;
+    rate: string;
+    currency: string;
+    reference: string | null;
+    corrects_reading_id: number | null;
+    charge_preview: string;
+    billed: boolean;
+    invoice_reference: string | null;
+    can_edit: boolean;
+    can_delete: boolean;
+};
+
+export type UtilityMeter = {
+    id: number;
+    utility_type: 'electricity' | 'water' | 'custom';
+    identifier: string;
+    measurement_unit: string;
+    rate: string;
+    currency: string;
+    is_active: boolean;
+    readings: UtilityReading[];
+};
+
 export type Unit = {
     id: number;
     name: string;

--- a/resources/js/types/models.ts
+++ b/resources/js/types/models.ts
@@ -142,6 +142,7 @@ export type UtilityReading = {
     invoice_reference: string | null;
     can_edit: boolean;
     can_delete: boolean;
+    correction_exists: boolean;
 };
 
 export type UtilityMeter = {

--- a/resources/js/types/models.ts
+++ b/resources/js/types/models.ts
@@ -148,6 +148,7 @@ export type UtilityReading = {
 export type UtilityMeter = {
     id: number;
     utility_type: 'electricity' | 'water' | 'custom';
+    utility_name: string | null;
     identifier: string;
     measurement_unit: string;
     rate: string;

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,6 +22,7 @@ use App\Http\Controllers\TenantPortal\LeaseController as TenantPortalLeaseContro
 use App\Http\Controllers\TenantPortal\NotificationController as TenantPortalNotificationController;
 use App\Http\Controllers\TenantPortal\PaymentController as TenantPortalPaymentController;
 use App\Http\Controllers\UnitController;
+use App\Http\Controllers\UnitUtilityController;
 use App\Http\Controllers\UserController;
 use Illuminate\Support\Facades\Route;
 
@@ -107,6 +108,25 @@ Route::middleware(['auth', 'verified', 'permission:dashboard.view'])->group(func
                         Route::delete('/', [UnitController::class, 'destroy'])->name('destroy')->middleware('permission:units.delete');
                         Route::post('restore', [UnitController::class, 'restore'])->name('restore')->withTrashed()->middleware('permission:units.update');
                         Route::get('rates', [UnitController::class, 'rates'])->name('rates')->middleware('permission:units.view');
+                        Route::get('utilities', [UnitUtilityController::class, 'index'])->name('utilities')->middleware('permission:units.view');
+                        Route::post('utilities/meters', [UnitUtilityController::class, 'storeMeter'])
+                            ->name('utilities.meters.store')
+                            ->middleware('permission:units.update');
+                        Route::put('utilities/meters/{meter}', [UnitUtilityController::class, 'updateMeter'])
+                            ->name('utilities.meters.update')
+                            ->middleware('permission:units.update');
+                        Route::post('utilities/meters/{meter}/readings', [UnitUtilityController::class, 'storeReading'])
+                            ->name('utilities.readings.store')
+                            ->middleware('permission:units.update');
+                        Route::put('utilities/meters/{meter}/readings/{reading}', [UnitUtilityController::class, 'updateReading'])
+                            ->name('utilities.readings.update')
+                            ->middleware('permission:units.update');
+                        Route::delete('utilities/meters/{meter}/readings/{reading}', [UnitUtilityController::class, 'destroyReading'])
+                            ->name('utilities.readings.destroy')
+                            ->middleware('permission:units.update');
+                        Route::post('utilities/meters/{meter}/readings/{reading}/correction', [UnitUtilityController::class, 'storeCorrection'])
+                            ->name('utilities.readings.corrections.store')
+                            ->middleware('permission:units.update');
                         Route::get('maintenance-history', [UnitController::class, 'maintenanceHistory'])
                             ->name('maintenance-history')
                             ->middleware('permission:maintenance-tickets.view');

--- a/tests/Feature/Schema/CompositeIndexTest.php
+++ b/tests/Feature/Schema/CompositeIndexTest.php
@@ -34,6 +34,12 @@ $expected = [
     'media' => [
         'idx_media_owner_collection_position' => ['mediable_type', 'mediable_id', 'collection', 'position'],
     ],
+    'utility_meters' => [
+        'idx_utility_meters_unit_active' => ['unit_id', 'is_active'],
+    ],
+    'utility_readings' => [
+        'idx_utility_readings_meter_period' => ['utility_meter_id', 'period_start', 'period_end'],
+    ],
 ];
 
 $appTables = array_keys($expected);

--- a/tests/Feature/Schema/ForeignKeyDeleteStrategyTest.php
+++ b/tests/Feature/Schema/ForeignKeyDeleteStrategyTest.php
@@ -40,7 +40,7 @@ $expected = [
     'payments' => ['invoice_id' => 'CASCADE', 'confirmed_by' => 'SET NULL', 'recorded_by' => 'SET NULL', 'verified_by' => 'SET NULL'],
     'payment_attempts' => ['invoice_id' => 'CASCADE', 'payment_id' => 'SET NULL'],
     'invoices' => ['lease_id' => 'CASCADE'],
-    'invoice_line_items' => ['invoice_id' => 'CASCADE'],
+    'invoice_line_items' => ['invoice_id' => 'CASCADE', 'utility_reading_id' => 'RESTRICT'],
     'properties' => ['region_id' => 'SET NULL', 'city_id' => 'SET NULL'],
     'tenants' => ['user_id' => 'SET NULL'],
 
@@ -51,6 +51,12 @@ $expected = [
     'role_has_permissions' => ['permission_id' => 'CASCADE', 'role_id' => 'CASCADE'],
     'property_user' => ['user_id' => 'CASCADE', 'property_id' => 'CASCADE'],
     'payment_proofs' => ['payment_id' => 'CASCADE', 'media_id' => 'RESTRICT'],
+    'utility_meters' => ['unit_id' => 'RESTRICT'],
+    'utility_readings' => [
+        'utility_meter_id' => 'RESTRICT',
+        'previous_reading_id' => 'RESTRICT',
+        'corrects_reading_id' => 'RESTRICT',
+    ],
 ];
 
 $appTables = array_keys($expected);

--- a/tests/Feature/UtilityBillingTest.php
+++ b/tests/Feature/UtilityBillingTest.php
@@ -183,6 +183,18 @@ it('bills corrections as signed deltas linked to the original bill', function ()
     app(GenerateInvoices::class)->execute($lease);
     $correctionLineItem = $correction->refresh()->invoiceLineItem;
 
+    $user = User::factory()->owner()->create();
+
+    $this->actingAs($user)
+        ->get(route('properties.units.utilities', [$lease->unit->property, $lease->unit]))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('meters.0.readings.0.id', $correction->id)
+            ->where('meters.0.readings.0.correction_exists', false)
+            ->where('meters.0.readings.1.id', $reading->id)
+            ->where('meters.0.readings.1.correction_exists', true)
+        );
+
     expect($correction->adjustment_consumption)->toBe('-10.000')
         ->and($correctionLineItem)->not->toBeNull()
         ->and($correctionLineItem->amount)->toBe('-10000.000')

--- a/tests/Feature/UtilityBillingTest.php
+++ b/tests/Feature/UtilityBillingTest.php
@@ -117,6 +117,9 @@ it('bills only eligible unit readings within partial lease boundaries', function
 it('uses the reading rate snapshot, copies metadata, and is idempotent', function () {
     $lease = makeUtilityLease();
     $meter = UtilityMeter::factory()->for($lease->unit)->create([
+        'utility_type' => 'custom',
+        'utility_name' => 'Gas',
+        'measurement_unit' => 'kg',
         'rate' => '1000',
         'currency' => 'IDR',
     ]);
@@ -131,6 +134,7 @@ it('uses the reading rate snapshot, copies metadata, and is idempotent', functio
 
     $meter->update([
         'utility_type' => $meter->utility_type->value,
+        'utility_name' => $meter->utility_name,
         'identifier' => $meter->identifier,
         'measurement_unit' => $meter->measurement_unit,
         'rate' => '2000',
@@ -147,6 +151,7 @@ it('uses the reading rate snapshot, copies metadata, and is idempotent', functio
         ->and($lineItem->amount)->toBe('100000.000')
         ->and($lineItem->metadata['rate'])->toBe('1000.000')
         ->and($lineItem->metadata['currency'])->toBe('IDR')
+        ->and($lineItem->metadata['utility_name'])->toBe('Gas')
         ->and($lineItem->metadata['reading_reference'])->toBe('manual-reading-001');
 
     expect(app(GenerateInvoices::class)->execute($lease))->toBe(0)

--- a/tests/Feature/UtilityBillingTest.php
+++ b/tests/Feature/UtilityBillingTest.php
@@ -1,0 +1,220 @@
+<?php
+
+use App\Actions\Invoices\GenerateInvoices;
+use App\Actions\Utility\CreateUtilityReadingCorrection;
+use App\Actions\Utility\RecordUtilityReading;
+use App\Actions\Utility\UpdateUtilityReading;
+use App\Enums\InvoiceStatus;
+use App\Models\InvoiceLineItem;
+use App\Models\Lease;
+use App\Models\Property;
+use App\Models\Setting;
+use App\Models\Tenant;
+use App\Models\Unit;
+use App\Models\User;
+use App\Models\UtilityMeter;
+use Carbon\CarbonImmutable;
+use Database\Seeders\RoleAndPermissionSeeder;
+use Illuminate\Validation\ValidationException;
+
+beforeEach(function () {
+    $this->seed(RoleAndPermissionSeeder::class);
+    Setting::set('supported_currencies', ['IDR', 'USD']);
+});
+
+function makeUtilityLease(array $overrides = []): Lease
+{
+    $property = Property::factory()->create();
+    $unit = Unit::factory()->for($property)->create();
+    $tenant = Tenant::factory()->create();
+
+    return Lease::factory()->create(array_merge([
+        'unit_id' => $unit->id,
+        'primary_tenant_id' => $tenant->id,
+        'start_date' => CarbonImmutable::today()->startOfMonth(),
+        'end_date' => null,
+        'rent_amount' => '1000000',
+        'rent_due_day' => 1,
+        'billing_interval' => 1,
+        'billing_unit' => 'month',
+        'status' => 'active',
+    ], $overrides));
+}
+
+it('bills only eligible unit readings within partial lease boundaries', function () {
+    $leaseEnd = CarbonImmutable::today()->startOfMonth()->addDays(14);
+    $lease = makeUtilityLease(['end_date' => $leaseEnd]);
+    $meter = UtilityMeter::factory()->for($lease->unit)->create([
+        'rate' => '1000',
+        'currency' => 'IDR',
+    ]);
+    $boundaryMeter = UtilityMeter::factory()->for($lease->unit)->create([
+        'identifier' => 'BOUNDARY-001',
+        'rate' => '1000',
+        'currency' => 'IDR',
+    ]);
+    $crossingMeter = UtilityMeter::factory()->for($lease->unit)->create([
+        'identifier' => 'CROSSING-001',
+        'rate' => '1000',
+        'currency' => 'IDR',
+    ]);
+    $otherUnit = Unit::factory()->create();
+    $otherMeter = UtilityMeter::factory()->for($otherUnit)->create([
+        'identifier' => 'OTHER-001',
+        'rate' => '1000',
+        'currency' => 'IDR',
+    ]);
+    $record = app(RecordUtilityReading::class);
+
+    $eligible = $record->execute($meter, [
+        'reading_date' => $leaseEnd->subDays(2)->toDateString(),
+        'period_start' => $lease->start_date->addDays(2)->toDateString(),
+        'period_end' => $leaseEnd->subDays(2)->toDateString(),
+        'previous_reading' => '0',
+        'current_reading' => '100',
+    ]);
+    $crossing = $record->execute($crossingMeter, [
+        'reading_date' => $leaseEnd->toDateString(),
+        'period_start' => $leaseEnd->subDay()->toDateString(),
+        'period_end' => $leaseEnd->addDay()->toDateString(),
+        'previous_reading' => '0',
+        'current_reading' => '50',
+    ]);
+    $otherReading = $record->execute($otherMeter, [
+        'reading_date' => $leaseEnd->toDateString(),
+        'period_start' => $lease->start_date->toDateString(),
+        'period_end' => $leaseEnd->toDateString(),
+        'previous_reading' => '0',
+        'current_reading' => '75',
+    ]);
+    $record->execute($boundaryMeter, [
+        'reading_date' => $lease->start_date->subDay()->toDateString(),
+        'period_start' => $lease->start_date->subMonth()->startOfMonth()->toDateString(),
+        'period_end' => $lease->start_date->subDay()->toDateString(),
+        'previous_reading' => '0',
+        'current_reading' => '20',
+    ]);
+    $boundaryReading = $record->execute($boundaryMeter, [
+        'reading_date' => $lease->start_date->addDay()->toDateString(),
+        'period_start' => $lease->start_date->toDateString(),
+        'period_end' => $lease->start_date->addDays(2)->toDateString(),
+        'previous_reading' => '20',
+        'current_reading' => '50',
+    ]);
+
+    expect(app(GenerateInvoices::class)->execute($lease))->toBe(1);
+
+    $eligibleLineItem = $eligible->refresh()->invoiceLineItem;
+    $crossingLineItem = $crossing->refresh()->invoiceLineItem;
+
+    expect($eligibleLineItem)->not->toBeNull()
+        ->and($eligibleLineItem->type)->toBe('utility')
+        ->and($crossingLineItem)->toBeNull()
+        ->and($otherReading->refresh()->invoiceLineItem)->toBeNull()
+        ->and($boundaryReading->refresh()->invoiceLineItem)->toBeNull();
+});
+
+it('uses the reading rate snapshot, copies metadata, and is idempotent', function () {
+    $lease = makeUtilityLease();
+    $meter = UtilityMeter::factory()->for($lease->unit)->create([
+        'rate' => '1000',
+        'currency' => 'IDR',
+    ]);
+    $reading = app(RecordUtilityReading::class)->execute($meter, [
+        'reading_date' => $lease->start_date->endOfMonth()->toDateString(),
+        'period_start' => $lease->start_date->startOfMonth()->toDateString(),
+        'period_end' => $lease->start_date->endOfMonth()->toDateString(),
+        'previous_reading' => '0',
+        'current_reading' => '100',
+        'reference' => 'manual-reading-001',
+    ]);
+
+    $meter->update([
+        'utility_type' => $meter->utility_type->value,
+        'identifier' => $meter->identifier,
+        'measurement_unit' => $meter->measurement_unit,
+        'rate' => '2000',
+        'currency' => 'IDR',
+        'is_active' => true,
+    ]);
+
+    expect(app(GenerateInvoices::class)->execute($lease))->toBeGreaterThan(0);
+
+    $invoice = $lease->invoices()->orderBy('period_start')->firstOrFail();
+    $lineItem = $reading->refresh()->invoiceLineItem;
+
+    expect($lineItem)->not->toBeNull()
+        ->and($lineItem->amount)->toBe('100000.000')
+        ->and($lineItem->metadata['rate'])->toBe('1000.000')
+        ->and($lineItem->metadata['currency'])->toBe('IDR')
+        ->and($lineItem->metadata['reading_reference'])->toBe('manual-reading-001');
+
+    expect(app(GenerateInvoices::class)->execute($lease))->toBe(0)
+        ->and($invoice->lineItems()->where('utility_reading_id', $reading->id)->count())->toBe(1);
+});
+
+it('bills corrections as signed deltas linked to the original bill', function () {
+    $lease = makeUtilityLease();
+    $meter = UtilityMeter::factory()->for($lease->unit)->create([
+        'rate' => '1000',
+        'currency' => 'IDR',
+    ]);
+    $reading = app(RecordUtilityReading::class)->execute($meter, [
+        'reading_date' => $lease->start_date->endOfMonth()->toDateString(),
+        'period_start' => $lease->start_date->startOfMonth()->toDateString(),
+        'period_end' => $lease->start_date->endOfMonth()->toDateString(),
+        'previous_reading' => '0',
+        'current_reading' => '100',
+    ]);
+
+    app(GenerateInvoices::class)->execute($lease);
+    $invoice = $lease->invoices()->firstOrFail();
+    $originalLineItem = $reading->refresh()->invoiceLineItem;
+
+    expect(fn () => app(UpdateUtilityReading::class)->execute($reading, [
+        'current_reading' => '90',
+    ]))->toThrow(ValidationException::class);
+
+    $correction = app(CreateUtilityReadingCorrection::class)->execute($reading, [
+        'current_reading' => '90',
+        'reference' => 'corrected-meter-entry',
+    ]);
+
+    app(GenerateInvoices::class)->execute($lease);
+    $correctionLineItem = $correction->refresh()->invoiceLineItem;
+
+    expect($correction->adjustment_consumption)->toBe('-10.000')
+        ->and($correctionLineItem)->not->toBeNull()
+        ->and($correctionLineItem->amount)->toBe('-10000.000')
+        ->and($correctionLineItem->metadata['adjustment_consumption'])->toBe('-10.000')
+        ->and($correctionLineItem->metadata['corrects_reading_id'])->toBe($reading->id)
+        ->and($correctionLineItem->metadata['original_invoice_line_item_id'])->toBe($originalLineItem->id)
+        ->and($reading->refresh()->current_reading)->toBe('100.000')
+        ->and($invoice->refresh()->status)->toBe(InvoiceStatus::Pending)
+        ->and(InvoiceLineItem::query()->where('utility_reading_id', $correction->id)->count())->toBe(1);
+});
+
+it('exposes billed readings as read-only in the unit workspace', function () {
+    $user = User::factory()->owner()->create();
+    $lease = makeUtilityLease();
+    $meter = UtilityMeter::factory()->for($lease->unit)->create();
+    $reading = app(RecordUtilityReading::class)->execute($meter, [
+        'reading_date' => $lease->start_date->endOfMonth()->toDateString(),
+        'period_start' => $lease->start_date->startOfMonth()->toDateString(),
+        'period_end' => $lease->start_date->endOfMonth()->toDateString(),
+        'previous_reading' => '0',
+        'current_reading' => '100',
+    ]);
+
+    app(GenerateInvoices::class)->execute($lease);
+
+    $this->actingAs($user)
+        ->get(route('properties.units.utilities', [$lease->unit->property, $lease->unit]))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('meters.0.readings.0.id', $reading->id)
+            ->where('meters.0.readings.0.billed', true)
+            ->where('meters.0.readings.0.can_edit', false)
+            ->where('meters.0.readings.0.can_delete', false)
+        );
+});

--- a/tests/Feature/UtilityMeterTest.php
+++ b/tests/Feature/UtilityMeterTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use App\Actions\Utility\RecordUtilityReading;
+use App\Models\Property;
+use App\Models\Setting;
+use App\Models\Unit;
+use App\Models\User;
+use App\Models\UtilityMeter;
+use App\Models\UtilityReading;
+use Database\Seeders\RoleAndPermissionSeeder;
+
+beforeEach(function () {
+    $this->seed(RoleAndPermissionSeeder::class);
+    Setting::set('supported_currencies', ['IDR', 'USD']);
+});
+
+it('provides a utilities workspace and manages unit meters', function () {
+    $user = User::factory()->owner()->create();
+    $property = Property::factory()->create();
+    $unit = Unit::factory()->for($property)->create();
+
+    $this->actingAs($user)
+        ->get(route('properties.units.utilities', [$property, $unit]))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->component('properties/units/utilities')
+            ->has('meters', 0)
+        );
+
+    $this->actingAs($user)
+        ->post(route('properties.units.utilities.meters.store', [$property, $unit]), [
+            'utility_type' => 'electricity',
+            'identifier' => 'ELEC-001',
+            'measurement_unit' => 'kWh',
+            'rate' => '1000',
+            'currency' => 'IDR',
+            'is_active' => true,
+        ])
+        ->assertRedirect()
+        ->assertSessionHasNoErrors();
+
+    $meter = UtilityMeter::query()->where('identifier', 'ELEC-001')->firstOrFail();
+
+    expect($meter->unit_id)->toBe($unit->id)
+        ->and($meter->rate)->toBe('1000.000')
+        ->and($meter->currency)->toBe('IDR');
+
+    $this->actingAs($user)
+        ->put(route('properties.units.utilities.meters.update', [$property, $unit, $meter]), [
+            'utility_type' => 'electricity',
+            'identifier' => 'ELEC-001',
+            'measurement_unit' => 'kWh',
+            'rate' => '1250',
+            'currency' => 'IDR',
+            'is_active' => true,
+        ])
+        ->assertRedirect()
+        ->assertSessionHasNoErrors();
+
+    expect($meter->refresh()->rate)->toBe('1250.000');
+});
+
+it('snapshots meter rate and currency on each reading', function () {
+    $property = Property::factory()->create();
+    $unit = Unit::factory()->for($property)->create();
+    $meter = UtilityMeter::factory()->for($unit)->create([
+        'rate' => '1000',
+        'currency' => 'IDR',
+    ]);
+
+    $first = app(RecordUtilityReading::class)->execute($meter, [
+        'reading_date' => '2026-01-31',
+        'period_start' => '2026-01-01',
+        'period_end' => '2026-01-31',
+        'previous_reading' => '0',
+        'current_reading' => '10',
+    ]);
+
+    $meter->update([
+        'utility_type' => $meter->utility_type->value,
+        'identifier' => $meter->identifier,
+        'measurement_unit' => $meter->measurement_unit,
+        'rate' => '1500',
+        'currency' => 'IDR',
+        'is_active' => true,
+    ]);
+
+    $second = app(RecordUtilityReading::class)->execute($meter->refresh(), [
+        'reading_date' => '2026-02-28',
+        'period_start' => '2026-02-01',
+        'period_end' => '2026-02-28',
+        'previous_reading' => '10',
+        'current_reading' => '20',
+    ]);
+
+    expect($first->rate)->toBe('1000.000')
+        ->and($first->currency)->toBe('IDR')
+        ->and($second->rate)->toBe('1500.000')
+        ->and($second->currency)->toBe('IDR')
+        ->and(UtilityReading::query()->count())->toBe(2);
+});

--- a/tests/Feature/UtilityMeterTest.php
+++ b/tests/Feature/UtilityMeterTest.php
@@ -99,3 +99,41 @@ it('snapshots meter rate and currency on each reading', function () {
         ->and($second->currency)->toBe('IDR')
         ->and(UtilityReading::query()->count())->toBe(2);
 });
+
+it('stores custom utility names and clears them for standard meters', function () {
+    $user = User::factory()->owner()->create();
+    $property = Property::factory()->create();
+    $unit = Unit::factory()->for($property)->create();
+
+    $this->actingAs($user)
+        ->post(route('properties.units.utilities.meters.store', [$property, $unit]), [
+            'utility_type' => 'custom',
+            'utility_name' => 'Gas',
+            'identifier' => 'GAS-001',
+            'measurement_unit' => 'kg',
+            'rate' => '20000',
+            'currency' => 'IDR',
+            'is_active' => true,
+        ])
+        ->assertRedirect()
+        ->assertSessionHasNoErrors();
+
+    $meter = UtilityMeter::query()->where('identifier', 'GAS-001')->firstOrFail();
+
+    expect($meter->utility_name)->toBe('Gas');
+
+    $this->actingAs($user)
+        ->put(route('properties.units.utilities.meters.update', [$property, $unit, $meter]), [
+            'utility_type' => 'water',
+            'utility_name' => 'Gas',
+            'identifier' => 'GAS-001',
+            'measurement_unit' => 'm³',
+            'rate' => '7500',
+            'currency' => 'IDR',
+            'is_active' => true,
+        ])
+        ->assertRedirect()
+        ->assertSessionHasNoErrors();
+
+    expect($meter->refresh()->utility_name)->toBeNull();
+});

--- a/tests/Feature/UtilityReadingTest.php
+++ b/tests/Feature/UtilityReadingTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use App\Actions\Utility\RecordUtilityReading;
+use App\Actions\Utility\UpdateUtilityReading;
+use App\Models\Unit;
+use App\Models\UtilityMeter;
+use Illuminate\Validation\ValidationException;
+
+it('calculates chained consumption and rejects duplicate or decreasing readings', function () {
+    $unit = Unit::factory()->create();
+    $meter = UtilityMeter::factory()->for($unit)->create();
+    $action = app(RecordUtilityReading::class);
+
+    $first = $action->execute($meter, [
+        'reading_date' => '2026-01-31',
+        'period_start' => '2026-01-01',
+        'period_end' => '2026-01-31',
+        'previous_reading' => '25',
+        'current_reading' => '100',
+    ]);
+
+    $second = $action->execute($meter, [
+        'reading_date' => '2026-02-28',
+        'period_start' => '2026-02-01',
+        'period_end' => '2026-02-28',
+        'previous_reading' => '100',
+        'current_reading' => '145',
+    ]);
+
+    expect($first->consumption)->toBe('75.000')
+        ->and($second->previous_reading_id)->toBe($first->id)
+        ->and($second->consumption)->toBe('45.000');
+
+    expect(fn () => $action->execute($meter, [
+        'reading_date' => '2026-02-15',
+        'period_start' => '2026-02-01',
+        'period_end' => '2026-02-28',
+        'previous_reading' => '100',
+        'current_reading' => '120',
+    ]))->toThrow(ValidationException::class);
+
+    expect(fn () => $action->execute($meter, [
+        'reading_date' => '2026-03-31',
+        'period_start' => '2026-03-01',
+        'period_end' => '2026-03-31',
+        'previous_reading' => '145',
+        'current_reading' => '144',
+    ]))->toThrow(ValidationException::class);
+});
+
+it('protects readings that later readings depend on', function () {
+    $meter = UtilityMeter::factory()->create();
+    $action = app(RecordUtilityReading::class);
+
+    $first = $action->execute($meter, [
+        'reading_date' => '2026-01-31',
+        'period_start' => '2026-01-01',
+        'period_end' => '2026-01-31',
+        'previous_reading' => '0',
+        'current_reading' => '100',
+    ]);
+    $action->execute($meter, [
+        'reading_date' => '2026-02-28',
+        'period_start' => '2026-02-01',
+        'period_end' => '2026-02-28',
+        'previous_reading' => '100',
+        'current_reading' => '150',
+    ]);
+
+    expect(fn () => app(UpdateUtilityReading::class)->execute($first, [
+        'current_reading' => '110',
+    ]))->toThrow(ValidationException::class);
+
+    expect(fn () => $first->delete())->toThrow(LogicException::class);
+});


### PR DESCRIPTION
## Summary
- add unit-associated meters and manual reading history
- snapshot rate/currency and bill eligible readings as invoice line items
- add signed corrections with immutable billed readings
- add utilities management to the unit workspace

## Verification
- php artisan test --compact tests/Feature/UtilityMeterTest.php tests/Feature/UtilityReadingTest.php tests/Feature/UtilityBillingTest.php tests/Feature/GenerateInvoicesTest.php tests/Feature/Schema/CompositeIndexTest.php tests/Feature/Schema/ForeignKeyDeleteStrategyTest.php
- npm run lint:check
- npm run types:check
- npm run build

Refs OPE-190