### PR TITLE
feat(dashboard): add financial analytics

### DIFF
--- a/app/Business/Dashboard/FinancialDashboardCalculator.php
+++ b/app/Business/Dashboard/FinancialDashboardCalculator.php
@@ -1,0 +1,533 @@
+<?php
+
+namespace App\Business\Dashboard;
+
+use App\Enums\ExpenseStatus;
+use App\Enums\InvoiceStatus;
+use App\Enums\LeaseStatus;
+use App\Enums\PaymentStatus;
+use App\Enums\UnitStatus;
+use App\Models\Expense;
+use App\Models\Invoice;
+use App\Models\Payment;
+use App\Models\PaymentAllocation;
+use App\Models\Property;
+use Brick\Math\BigDecimal;
+use Brick\Math\RoundingMode;
+use Carbon\Carbon;
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+class FinancialDashboardCalculator
+{
+    /**
+     * @param  Collection<int, Property>  $accessibleProperties
+     * @return array<string, mixed>
+     */
+    public function calculate(Collection $accessibleProperties, ?int $selectedPropertyId, string $period): array
+    {
+        $propertyIds = $accessibleProperties->pluck('id');
+
+        if ($selectedPropertyId !== null) {
+            $propertyIds = collect([$selectedPropertyId]);
+        }
+
+        $now = now();
+        $periodStart = $period === 'ytd'
+            ? $now->copy()->startOfYear()
+            : $now->copy()->startOfMonth();
+        $periodEnd = $now->copy()->endOfDay();
+        $trendStart = $now->copy()->startOfMonth()->subMonthsNoOverflow(11);
+
+        $invoiceRows = $this->invoiceAggregates($propertyIds, $trendStart, $now);
+        $expenseRows = $this->expenseAggregates($propertyIds, $trendStart, $now);
+        $paymentRows = $this->paymentAggregates($propertyIds, $trendStart, $now);
+        $allocationRows = $this->allocationAggregates($propertyIds, $periodStart, $periodEnd);
+        $upcomingRows = $this->upcomingReceivableAggregates($propertyIds, $now);
+
+        $selectedInvoices = $this->rowsInPeriod($invoiceRows, $periodStart, $periodEnd);
+        $selectedExpenses = $this->rowsInPeriod($expenseRows, $periodStart, $periodEnd);
+        $revenue = $this->amountGroups($selectedInvoices, 'revenue');
+        $expenses = $this->amountGroups($selectedExpenses, 'expenses');
+        $noi = $this->subtractGroups($revenue, $expenses);
+        $billed = $revenue;
+        $collected = $this->completeAmountGroups($this->amountGroups($allocationRows, 'collected'), $billed);
+        $outstanding = $this->amountGroups($selectedInvoices, 'outstanding_amount');
+        $occupancy = $this->occupancy($propertyIds);
+
+        return [
+            'period' => $period,
+            'period_start' => $periodStart->toDateString(),
+            'period_end' => $periodEnd->toDateString(),
+            'overview' => [
+                'revenue' => $revenue,
+                'expenses' => $expenses,
+                'noi' => $noi,
+                'operating_margin' => $this->percentageGroups($noi, $revenue),
+            ],
+            'collections' => [
+                'billed' => $billed,
+                'collected' => $collected,
+                'outstanding' => $outstanding,
+                'collection_rate' => $this->percentageGroups($collected, $billed),
+            ],
+            'cash_flow' => $this->monthlyGroups($paymentRows, 'collected', $expenseRows, 'expenses', $periodStart, $periodEnd),
+            'trends' => $this->monthlyGroups($invoiceRows, 'revenue', $expenseRows, 'expenses', $trendStart, $now),
+            'property_performance' => $this->propertyPerformance(
+                $accessibleProperties,
+                $propertyIds,
+                $selectedInvoices,
+                $selectedExpenses,
+                $allocationRows,
+                $occupancy['properties'],
+            ),
+            'occupancy' => $occupancy,
+            'expense_breakdown' => $this->expenseBreakdown($selectedExpenses),
+            'upcoming_receivables' => $this->monthlyAmountGroups($upcomingRows, 'receivable', $now),
+        ];
+    }
+
+    /**
+     * @param  Collection<int, int>  $propertyIds
+     * @return Collection<int, object>
+     */
+    private function invoiceAggregates(Collection $propertyIds, CarbonInterface $start, CarbonInterface $end): Collection
+    {
+        $month = $this->monthExpression('invoices.period_start');
+
+        return Invoice::query()
+            ->join('leases', 'leases.id', '=', 'invoices.lease_id')
+            ->join('units', 'units.id', '=', 'leases.unit_id')
+            ->whereIn('units.property_id', $propertyIds)
+            ->whereBetween('invoices.period_start', [$start->toDateString(), $end->toDateString()])
+            ->whereIn('invoices.status', $this->eligibleInvoiceStatuses())
+            ->selectRaw("units.property_id, invoices.currency, {$month} as month, SUM(invoices.total) as revenue, SUM(invoices.total - invoices.amount_paid) as outstanding_amount")
+            ->groupBy('units.property_id', 'invoices.currency')
+            ->groupByRaw($month)
+            ->get();
+    }
+
+    /**
+     * @param  Collection<int, int>  $propertyIds
+     * @return Collection<int, object>
+     */
+    private function expenseAggregates(Collection $propertyIds, CarbonInterface $start, CarbonInterface $end): Collection
+    {
+        $month = $this->monthExpression('expenses.expense_date');
+
+        return Expense::query()
+            ->join('expense_categories', 'expense_categories.id', '=', 'expenses.expense_category_id')
+            ->whereIn('expenses.property_id', $propertyIds)
+            ->where('expenses.status', ExpenseStatus::Active->value)
+            ->whereBetween('expenses.expense_date', [$start->toDateString(), $end->toDateString()])
+            ->selectRaw("expenses.property_id, expenses.expense_category_id as category_id, expense_categories.label as category_label, expenses.currency, {$month} as month, SUM(expenses.amount) as expenses")
+            ->groupBy('expenses.property_id', 'expenses.expense_category_id', 'expense_categories.label', 'expenses.currency')
+            ->groupByRaw($month)
+            ->get();
+    }
+
+    /**
+     * @param  Collection<int, int>  $propertyIds
+     * @return Collection<int, object>
+     */
+    private function paymentAggregates(Collection $propertyIds, CarbonInterface $start, CarbonInterface $end): Collection
+    {
+        $month = $this->monthExpression('payments.payment_date');
+        $currency = 'COALESCE(payments.currency, invoices.currency)';
+
+        return Payment::query()
+            ->join('invoices', 'invoices.id', '=', 'payments.invoice_id')
+            ->join('leases', 'leases.id', '=', 'invoices.lease_id')
+            ->join('units', 'units.id', '=', 'leases.unit_id')
+            ->whereIn('units.property_id', $propertyIds)
+            ->where('payments.status', PaymentStatus::Confirmed->value)
+            ->whereBetween('payments.payment_date', [$start, $end])
+            ->selectRaw("units.property_id, {$currency} as currency, {$month} as month, SUM(payments.amount) as collected")
+            ->groupBy('units.property_id')
+            ->groupByRaw($currency)
+            ->groupByRaw($month)
+            ->get();
+    }
+
+    /**
+     * @param  Collection<int, int>  $propertyIds
+     * @return Collection<int, object>
+     */
+    private function allocationAggregates(Collection $propertyIds, CarbonInterface $start, CarbonInterface $end): Collection
+    {
+        return PaymentAllocation::query()
+            ->join('payments', 'payments.id', '=', 'payment_allocations.payment_id')
+            ->join('invoices', 'invoices.id', '=', 'payment_allocations.invoice_id')
+            ->join('leases', 'leases.id', '=', 'invoices.lease_id')
+            ->join('units', 'units.id', '=', 'leases.unit_id')
+            ->whereIn('units.property_id', $propertyIds)
+            ->where('payments.status', PaymentStatus::Confirmed->value)
+            ->whereIn('invoices.status', $this->eligibleInvoiceStatuses())
+            ->whereBetween('invoices.period_start', [$start->toDateString(), $end->toDateString()])
+            ->selectRaw('units.property_id, invoices.currency, SUM(payment_allocations.amount) as collected')
+            ->groupBy('units.property_id', 'invoices.currency')
+            ->get();
+    }
+
+    /**
+     * @param  Collection<int, int>  $propertyIds
+     * @return Collection<int, object>
+     */
+    private function upcomingReceivableAggregates(Collection $propertyIds, CarbonInterface $now): Collection
+    {
+        $month = $this->monthExpression('invoices.due_date');
+
+        return Invoice::query()
+            ->join('leases', 'leases.id', '=', 'invoices.lease_id')
+            ->join('units', 'units.id', '=', 'leases.unit_id')
+            ->whereIn('units.property_id', $propertyIds)
+            ->whereIn('invoices.status', [InvoiceStatus::Pending->value, InvoiceStatus::Partial->value])
+            ->whereDate('invoices.due_date', '>=', $now->toDateString())
+            ->selectRaw("units.property_id, invoices.currency, {$month} as month, SUM(invoices.total - invoices.amount_paid) as receivable")
+            ->groupBy('units.property_id', 'invoices.currency')
+            ->groupByRaw($month)
+            ->orderByRaw($month)
+            ->get();
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function eligibleInvoiceStatuses(): array
+    {
+        return [
+            InvoiceStatus::Pending->value,
+            InvoiceStatus::Partial->value,
+            InvoiceStatus::Paid->value,
+        ];
+    }
+
+    private function monthExpression(string $column): string
+    {
+        return DB::connection()->getDriverName() === 'sqlite'
+            ? "strftime('%Y-%m-01', {$column})"
+            : "DATE_TRUNC('month', {$column})::date";
+    }
+
+    /**
+     * @param  Collection<int, object>  $rows
+     * @return Collection<int, object>
+     */
+    private function rowsInPeriod(Collection $rows, CarbonInterface $start, CarbonInterface $end): Collection
+    {
+        return $rows->filter(function (object $row) use ($start, $end): bool {
+            $month = Carbon::parse($row->month);
+
+            return $month->betweenIncluded($start->copy()->startOfMonth(), $end->copy()->startOfMonth());
+        });
+    }
+
+    /**
+     * @param  Collection<int, object>  $rows
+     * @return array<int, array{currency: string, amount: string}>
+     */
+    private function amountGroups(Collection $rows, string $amountColumn): array
+    {
+        return $rows
+            ->groupBy(fn (object $row): string => (string) $row->currency)
+            ->map(function (Collection $currencyRows, string $currency) use ($amountColumn): array {
+                $amount = $currencyRows->reduce(
+                    fn (BigDecimal $total, object $row): BigDecimal => $total->plus((string) ($row->{$amountColumn} ?? '0')),
+                    BigDecimal::zero(),
+                );
+
+                return ['currency' => $currency, 'amount' => $amount->toString()];
+            })
+            ->sortKeys()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param  array<int, array{currency: string, amount: string}>  $left
+     * @param  array<int, array{currency: string, amount: string}>  $right
+     * @return array<int, array{currency: string, amount: string}>
+     */
+    private function subtractGroups(array $left, array $right): array
+    {
+        $leftByCurrency = collect($left)->keyBy('currency');
+        $rightByCurrency = collect($right)->keyBy('currency');
+        $currencies = $leftByCurrency->keys()->merge($rightByCurrency->keys())->unique()->sort();
+
+        return $currencies->map(fn (string $currency): array => [
+            'currency' => $currency,
+            'amount' => BigDecimal::of((string) ($leftByCurrency->get($currency)['amount'] ?? '0'))
+                ->minus((string) ($rightByCurrency->get($currency)['amount'] ?? '0'))
+                ->toString(),
+        ])->values()->all();
+    }
+
+    /**
+     * @param  array<int, array{currency: string, amount: string}>  $numerators
+     * @param  array<int, array{currency: string, amount: string}>  $denominators
+     * @return array<int, array{currency: string, rate: string}>
+     */
+    private function percentageGroups(array $numerators, array $denominators): array
+    {
+        $numeratorsByCurrency = collect($numerators)->keyBy('currency');
+        $denominatorsByCurrency = collect($denominators)->keyBy('currency');
+        $currencies = $denominatorsByCurrency
+            ->filter(fn (array $group): bool => BigDecimal::of((string) $group['amount'])->isPositive())
+            ->keys()
+            ->sort();
+
+        return $currencies->map(function (string $currency) use ($numeratorsByCurrency, $denominatorsByCurrency): array {
+            $numerator = BigDecimal::of((string) ($numeratorsByCurrency->get($currency)['amount'] ?? '0'));
+            $denominator = BigDecimal::of((string) ($denominatorsByCurrency->get($currency)['amount'] ?? '0'));
+
+            return [
+                'currency' => $currency,
+                'rate' => $denominator->isPositive()
+                    ? $numerator->dividedBy($denominator, 6, RoundingMode::HalfUp)->multipliedBy(100)->toScale(1, RoundingMode::HalfUp)->toString()
+                    : '0.0',
+            ];
+        })->values()->all();
+    }
+
+    /**
+     * @param  Collection<int, object>  $leftRows
+     * @param  Collection<int, object>  $rightRows
+     * @return array<int, array<string, mixed>>
+     */
+    private function monthlyGroups(
+        Collection $leftRows,
+        string $leftColumn,
+        Collection $rightRows,
+        string $rightColumn,
+        CarbonInterface $start,
+        CarbonInterface $end,
+    ): array {
+        $startMonth = $start->copy()->startOfMonth();
+        $monthCount = $startMonth->diffInMonths($end->copy()->startOfMonth());
+        $months = collect(range(0, $monthCount))->map(fn (int $offset): CarbonInterface => $startMonth->copy()->addMonthsNoOverflow($offset));
+        $left = $this->monthlyAmountMap($leftRows, $leftColumn);
+        $right = $this->monthlyAmountMap($rightRows, $rightColumn);
+
+        return $months->map(function (CarbonInterface $month) use ($left, $right, $leftColumn, $rightColumn): array {
+            $monthKey = $month->toDateString();
+            $leftGroups = $this->mapToGroups($left[$monthKey] ?? []);
+            $rightGroups = $this->mapToGroups($right[$monthKey] ?? []);
+            $result = [
+                'month' => $monthKey,
+                'label' => $month->format('M Y'),
+                $leftColumn => $leftGroups,
+                $rightColumn => $rightGroups,
+            ];
+
+            if ($leftColumn === 'revenue' && $rightColumn === 'expenses') {
+                $result['noi'] = $this->subtractGroups($leftGroups, $rightGroups);
+            }
+
+            return $result;
+        })->all();
+    }
+
+    /**
+     * @param  Collection<int, object>  $rows
+     * @return array<string, array<string, string>>
+     */
+    private function monthlyAmountMap(Collection $rows, string $amountColumn): array
+    {
+        $map = [];
+
+        foreach ($rows as $row) {
+            $month = (string) $row->month;
+            $currency = (string) $row->currency;
+            $map[$month][$currency] = isset($map[$month][$currency])
+                ? BigDecimal::of($map[$month][$currency])->plus((string) ($row->{$amountColumn} ?? '0'))->toString()
+                : BigDecimal::of((string) ($row->{$amountColumn} ?? '0'))->toString();
+        }
+
+        return $map;
+    }
+
+    /**
+     * @param  array<string, string>  $amounts
+     * @return array<int, array{currency: string, amount: string}>
+     */
+    private function mapToGroups(array $amounts): array
+    {
+        return collect($amounts)
+            ->sortKeys()
+            ->map(fn (string $amount, string $currency): array => ['currency' => $currency, 'amount' => $amount])
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param  array<int, array{currency: string, amount: string}>  $amounts
+     * @param  array<int, array{currency: string, amount: string}>  $reference
+     * @return array<int, array{currency: string, amount: string}>
+     */
+    private function completeAmountGroups(array $amounts, array $reference): array
+    {
+        $amountsByCurrency = collect($amounts)->keyBy('currency');
+        $currencies = collect($reference)
+            ->pluck('currency')
+            ->merge($amountsByCurrency->keys())
+            ->unique()
+            ->sort()
+            ->values();
+
+        return $currencies->map(fn (string $currency): array => [
+            'currency' => $currency,
+            'amount' => (string) ($amountsByCurrency->get($currency)['amount'] ?? '0'),
+        ])->all();
+    }
+
+    /**
+     * @param  Collection<int, object>  $rows
+     * @return array<int, array{month: string, label: string, receivable: array<int, array{currency: string, amount: string}>}>
+     */
+    private function monthlyAmountGroups(Collection $rows, string $column, CarbonInterface $start): array
+    {
+        $map = $this->monthlyAmountMap($rows, $column);
+
+        return collect(array_keys($map))
+            ->sort()
+            ->filter(fn (string $month): bool => Carbon::parse($month)->gte($start->copy()->startOfMonth()))
+            ->map(fn (string $month): array => [
+                'month' => $month,
+                'label' => Carbon::parse($month)->format('M Y'),
+                $column => $this->mapToGroups($map[$month] ?? []),
+            ])
+            ->all();
+    }
+
+    /**
+     * @param  Collection<int, Property>  $accessibleProperties
+     * @param  Collection<int, int>  $propertyIds
+     * @param  Collection<int, object>  $invoiceRows
+     * @param  Collection<int, object>  $expenseRows
+     * @param  Collection<int, object>  $allocationRows
+     * @param  array<int, array{id: int, name: string, total_units: int, occupied_units: int, occupancy_percentage: int}>  $occupancyProperties
+     * @return array<int, array<string, mixed>>
+     */
+    private function propertyPerformance(
+        Collection $accessibleProperties,
+        Collection $propertyIds,
+        Collection $invoiceRows,
+        Collection $expenseRows,
+        Collection $allocationRows,
+        array $occupancyProperties,
+    ): array {
+        $properties = $accessibleProperties->whereIn('id', $propertyIds);
+        $invoiceAmounts = $this->propertyAmountMap($invoiceRows, 'revenue');
+        $expenseAmounts = $this->propertyAmountMap($expenseRows, 'expenses');
+        $collectedAmounts = $this->propertyAmountMap($allocationRows, 'collected');
+        $outstandingAmounts = $this->propertyAmountMap($invoiceRows, 'outstanding_amount');
+
+        $occupancyByProperty = collect($occupancyProperties)->keyBy('id');
+
+        return $properties->map(function (Property $property) use ($invoiceAmounts, $expenseAmounts, $collectedAmounts, $outstandingAmounts, $occupancyByProperty): array {
+            $revenue = $this->mapToGroups($invoiceAmounts[$property->id] ?? []);
+            $expenses = $this->mapToGroups($expenseAmounts[$property->id] ?? []);
+            $noi = $this->subtractGroups($revenue, $expenses);
+            $collected = $this->completeAmountGroups($this->mapToGroups($collectedAmounts[$property->id] ?? []), $revenue);
+            $outstanding = $this->mapToGroups($outstandingAmounts[$property->id] ?? []);
+
+            return [
+                'id' => $property->id,
+                'name' => $property->name,
+                'revenue' => $revenue,
+                'expenses' => $expenses,
+                'noi' => $noi,
+                'operating_margin' => $this->percentageGroups($noi, $revenue),
+                'billed' => $revenue,
+                'collected' => $collected,
+                'outstanding' => $outstanding,
+                'collection_rate' => $this->percentageGroups($collected, $revenue),
+                'occupancy' => $occupancyByProperty->get($property->id, [
+                    'total_units' => 0,
+                    'occupied_units' => 0,
+                    'occupancy_percentage' => 0,
+                ]),
+            ];
+        })->values()->all();
+    }
+
+    /**
+     * @param  Collection<int, object>  $rows
+     * @return array<int, array<string, string>>
+     */
+    private function propertyAmountMap(Collection $rows, string $amountColumn): array
+    {
+        $map = [];
+
+        foreach ($rows as $row) {
+            $propertyId = (int) $row->property_id;
+            $currency = (string) $row->currency;
+            $map[$propertyId][$currency] = isset($map[$propertyId][$currency])
+                ? BigDecimal::of($map[$propertyId][$currency])->plus((string) ($row->{$amountColumn} ?? '0'))->toString()
+                : BigDecimal::of((string) ($row->{$amountColumn} ?? '0'))->toString();
+        }
+
+        return $map;
+    }
+
+    /**
+     * @param  Collection<int, int>  $propertyIds
+     * @return array<string, mixed>
+     */
+    private function occupancy(Collection $propertyIds): array
+    {
+        $properties = Property::query()
+            ->whereIn('id', $propertyIds)
+            ->withCount([
+                'units',
+                'units as occupied_units_count' => fn (Builder $query) => $query
+                    ->where(function (Builder $query): void {
+                        $query->where('status', UnitStatus::Occupied)
+                            ->orWhereHas('leases', fn (Builder $query) => $query->where('status', LeaseStatus::Active->value));
+                    }),
+            ])
+            ->get(['id', 'name']);
+
+        $totalUnits = $properties->sum('units_count');
+        $occupiedUnits = $properties->sum('occupied_units_count');
+
+        return [
+            'total_units' => $totalUnits,
+            'occupied_units' => $occupiedUnits,
+            'occupancy_percentage' => $totalUnits > 0 ? round(($occupiedUnits / $totalUnits) * 100) : 0,
+            'properties' => $properties->map(fn (Property $property): array => [
+                'id' => $property->id,
+                'name' => $property->name,
+                'total_units' => $property->units_count,
+                'occupied_units' => $property->occupied_units_count,
+                'occupancy_percentage' => $property->units_count > 0
+                    ? round(($property->occupied_units_count / $property->units_count) * 100)
+                    : 0,
+            ])->values()->all(),
+        ];
+    }
+
+    /**
+     * @param  Collection<int, object>  $rows
+     * @return array<int, array{category_id: int, category_label: string, amounts: array<int, array{currency: string, amount: string}>}>
+     */
+    private function expenseBreakdown(Collection $rows): array
+    {
+        return $rows
+            ->groupBy(fn (object $row): string => (string) $row->category_id)
+            ->map(function (Collection $categoryRows, string $categoryId): array {
+                $first = $categoryRows->first();
+
+                return [
+                    'category_id' => (int) $categoryId,
+                    'category_label' => (string) $first->category_label,
+                    'amounts' => $this->amountGroups($categoryRows, 'expenses'),
+                ];
+            })
+            ->sortBy('category_label')
+            ->values()
+            ->all();
+    }
+}

--- a/app/Business/Dashboard/FinancialDashboardCalculator.php
+++ b/app/Business/Dashboard/FinancialDashboardCalculator.php
@@ -206,9 +206,13 @@ class FinancialDashboardCalculator
 
     private function monthExpression(string $column): string
     {
-        return DB::connection()->getDriverName() === 'sqlite'
-            ? "strftime('%Y-%m-01', {$column})"
-            : "DATE_TRUNC('month', {$column})::date";
+        return match (DB::connection()->getDriverName()) {
+            'sqlite' => "strftime('%Y-%m-01', {$column})",
+            'mysql', 'mariadb' => "DATE_FORMAT({$column}, '%Y-%m-01')",
+            'pgsql' => "DATE_TRUNC('month', {$column})::date",
+            'sqlsrv' => "DATEFROMPARTS(YEAR({$column}), MONTH({$column}), 1)",
+            default => throw new \RuntimeException('Unsupported database driver for financial month grouping.'),
+        };
     }
 
     /**

--- a/app/Http/Controllers/Dashboard/FinancialController.php
+++ b/app/Http/Controllers/Dashboard/FinancialController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Controllers\Dashboard;
+
+use App\Business\Dashboard\FinancialDashboardCalculator;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Dashboard\FinancialDashboardRequest;
+use App\Models\Property;
+use Illuminate\Database\Eloquent\Builder;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class FinancialController extends Controller
+{
+    public function __invoke(FinancialDashboardRequest $request, FinancialDashboardCalculator $calculator): Response
+    {
+        $accessibleProperties = Property::query()
+            ->when(! $request->user()->isOwner(), fn (Builder $query) => $query->whereHas(
+                'users',
+                fn (Builder $userQuery) => $userQuery->whereKey($request->user()->id),
+            ))
+            ->orderBy('name')
+            ->get(['id', 'name']);
+        $validated = $request->validated();
+        $selectedPropertyId = isset($validated['property_id']) ? (int) $validated['property_id'] : null;
+
+        abort_if(
+            $selectedPropertyId !== null && ! $accessibleProperties->contains('id', $selectedPropertyId),
+            403,
+        );
+
+        $period = $validated['period'] ?? 'current_month';
+
+        return Inertia::render('dashboard/financial', [
+            'financial' => $calculator->calculate($accessibleProperties, $selectedPropertyId, $period),
+            'filters' => [
+                'period' => $period,
+                'property_id' => $selectedPropertyId,
+            ],
+            'properties' => $accessibleProperties,
+        ]);
+    }
+}

--- a/app/Http/Requests/Dashboard/FinancialDashboardRequest.php
+++ b/app/Http/Requests/Dashboard/FinancialDashboardRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests\Dashboard;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class FinancialDashboardRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'period' => ['sometimes', 'string', Rule::in(['current_month', 'ytd'])],
+            'property_id' => ['nullable', 'integer', 'exists:properties,id'],
+        ];
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
                 "react": "^19.2.0",
                 "react-compiler-runtime": "^1.0.0",
                 "react-dom": "^19.2.0",
+                "recharts": "^3.10.1",
                 "sonner": "^2.0.0",
                 "tailwind-merge": "^3.0.1",
                 "tailwindcss": "^4.0.0",
@@ -4405,6 +4406,32 @@
                 "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
             }
         },
+        "node_modules/@reduxjs/toolkit": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+            "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.0.0",
+                "@standard-schema/utils": "^0.3.0",
+                "immer": "^11.0.0",
+                "redux": "^5.0.1",
+                "redux-thunk": "^3.1.0",
+                "reselect": "^5.1.0"
+            },
+            "peerDependencies": {
+                "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+                "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+            },
+            "peerDependenciesMeta": {
+                "react": {
+                    "optional": true
+                },
+                "react-redux": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@rolldown/binding-android-arm64": {
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
@@ -4742,6 +4769,18 @@
             "version": "13.3.0",
             "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-13.3.0.tgz",
             "integrity": "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==",
+            "license": "MIT"
+        },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "license": "MIT"
+        },
+        "node_modules/@standard-schema/utils": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+            "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
             "license": "MIT"
         },
         "node_modules/@stylistic/eslint-plugin": {
@@ -5121,6 +5160,69 @@
                 "@babel/types": "^7.28.2"
             }
         },
+        "node_modules/@types/d3-array": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+            "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-color": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+            "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-ease": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+            "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-interpolate": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+            "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-color": "*"
+            }
+        },
+        "node_modules/@types/d3-path": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+            "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-scale": {
+            "version": "4.0.9",
+            "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+            "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-time": "*"
+            }
+        },
+        "node_modules/@types/d3-shape": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.2.0.tgz",
+            "integrity": "sha512-kVd74ta9eof3eJOvbNd1vGKS/XERRyQbT26Og63hIsvDO84cjD5gEOhsXf26w3FSoNlPVz84DOFcKv/oou+fMw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-path": "*"
+            }
+        },
+        "node_modules/@types/d3-time": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+            "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-timer": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+            "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+            "license": "MIT"
+        },
         "node_modules/@types/estree": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -5169,6 +5271,12 @@
             "peerDependencies": {
                 "@types/react": "^19.2.0"
             }
+        },
+        "node_modules/@types/use-sync-external-store": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+            "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+            "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "8.59.4",
@@ -6405,6 +6513,127 @@
             "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
             "license": "MIT"
         },
+        "node_modules/d3-array": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+            "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+            "license": "ISC",
+            "dependencies": {
+                "internmap": "1 - 2"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-color": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+            "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-ease": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+            "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-format": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+            "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-interpolate": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+            "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-color": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-path": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+            "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-scale": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+            "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-array": "2.10.0 - 3",
+                "d3-format": "1 - 3",
+                "d3-interpolate": "1.2.0 - 3",
+                "d3-time": "2.1.1 - 3",
+                "d3-time-format": "2 - 4"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-shape": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+            "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-path": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-time": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+            "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-array": "2 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-time-format": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+            "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-time": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-timer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+            "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/data-view-buffer": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -6475,6 +6704,12 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/decimal.js-light": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+            "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+            "license": "MIT"
         },
         "node_modules/deep-is": {
             "version": "0.1.4",
@@ -7173,6 +7408,12 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/eventemitter3": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+            "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+            "license": "MIT"
+        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -7621,6 +7862,16 @@
                 "node": ">= 4"
             }
         },
+        "node_modules/immer": {
+            "version": "11.1.18",
+            "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.18.tgz",
+            "integrity": "sha512-EQyQtLiYW029lyoczMl/Hh4Xu7cDecSc58JRYpHyL4tIAu3eqd1yJzQX04d2BZHDkzFFvm6qJEJWOtfDSWAXbQ==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/immer"
+            }
+        },
         "node_modules/import-fresh": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -7671,6 +7922,15 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/internmap": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+            "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/is-array-buffer": {
@@ -9400,8 +9660,30 @@
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-            "dev": true,
             "license": "MIT"
+        },
+        "node_modules/react-redux": {
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+            "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/use-sync-external-store": "^0.0.6",
+                "use-sync-external-store": "^1.4.0"
+            },
+            "peerDependencies": {
+                "@types/react": "^18.2.25 || ^19",
+                "react": "^18.0 || ^19",
+                "redux": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "redux": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/react-refresh": {
             "version": "0.18.0",
@@ -9496,6 +9778,51 @@
                 "@types/react": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/recharts": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.10.1.tgz",
+            "integrity": "sha512-QXFrvt6IVcw7eeZCoyXTwkIJAX3Dv1nyVhMicXJ47GsGDDpcN8z6o644DibE9XjpBTThtsomLKnTV6lc+cVFUA==",
+            "license": "MIT",
+            "workspaces": [
+                "www"
+            ],
+            "dependencies": {
+                "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+                "clsx": "^2.1.1",
+                "decimal.js-light": "^2.5.1",
+                "es-toolkit": "^1.39.3",
+                "eventemitter3": "^5.0.1",
+                "immer": "^11.1.8",
+                "react-redux": "8.x.x || 9.x.x",
+                "reselect": "5.2.0",
+                "tiny-invariant": "^1.3.3",
+                "use-sync-external-store": "^1.2.2",
+                "victory-vendor": "^37.0.2"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/redux": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+            "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+            "license": "MIT"
+        },
+        "node_modules/redux-thunk": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+            "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "redux": "^5.0.0"
             }
         },
         "node_modules/reflect.getprototypeof": {
@@ -10132,6 +10459,12 @@
                 "url": "https://opencollective.com/webpack"
             }
         },
+        "node_modules/tiny-invariant": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+            "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+            "license": "MIT"
+        },
         "node_modules/tinyglobby": {
             "version": "0.2.17",
             "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -10493,6 +10826,28 @@
             "license": "MIT",
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/victory-vendor": {
+            "version": "37.3.6",
+            "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+            "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+            "license": "MIT AND ISC",
+            "dependencies": {
+                "@types/d3-array": "^3.0.3",
+                "@types/d3-ease": "^3.0.0",
+                "@types/d3-interpolate": "^3.0.1",
+                "@types/d3-scale": "^4.0.2",
+                "@types/d3-shape": "^3.1.0",
+                "@types/d3-time": "^3.0.0",
+                "@types/d3-timer": "^3.0.0",
+                "d3-array": "^3.1.6",
+                "d3-ease": "^3.0.1",
+                "d3-interpolate": "^3.0.1",
+                "d3-scale": "^4.0.2",
+                "d3-shape": "^3.1.0",
+                "d3-time": "^3.0.0",
+                "d3-timer": "^3.0.1"
             }
         },
         "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
         "react": "^19.2.0",
         "react-compiler-runtime": "^1.0.0",
         "react-dom": "^19.2.0",
+        "recharts": "^3.10.1",
         "sonner": "^2.0.0",
         "tailwind-merge": "^3.0.1",
         "tailwindcss": "^4.0.0",

--- a/resources/js/components/features/app/app-sidebar.tsx
+++ b/resources/js/components/features/app/app-sidebar.tsx
@@ -99,34 +99,51 @@ export function AppSidebar() {
               },
           ]
         : [
-              ...(isOwner || permissions.includes('dashboard.view')
+              ...(isOwner ||
+              permissions.includes('dashboard.view') ||
+              permissions.includes('financials.view')
                   ? [
                         {
                             title: 'OVERVIEW',
                             items: [
-                                {
-                                    title: 'Dashboard',
-                                    icon: LayoutGrid,
-                                    href: dashboard(),
-                                    ...(platformPageNavItems(
-                                        platform.dashboard,
-                                        auth,
-                                    ).length > 0
-                                        ? {
-                                              children: [
-                                                  {
-                                                      title: 'Overview',
-                                                      icon: LayoutGrid,
-                                                      href: dashboard(),
-                                                  },
-                                                  ...platformPageNavItems(
-                                                      platform.dashboard,
-                                                      auth,
-                                                  ),
-                                              ],
-                                          }
-                                        : {}),
-                                },
+                                ...(isOwner ||
+                                permissions.includes('dashboard.view')
+                                    ? [
+                                          {
+                                              title: 'Dashboard',
+                                              icon: LayoutGrid,
+                                              href: dashboard(),
+                                              ...(platformPageNavItems(
+                                                  platform.dashboard,
+                                                  auth,
+                                              ).length > 0
+                                                  ? {
+                                                        children: [
+                                                            {
+                                                                title: 'Overview',
+                                                                icon: LayoutGrid,
+                                                                href: dashboard(),
+                                                            },
+                                                            ...platformPageNavItems(
+                                                                platform.dashboard,
+                                                                auth,
+                                                            ),
+                                                        ],
+                                                    }
+                                                  : {}),
+                                          },
+                                      ]
+                                    : []),
+                                ...(isOwner ||
+                                permissions.includes('financials.view')
+                                    ? [
+                                          {
+                                              title: 'Financial Dashboard',
+                                              icon: Landmark,
+                                              href: dashboardFinancial(),
+                                          },
+                                      ]
+                                    : []),
                             ],
                         },
                     ]
@@ -184,20 +201,6 @@ export function AppSidebar() {
                                           },
                                       ]
                                     : []),
-                            ],
-                        },
-                    ]
-                  : []),
-              ...(isOwner || permissions.includes('financials.view')
-                  ? [
-                        {
-                            title: 'FINANCIAL INSIGHTS',
-                            items: [
-                                {
-                                    title: 'Financial Dashboard',
-                                    icon: Landmark,
-                                    href: dashboardFinancial(),
-                                },
                             ],
                         },
                     ]

--- a/resources/js/components/features/app/app-sidebar.tsx
+++ b/resources/js/components/features/app/app-sidebar.tsx
@@ -29,7 +29,10 @@ import {
 } from '@/components/ui/sidebar';
 import { platformNavItems, platformPageNavItems } from '@/lib/platform';
 import { dashboard } from '@/routes';
-import { rent as dashboardRent } from '@/routes/dashboard';
+import {
+    financial as dashboardFinancial,
+    rent as dashboardRent,
+} from '@/routes/dashboard';
 import expenses from '@/routes/expenses';
 import leases from '@/routes/leases';
 import maintenanceTickets from '@/routes/maintenance-tickets';
@@ -181,6 +184,20 @@ export function AppSidebar() {
                                           },
                                       ]
                                     : []),
+                            ],
+                        },
+                    ]
+                  : []),
+              ...(isOwner || permissions.includes('financials.view')
+                  ? [
+                        {
+                            title: 'FINANCIAL INSIGHTS',
+                            items: [
+                                {
+                                    title: 'Financial Dashboard',
+                                    icon: Landmark,
+                                    href: dashboardFinancial(),
+                                },
                             ],
                         },
                     ]

--- a/resources/js/components/features/dashboard/financial-trend-chart.tsx
+++ b/resources/js/components/features/dashboard/financial-trend-chart.tsx
@@ -43,7 +43,6 @@ type ExpenseBreakdownCategory = {
 };
 
 type PlotPoint = {
-    bucket: number;
     month: string;
     label: string;
     raw: Partial<Record<SeriesKey, string>>;
@@ -59,7 +58,7 @@ const SERIES_COLORS: Record<SeriesKey, string> = {
     revenue: 'var(--chart-2)',
     expenses: 'var(--surface-amber-foreground)',
     noi: 'var(--surface-blue-foreground)',
-    collected: 'var(--surface-green-foreground)',
+    collected: 'var(--chart-2)',
 };
 
 const TOOLTIP_CONTENT_STYLE = {
@@ -227,7 +226,7 @@ export function FinancialTrendChart({
         );
     }
 
-    const data = points.map<PlotPoint>((point, bucket) => {
+    const data = points.map<PlotPoint>((point) => {
         const raw: Partial<Record<SeriesKey, string>> = {};
         const values = {
             revenue: 0,
@@ -244,7 +243,6 @@ export function FinancialTrendChart({
         });
 
         return {
-            bucket,
             month: point.month,
             label: point.label,
             raw,
@@ -266,6 +264,8 @@ export function FinancialTrendChart({
                 <ResponsiveContainer width="100%" height="100%">
                     <ComposedChart
                         data={data}
+                        barCategoryGap={0}
+                        barGap={4}
                         margin={{ top: 8, right: 4, left: 0, bottom: 0 }}
                     >
                         <CartesianGrid
@@ -274,11 +274,9 @@ export function FinancialTrendChart({
                             vertical={false}
                         />
                         <XAxis
-                            dataKey="bucket"
-                            type="number"
-                            domain={[-0.5, Math.max(data.length - 0.5, 0.5)]}
-                            ticks={data.map((point) => point.bucket)}
-                            allowDecimals={false}
+                            dataKey="label"
+                            type="category"
+                            allowDuplicatedCategory={false}
                             axisLine={false}
                             tickLine={false}
                             tick={{
@@ -286,11 +284,7 @@ export function FinancialTrendChart({
                                 fontSize: 11,
                             }}
                             interval={0}
-                            tickFormatter={(value) =>
-                                monthTick(
-                                    data[Number(value)]?.label ?? String(value),
-                                )
-                            }
+                            tickFormatter={monthTick}
                             tickMargin={8}
                         />
                         <YAxis domain={chartDomain(hasNegative)} hide />
@@ -302,9 +296,6 @@ export function FinancialTrendChart({
                                 fontWeight: 600,
                                 marginBottom: 4,
                             }}
-                            labelFormatter={(value) =>
-                                data[Number(value)]?.label ?? String(value)
-                            }
                             formatter={(value, name, item) =>
                                 tooltipFormatter(
                                     value,
@@ -350,7 +341,6 @@ export function FinancialTrendChart({
                                     name={item.label}
                                     fill={SERIES_COLORS[item.key]}
                                     radius={[3, 3, 0, 0]}
-                                    maxBarSize={18}
                                     isAnimationActive={false}
                                 />
                             ),

--- a/resources/js/components/features/dashboard/financial-trend-chart.tsx
+++ b/resources/js/components/features/dashboard/financial-trend-chart.tsx
@@ -274,7 +274,7 @@ export function FinancialTrendChart({
                             vertical={false}
                         />
                         <XAxis
-                            dataKey="label"
+                            dataKey="month"
                             type="category"
                             allowDuplicatedCategory={false}
                             axisLine={false}
@@ -284,7 +284,12 @@ export function FinancialTrendChart({
                                 fontSize: 11,
                             }}
                             interval={0}
-                            tickFormatter={monthTick}
+                            tickFormatter={(value) =>
+                                monthTick(
+                                    data.find((point) => point.month === value)
+                                        ?.label ?? String(value),
+                                )
+                            }
                             tickMargin={8}
                         />
                         <YAxis domain={chartDomain(hasNegative)} hide />
@@ -296,6 +301,10 @@ export function FinancialTrendChart({
                                 fontWeight: 600,
                                 marginBottom: 4,
                             }}
+                            labelFormatter={(value) =>
+                                data.find((point) => point.month === value)
+                                    ?.label ?? String(value)
+                            }
                             formatter={(value, name, item) =>
                                 tooltipFormatter(
                                     value,

--- a/resources/js/components/features/dashboard/financial-trend-chart.tsx
+++ b/resources/js/components/features/dashboard/financial-trend-chart.tsx
@@ -1,5 +1,17 @@
+import {
+    Bar,
+    BarChart,
+    CartesianGrid,
+    ComposedChart,
+    Line,
+    ReferenceLine,
+    ResponsiveContainer,
+    Tooltip,
+    XAxis,
+    YAxis,
+} from 'recharts';
 import { formatPrice } from '@/lib/formatters';
-import { cn } from '@/lib/utils';
+import { t } from '@/lib/i18n';
 import type { MoneyAggregate } from '@/types';
 
 type SeriesKey = 'revenue' | 'expenses' | 'noi' | 'collected';
@@ -13,17 +25,54 @@ type FinancialChartPoint = {
     collected?: MoneyAggregate[];
 };
 
+type ChartSeries = {
+    key: SeriesKey;
+    label: string;
+};
+
 type FinancialTrendChartProps = {
     points: FinancialChartPoint[];
     currency: string;
-    series: Array<{
-        key: SeriesKey;
-        label: string;
-        className: string;
-    }>;
+    series: ChartSeries[];
+};
+
+type ExpenseBreakdownCategory = {
+    category_id: number;
+    category_label: string;
+    amounts: MoneyAggregate[];
+};
+
+type PlotPoint = {
+    month: string;
+    label: string;
+    raw: Partial<Record<SeriesKey, string>>;
+    revenue: number;
+    expenses: number;
+    noi: number;
+    collected: number;
 };
 
 const MONEY_SCALE = 3;
+const PLOT_SCALE = 1_000_000;
+const SERIES_COLORS: Record<SeriesKey, string> = {
+    revenue: 'var(--surface-green-foreground)',
+    expenses: 'var(--surface-amber-foreground)',
+    noi: 'var(--surface-blue-foreground)',
+    collected: 'var(--surface-green-foreground)',
+};
+
+const TOOLTIP_CONTENT_STYLE = {
+    border: '1px solid var(--border)',
+    borderRadius: '0.5rem',
+    backgroundColor: 'var(--popover)',
+    color: 'var(--popover-foreground)',
+    boxShadow: '0 4px 6px -1px rgb(0 0 0 / 0.1)',
+};
+
+const TOOLTIP_ITEM_STYLE = {
+    color: 'var(--popover-foreground)',
+    padding: '2px 0',
+};
 
 function toMinorUnits(amount: string): bigint {
     const negative = amount.startsWith('-');
@@ -48,18 +97,76 @@ function amountFor(
     );
 }
 
-function barWidth(amount: string, maximum: bigint): string {
+function amountForCategory(
+    category: ExpenseBreakdownCategory,
+    currency: string,
+): string {
+    return (
+        category.amounts.find((group) => group.currency === currency)?.amount ??
+        '0'
+    );
+}
+
+function toPlotValue(amount: string, maximum: bigint): number {
     if (maximum === 0n) {
-        return '0%';
+        return 0;
     }
 
-    const value = toMinorUnits(amount);
-    const absoluteValue = value < 0n ? -value : value;
-    const percentage = (absoluteValue * 10000n) / maximum;
-    const whole = percentage / 100n;
-    const fraction = (percentage % 100n).toString().padStart(2, '0');
+    return Number((toMinorUnits(amount) * BigInt(PLOT_SCALE)) / maximum);
+}
 
-    return `${whole}.${fraction}%`;
+function seriesLabel(series: ChartSeries[], key: string): string {
+    return series.find((item) => item.key === key)?.label ?? key;
+}
+
+function tooltipFormatter(
+    _value: unknown,
+    name: unknown,
+    item: { dataKey?: unknown; payload?: unknown },
+    currency: string,
+    series: ChartSeries[],
+): [string, string] {
+    const key =
+        typeof item.dataKey === 'string' ? (item.dataKey as SeriesKey) : null;
+    const payload = item.payload as PlotPoint | undefined;
+    const amount = key ? payload?.raw[key] : undefined;
+
+    return [
+        formatPrice(amount ?? '0', currency),
+        seriesLabel(series, key ?? String(name ?? '')),
+    ];
+}
+
+function ChartLegend({ series }: { series: ChartSeries[] }) {
+    return (
+        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+            {series.map((item) => (
+                <span
+                    key={item.key}
+                    className="inline-flex items-center gap-1.5"
+                >
+                    <span
+                        className="size-2 rounded-full"
+                        style={{ backgroundColor: SERIES_COLORS[item.key] }}
+                        aria-hidden="true"
+                    />
+                    {item.label}
+                </span>
+            ))}
+        </div>
+    );
+}
+
+function ChartEmptyState({ message }: { message: string }) {
+    return (
+        <p className="py-8 text-center text-sm text-muted-foreground">
+            {message}
+        </p>
+    );
+}
+
+function chartDomain(hasNegative: boolean): [number, number] {
+    return hasNegative ? [-PLOT_SCALE, PLOT_SCALE] : [0, PLOT_SCALE];
 }
 
 export function FinancialTrendChart({
@@ -70,96 +177,245 @@ export function FinancialTrendChart({
     const maximum = points.reduce((max, point) => {
         return series.reduce((seriesMax, item) => {
             const value = toMinorUnits(amountFor(point, item.key, currency));
+            const absoluteValue = value < 0n ? -value : value;
 
-            return value < 0n
-                ? seriesMax > -value
-                    ? seriesMax
-                    : -value
-                : seriesMax > value
-                  ? seriesMax
-                  : value;
+            return absoluteValue > seriesMax ? absoluteValue : seriesMax;
         }, max);
     }, 0n);
 
-    if (points.length === 0 || series.length === 0) {
+    if (points.length === 0 || series.length === 0 || maximum === 0n) {
         return (
-            <p className="py-8 text-center text-sm text-muted-foreground">
-                No financial activity for this period.
-            </p>
+            <ChartEmptyState message={t('No financial activity recorded.')} />
         );
     }
 
-    return (
-        <div className="space-y-4">
-            <div className="flex flex-wrap gap-3 text-xs text-muted-foreground">
-                {series.map((item) => (
-                    <span
-                        key={item.key}
-                        className="inline-flex items-center gap-1.5"
-                    >
-                        <span
-                            className={cn(
-                                'size-2 rounded-full',
-                                item.className,
-                            )}
-                        />
-                        {item.label}
-                    </span>
-                ))}
-            </div>
-            <div
-                className="space-y-4"
-                role="img"
-                aria-label={`${currency} financial trend chart`}
-            >
-                {points.map((point) => (
-                    <div
-                        key={point.month}
-                        className="grid gap-2 sm:grid-cols-[5rem_1fr] sm:items-center"
-                    >
-                        <span className="text-xs font-medium text-muted-foreground tabular-nums">
-                            {point.label}
-                        </span>
-                        <div className="space-y-1.5">
-                            {series.map((item) => {
-                                const amount = amountFor(
-                                    point,
-                                    item.key,
-                                    currency,
-                                );
+    const data = points.map<PlotPoint>((point) => {
+        const raw: Partial<Record<SeriesKey, string>> = {};
+        const values = {
+            revenue: 0,
+            expenses: 0,
+            noi: 0,
+            collected: 0,
+        };
 
-                                return (
-                                    <div
-                                        key={item.key}
-                                        className="grid grid-cols-[5rem_1fr_auto] items-center gap-2"
-                                    >
-                                        <span className="truncate text-xs text-muted-foreground sm:hidden">
-                                            {item.label}
-                                        </span>
-                                        <div className="h-2 overflow-hidden rounded-full bg-muted sm:col-span-2">
-                                            <div
-                                                className={cn(
-                                                    'h-full rounded-full transition-[width]',
-                                                    item.className,
-                                                )}
-                                                style={{
-                                                    width: barWidth(
-                                                        amount,
-                                                        maximum,
-                                                    ),
-                                                }}
-                                            />
-                                        </div>
-                                        <span className="text-right text-xs font-medium whitespace-nowrap tabular-nums">
-                                            {formatPrice(amount, currency)}
-                                        </span>
-                                    </div>
-                                );
-                            })}
-                        </div>
-                    </div>
-                ))}
+        series.forEach((item) => {
+            const amount = amountFor(point, item.key, currency);
+
+            raw[item.key] = amount;
+            values[item.key] = toPlotValue(amount, maximum);
+        });
+
+        return { month: point.month, label: point.label, raw, ...values };
+    });
+    const hasNegative = data.some((point) =>
+        series.some((item) => point[item.key] < 0),
+    );
+
+    return (
+        <div
+            className="space-y-3"
+            role="img"
+            aria-label={`${currency} financial trend chart`}
+        >
+            <ChartLegend series={series} />
+            <div className="h-64 w-full min-w-0">
+                <ResponsiveContainer width="100%" height="100%">
+                    <ComposedChart
+                        data={data}
+                        margin={{ top: 8, right: 4, left: 0, bottom: 0 }}
+                    >
+                        <CartesianGrid
+                            stroke="var(--border)"
+                            strokeDasharray="3 3"
+                            vertical={false}
+                        />
+                        <XAxis
+                            dataKey="label"
+                            axisLine={false}
+                            tickLine={false}
+                            tick={{
+                                fill: 'var(--muted-foreground)',
+                                fontSize: 11,
+                            }}
+                            tickMargin={8}
+                            minTickGap={14}
+                        />
+                        <YAxis domain={chartDomain(hasNegative)} hide />
+                        <Tooltip
+                            contentStyle={TOOLTIP_CONTENT_STYLE}
+                            itemStyle={TOOLTIP_ITEM_STYLE}
+                            labelStyle={{
+                                color: 'var(--popover-foreground)',
+                                fontWeight: 600,
+                                marginBottom: 4,
+                            }}
+                            formatter={(value, name, item) =>
+                                tooltipFormatter(
+                                    value,
+                                    name,
+                                    item,
+                                    currency,
+                                    series,
+                                )
+                            }
+                            cursor={{
+                                fill: 'var(--muted)',
+                                opacity: 0.35,
+                            }}
+                        />
+                        {hasNegative && (
+                            <ReferenceLine
+                                y={0}
+                                stroke="var(--border)"
+                                strokeWidth={1}
+                            />
+                        )}
+                        {series.map((item) =>
+                            item.key === 'noi' ? (
+                                <Line
+                                    key={item.key}
+                                    type="monotone"
+                                    dataKey={item.key}
+                                    name={item.label}
+                                    stroke={SERIES_COLORS[item.key]}
+                                    strokeWidth={2}
+                                    dot={{
+                                        r: 3,
+                                        fill: SERIES_COLORS[item.key],
+                                        strokeWidth: 0,
+                                    }}
+                                    activeDot={{ r: 5 }}
+                                    isAnimationActive={false}
+                                />
+                            ) : (
+                                <Bar
+                                    key={item.key}
+                                    dataKey={item.key}
+                                    name={item.label}
+                                    fill={SERIES_COLORS[item.key]}
+                                    radius={[3, 3, 0, 0]}
+                                    maxBarSize={18}
+                                    isAnimationActive={false}
+                                />
+                            ),
+                        )}
+                    </ComposedChart>
+                </ResponsiveContainer>
             </div>
+        </div>
+    );
+}
+
+export function ExpenseBreakdownChart({
+    categories,
+    currency,
+}: {
+    categories: ExpenseBreakdownCategory[];
+    currency: string;
+}) {
+    const maximum = categories.reduce((max, category) => {
+        const value = toMinorUnits(amountForCategory(category, currency));
+        const absoluteValue = value < 0n ? -value : value;
+
+        return absoluteValue > max ? absoluteValue : max;
+    }, 0n);
+
+    if (categories.length === 0 || maximum === 0n) {
+        return (
+            <ChartEmptyState message={t('No operating expenses recorded.')} />
+        );
+    }
+
+    const data = categories.map((category) => {
+        const amount = amountForCategory(category, currency);
+
+        return {
+            category: category.category_label,
+            raw: amount,
+            value: toPlotValue(amount, maximum),
+        };
+    });
+    const hasNegative = data.some((category) => category.value < 0);
+    const height = Math.max(180, data.length * 36);
+    const series = [{ key: 'expenses' as const, label: t('Expenses') }];
+
+    return (
+        <div
+            className="w-full min-w-0"
+            style={{ height }}
+            role="img"
+            aria-label={`${currency} expense breakdown chart`}
+        >
+            <ResponsiveContainer width="100%" height="100%">
+                <BarChart
+                    data={data}
+                    layout="vertical"
+                    margin={{ top: 4, right: 8, left: 0, bottom: 4 }}
+                >
+                    <CartesianGrid
+                        stroke="var(--border)"
+                        strokeDasharray="3 3"
+                        horizontal={false}
+                    />
+                    <XAxis
+                        type="number"
+                        domain={chartDomain(hasNegative)}
+                        hide
+                    />
+                    <YAxis
+                        type="category"
+                        dataKey="category"
+                        axisLine={false}
+                        tickLine={false}
+                        tick={{
+                            fill: 'var(--muted-foreground)',
+                            fontSize: 11,
+                        }}
+                        tickFormatter={(value: string) =>
+                            value.length > 20 ? `${value.slice(0, 19)}…` : value
+                        }
+                        width={120}
+                    />
+                    <Tooltip
+                        contentStyle={TOOLTIP_CONTENT_STYLE}
+                        itemStyle={TOOLTIP_ITEM_STYLE}
+                        labelStyle={{
+                            color: 'var(--popover-foreground)',
+                            fontWeight: 600,
+                            marginBottom: 4,
+                        }}
+                        formatter={(value, name, item) =>
+                            tooltipFormatter(
+                                value,
+                                name,
+                                {
+                                    ...item,
+                                    dataKey: 'expenses',
+                                    payload: {
+                                        raw: {
+                                            expenses: item.payload?.raw ?? '0',
+                                        },
+                                    },
+                                },
+                                currency,
+                                series,
+                            )
+                        }
+                        cursor={{
+                            fill: 'var(--muted)',
+                            opacity: 0.35,
+                        }}
+                    />
+                    <Bar
+                        dataKey="value"
+                        name="Expenses"
+                        fill={SERIES_COLORS.expenses}
+                        radius={[0, 3, 3, 0]}
+                        maxBarSize={24}
+                        isAnimationActive={false}
+                    />
+                </BarChart>
+            </ResponsiveContainer>
         </div>
     );
 }

--- a/resources/js/components/features/dashboard/financial-trend-chart.tsx
+++ b/resources/js/components/features/dashboard/financial-trend-chart.tsx
@@ -1,0 +1,165 @@
+import { formatPrice } from '@/lib/formatters';
+import { cn } from '@/lib/utils';
+import type { MoneyAggregate } from '@/types';
+
+type SeriesKey = 'revenue' | 'expenses' | 'noi' | 'collected';
+
+type FinancialChartPoint = {
+    month: string;
+    label: string;
+    revenue?: MoneyAggregate[];
+    expenses?: MoneyAggregate[];
+    noi?: MoneyAggregate[];
+    collected?: MoneyAggregate[];
+};
+
+type FinancialTrendChartProps = {
+    points: FinancialChartPoint[];
+    currency: string;
+    series: Array<{
+        key: SeriesKey;
+        label: string;
+        className: string;
+    }>;
+};
+
+const MONEY_SCALE = 3;
+
+function toMinorUnits(amount: string): bigint {
+    const negative = amount.startsWith('-');
+    const normalized =
+        negative || amount.startsWith('+') ? amount.slice(1) : amount;
+    const [whole, fraction = ''] = normalized.split('.');
+    const scaledFraction = fraction
+        .padEnd(MONEY_SCALE, '0')
+        .slice(0, MONEY_SCALE);
+    const value = BigInt(`${whole || '0'}${scaledFraction}`);
+
+    return negative ? -value : value;
+}
+
+function amountFor(
+    point: FinancialChartPoint,
+    key: SeriesKey,
+    currency: string,
+): string {
+    return (
+        point[key]?.find((group) => group.currency === currency)?.amount ?? '0'
+    );
+}
+
+function barWidth(amount: string, maximum: bigint): string {
+    if (maximum === 0n) {
+        return '0%';
+    }
+
+    const value = toMinorUnits(amount);
+    const absoluteValue = value < 0n ? -value : value;
+    const percentage = (absoluteValue * 10000n) / maximum;
+    const whole = percentage / 100n;
+    const fraction = (percentage % 100n).toString().padStart(2, '0');
+
+    return `${whole}.${fraction}%`;
+}
+
+export function FinancialTrendChart({
+    points,
+    currency,
+    series,
+}: FinancialTrendChartProps) {
+    const maximum = points.reduce((max, point) => {
+        return series.reduce((seriesMax, item) => {
+            const value = toMinorUnits(amountFor(point, item.key, currency));
+
+            return value < 0n
+                ? seriesMax > -value
+                    ? seriesMax
+                    : -value
+                : seriesMax > value
+                  ? seriesMax
+                  : value;
+        }, max);
+    }, 0n);
+
+    if (points.length === 0 || series.length === 0) {
+        return (
+            <p className="py-8 text-center text-sm text-muted-foreground">
+                No financial activity for this period.
+            </p>
+        );
+    }
+
+    return (
+        <div className="space-y-4">
+            <div className="flex flex-wrap gap-3 text-xs text-muted-foreground">
+                {series.map((item) => (
+                    <span
+                        key={item.key}
+                        className="inline-flex items-center gap-1.5"
+                    >
+                        <span
+                            className={cn(
+                                'size-2 rounded-full',
+                                item.className,
+                            )}
+                        />
+                        {item.label}
+                    </span>
+                ))}
+            </div>
+            <div
+                className="space-y-4"
+                role="img"
+                aria-label={`${currency} financial trend chart`}
+            >
+                {points.map((point) => (
+                    <div
+                        key={point.month}
+                        className="grid gap-2 sm:grid-cols-[5rem_1fr] sm:items-center"
+                    >
+                        <span className="text-xs font-medium text-muted-foreground tabular-nums">
+                            {point.label}
+                        </span>
+                        <div className="space-y-1.5">
+                            {series.map((item) => {
+                                const amount = amountFor(
+                                    point,
+                                    item.key,
+                                    currency,
+                                );
+
+                                return (
+                                    <div
+                                        key={item.key}
+                                        className="grid grid-cols-[5rem_1fr_auto] items-center gap-2"
+                                    >
+                                        <span className="truncate text-xs text-muted-foreground sm:hidden">
+                                            {item.label}
+                                        </span>
+                                        <div className="h-2 overflow-hidden rounded-full bg-muted sm:col-span-2">
+                                            <div
+                                                className={cn(
+                                                    'h-full rounded-full transition-[width]',
+                                                    item.className,
+                                                )}
+                                                style={{
+                                                    width: barWidth(
+                                                        amount,
+                                                        maximum,
+                                                    ),
+                                                }}
+                                            />
+                                        </div>
+                                        <span className="text-right text-xs font-medium whitespace-nowrap tabular-nums">
+                                            {formatPrice(amount, currency)}
+                                        </span>
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/resources/js/components/features/dashboard/financial-trend-chart.tsx
+++ b/resources/js/components/features/dashboard/financial-trend-chart.tsx
@@ -1,8 +1,10 @@
+import type { ReactElement } from 'react';
 import {
     Bar,
     BarChart,
     CartesianGrid,
     ComposedChart,
+    Rectangle,
     Line,
     ReferenceLine,
     ResponsiveContainer,
@@ -10,6 +12,7 @@ import {
     XAxis,
     YAxis,
 } from 'recharts';
+import type { BarShapeProps } from 'recharts';
 import { formatPrice } from '@/lib/formatters';
 import { t } from '@/lib/i18n';
 import type { MoneyAggregate } from '@/types';
@@ -54,6 +57,7 @@ type PlotPoint = {
 
 const MONEY_SCALE = 3;
 const PLOT_SCALE = 1_000_000;
+const BAR_GAP = 4;
 const SERIES_COLORS: Record<SeriesKey, string> = {
     revenue: 'var(--chart-2)',
     expenses: 'var(--surface-amber-foreground)',
@@ -206,6 +210,32 @@ function monthTick(label: string): string {
     return label.split(' ')[0] ?? label;
 }
 
+function centeredBarShape(
+    barKey: SeriesKey,
+    barKeys: SeriesKey[],
+): (props: BarShapeProps) => ReactElement {
+    return (props) => {
+        const point = props.payload as PlotPoint | undefined;
+        const visibleBarKeys = barKeys.filter(
+            (key) => (point?.[key] ?? 0) !== 0,
+        );
+
+        if (visibleBarKeys.length !== 1 || visibleBarKeys[0] !== barKey) {
+            return <Rectangle {...props} />;
+        }
+
+        const barIndex = barKeys.indexOf(barKey);
+        const shift = (props.width + BAR_GAP) / 2;
+
+        return (
+            <Rectangle
+                {...props}
+                x={props.x + (barIndex === 0 ? shift : -shift)}
+            />
+        );
+    };
+}
+
 export function FinancialTrendChart({
     points,
     currency,
@@ -252,6 +282,9 @@ export function FinancialTrendChart({
     const hasNegative = data.some((point) =>
         series.some((item) => point[item.key] < 0),
     );
+    const barKeys = series
+        .filter((item) => item.key !== 'noi')
+        .map((item) => item.key);
 
     return (
         <div
@@ -265,7 +298,7 @@ export function FinancialTrendChart({
                     <ComposedChart
                         data={data}
                         barCategoryGap={0}
-                        barGap={4}
+                        barGap={BAR_GAP}
                         margin={{ top: 8, right: 4, left: 0, bottom: 0 }}
                     >
                         <CartesianGrid
@@ -350,6 +383,14 @@ export function FinancialTrendChart({
                                     name={item.label}
                                     fill={SERIES_COLORS[item.key]}
                                     radius={[3, 3, 0, 0]}
+                                    shape={
+                                        barKeys.length === 2
+                                            ? centeredBarShape(
+                                                  item.key,
+                                                  barKeys,
+                                              )
+                                            : undefined
+                                    }
                                     isAnimationActive={false}
                                 />
                             ),

--- a/resources/js/components/features/dashboard/financial-trend-chart.tsx
+++ b/resources/js/components/features/dashboard/financial-trend-chart.tsx
@@ -43,6 +43,7 @@ type ExpenseBreakdownCategory = {
 };
 
 type PlotPoint = {
+    bucket: number;
     month: string;
     label: string;
     raw: Partial<Record<SeriesKey, string>>;
@@ -55,7 +56,7 @@ type PlotPoint = {
 const MONEY_SCALE = 3;
 const PLOT_SCALE = 1_000_000;
 const SERIES_COLORS: Record<SeriesKey, string> = {
-    revenue: 'var(--surface-green-foreground)',
+    revenue: 'var(--chart-2)',
     expenses: 'var(--surface-amber-foreground)',
     noi: 'var(--surface-blue-foreground)',
     collected: 'var(--surface-green-foreground)',
@@ -226,7 +227,7 @@ export function FinancialTrendChart({
         );
     }
 
-    const data = points.map<PlotPoint>((point) => {
+    const data = points.map<PlotPoint>((point, bucket) => {
         const raw: Partial<Record<SeriesKey, string>> = {};
         const values = {
             revenue: 0,
@@ -242,7 +243,13 @@ export function FinancialTrendChart({
             values[item.key] = toPlotValue(amount, maximum);
         });
 
-        return { month: point.month, label: point.label, raw, ...values };
+        return {
+            bucket,
+            month: point.month,
+            label: point.label,
+            raw,
+            ...values,
+        };
     });
     const hasNegative = data.some((point) =>
         series.some((item) => point[item.key] < 0),
@@ -267,7 +274,11 @@ export function FinancialTrendChart({
                             vertical={false}
                         />
                         <XAxis
-                            dataKey="label"
+                            dataKey="bucket"
+                            type="number"
+                            domain={[-0.5, Math.max(data.length - 0.5, 0.5)]}
+                            ticks={data.map((point) => point.bucket)}
+                            allowDecimals={false}
                             axisLine={false}
                             tickLine={false}
                             tick={{
@@ -275,7 +286,11 @@ export function FinancialTrendChart({
                                 fontSize: 11,
                             }}
                             interval={0}
-                            tickFormatter={monthTick}
+                            tickFormatter={(value) =>
+                                monthTick(
+                                    data[Number(value)]?.label ?? String(value),
+                                )
+                            }
                             tickMargin={8}
                         />
                         <YAxis domain={chartDomain(hasNegative)} hide />
@@ -287,6 +302,9 @@ export function FinancialTrendChart({
                                 fontWeight: 600,
                                 marginBottom: 4,
                             }}
+                            labelFormatter={(value) =>
+                                data[Number(value)]?.label ?? String(value)
+                            }
                             formatter={(value, name, item) =>
                                 tooltipFormatter(
                                     value,

--- a/resources/js/components/features/dashboard/financial-trend-chart.tsx
+++ b/resources/js/components/features/dashboard/financial-trend-chart.tsx
@@ -87,6 +87,39 @@ function toMinorUnits(amount: string): bigint {
     return negative ? -value : value;
 }
 
+function fromMinorUnits(amount: bigint): string {
+    if (amount === 0n) {
+        return '0';
+    }
+
+    const negative = amount < 0n;
+    const absolute = negative ? -amount : amount;
+    const factor = 10n ** BigInt(MONEY_SCALE);
+    const whole = absolute / factor;
+    const fraction = (absolute % factor).toString().padStart(MONEY_SCALE, '0');
+
+    return `${negative ? '-' : ''}${whole}.${fraction}`;
+}
+
+export function sumCurrencyAmounts(
+    groups: MoneyAggregate[],
+    currency: string,
+): string {
+    return fromMinorUnits(
+        groups.reduce(
+            (total, group) =>
+                group.currency === currency
+                    ? total + toMinorUnits(group.amount)
+                    : total,
+            0n,
+        ),
+    );
+}
+
+export function subtractCurrencyAmounts(left: string, right: string): string {
+    return fromMinorUnits(toMinorUnits(left) - toMinorUnits(right));
+}
+
 function amountFor(
     point: FinancialChartPoint,
     key: SeriesKey,
@@ -169,6 +202,10 @@ function chartDomain(hasNegative: boolean): [number, number] {
     return hasNegative ? [-PLOT_SCALE, PLOT_SCALE] : [0, PLOT_SCALE];
 }
 
+function monthTick(label: string): string {
+    return label.split(' ')[0] ?? label;
+}
+
 export function FinancialTrendChart({
     points,
     currency,
@@ -237,8 +274,9 @@ export function FinancialTrendChart({
                                 fill: 'var(--muted-foreground)',
                                 fontSize: 11,
                             }}
+                            interval={0}
+                            tickFormatter={monthTick}
                             tickMargin={8}
-                            minTickGap={14}
                         />
                         <YAxis domain={chartDomain(hasNegative)} hide />
                         <Tooltip
@@ -408,7 +446,7 @@ export function ExpenseBreakdownChart({
                     />
                     <Bar
                         dataKey="value"
-                        name="Expenses"
+                        name={series[0].label}
                         fill={SERIES_COLORS.expenses}
                         radius={[0, 3, 3, 0]}
                         maxBarSize={24}

--- a/resources/js/components/shared/metric-card.tsx
+++ b/resources/js/components/shared/metric-card.tsx
@@ -246,14 +246,14 @@ export function MetricCard({
                     <p className="text-xs font-semibold tracking-wider text-muted-foreground uppercase">
                         {label}
                     </p>
-                    <p
+                    <div
                         className={cn(
                             'mt-1.5 text-2xl font-bold tabular-nums sm:text-3xl',
                             styles.value,
                         )}
                     >
                         {value}
-                    </p>
+                    </div>
                     {subtext && !subtextFullWidth && (
                         <div className="mt-1 text-xs font-medium text-muted-foreground">
                             {subtext}

--- a/resources/js/components/shared/metric-card.tsx
+++ b/resources/js/components/shared/metric-card.tsx
@@ -20,6 +20,7 @@ export interface MetricCardProps {
     variant?: MetricVariant;
     emphasis?: MetricEmphasis;
     icon?: React.ComponentType<{ className?: string }>;
+    valueFullWidth?: boolean;
     subtextFullWidth?: boolean;
     progress?: number;
     onClick?: () => void;
@@ -220,6 +221,7 @@ export function MetricCard({
     variant = 'neutral',
     emphasis = 'subtle',
     icon: Icon,
+    valueFullWidth = false,
     subtextFullWidth = false,
     progress,
     onClick,
@@ -253,14 +255,16 @@ export function MetricCard({
                             {subParams}
                         </div>
                     )}
-                    <div
-                        className={cn(
-                            'mt-1.5 text-2xl font-bold tabular-nums sm:text-3xl',
-                            styles.value,
-                        )}
-                    >
-                        {value}
-                    </div>
+                    {!valueFullWidth && (
+                        <div
+                            className={cn(
+                                'mt-1.5 text-2xl font-bold tabular-nums sm:text-3xl',
+                                styles.value,
+                            )}
+                        >
+                            {value}
+                        </div>
+                    )}
                     {subtext && !subtextFullWidth && (
                         <div className="mt-1 text-xs font-medium text-muted-foreground">
                             {subtext}
@@ -279,6 +283,17 @@ export function MetricCard({
                     </div>
                 )}
             </div>
+
+            {valueFullWidth && (
+                <div
+                    className={cn(
+                        'mt-3 border-t border-border pt-3 text-xs font-medium',
+                        styles.value,
+                    )}
+                >
+                    {value}
+                </div>
+            )}
 
             {subtext && subtextFullWidth && (
                 <div className="mt-3 border-t border-border pt-3 text-xs font-medium text-muted-foreground">

--- a/resources/js/components/shared/metric-card.tsx
+++ b/resources/js/components/shared/metric-card.tsx
@@ -14,6 +14,7 @@ export type MetricEmphasis = 'neutral' | 'subtle' | 'attention';
 
 export interface MetricCardProps {
     label: string;
+    subParams?: React.ReactNode;
     value: React.ReactNode;
     subtext?: React.ReactNode;
     variant?: MetricVariant;
@@ -213,6 +214,7 @@ const VARIANT_STYLES: Record<
 
 export function MetricCard({
     label,
+    subParams,
     value,
     subtext,
     variant = 'neutral',
@@ -246,6 +248,11 @@ export function MetricCard({
                     <p className="text-xs font-semibold tracking-wider text-muted-foreground uppercase">
                         {label}
                     </p>
+                    {subParams && (
+                        <div className="mt-1 text-xs font-medium text-muted-foreground">
+                            {subParams}
+                        </div>
+                    )}
                     <div
                         className={cn(
                             'mt-1.5 text-2xl font-bold tabular-nums sm:text-3xl',

--- a/resources/js/pages/dashboard/financial.tsx
+++ b/resources/js/pages/dashboard/financial.tsx
@@ -416,7 +416,7 @@ function PropertyPerformanceDetails({
                         {t('Occupancy')}
                     </h4>
                     <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1">
-                        <span className="text-base font-semibold tabular-nums">
+                        <span className="text-sm font-semibold tabular-nums">
                             {row.occupancy.occupied_units} /{' '}
                             {row.occupancy.total_units} {t('units')}
                         </span>

--- a/resources/js/pages/dashboard/financial.tsx
+++ b/resources/js/pages/dashboard/financial.tsx
@@ -4,13 +4,14 @@ import {
     BarChart3,
     Building2,
     CalendarRange,
+    ChevronDown,
     CircleDollarSign,
     Receipt,
     TrendingDown,
     TrendingUp,
 } from 'lucide-react';
-import { useState } from 'react';
-import type { ComponentType } from 'react';
+import { Fragment, useState } from 'react';
+import type { ComponentType, ReactNode } from 'react';
 import { CurrencyAmountList } from '@/components/features/dashboard/currency-amount-list';
 import {
     ExpenseBreakdownChart,
@@ -197,11 +198,218 @@ function amountForCurrency(groups: MoneyAggregate[], currency: string): string {
     return groups.find((group) => group.currency === currency)?.amount ?? '0';
 }
 
+function compactPerformanceAmount(group: MoneyAggregate): string {
+    const match = group.amount.match(/^(-?)(\d+)(?:\.(\d+))?$/);
+
+    if (!match) {
+        return formatPrice(group.amount, group.currency);
+    }
+
+    const [, sign, whole, fraction = ''] = match;
+    const absoluteAmount = BigInt(`${whole}${fraction}` || '0');
+    const denominator = 10n ** BigInt(fraction.length);
+    const units = [
+        { value: 1_000_000_000n, suffix: 'B' },
+        { value: 1_000_000n, suffix: 'M' },
+        { value: 1_000n, suffix: 'K' },
+    ];
+    let unitIndex = units.findIndex(({ value }) => BigInt(whole) >= value);
+
+    if (unitIndex === -1) {
+        return formatPrice(group.amount, group.currency).replace(
+            new RegExp(`^${group.currency}\\s*`),
+            '',
+        );
+    }
+
+    const compactValue = (value: bigint) => {
+        const scaled = absoluteAmount * 10n;
+        const divisor = value * denominator;
+        let tenths = scaled / divisor;
+
+        if ((scaled % divisor) * 2n >= divisor) {
+            tenths += 1n;
+        }
+
+        return tenths;
+    };
+
+    let tenths = compactValue(units[unitIndex].value);
+
+    if (tenths >= 1000n && unitIndex > 0) {
+        unitIndex -= 1;
+        tenths = compactValue(units[unitIndex].value);
+    }
+
+    const wholePart = tenths / 10n;
+    const decimalPart = tenths % 10n;
+
+    return `${sign}${wholePart}${decimalPart > 0n ? `.${decimalPart}` : ''}${units[unitIndex].suffix}`;
+}
+
+function ExactPerformanceAmounts({
+    groups,
+}: {
+    groups: MoneyAggregate[];
+}): ReactNode {
+    if (groups.length === 0) {
+        return <span className="text-muted-foreground">—</span>;
+    }
+
+    return (
+        <div className="flex flex-col gap-1 tabular-nums">
+            {groups.map((group) => (
+                <span key={group.currency}>
+                    {formatPrice(group.amount, group.currency)}
+                </span>
+            ))}
+        </div>
+    );
+}
+
 function PerformanceValue({ groups }: { groups: MoneyAggregate[] }) {
-    return <CurrencyAmountList groups={groups} compact />;
+    if (groups.length === 0) {
+        return <span className="text-muted-foreground">—</span>;
+    }
+
+    const exactValues = groups
+        .map((group) => formatPrice(group.amount, group.currency))
+        .join(' · ');
+
+    return (
+        <div
+            className="flex flex-col items-end gap-1 text-xs tabular-nums sm:text-sm"
+            title={exactValues}
+            aria-label={exactValues}
+        >
+            {groups.map((group) => (
+                <span
+                    key={group.currency}
+                    className="inline-flex items-baseline gap-2 whitespace-nowrap"
+                >
+                    <span className="text-[10px] font-semibold tracking-wide text-muted-foreground uppercase">
+                        {group.currency}
+                    </span>
+                    <span className="font-semibold">
+                        {compactPerformanceAmount(group)}
+                    </span>
+                </span>
+            ))}
+        </div>
+    );
+}
+
+function PerformanceRate({ rates }: { rates: RateAggregate[] }) {
+    if (rates.length === 0) {
+        return <span className="text-muted-foreground">—</span>;
+    }
+
+    return (
+        <div className="flex flex-col items-end gap-1 text-xs tabular-nums sm:text-sm">
+            {rates.map((rate) => (
+                <span key={rate.currency} className="whitespace-nowrap">
+                    <span className="mr-2 text-[10px] font-semibold tracking-wide text-muted-foreground uppercase">
+                        {rate.currency}
+                    </span>
+                    <span className="font-semibold">{rate.rate}%</span>
+                </span>
+            ))}
+        </div>
+    );
+}
+
+function PerformanceDetailMetric({
+    label,
+    children,
+}: {
+    label: string;
+    children: ReactNode;
+}) {
+    return (
+        <div className="flex items-start justify-between gap-4">
+            <dt className="text-sm text-muted-foreground">{label}</dt>
+            <dd className="text-right text-sm font-medium">{children}</dd>
+        </div>
+    );
+}
+
+function PropertyPerformanceDetails({
+    row,
+}: {
+    row: FinancialPropertyPerformance;
+}) {
+    return (
+        <div className="rounded-md bg-muted/30 p-4">
+            <p className="mb-4 text-sm font-semibold">{row.name}</p>
+            <div className="grid gap-6 sm:grid-cols-3">
+                <section>
+                    <h4 className="mb-3 text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+                        {t('Financial')}
+                    </h4>
+                    <dl className="space-y-2.5">
+                        <PerformanceDetailMetric label={t('Revenue')}>
+                            <ExactPerformanceAmounts groups={row.revenue} />
+                        </PerformanceDetailMetric>
+                        <PerformanceDetailMetric label={t('Expenses')}>
+                            <ExactPerformanceAmounts groups={row.expenses} />
+                        </PerformanceDetailMetric>
+                        <PerformanceDetailMetric label={t('NOI')}>
+                            <ExactPerformanceAmounts groups={row.noi} />
+                        </PerformanceDetailMetric>
+                        <PerformanceDetailMetric label={t('Operating margin')}>
+                            <PerformanceRate rates={row.operating_margin} />
+                        </PerformanceDetailMetric>
+                    </dl>
+                </section>
+
+                <section>
+                    <h4 className="mb-3 text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+                        {t('Collections')}
+                    </h4>
+                    <dl className="space-y-2.5">
+                        <PerformanceDetailMetric label={t('Billed')}>
+                            <ExactPerformanceAmounts groups={row.billed} />
+                        </PerformanceDetailMetric>
+                        <PerformanceDetailMetric label={t('Applied')}>
+                            <ExactPerformanceAmounts groups={row.collected} />
+                        </PerformanceDetailMetric>
+                        <PerformanceDetailMetric label={t('Outstanding')}>
+                            <ExactPerformanceAmounts groups={row.outstanding} />
+                        </PerformanceDetailMetric>
+                        <PerformanceDetailMetric label={t('Collection rate')}>
+                            <PerformanceRate rates={row.collection_rate} />
+                        </PerformanceDetailMetric>
+                    </dl>
+                </section>
+
+                <section>
+                    <h4 className="mb-3 text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+                        {t('Occupancy')}
+                    </h4>
+                    <dl className="space-y-2.5">
+                        <PerformanceDetailMetric label={t('Occupied')}>
+                            <span className="tabular-nums">
+                                {row.occupancy.occupied_units} /{' '}
+                                {row.occupancy.total_units}
+                            </span>
+                        </PerformanceDetailMetric>
+                        <PerformanceDetailMetric label={t('Occupancy rate')}>
+                            <span className="tabular-nums">
+                                {row.occupancy.occupancy_percentage}%
+                            </span>
+                        </PerformanceDetailMetric>
+                    </dl>
+                </section>
+            </div>
+        </div>
+    );
 }
 
 function PerformanceTable({ rows }: { rows: FinancialPropertyPerformance[] }) {
+    const [expandedPropertyId, setExpandedPropertyId] = useState<number | null>(
+        null,
+    );
+
     if (rows.length === 0) {
         return (
             <p className="py-8 text-center text-sm text-muted-foreground">
@@ -212,73 +420,97 @@ function PerformanceTable({ rows }: { rows: FinancialPropertyPerformance[] }) {
 
     return (
         <div className="overflow-x-auto">
-            <table className="w-full min-w-[900px] text-sm">
+            <table className="w-full text-sm">
                 <thead>
                     <tr className="border-b border-border text-left text-xs tracking-wide text-muted-foreground uppercase">
-                        <th className="px-2 py-3 font-medium">Property</th>
-                        <th className="px-2 py-3 text-right font-medium">
-                            Revenue
+                        <th className="px-2 py-3 font-medium">
+                            {t('Property')}
                         </th>
                         <th className="px-2 py-3 text-right font-medium">
-                            Expenses
+                            {t('Revenue')}
                         </th>
                         <th className="px-2 py-3 text-right font-medium">
-                            NOI
+                            {t('Expenses')}
                         </th>
                         <th className="px-2 py-3 text-right font-medium">
-                            Margin
+                            {t('NOI')}
                         </th>
                         <th className="px-2 py-3 text-right font-medium">
-                            Applied
-                        </th>
-                        <th className="px-2 py-3 text-right font-medium">
-                            Outstanding
-                        </th>
-                        <th className="px-2 py-3 text-right font-medium">
-                            Rate
-                        </th>
-                        <th className="px-2 py-3 text-right font-medium">
-                            Occupancy
+                            {t('Margin')}
                         </th>
                     </tr>
                 </thead>
                 <tbody>
-                    {rows.map((row) => (
-                        <tr
-                            key={row.id}
-                            className="border-b border-border/60 last:border-0"
-                        >
-                            <td className="px-2 py-3 font-medium">
-                                {row.name}
-                            </td>
-                            <td className="px-2 py-3 text-right">
-                                <PerformanceValue groups={row.revenue} />
-                            </td>
-                            <td className="px-2 py-3 text-right">
-                                <PerformanceValue groups={row.expenses} />
-                            </td>
-                            <td className="px-2 py-3 text-right">
-                                <PerformanceValue groups={row.noi} />
-                            </td>
-                            <td className="px-2 py-3 text-right">
-                                <RateList rates={row.operating_margin} />
-                            </td>
-                            <td className="px-2 py-3 text-right">
-                                <PerformanceValue groups={row.collected} />
-                            </td>
-                            <td className="px-2 py-3 text-right">
-                                <PerformanceValue groups={row.outstanding} />
-                            </td>
-                            <td className="px-2 py-3 text-right">
-                                <RateList rates={row.collection_rate} />
-                            </td>
-                            <td className="px-2 py-3 text-right">
-                                {row.occupancy.occupancy_percentage}% ·{' '}
-                                {row.occupancy.occupied_units}/
-                                {row.occupancy.total_units}
-                            </td>
-                        </tr>
-                    ))}
+                    {rows.map((row) => {
+                        const isExpanded = expandedPropertyId === row.id;
+                        const detailId = `property-performance-details-${row.id}`;
+
+                        return (
+                            <Fragment key={row.id}>
+                                <tr
+                                    className={`border-b border-border/60 hover:bg-muted/30 ${isExpanded ? 'bg-muted/20' : ''}`}
+                                >
+                                    <td className="px-2 py-3">
+                                        <button
+                                            type="button"
+                                            className="group flex w-full min-w-0 items-center gap-2 rounded-md py-1 text-left font-medium transition-colors outline-none hover:text-primary focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                                            aria-expanded={isExpanded}
+                                            aria-controls={detailId}
+                                            onClick={() =>
+                                                setExpandedPropertyId(
+                                                    isExpanded ? null : row.id,
+                                                )
+                                            }
+                                        >
+                                            <span className="truncate">
+                                                {row.name}
+                                            </span>
+                                            <ChevronDown
+                                                className={`size-4 shrink-0 text-muted-foreground transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+                                                aria-hidden="true"
+                                            />
+                                            <span className="sr-only">
+                                                {isExpanded
+                                                    ? t('Hide details')
+                                                    : t('View details')}
+                                            </span>
+                                        </button>
+                                    </td>
+                                    <td className="px-2 py-3 text-right">
+                                        <PerformanceValue
+                                            groups={row.revenue}
+                                        />
+                                    </td>
+                                    <td className="px-2 py-3 text-right">
+                                        <PerformanceValue
+                                            groups={row.expenses}
+                                        />
+                                    </td>
+                                    <td className="px-2 py-3 text-right">
+                                        <PerformanceValue groups={row.noi} />
+                                    </td>
+                                    <td className="px-2 py-3 text-right">
+                                        <PerformanceRate
+                                            rates={row.operating_margin}
+                                        />
+                                    </td>
+                                </tr>
+                                {isExpanded && (
+                                    <tr className="border-b border-border/60">
+                                        <td
+                                            id={detailId}
+                                            colSpan={5}
+                                            className="px-2 pb-4"
+                                        >
+                                            <PropertyPerformanceDetails
+                                                row={row}
+                                            />
+                                        </td>
+                                    </tr>
+                                )}
+                            </Fragment>
+                        );
+                    })}
                 </tbody>
             </table>
         </div>
@@ -699,7 +931,7 @@ export default function Financial({
                             <CardTitle>{t('Property Performance')}</CardTitle>
                             <p className="text-sm text-muted-foreground">
                                 {t(
-                                    'Selected-period financial performance by accessible property',
+                                    'Selected-period financial performance by accessible property. Select a property to view full detail.',
                                 )}
                             </p>
                         </CardHeader>

--- a/resources/js/pages/dashboard/financial.tsx
+++ b/resources/js/pages/dashboard/financial.tsx
@@ -11,7 +11,10 @@ import {
 } from 'lucide-react';
 import type { ComponentType } from 'react';
 import { CurrencyAmountList } from '@/components/features/dashboard/currency-amount-list';
-import { FinancialTrendChart } from '@/components/features/dashboard/financial-trend-chart';
+import {
+    ExpenseBreakdownChart,
+    FinancialTrendChart,
+} from '@/components/features/dashboard/financial-trend-chart';
 import { MetricCard } from '@/components/shared/metric-card';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
@@ -42,28 +45,17 @@ type PageProps = {
     properties: Array<{ id: number; name: string }>;
 };
 
-function currenciesFromGroups(groups: MoneyAggregate[]): string[] {
-    return groups.map((group) => group.currency);
-}
+type FinancialSeriesKey = 'revenue' | 'expenses' | 'noi' | 'collected';
 
-function currenciesFromFinancial(financial: FinancialDashboardData): string[] {
-    const groups = [
-        ...financial.overview.revenue,
-        ...financial.overview.expenses,
-        ...financial.overview.noi,
-        ...financial.collections.collected,
-        ...financial.trends.flatMap((point) => [
-            ...point.revenue,
-            ...point.expenses,
-            ...point.noi,
-        ]),
-        ...financial.cash_flow.flatMap((point) => [
-            ...point.collected,
-            ...point.expenses,
-        ]),
-    ];
+function currenciesFromPoints(
+    points: Array<Partial<Record<FinancialSeriesKey, MoneyAggregate[]>>>,
+    keys: FinancialSeriesKey[],
+): string[] {
+    const groups = points.flatMap((point) =>
+        keys.flatMap((key) => point[key] ?? []),
+    );
 
-    return [...new Set(currenciesFromGroups(groups))].sort();
+    return [...new Set(groups.map((group) => group.currency))].sort();
 }
 
 function RateList({ rates }: { rates: RateAggregate[] }) {
@@ -225,7 +217,22 @@ export default function Financial({
     filters,
     properties,
 }: PageProps) {
-    const trendCurrencies = currenciesFromFinancial(financial);
+    const trendCurrencies = currenciesFromPoints(financial.trends, [
+        'revenue',
+        'expenses',
+        'noi',
+    ]);
+    const cashFlowCurrencies = currenciesFromPoints(financial.cash_flow, [
+        'collected',
+        'expenses',
+    ]);
+    const expenseCurrencies = [
+        ...new Set(
+            financial.expense_breakdown.flatMap((category) =>
+                category.amounts.map((group) => group.currency),
+            ),
+        ),
+    ].sort();
 
     function updateFilters(changes: {
         period?: Period;
@@ -339,7 +346,7 @@ export default function Financial({
                     </p>
                 </div>
 
-                <section className="mb-10 flex flex-col gap-3">
+                <section className="mb-8 flex flex-col gap-3">
                     <h2 className="text-xs font-semibold tracking-wider text-muted-foreground uppercase">
                         {t('Financial Overview')}
                     </h2>
@@ -381,7 +388,7 @@ export default function Financial({
                     </div>
                 </section>
 
-                <section className="mb-10 flex flex-col gap-3">
+                <section className="mb-8 flex flex-col gap-3">
                     <h2 className="text-xs font-semibold tracking-wider text-muted-foreground uppercase">
                         {t('Collections')}
                     </h2>
@@ -431,7 +438,7 @@ export default function Financial({
                     </div>
                 </section>
 
-                <section className="mb-10 grid gap-6 xl:grid-cols-2">
+                <section className="mb-8 grid gap-6 xl:grid-cols-2">
                     <Card>
                         <CardHeader>
                             <CardTitle>
@@ -443,7 +450,7 @@ export default function Financial({
                                 )}
                             </p>
                         </CardHeader>
-                        <CardContent className="space-y-8">
+                        <CardContent className="space-y-5">
                             {trendCurrencies.length > 0 ? (
                                 trendCurrencies.map((currency) => (
                                     <div key={currency}>
@@ -457,20 +464,14 @@ export default function Financial({
                                                 {
                                                     key: 'revenue',
                                                     label: t('Revenue'),
-                                                    className:
-                                                        'bg-surface-green-foreground',
                                                 },
                                                 {
                                                     key: 'expenses',
                                                     label: t('Expenses'),
-                                                    className:
-                                                        'bg-surface-amber-foreground',
                                                 },
                                                 {
                                                     key: 'noi',
                                                     label: t('NOI'),
-                                                    className:
-                                                        'bg-surface-blue-foreground',
                                                 },
                                             ]}
                                         />
@@ -492,9 +493,9 @@ export default function Financial({
                                 )}
                             </p>
                         </CardHeader>
-                        <CardContent className="space-y-8">
-                            {trendCurrencies.length > 0 ? (
-                                trendCurrencies.map((currency) => (
+                        <CardContent className="space-y-5">
+                            {cashFlowCurrencies.length > 0 ? (
+                                cashFlowCurrencies.map((currency) => (
                                     <div key={currency}>
                                         <h3 className="mb-4 text-sm font-semibold">
                                             {currency}
@@ -506,14 +507,10 @@ export default function Financial({
                                                 {
                                                     key: 'collected',
                                                     label: t('Cash Collected'),
-                                                    className:
-                                                        'bg-surface-green-foreground',
                                                 },
                                                 {
                                                     key: 'expenses',
                                                     label: t('Expenses'),
-                                                    className:
-                                                        'bg-surface-amber-foreground',
                                                 },
                                             ]}
                                         />
@@ -528,7 +525,7 @@ export default function Financial({
                     </Card>
                 </section>
 
-                <section className="mb-10 grid gap-6 xl:grid-cols-[1.4fr_1fr]">
+                <section className="mb-8 grid gap-6 xl:grid-cols-[1.4fr_1fr]">
                     <Card>
                         <CardHeader>
                             <CardTitle>{t('Property Performance')}</CardTitle>
@@ -592,7 +589,7 @@ export default function Financial({
                     </Card>
                 </section>
 
-                <section className="mb-10 grid gap-6 xl:grid-cols-2">
+                <section className="mb-8 grid gap-6 xl:grid-cols-2">
                     <Card>
                         <CardHeader>
                             <CardTitle>{t('Expense Breakdown')}</CardTitle>
@@ -602,26 +599,21 @@ export default function Financial({
                                 )}
                             </p>
                         </CardHeader>
-                        <CardContent>
-                            {financial.expense_breakdown.length > 0 ? (
-                                <div className="space-y-4">
-                                    {financial.expense_breakdown.map(
-                                        (category) => (
-                                            <div
-                                                key={category.category_id}
-                                                className="flex items-center justify-between gap-4 border-b border-border/60 pb-3 last:border-0 last:pb-0"
-                                            >
-                                                <span className="font-medium">
-                                                    {category.category_label}
-                                                </span>
-                                                <CurrencyAmountList
-                                                    groups={category.amounts}
-                                                    compact
-                                                />
-                                            </div>
-                                        ),
-                                    )}
-                                </div>
+                        <CardContent className="space-y-5">
+                            {expenseCurrencies.length > 0 ? (
+                                expenseCurrencies.map((currency) => (
+                                    <div key={currency} className="space-y-2">
+                                        <h3 className="text-sm font-semibold">
+                                            {currency}
+                                        </h3>
+                                        <ExpenseBreakdownChart
+                                            categories={
+                                                financial.expense_breakdown
+                                            }
+                                            currency={currency}
+                                        />
+                                    </div>
+                                ))
                             ) : (
                                 <p className="py-8 text-center text-sm text-muted-foreground">
                                     {t('No operating expenses recorded.')}

--- a/resources/js/pages/dashboard/financial.tsx
+++ b/resources/js/pages/dashboard/financial.tsx
@@ -247,26 +247,6 @@ function compactPerformanceAmount(group: MoneyAggregate): string {
     return `${sign}${wholePart}${decimalPart > 0n ? `.${decimalPart}` : ''}${units[unitIndex].suffix}`;
 }
 
-function ExactPerformanceAmounts({
-    groups,
-}: {
-    groups: MoneyAggregate[];
-}): ReactNode {
-    if (groups.length === 0) {
-        return <span className="text-muted-foreground">—</span>;
-    }
-
-    return (
-        <div className="flex flex-col gap-1 tabular-nums">
-            {groups.map((group) => (
-                <span key={group.currency}>
-                    {formatPrice(group.amount, group.currency)}
-                </span>
-            ))}
-        </div>
-    );
-}
-
 function PerformanceValue({ groups }: { groups: MoneyAggregate[] }) {
     if (groups.length === 0) {
         return <span className="text-muted-foreground">—</span>;
@@ -318,7 +298,47 @@ function PerformanceRate({ rates }: { rates: RateAggregate[] }) {
     );
 }
 
-function PerformanceDetailMetric({
+function CompactPerformanceAmounts({ groups }: { groups: MoneyAggregate[] }) {
+    if (groups.length === 0) {
+        return <span className="text-muted-foreground">—</span>;
+    }
+
+    const exactValues = groups
+        .map((group) => formatPrice(group.amount, group.currency))
+        .join(' · ');
+
+    return (
+        <div
+            className="flex flex-col gap-1 text-sm font-semibold tabular-nums"
+            title={exactValues}
+            aria-label={exactValues}
+        >
+            {groups.map((group) => (
+                <span key={group.currency} className="whitespace-nowrap">
+                    {group.currency} {compactPerformanceAmount(group)}
+                </span>
+            ))}
+        </div>
+    );
+}
+
+function CompactPerformanceRates({ rates }: { rates: RateAggregate[] }) {
+    if (rates.length === 0) {
+        return <span className="text-muted-foreground">—</span>;
+    }
+
+    return (
+        <div className="flex flex-wrap gap-x-3 gap-y-1 text-sm font-semibold tabular-nums">
+            {rates.map((rate) => (
+                <span key={rate.currency} className="whitespace-nowrap">
+                    {rate.currency} {rate.rate}%
+                </span>
+            ))}
+        </div>
+    );
+}
+
+function PerformanceDetailBlock({
     label,
     children,
 }: {
@@ -326,9 +346,9 @@ function PerformanceDetailMetric({
     children: ReactNode;
 }) {
     return (
-        <div className="flex items-start justify-between gap-4">
-            <dt className="text-sm text-muted-foreground">{label}</dt>
-            <dd className="text-right text-sm font-medium">{children}</dd>
+        <div className="min-w-0">
+            <p className="text-xs font-medium text-muted-foreground">{label}</p>
+            <div className="mt-1.5">{children}</div>
         </div>
     );
 }
@@ -339,66 +359,72 @@ function PropertyPerformanceDetails({
     row: FinancialPropertyPerformance;
 }) {
     return (
-        <div className="rounded-md bg-muted/30 p-4">
-            <p className="mb-4 text-sm font-semibold">{row.name}</p>
-            <div className="grid gap-6 sm:grid-cols-3">
+        <div className="bg-muted/30 p-4">
+            <div className="space-y-5">
                 <section>
                     <h4 className="mb-3 text-xs font-semibold tracking-wide text-muted-foreground uppercase">
                         {t('Financial')}
                     </h4>
-                    <dl className="space-y-2.5">
-                        <PerformanceDetailMetric label={t('Revenue')}>
-                            <ExactPerformanceAmounts groups={row.revenue} />
-                        </PerformanceDetailMetric>
-                        <PerformanceDetailMetric label={t('Expenses')}>
-                            <ExactPerformanceAmounts groups={row.expenses} />
-                        </PerformanceDetailMetric>
-                        <PerformanceDetailMetric label={t('NOI')}>
-                            <ExactPerformanceAmounts groups={row.noi} />
-                        </PerformanceDetailMetric>
-                        <PerformanceDetailMetric label={t('Operating margin')}>
-                            <PerformanceRate rates={row.operating_margin} />
-                        </PerformanceDetailMetric>
-                    </dl>
+                    <div className="grid gap-4 sm:grid-cols-3">
+                        <PerformanceDetailBlock label={t('Revenue')}>
+                            <CompactPerformanceAmounts groups={row.revenue} />
+                        </PerformanceDetailBlock>
+                        <PerformanceDetailBlock label={t('Expenses')}>
+                            <CompactPerformanceAmounts groups={row.expenses} />
+                        </PerformanceDetailBlock>
+                        <PerformanceDetailBlock label={t('NOI')}>
+                            <CompactPerformanceAmounts groups={row.noi} />
+                        </PerformanceDetailBlock>
+                    </div>
+                    <div className="mt-4 border-t border-border/60 pt-3">
+                        <PerformanceDetailBlock label={t('Operating margin')}>
+                            <CompactPerformanceRates
+                                rates={row.operating_margin}
+                            />
+                        </PerformanceDetailBlock>
+                    </div>
                 </section>
 
-                <section>
+                <section className="border-t border-border/60 pt-5">
                     <h4 className="mb-3 text-xs font-semibold tracking-wide text-muted-foreground uppercase">
                         {t('Collections')}
                     </h4>
-                    <dl className="space-y-2.5">
-                        <PerformanceDetailMetric label={t('Billed')}>
-                            <ExactPerformanceAmounts groups={row.billed} />
-                        </PerformanceDetailMetric>
-                        <PerformanceDetailMetric label={t('Applied')}>
-                            <ExactPerformanceAmounts groups={row.collected} />
-                        </PerformanceDetailMetric>
-                        <PerformanceDetailMetric label={t('Outstanding')}>
-                            <ExactPerformanceAmounts groups={row.outstanding} />
-                        </PerformanceDetailMetric>
-                        <PerformanceDetailMetric label={t('Collection rate')}>
-                            <PerformanceRate rates={row.collection_rate} />
-                        </PerformanceDetailMetric>
-                    </dl>
+                    <div className="grid gap-4 sm:grid-cols-3">
+                        <PerformanceDetailBlock label={t('Billed')}>
+                            <CompactPerformanceAmounts groups={row.billed} />
+                        </PerformanceDetailBlock>
+                        <PerformanceDetailBlock label={t('Collected')}>
+                            <CompactPerformanceAmounts groups={row.collected} />
+                        </PerformanceDetailBlock>
+                        <PerformanceDetailBlock label={t('Outstanding')}>
+                            <CompactPerformanceAmounts
+                                groups={row.outstanding}
+                            />
+                        </PerformanceDetailBlock>
+                    </div>
+                    <div className="mt-4 border-t border-border/60 pt-3">
+                        <PerformanceDetailBlock label={t('Collection rate')}>
+                            <CompactPerformanceRates
+                                rates={row.collection_rate}
+                            />
+                        </PerformanceDetailBlock>
+                    </div>
                 </section>
 
-                <section>
+                <section className="border-t border-border/60 pt-5">
                     <h4 className="mb-3 text-xs font-semibold tracking-wide text-muted-foreground uppercase">
                         {t('Occupancy')}
                     </h4>
-                    <dl className="space-y-2.5">
-                        <PerformanceDetailMetric label={t('Occupied')}>
-                            <span className="tabular-nums">
-                                {row.occupancy.occupied_units} /{' '}
-                                {row.occupancy.total_units}
-                            </span>
-                        </PerformanceDetailMetric>
-                        <PerformanceDetailMetric label={t('Occupancy rate')}>
-                            <span className="tabular-nums">
-                                {row.occupancy.occupancy_percentage}%
-                            </span>
-                        </PerformanceDetailMetric>
-                    </dl>
+                    <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1">
+                        <span className="text-base font-semibold tabular-nums">
+                            {row.occupancy.occupied_units} /{' '}
+                            {row.occupancy.total_units} {t('units')}
+                        </span>
+                        <span className="text-sm font-medium text-muted-foreground tabular-nums">
+                            {row.occupancy.occupancy_percentage}%{' '}
+                            {t('occupied')}
+                        </span>
+                    </div>
                 </section>
             </div>
         </div>

--- a/resources/js/pages/dashboard/financial.tsx
+++ b/resources/js/pages/dashboard/financial.tsx
@@ -112,16 +112,11 @@ function FinancialCard({
     return (
         <MetricCard
             label={label}
-            value={
-                <span className="text-sm font-medium text-muted-foreground">
-                    {subtext}
-                </span>
-            }
-            subtext={<CurrencyAmountList groups={groups} compact />}
+            subParams={subtext}
+            value={<CurrencyAmountList groups={groups} />}
             icon={Icon}
             variant={variant}
             emphasis="subtle"
-            subtextFullWidth
         />
     );
 }

--- a/resources/js/pages/dashboard/financial.tsx
+++ b/resources/js/pages/dashboard/financial.tsx
@@ -9,11 +9,14 @@ import {
     TrendingDown,
     TrendingUp,
 } from 'lucide-react';
+import { useState } from 'react';
 import type { ComponentType } from 'react';
 import { CurrencyAmountList } from '@/components/features/dashboard/currency-amount-list';
 import {
     ExpenseBreakdownChart,
     FinancialTrendChart,
+    subtractCurrencyAmounts,
+    sumCurrencyAmounts,
 } from '@/components/features/dashboard/financial-trend-chart';
 import { MetricCard } from '@/components/shared/metric-card';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -24,7 +27,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@/components/ui/select';
-import { formatDate } from '@/lib/formatters';
+import { formatDate, formatPrice } from '@/lib/formatters';
 import { t } from '@/lib/i18n';
 import { financial as dashboardFinancial } from '@/routes/dashboard';
 import type {
@@ -122,6 +125,81 @@ function FinancialCard({
             subtextFullWidth
         />
     );
+}
+
+function ChartCurrencySelector({
+    currencies,
+    value,
+    onValueChange,
+}: {
+    currencies: string[];
+    value: string;
+    onValueChange: (value: string) => void;
+}) {
+    if (currencies.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className="flex items-center gap-2">
+            <span className="text-xs font-medium text-muted-foreground">
+                {t('Currency')}
+            </span>
+            <Select value={value} onValueChange={onValueChange}>
+                <SelectTrigger
+                    className="w-[104px] bg-card"
+                    aria-label={t('Chart currency')}
+                >
+                    <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                    {currencies.map((currency) => (
+                        <SelectItem key={currency} value={currency}>
+                            {currency}
+                        </SelectItem>
+                    ))}
+                </SelectContent>
+            </Select>
+        </div>
+    );
+}
+
+function ChartSummary({
+    currency,
+    metrics,
+}: {
+    currency: string;
+    metrics: Array<{
+        label: string;
+        amount: string;
+        className: string;
+    }>;
+}) {
+    return (
+        <div className="space-y-3 border-y border-border/60 py-3">
+            <p className="text-xs font-medium text-muted-foreground">
+                {t('Selected period')} · {currency}
+            </p>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-3 sm:gap-4">
+                {metrics.map((metric) => (
+                    <div key={metric.label} className="min-w-0">
+                        <p className="text-xs font-medium text-muted-foreground">
+                            {metric.label}
+                        </p>
+                        <p
+                            className={`mt-1 overflow-hidden text-sm font-semibold whitespace-nowrap tabular-nums sm:text-base ${metric.className}`}
+                        >
+                            {formatPrice(metric.amount, currency)}
+                        </p>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}
+
+function amountForCurrency(groups: MoneyAggregate[], currency: string): string {
+    return groups.find((group) => group.currency === currency)?.amount ?? '0';
 }
 
 function PerformanceValue({ groups }: { groups: MoneyAggregate[] }) {
@@ -233,6 +311,38 @@ export default function Financial({
             ),
         ),
     ].sort();
+    const [trendCurrency, setTrendCurrency] = useState(
+        () => trendCurrencies[0] ?? '',
+    );
+    const [cashFlowCurrency, setCashFlowCurrency] = useState(
+        () => cashFlowCurrencies[0] ?? '',
+    );
+    const [expenseCurrency, setExpenseCurrency] = useState(
+        () => expenseCurrencies[0] ?? '',
+    );
+    const selectedTrendCurrency = trendCurrencies.includes(trendCurrency)
+        ? trendCurrency
+        : (trendCurrencies[0] ?? '');
+    const selectedCashFlowCurrency = cashFlowCurrencies.includes(
+        cashFlowCurrency,
+    )
+        ? cashFlowCurrency
+        : (cashFlowCurrencies[0] ?? '');
+    const selectedExpenseCurrency = expenseCurrencies.includes(expenseCurrency)
+        ? expenseCurrency
+        : (expenseCurrencies[0] ?? '');
+    const cashFlowCollected = sumCurrencyAmounts(
+        financial.cash_flow.flatMap((point) => point.collected),
+        selectedCashFlowCurrency,
+    );
+    const cashFlowExpenses = sumCurrencyAmounts(
+        financial.cash_flow.flatMap((point) => point.expenses),
+        selectedCashFlowCurrency,
+    );
+    const netCashFlow = subtractCurrencyAmounts(
+        cashFlowCollected,
+        cashFlowExpenses,
+    );
 
     function updateFilters(changes: {
         period?: Period;
@@ -441,42 +551,78 @@ export default function Financial({
                 <section className="mb-8 grid gap-6 xl:grid-cols-2">
                     <Card>
                         <CardHeader>
-                            <CardTitle>
-                                {t('Revenue, Expenses & NOI')}
-                            </CardTitle>
-                            <p className="text-sm text-muted-foreground">
-                                {t(
-                                    'Last 12 complete/current calendar-month buckets',
-                                )}
-                            </p>
+                            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                                <div className="space-y-1.5">
+                                    <CardTitle>
+                                        {t('Revenue, Expenses & NOI')}
+                                    </CardTitle>
+                                    <p className="text-sm text-muted-foreground">
+                                        {t(
+                                            'Last 12 calendar-month buckets, independent of the selected period',
+                                        )}
+                                    </p>
+                                </div>
+                                <ChartCurrencySelector
+                                    currencies={trendCurrencies}
+                                    value={selectedTrendCurrency}
+                                    onValueChange={setTrendCurrency}
+                                />
+                            </div>
                         </CardHeader>
-                        <CardContent className="space-y-5">
-                            {trendCurrencies.length > 0 ? (
-                                trendCurrencies.map((currency) => (
-                                    <div key={currency}>
-                                        <h3 className="mb-4 text-sm font-semibold">
-                                            {currency}
-                                        </h3>
-                                        <FinancialTrendChart
-                                            points={financial.trends}
-                                            currency={currency}
-                                            series={[
-                                                {
-                                                    key: 'revenue',
-                                                    label: t('Revenue'),
-                                                },
-                                                {
-                                                    key: 'expenses',
-                                                    label: t('Expenses'),
-                                                },
-                                                {
-                                                    key: 'noi',
-                                                    label: t('NOI'),
-                                                },
-                                            ]}
-                                        />
-                                    </div>
-                                ))
+                        <CardContent className="space-y-4">
+                            {selectedTrendCurrency ? (
+                                <>
+                                    <ChartSummary
+                                        currency={selectedTrendCurrency}
+                                        metrics={[
+                                            {
+                                                label: t('Revenue'),
+                                                amount: amountForCurrency(
+                                                    financial.overview.revenue,
+                                                    selectedTrendCurrency,
+                                                ),
+                                                className:
+                                                    'text-surface-green-foreground',
+                                            },
+                                            {
+                                                label: t('Expenses'),
+                                                amount: amountForCurrency(
+                                                    financial.overview.expenses,
+                                                    selectedTrendCurrency,
+                                                ),
+                                                className:
+                                                    'text-surface-amber-foreground',
+                                            },
+                                            {
+                                                label: t('NOI'),
+                                                amount: amountForCurrency(
+                                                    financial.overview.noi,
+                                                    selectedTrendCurrency,
+                                                ),
+                                                className:
+                                                    'text-surface-blue-foreground',
+                                            },
+                                        ]}
+                                    />
+                                    <FinancialTrendChart
+                                        points={financial.trends}
+                                        currency={selectedTrendCurrency}
+                                        series={[
+                                            {
+                                                key: 'revenue',
+                                                label: t('Revenue'),
+                                            },
+                                            {
+                                                key: 'expenses',
+                                                label: t('Expenses'),
+                                            },
+                                            {
+                                                key: 'noi',
+                                                label: t('NOI'),
+                                            },
+                                        ]}
+                                    />
+                                </>
                             ) : (
                                 <p className="py-8 text-center text-sm text-muted-foreground">
                                     {t('No financial activity recorded.')}
@@ -486,36 +632,63 @@ export default function Financial({
                     </Card>
                     <Card>
                         <CardHeader>
-                            <CardTitle>{t('Cash Flow')}</CardTitle>
-                            <p className="text-sm text-muted-foreground">
-                                {t(
-                                    'Confirmed payments and expenses by payment/expense date',
-                                )}
-                            </p>
+                            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                                <div className="space-y-1.5">
+                                    <CardTitle>{t('Cash Flow')}</CardTitle>
+                                    <p className="text-sm text-muted-foreground">
+                                        {t(
+                                            'Selected-period cash movement by payment and expense date',
+                                        )}
+                                    </p>
+                                </div>
+                                <ChartCurrencySelector
+                                    currencies={cashFlowCurrencies}
+                                    value={selectedCashFlowCurrency}
+                                    onValueChange={setCashFlowCurrency}
+                                />
+                            </div>
                         </CardHeader>
-                        <CardContent className="space-y-5">
-                            {cashFlowCurrencies.length > 0 ? (
-                                cashFlowCurrencies.map((currency) => (
-                                    <div key={currency}>
-                                        <h3 className="mb-4 text-sm font-semibold">
-                                            {currency}
-                                        </h3>
-                                        <FinancialTrendChart
-                                            points={financial.cash_flow}
-                                            currency={currency}
-                                            series={[
-                                                {
-                                                    key: 'collected',
-                                                    label: t('Cash Collected'),
-                                                },
-                                                {
-                                                    key: 'expenses',
-                                                    label: t('Expenses'),
-                                                },
-                                            ]}
-                                        />
-                                    </div>
-                                ))
+                        <CardContent className="space-y-4">
+                            {selectedCashFlowCurrency ? (
+                                <>
+                                    <ChartSummary
+                                        currency={selectedCashFlowCurrency}
+                                        metrics={[
+                                            {
+                                                label: t('Cash Collected'),
+                                                amount: cashFlowCollected,
+                                                className:
+                                                    'text-surface-green-foreground',
+                                            },
+                                            {
+                                                label: t('Expenses'),
+                                                amount: cashFlowExpenses,
+                                                className:
+                                                    'text-surface-amber-foreground',
+                                            },
+                                            {
+                                                label: t('Net Cash Flow'),
+                                                amount: netCashFlow,
+                                                className:
+                                                    'text-surface-blue-foreground',
+                                            },
+                                        ]}
+                                    />
+                                    <FinancialTrendChart
+                                        points={financial.cash_flow}
+                                        currency={selectedCashFlowCurrency}
+                                        series={[
+                                            {
+                                                key: 'collected',
+                                                label: t('Cash Collected'),
+                                            },
+                                            {
+                                                key: 'expenses',
+                                                label: t('Expenses'),
+                                            },
+                                        ]}
+                                    />
+                                </>
                             ) : (
                                 <p className="py-8 text-center text-sm text-muted-foreground">
                                     {t('No cash movement recorded.')}
@@ -592,28 +765,30 @@ export default function Financial({
                 <section className="mb-8 grid gap-6 xl:grid-cols-2">
                     <Card>
                         <CardHeader>
-                            <CardTitle>{t('Expense Breakdown')}</CardTitle>
-                            <p className="text-sm text-muted-foreground">
-                                {t(
-                                    'Active operating expenses by category for the selected period',
-                                )}
-                            </p>
+                            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                                <div className="space-y-1.5">
+                                    <CardTitle>
+                                        {t('Expense Breakdown')}
+                                    </CardTitle>
+                                    <p className="text-sm text-muted-foreground">
+                                        {t(
+                                            'Active operating expenses by category for the selected period',
+                                        )}
+                                    </p>
+                                </div>
+                                <ChartCurrencySelector
+                                    currencies={expenseCurrencies}
+                                    value={selectedExpenseCurrency}
+                                    onValueChange={setExpenseCurrency}
+                                />
+                            </div>
                         </CardHeader>
-                        <CardContent className="space-y-5">
-                            {expenseCurrencies.length > 0 ? (
-                                expenseCurrencies.map((currency) => (
-                                    <div key={currency} className="space-y-2">
-                                        <h3 className="text-sm font-semibold">
-                                            {currency}
-                                        </h3>
-                                        <ExpenseBreakdownChart
-                                            categories={
-                                                financial.expense_breakdown
-                                            }
-                                            currency={currency}
-                                        />
-                                    </div>
-                                ))
+                        <CardContent>
+                            {selectedExpenseCurrency ? (
+                                <ExpenseBreakdownChart
+                                    categories={financial.expense_breakdown}
+                                    currency={selectedExpenseCurrency}
+                                />
                             ) : (
                                 <p className="py-8 text-center text-sm text-muted-foreground">
                                     {t('No operating expenses recorded.')}

--- a/resources/js/pages/dashboard/financial.tsx
+++ b/resources/js/pages/dashboard/financial.tsx
@@ -1,0 +1,689 @@
+import { Head, router } from '@inertiajs/react';
+import {
+    Banknote,
+    BarChart3,
+    Building2,
+    CalendarRange,
+    CircleDollarSign,
+    Receipt,
+    TrendingDown,
+    TrendingUp,
+} from 'lucide-react';
+import type { ComponentType } from 'react';
+import { CurrencyAmountList } from '@/components/features/dashboard/currency-amount-list';
+import { FinancialTrendChart } from '@/components/features/dashboard/financial-trend-chart';
+import { MetricCard } from '@/components/shared/metric-card';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import { formatDate } from '@/lib/formatters';
+import { t } from '@/lib/i18n';
+import { financial as dashboardFinancial } from '@/routes/dashboard';
+import type {
+    FinancialDashboardData,
+    FinancialPropertyPerformance,
+    RateAggregate,
+    MoneyAggregate,
+} from '@/types';
+
+type Period = 'current_month' | 'ytd';
+
+type PageProps = {
+    financial: FinancialDashboardData;
+    filters: {
+        period: Period;
+        property_id: number | null;
+    };
+    properties: Array<{ id: number; name: string }>;
+};
+
+function currenciesFromGroups(groups: MoneyAggregate[]): string[] {
+    return groups.map((group) => group.currency);
+}
+
+function currenciesFromFinancial(financial: FinancialDashboardData): string[] {
+    const groups = [
+        ...financial.overview.revenue,
+        ...financial.overview.expenses,
+        ...financial.overview.noi,
+        ...financial.collections.collected,
+        ...financial.trends.flatMap((point) => [
+            ...point.revenue,
+            ...point.expenses,
+            ...point.noi,
+        ]),
+        ...financial.cash_flow.flatMap((point) => [
+            ...point.collected,
+            ...point.expenses,
+        ]),
+    ];
+
+    return [...new Set(currenciesFromGroups(groups))].sort();
+}
+
+function RateList({ rates }: { rates: RateAggregate[] }) {
+    if (rates.length === 0) {
+        return (
+            <span className="text-2xl font-bold text-muted-foreground">—</span>
+        );
+    }
+
+    return (
+        <div className="space-y-2">
+            {rates.map((rate) => {
+                const percentage = Number.parseFloat(rate.rate);
+
+                return (
+                    <div key={rate.currency} className="space-y-1">
+                        <div className="flex items-center justify-between text-sm font-semibold tabular-nums">
+                            <span className="text-xs tracking-wide text-muted-foreground uppercase">
+                                {rate.currency}
+                            </span>
+                            <span>{rate.rate}%</span>
+                        </div>
+                        <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+                            <div
+                                className="h-full rounded-full bg-primary"
+                                style={{
+                                    width: `${Math.min(100, Math.max(0, percentage))}%`,
+                                }}
+                            />
+                        </div>
+                    </div>
+                );
+            })}
+        </div>
+    );
+}
+
+function FinancialCard({
+    label,
+    groups,
+    icon: Icon,
+    variant,
+    subtext,
+}: {
+    label: string;
+    groups: MoneyAggregate[];
+    icon: ComponentType<{ className?: string }>;
+    variant: 'blue' | 'green' | 'red' | 'amber';
+    subtext: string;
+}) {
+    return (
+        <MetricCard
+            label={label}
+            value={
+                <CurrencyAmountList
+                    groups={groups}
+                    amountClassName="text-xl font-bold tabular-nums sm:text-2xl"
+                />
+            }
+            subtext={subtext}
+            icon={Icon}
+            variant={variant}
+            emphasis="subtle"
+            subtextFullWidth
+        />
+    );
+}
+
+function PerformanceValue({ groups }: { groups: MoneyAggregate[] }) {
+    return <CurrencyAmountList groups={groups} compact />;
+}
+
+function PerformanceTable({ rows }: { rows: FinancialPropertyPerformance[] }) {
+    if (rows.length === 0) {
+        return (
+            <p className="py-8 text-center text-sm text-muted-foreground">
+                No accessible properties.
+            </p>
+        );
+    }
+
+    return (
+        <div className="overflow-x-auto">
+            <table className="w-full min-w-[900px] text-sm">
+                <thead>
+                    <tr className="border-b border-border text-left text-xs tracking-wide text-muted-foreground uppercase">
+                        <th className="px-2 py-3 font-medium">Property</th>
+                        <th className="px-2 py-3 text-right font-medium">
+                            Revenue
+                        </th>
+                        <th className="px-2 py-3 text-right font-medium">
+                            Expenses
+                        </th>
+                        <th className="px-2 py-3 text-right font-medium">
+                            NOI
+                        </th>
+                        <th className="px-2 py-3 text-right font-medium">
+                            Margin
+                        </th>
+                        <th className="px-2 py-3 text-right font-medium">
+                            Applied
+                        </th>
+                        <th className="px-2 py-3 text-right font-medium">
+                            Outstanding
+                        </th>
+                        <th className="px-2 py-3 text-right font-medium">
+                            Rate
+                        </th>
+                        <th className="px-2 py-3 text-right font-medium">
+                            Occupancy
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {rows.map((row) => (
+                        <tr
+                            key={row.id}
+                            className="border-b border-border/60 last:border-0"
+                        >
+                            <td className="px-2 py-3 font-medium">
+                                {row.name}
+                            </td>
+                            <td className="px-2 py-3 text-right">
+                                <PerformanceValue groups={row.revenue} />
+                            </td>
+                            <td className="px-2 py-3 text-right">
+                                <PerformanceValue groups={row.expenses} />
+                            </td>
+                            <td className="px-2 py-3 text-right">
+                                <PerformanceValue groups={row.noi} />
+                            </td>
+                            <td className="px-2 py-3 text-right">
+                                <RateList rates={row.operating_margin} />
+                            </td>
+                            <td className="px-2 py-3 text-right">
+                                <PerformanceValue groups={row.collected} />
+                            </td>
+                            <td className="px-2 py-3 text-right">
+                                <PerformanceValue groups={row.outstanding} />
+                            </td>
+                            <td className="px-2 py-3 text-right">
+                                <RateList rates={row.collection_rate} />
+                            </td>
+                            <td className="px-2 py-3 text-right">
+                                {row.occupancy.occupancy_percentage}% ·{' '}
+                                {row.occupancy.occupied_units}/
+                                {row.occupancy.total_units}
+                            </td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+}
+
+export default function Financial({
+    financial,
+    filters,
+    properties,
+}: PageProps) {
+    const trendCurrencies = currenciesFromFinancial(financial);
+
+    function updateFilters(changes: {
+        period?: Period;
+        propertyId?: number | null;
+    }) {
+        const period = changes.period ?? filters.period;
+        const propertyId =
+            changes.propertyId === undefined
+                ? filters.property_id
+                : changes.propertyId;
+
+        router.get(
+            dashboardFinancial({
+                query: {
+                    period,
+                    property_id: propertyId ?? undefined,
+                },
+            }).url,
+            {},
+            {
+                preserveScroll: true,
+                preserveState: true,
+                replace: true,
+            },
+        );
+    }
+
+    return (
+        <>
+            <Head title={t('Financial Dashboard')} />
+            <div className="flex h-full flex-1 flex-col overflow-x-auto p-4 md:p-6 lg:p-8">
+                <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+                    <div>
+                        <h1 className="text-2xl font-bold tracking-tight text-foreground sm:text-3xl">
+                            {t('Financial Dashboard')}
+                        </h1>
+                        <p className="mt-1 max-w-2xl text-xs text-muted-foreground sm:text-sm">
+                            {t(
+                                'Understand billed performance, profitability, and cash movement across your properties.',
+                            )}
+                        </p>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                        <Select
+                            value={filters.period}
+                            onValueChange={(value) =>
+                                updateFilters({ period: value as Period })
+                            }
+                        >
+                            <SelectTrigger
+                                className="w-[150px] bg-card"
+                                aria-label={t('Reporting period')}
+                            >
+                                <CalendarRange className="size-4 text-muted-foreground" />
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="current_month">
+                                    {t('Current Month')}
+                                </SelectItem>
+                                <SelectItem value="ytd">
+                                    {t('Year to Date')}
+                                </SelectItem>
+                            </SelectContent>
+                        </Select>
+                        <Select
+                            value={
+                                filters.property_id === null
+                                    ? 'all'
+                                    : String(filters.property_id)
+                            }
+                            onValueChange={(value) =>
+                                updateFilters({
+                                    propertyId:
+                                        value === 'all' ? null : Number(value),
+                                })
+                            }
+                        >
+                            <SelectTrigger
+                                className="w-[190px] bg-card"
+                                aria-label={t('Property')}
+                            >
+                                <Building2 className="size-4 text-muted-foreground" />
+                                <SelectValue
+                                    placeholder={t('All Properties')}
+                                />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="all">
+                                    {t('All Properties')}
+                                </SelectItem>
+                                {properties.map((property) => (
+                                    <SelectItem
+                                        key={property.id}
+                                        value={String(property.id)}
+                                    >
+                                        {property.name}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+                </div>
+
+                <div className="mb-8 flex items-center gap-2 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-900 dark:border-blue-900/50 dark:bg-blue-950/30 dark:text-blue-100">
+                    <CircleDollarSign className="size-4 shrink-0" />
+                    <p>
+                        {t(
+                            'Revenue and NOI use billed accruals. Cash Flow uses confirmed payments by payment date.',
+                        )}
+                    </p>
+                </div>
+
+                <section className="mb-10 flex flex-col gap-3">
+                    <h2 className="text-xs font-semibold tracking-wider text-muted-foreground uppercase">
+                        {t('Financial Overview')}
+                    </h2>
+                    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+                        <FinancialCard
+                            label={t('Billed Revenue')}
+                            groups={financial.overview.revenue}
+                            icon={TrendingUp}
+                            variant="green"
+                            subtext={t('Accrual basis')}
+                        />
+                        <FinancialCard
+                            label={t('Operating Expenses')}
+                            groups={financial.overview.expenses}
+                            icon={TrendingDown}
+                            variant="amber"
+                            subtext={t('Active expenses only')}
+                        />
+                        <FinancialCard
+                            label={t('NOI')}
+                            groups={financial.overview.noi}
+                            icon={BarChart3}
+                            variant="blue"
+                            subtext={t('Revenue minus expenses')}
+                        />
+                        <MetricCard
+                            label={t('Operating Margin')}
+                            value={
+                                <RateList
+                                    rates={financial.overview.operating_margin}
+                                />
+                            }
+                            subtext={t('Per-currency percentage')}
+                            icon={CircleDollarSign}
+                            variant="blue"
+                            emphasis="subtle"
+                            subtextFullWidth
+                        />
+                    </div>
+                </section>
+
+                <section className="mb-10 flex flex-col gap-3">
+                    <h2 className="text-xs font-semibold tracking-wider text-muted-foreground uppercase">
+                        {t('Collections')}
+                    </h2>
+                    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+                        <FinancialCard
+                            label={t('Billed')}
+                            groups={financial.collections.billed}
+                            icon={Receipt}
+                            variant="blue"
+                            subtext={t('Selected invoice cohort')}
+                        />
+                        <FinancialCard
+                            label={t('Applied Collections')}
+                            groups={financial.collections.collected}
+                            icon={Banknote}
+                            variant="green"
+                            subtext={t(
+                                'Confirmed allocations to selected invoices; any payment date',
+                            )}
+                        />
+                        <FinancialCard
+                            label={t('Outstanding Receivables')}
+                            groups={financial.collections.outstanding}
+                            icon={CircleDollarSign}
+                            variant="red"
+                            subtext={t(
+                                'Selected billed invoices minus confirmed payments',
+                            )}
+                        />
+                        <MetricCard
+                            label={t('Collection Rate')}
+                            value={
+                                <RateList
+                                    rates={
+                                        financial.collections.collection_rate
+                                    }
+                                />
+                            }
+                            subtext={t(
+                                'Confirmed applied ÷ selected billed invoices',
+                            )}
+                            icon={BarChart3}
+                            variant="green"
+                            emphasis="subtle"
+                            subtextFullWidth
+                        />
+                    </div>
+                </section>
+
+                <section className="mb-10 grid gap-6 xl:grid-cols-2">
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>
+                                {t('Revenue, Expenses & NOI')}
+                            </CardTitle>
+                            <p className="text-sm text-muted-foreground">
+                                {t(
+                                    'Last 12 complete/current calendar-month buckets',
+                                )}
+                            </p>
+                        </CardHeader>
+                        <CardContent className="space-y-8">
+                            {trendCurrencies.length > 0 ? (
+                                trendCurrencies.map((currency) => (
+                                    <div key={currency}>
+                                        <h3 className="mb-4 text-sm font-semibold">
+                                            {currency}
+                                        </h3>
+                                        <FinancialTrendChart
+                                            points={financial.trends}
+                                            currency={currency}
+                                            series={[
+                                                {
+                                                    key: 'revenue',
+                                                    label: t('Revenue'),
+                                                    className:
+                                                        'bg-surface-green-foreground',
+                                                },
+                                                {
+                                                    key: 'expenses',
+                                                    label: t('Expenses'),
+                                                    className:
+                                                        'bg-surface-amber-foreground',
+                                                },
+                                                {
+                                                    key: 'noi',
+                                                    label: t('NOI'),
+                                                    className:
+                                                        'bg-surface-blue-foreground',
+                                                },
+                                            ]}
+                                        />
+                                    </div>
+                                ))
+                            ) : (
+                                <p className="py-8 text-center text-sm text-muted-foreground">
+                                    {t('No financial activity recorded.')}
+                                </p>
+                            )}
+                        </CardContent>
+                    </Card>
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>{t('Cash Flow')}</CardTitle>
+                            <p className="text-sm text-muted-foreground">
+                                {t(
+                                    'Confirmed payments and expenses by payment/expense date',
+                                )}
+                            </p>
+                        </CardHeader>
+                        <CardContent className="space-y-8">
+                            {trendCurrencies.length > 0 ? (
+                                trendCurrencies.map((currency) => (
+                                    <div key={currency}>
+                                        <h3 className="mb-4 text-sm font-semibold">
+                                            {currency}
+                                        </h3>
+                                        <FinancialTrendChart
+                                            points={financial.cash_flow}
+                                            currency={currency}
+                                            series={[
+                                                {
+                                                    key: 'collected',
+                                                    label: t('Cash Collected'),
+                                                    className:
+                                                        'bg-surface-green-foreground',
+                                                },
+                                                {
+                                                    key: 'expenses',
+                                                    label: t('Expenses'),
+                                                    className:
+                                                        'bg-surface-amber-foreground',
+                                                },
+                                            ]}
+                                        />
+                                    </div>
+                                ))
+                            ) : (
+                                <p className="py-8 text-center text-sm text-muted-foreground">
+                                    {t('No cash movement recorded.')}
+                                </p>
+                            )}
+                        </CardContent>
+                    </Card>
+                </section>
+
+                <section className="mb-10 grid gap-6 xl:grid-cols-[1.4fr_1fr]">
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>{t('Property Performance')}</CardTitle>
+                            <p className="text-sm text-muted-foreground">
+                                {t(
+                                    'Selected-period financial performance by accessible property',
+                                )}
+                            </p>
+                        </CardHeader>
+                        <CardContent>
+                            <PerformanceTable
+                                rows={financial.property_performance}
+                            />
+                        </CardContent>
+                    </Card>
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>{t('Current Occupancy')}</CardTitle>
+                            <p className="text-sm text-muted-foreground">
+                                {t('Current unit and active lease state only')}
+                            </p>
+                        </CardHeader>
+                        <CardContent>
+                            <div className="mb-6 flex items-end justify-between">
+                                <div>
+                                    <p className="text-3xl font-bold tabular-nums">
+                                        {
+                                            financial.occupancy
+                                                .occupancy_percentage
+                                        }
+                                        %
+                                    </p>
+                                    <p className="text-sm text-muted-foreground">
+                                        {financial.occupancy.occupied_units} /{' '}
+                                        {financial.occupancy.total_units}{' '}
+                                        {t('units occupied')}
+                                    </p>
+                                </div>
+                                <Building2 className="size-8 text-muted-foreground/60" />
+                            </div>
+                            <div className="space-y-3">
+                                {financial.occupancy.properties.map(
+                                    (property) => (
+                                        <div
+                                            key={property.id}
+                                            className="flex items-center justify-between gap-3 text-sm"
+                                        >
+                                            <span className="truncate font-medium">
+                                                {property.name}
+                                            </span>
+                                            <span className="shrink-0 text-muted-foreground tabular-nums">
+                                                {property.occupancy_percentage}%
+                                                · {property.occupied_units}/
+                                                {property.total_units}
+                                            </span>
+                                        </div>
+                                    ),
+                                )}
+                            </div>
+                        </CardContent>
+                    </Card>
+                </section>
+
+                <section className="mb-10 grid gap-6 xl:grid-cols-2">
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>{t('Expense Breakdown')}</CardTitle>
+                            <p className="text-sm text-muted-foreground">
+                                {t(
+                                    'Active operating expenses by category for the selected period',
+                                )}
+                            </p>
+                        </CardHeader>
+                        <CardContent>
+                            {financial.expense_breakdown.length > 0 ? (
+                                <div className="space-y-4">
+                                    {financial.expense_breakdown.map(
+                                        (category) => (
+                                            <div
+                                                key={category.category_id}
+                                                className="flex items-center justify-between gap-4 border-b border-border/60 pb-3 last:border-0 last:pb-0"
+                                            >
+                                                <span className="font-medium">
+                                                    {category.category_label}
+                                                </span>
+                                                <CurrencyAmountList
+                                                    groups={category.amounts}
+                                                    compact
+                                                />
+                                            </div>
+                                        ),
+                                    )}
+                                </div>
+                            ) : (
+                                <p className="py-8 text-center text-sm text-muted-foreground">
+                                    {t('No operating expenses recorded.')}
+                                </p>
+                            )}
+                        </CardContent>
+                    </Card>
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>{t('Upcoming Receivables')}</CardTitle>
+                            <p className="text-sm text-muted-foreground">
+                                {t(
+                                    'Forecast summary from generated invoices; no collection workflow',
+                                )}
+                            </p>
+                        </CardHeader>
+                        <CardContent>
+                            {financial.upcoming_receivables.length > 0 ? (
+                                <div className="space-y-4">
+                                    {financial.upcoming_receivables.map(
+                                        (bucket) => (
+                                            <div
+                                                key={bucket.month}
+                                                className="flex items-center justify-between gap-4 border-b border-border/60 pb-3 last:border-0 last:pb-0"
+                                            >
+                                                <span className="font-medium">
+                                                    {bucket.label}
+                                                </span>
+                                                <CurrencyAmountList
+                                                    groups={bucket.receivable}
+                                                    compact
+                                                />
+                                            </div>
+                                        ),
+                                    )}
+                                </div>
+                            ) : (
+                                <p className="py-8 text-center text-sm text-muted-foreground">
+                                    {t('No upcoming receivables recorded.')}
+                                </p>
+                            )}
+                        </CardContent>
+                    </Card>
+                </section>
+
+                <p className="mt-auto text-xs text-muted-foreground">
+                    {t('Reporting through')} {formatDate(financial.period_end)}{' '}
+                    ·{' '}
+                    {t(
+                        'Trends remain independent of the selected summary period.',
+                    )}
+                </p>
+            </div>
+        </>
+    );
+}
+
+Financial.layout = {
+    breadcrumbs: [
+        {
+            title: 'Financial Dashboard',
+            href: dashboardFinancial(),
+        },
+    ],
+};

--- a/resources/js/pages/dashboard/financial.tsx
+++ b/resources/js/pages/dashboard/financial.tsx
@@ -114,7 +114,13 @@ function FinancialCard({
         <MetricCard
             label={label}
             subParams={subtext}
-            value={<CurrencyAmountList groups={groups} compact />}
+            value={
+                <CurrencyAmountList
+                    groups={groups}
+                    compact
+                    className={variant === 'green' ? 'text-chart-2' : undefined}
+                />
+            }
             valueFullWidth
             icon={Icon}
             variant={variant}
@@ -784,11 +790,14 @@ export default function Financial({
                         <MetricCard
                             label={t('Collection Rate')}
                             value={
-                                <RateList
-                                    rates={
-                                        financial.collections.collection_rate
-                                    }
-                                />
+                                <div className="text-chart-2">
+                                    <RateList
+                                        rates={
+                                            financial.collections
+                                                .collection_rate
+                                        }
+                                    />
+                                </div>
                             }
                             subtext={t(
                                 'Confirmed applied ÷ selected billed invoices',
@@ -909,8 +918,7 @@ export default function Financial({
                                             {
                                                 label: t('Cash Collected'),
                                                 amount: cashFlowCollected,
-                                                className:
-                                                    'text-surface-green-foreground',
+                                                className: 'text-chart-2',
                                             },
                                             {
                                                 label: t('Expenses'),

--- a/resources/js/pages/dashboard/financial.tsx
+++ b/resources/js/pages/dashboard/financial.tsx
@@ -113,7 +113,8 @@ function FinancialCard({
         <MetricCard
             label={label}
             subParams={subtext}
-            value={<CurrencyAmountList groups={groups} />}
+            value={<CurrencyAmountList groups={groups} compact />}
+            valueFullWidth
             icon={Icon}
             variant={variant}
             emphasis="subtle"

--- a/resources/js/pages/dashboard/financial.tsx
+++ b/resources/js/pages/dashboard/financial.tsx
@@ -112,12 +112,7 @@ function FinancialCard({
     return (
         <MetricCard
             label={label}
-            value={
-                <CurrencyAmountList
-                    groups={groups}
-                    amountClassName="text-xl font-bold tabular-nums sm:text-2xl"
-                />
-            }
+            value={<CurrencyAmountList groups={groups} />}
             subtext={subtext}
             icon={Icon}
             variant={variant}

--- a/resources/js/pages/dashboard/financial.tsx
+++ b/resources/js/pages/dashboard/financial.tsx
@@ -112,8 +112,12 @@ function FinancialCard({
     return (
         <MetricCard
             label={label}
-            value={<CurrencyAmountList groups={groups} />}
-            subtext={subtext}
+            value={
+                <span className="text-sm font-medium text-muted-foreground">
+                    {subtext}
+                </span>
+            }
+            subtext={<CurrencyAmountList groups={groups} compact />}
             icon={Icon}
             variant={variant}
             emphasis="subtle"

--- a/resources/js/pages/dashboard/financial.tsx
+++ b/resources/js/pages/dashboard/financial.tsx
@@ -834,8 +834,7 @@ export default function Financial({
                                                     financial.overview.revenue,
                                                     selectedTrendCurrency,
                                                 ),
-                                                className:
-                                                    'text-surface-green-foreground',
+                                                className: 'text-chart-2',
                                             },
                                             {
                                                 label: t('Expenses'),

--- a/resources/js/types/dashboard.ts
+++ b/resources/js/types/dashboard.ts
@@ -29,6 +29,87 @@ export type MoneyAggregate = {
     amount: string;
 };
 
+export type RateAggregate = {
+    currency: string;
+    rate: string;
+};
+
+export type FinancialTrendPoint = {
+    month: string;
+    label: string;
+    revenue: MoneyAggregate[];
+    expenses: MoneyAggregate[];
+    noi: MoneyAggregate[];
+};
+
+export type FinancialCashFlowPoint = {
+    month: string;
+    label: string;
+    collected: MoneyAggregate[];
+    expenses: MoneyAggregate[];
+};
+
+export type FinancialPropertyPerformance = {
+    id: number;
+    name: string;
+    revenue: MoneyAggregate[];
+    expenses: MoneyAggregate[];
+    noi: MoneyAggregate[];
+    operating_margin: RateAggregate[];
+    billed: MoneyAggregate[];
+    collected: MoneyAggregate[];
+    outstanding: MoneyAggregate[];
+    collection_rate: RateAggregate[];
+    occupancy: {
+        total_units: number;
+        occupied_units: number;
+        occupancy_percentage: number;
+    };
+};
+
+export type FinancialDashboardData = {
+    period: 'current_month' | 'ytd';
+    period_start: string;
+    period_end: string;
+    overview: {
+        revenue: MoneyAggregate[];
+        expenses: MoneyAggregate[];
+        noi: MoneyAggregate[];
+        operating_margin: RateAggregate[];
+    };
+    collections: {
+        billed: MoneyAggregate[];
+        collected: MoneyAggregate[];
+        outstanding: MoneyAggregate[];
+        collection_rate: RateAggregate[];
+    };
+    cash_flow: FinancialCashFlowPoint[];
+    trends: FinancialTrendPoint[];
+    property_performance: FinancialPropertyPerformance[];
+    occupancy: {
+        total_units: number;
+        occupied_units: number;
+        occupancy_percentage: number;
+        properties: Array<{
+            id: number;
+            name: string;
+            total_units: number;
+            occupied_units: number;
+            occupancy_percentage: number;
+        }>;
+    };
+    expense_breakdown: Array<{
+        category_id: number;
+        category_label: string;
+        amounts: MoneyAggregate[];
+    }>;
+    upcoming_receivables: Array<{
+        month: string;
+        label: string;
+        receivable: MoneyAggregate[];
+    }>;
+};
+
 export type Stats = {
     total_units: number;
     occupied_units: number;

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Dashboard\FinancialController;
 use App\Http\Controllers\Dashboard\OverviewController;
 use App\Http\Controllers\Dashboard\RentController;
 use App\Http\Controllers\ExpenseController;
@@ -82,6 +83,9 @@ Route::middleware(['auth', 'verified', 'permission:dashboard.view'])->group(func
     Route::prefix('dashboard')->group(function () {
         Route::get('/', OverviewController::class)->name('dashboard');
         Route::get('rent', RentController::class)->name('dashboard.rent');
+        Route::get('financial', FinancialController::class)
+            ->name('dashboard.financial')
+            ->middleware('permission:financials.view');
     });
 
     Route::prefix('properties')->name('properties.')->group(function () {

--- a/tests/Feature/FinancialDashboardTest.php
+++ b/tests/Feature/FinancialDashboardTest.php
@@ -1,0 +1,250 @@
+<?php
+
+use App\Enums\ExpenseStatus;
+use App\Enums\InvoiceStatus;
+use App\Enums\LeaseStatus;
+use App\Enums\PaymentStatus;
+use App\Enums\UnitStatus;
+use App\Models\Expense;
+use App\Models\ExpenseCategory;
+use App\Models\Invoice;
+use App\Models\Lease;
+use App\Models\Payment;
+use App\Models\PaymentAllocation;
+use App\Models\Property;
+use App\Models\Unit;
+use App\Models\User;
+use Carbon\Carbon;
+use Database\Seeders\RegionAndCitySeeder;
+use Database\Seeders\RoleAndPermissionSeeder;
+use Illuminate\Support\Collection;
+
+uses()->beforeEach(function (): void {
+    $this->seed(RoleAndPermissionSeeder::class);
+    $this->seed(RegionAndCitySeeder::class);
+});
+
+function createFinancialLease(Property $property, string $currency = 'USD'): Lease
+{
+    $unit = Unit::factory()->for($property)->create([
+        'status' => UnitStatus::Occupied,
+    ]);
+
+    return Lease::factory()->for($unit)->create([
+        'currency' => $currency,
+        'rent_amount' => '1000.000',
+        'status' => LeaseStatus::Active,
+        'start_date' => now()->subYear(),
+    ]);
+}
+
+function createFinancialInvoice(
+    Lease $lease,
+    string $periodStart,
+    string $total,
+    string $amountPaid,
+    InvoiceStatus $status,
+): Invoice {
+    return Invoice::factory()->for($lease)->create([
+        'currency' => $lease->currency,
+        'period_start' => $periodStart,
+        'period_end' => Carbon::parse($periodStart)->endOfMonth()->toDateString(),
+        'due_date' => Carbon::parse($periodStart)->addDays(4)->toDateString(),
+        'total' => $total,
+        'amount_paid' => $amountPaid,
+        'status' => $status,
+    ]);
+}
+
+function createFinancialPayment(Invoice $invoice, string $amount, string $paymentDate, PaymentStatus $status = PaymentStatus::Confirmed): Payment
+{
+    $payment = Payment::factory()->for($invoice)->create([
+        'amount' => $amount,
+        'currency' => $invoice->currency,
+        'payment_date' => $paymentDate,
+        'status' => $status,
+    ]);
+
+    if ($status === PaymentStatus::Confirmed) {
+        PaymentAllocation::create([
+            'payment_id' => $payment->id,
+            'invoice_id' => $invoice->id,
+            'amount' => $amount,
+        ]);
+    }
+
+    return $payment;
+}
+
+test('financial dashboard separates accrual performance from cash attribution', function (): void {
+    Carbon::setTestNow(Carbon::parse('2026-09-15'));
+
+    try {
+        $user = User::factory()->owner()->create();
+        $property = Property::factory()->create(['name' => 'USD Property']);
+        $euroProperty = Property::factory()->create(['name' => 'EUR Property']);
+        $usdLease = createFinancialLease($property);
+        $eurLease = createFinancialLease($euroProperty, 'EUR');
+
+        $currentInvoice = createFinancialInvoice($usdLease, '2026-09-01', '1000.000', '400.000', InvoiceStatus::Partial);
+        createFinancialPayment($currentInvoice, '400.000', '2026-09-05');
+        createFinancialPayment($currentInvoice, '100.000', '2026-09-06', PaymentStatus::Pending);
+
+        $priorInvoice = createFinancialInvoice($usdLease, '2026-08-01', '700.000', '700.000', InvoiceStatus::Paid);
+        createFinancialPayment($priorInvoice, '700.000', '2026-09-05');
+
+        createFinancialInvoice($eurLease, '2026-09-01', '2000.000', '0.000', InvoiceStatus::Pending);
+        createFinancialInvoice($usdLease, '2026-09-03', '900.000', '0.000', InvoiceStatus::Cancelled);
+        createFinancialInvoice($usdLease, '2026-09-04', '800.000', '0.000', InvoiceStatus::Void);
+
+        $category = ExpenseCategory::factory()->create();
+        Expense::factory()->create([
+            'property_id' => $property->id,
+            'expense_category_id' => $category->id,
+            'amount' => '300.000',
+            'currency' => 'USD',
+            'expense_date' => '2026-09-10',
+            'status' => ExpenseStatus::Active,
+        ]);
+        Expense::factory()->voided()->create([
+            'property_id' => $property->id,
+            'amount' => '100.000',
+            'currency' => 'USD',
+            'expense_date' => '2026-09-10',
+        ]);
+        Expense::factory()->create([
+            'property_id' => $euroProperty->id,
+            'amount' => '500.000',
+            'currency' => 'EUR',
+            'expense_date' => '2026-09-10',
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('dashboard.financial'))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->where('filters.period', 'current_month')
+                ->where('financial.overview.revenue', [
+                    ['currency' => 'EUR', 'amount' => '2000'],
+                    ['currency' => 'USD', 'amount' => '1000'],
+                ])
+                ->where('financial.overview.expenses', [
+                    ['currency' => 'EUR', 'amount' => '500'],
+                    ['currency' => 'USD', 'amount' => '300'],
+                ])
+                ->where('financial.overview.noi', [
+                    ['currency' => 'EUR', 'amount' => '1500'],
+                    ['currency' => 'USD', 'amount' => '700'],
+                ])
+                ->where('financial.collections.collected', [
+                    ['currency' => 'EUR', 'amount' => '0'],
+                    ['currency' => 'USD', 'amount' => '400'],
+                ])
+                ->where('financial.collections.outstanding', [
+                    ['currency' => 'EUR', 'amount' => '2000'],
+                    ['currency' => 'USD', 'amount' => '600'],
+                ])
+                ->where('financial.collections.collection_rate', [
+                    ['currency' => 'EUR', 'rate' => '0.0'],
+                    ['currency' => 'USD', 'rate' => '40.0'],
+                ])
+                ->where('financial.cash_flow.0.collected', [[
+                    'currency' => 'USD',
+                    'amount' => '1100',
+                ]])
+                ->where('financial.property_performance', function (Collection $rows) use ($property): bool {
+                    $performance = $rows->firstWhere('id', $property->id);
+
+                    return $performance !== null
+                        && $performance['revenue'] === [['currency' => 'USD', 'amount' => '1000']]
+                        && $performance['expenses'] === [['currency' => 'USD', 'amount' => '300']]
+                        && $performance['noi'] === [['currency' => 'USD', 'amount' => '700']]
+                        && $performance['collected'] === [['currency' => 'USD', 'amount' => '400']]
+                        && $performance['outstanding'] === [['currency' => 'USD', 'amount' => '600']]
+                        && $performance['collection_rate'] === [['currency' => 'USD', 'rate' => '40.0']];
+                })
+                ->where('financial.expense_breakdown', function (Collection $breakdown) use ($category): bool {
+                    return $breakdown->contains(fn (array $entry): bool => $entry['category_id'] === $category->id
+                        && $entry['amounts'] === [['currency' => 'USD', 'amount' => '300']]);
+                })
+                ->where('financial.trends', fn ($trends) => count($trends) === 12)
+            );
+    } finally {
+        Carbon::setTestNow();
+    }
+});
+
+test('financial dashboard keeps ytd summaries separate from its twelve month trend', function (): void {
+    Carbon::setTestNow(Carbon::parse('2026-09-15'));
+
+    try {
+        $user = User::factory()->owner()->create();
+        $property = Property::factory()->create();
+        $lease = createFinancialLease($property);
+
+        $januaryInvoice = createFinancialInvoice($lease, '2026-01-01', '600.000', '600.000', InvoiceStatus::Paid);
+        createFinancialPayment($januaryInvoice, '600.000', '2026-09-05');
+        createFinancialInvoice($lease, '2026-09-01', '1000.000', '0.000', InvoiceStatus::Pending);
+
+        Expense::factory()->create([
+            'property_id' => $property->id,
+            'amount' => '100.000',
+            'currency' => 'USD',
+            'expense_date' => '2026-01-10',
+        ]);
+        Expense::factory()->create([
+            'property_id' => $property->id,
+            'amount' => '300.000',
+            'currency' => 'USD',
+            'expense_date' => '2026-09-10',
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('dashboard.financial', ['period' => 'ytd']))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->where('financial.period', 'ytd')
+                ->where('financial.overview.revenue', [['currency' => 'USD', 'amount' => '1600']])
+                ->where('financial.overview.expenses', [['currency' => 'USD', 'amount' => '400']])
+                ->where('financial.overview.noi', [['currency' => 'USD', 'amount' => '1200']])
+                ->where('financial.collections.collected', [['currency' => 'USD', 'amount' => '600']])
+                ->where('financial.collections.collection_rate', [['currency' => 'USD', 'rate' => '37.5']])
+                ->where('financial.cash_flow', fn ($cashFlow) => count($cashFlow) === 9)
+                ->where('financial.cash_flow.8.collected', [['currency' => 'USD', 'amount' => '600']])
+                ->where('financial.trends', fn ($trends) => count($trends) === 12)
+                ->where('financial.trends.3.month', '2026-01-01')
+            );
+    } finally {
+        Carbon::setTestNow();
+    }
+});
+
+test('financial dashboard enforces financial permission and property scope', function (): void {
+    $this->get(route('dashboard.financial'))->assertRedirect('login');
+
+    $staff = User::factory()->staff()->create();
+    $this->actingAs($staff)->get(route('dashboard.financial'))->assertForbidden();
+
+    $user = User::factory()->admin()->create();
+    $accessibleProperty = Property::factory()->create();
+    $hiddenProperty = Property::factory()->create();
+    $user->properties()->sync([$accessibleProperty->id]);
+
+    $accessibleLease = createFinancialLease($accessibleProperty);
+    $hiddenLease = createFinancialLease($hiddenProperty);
+    createFinancialInvoice($accessibleLease, now()->startOfMonth()->toDateString(), '100.000', '0.000', InvoiceStatus::Pending);
+    createFinancialInvoice($hiddenLease, now()->startOfMonth()->toDateString(), '900.000', '0.000', InvoiceStatus::Pending);
+
+    $this->actingAs($user)
+        ->get(route('dashboard.financial'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('financial.overview.revenue', [['currency' => 'USD', 'amount' => '100']])
+            ->where('properties.0.id', $accessibleProperty->id)
+            ->where('properties', fn ($properties) => count($properties) === 1)
+        );
+
+    $this->actingAs($user)
+        ->get(route('dashboard.financial', ['property_id' => $hiddenProperty->id]))
+        ->assertForbidden();
+});

--- a/tests/Feature/FinancialDashboardTest.php
+++ b/tests/Feature/FinancialDashboardTest.php
@@ -248,3 +248,33 @@ test('financial dashboard enforces financial permission and property scope', fun
         ->get(route('dashboard.financial', ['property_id' => $hiddenProperty->id]))
         ->assertForbidden();
 });
+
+test('financial dashboard omits margin when a currency has expenses but no revenue', function (): void {
+    Carbon::setTestNow(Carbon::parse('2026-09-15'));
+
+    try {
+        $user = User::factory()->owner()->create();
+        $property = Property::factory()->create();
+        $category = ExpenseCategory::factory()->create();
+
+        Expense::factory()->create([
+            'property_id' => $property->id,
+            'expense_category_id' => $category->id,
+            'amount' => '100.000',
+            'currency' => 'EUR',
+            'expense_date' => '2026-09-10',
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('dashboard.financial'))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->where('financial.overview.revenue', [])
+                ->where('financial.overview.expenses', [['currency' => 'EUR', 'amount' => '100']])
+                ->where('financial.overview.noi', [['currency' => 'EUR', 'amount' => '-100']])
+                ->where('financial.overview.operating_margin', [])
+            );
+    } finally {
+        Carbon::setTestNow();
+    }
+});


### PR DESCRIPTION
## Summary
- Add the OPE-86 financial dashboard with current-month and YTD controls.
- Keep 12-month calendar trends independent from the selected summary period.
- Separate accrual revenue/NOI, allocation-based collection rate, and payment-date cash flow.
- Preserve currency-separated decimal-string aggregates and current-only occupancy.

## Verification
- `php artisan test --compact tests/Feature/FinancialDashboardTest.php tests/Feature/DashboardTest.php tests/Feature/RentDashboardTest.php tests/Feature/ExpenseTest.php`
- `npm run build`
- `npm run lint:check`
- `npm run types:check`
- `vendor/bin/pint --dirty --format agent`

Refs OPE-86