### PR TITLE
feat(expenses): add recurring schedules

### DIFF
--- a/app/Actions/Expenses/GenerateRecurringExpenses.php
+++ b/app/Actions/Expenses/GenerateRecurringExpenses.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Actions\Expenses;
+
+use App\Models\Expense;
+use App\Models\RecurringExpense;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+class GenerateRecurringExpenses
+{
+    private const MAX_OCCURRENCES_PER_DEFINITION = 1000;
+
+    public function execute(): int
+    {
+        return DB::transaction(function (): int {
+            // ponytail: lock the active definition set once; split per definition if contention is measured.
+            $definitions = RecurringExpense::query()
+                ->active()
+                ->whereNotNull('next_due_on')
+                ->lockForUpdate()
+                ->get();
+            $generated = 0;
+            $today = CarbonImmutable::today();
+
+            foreach ($definitions as $definition) {
+                $generated += $this->generateFor($definition, $today);
+            }
+
+            return $generated;
+        });
+    }
+
+    private function generateFor(RecurringExpense $definition, CarbonImmutable $today): int
+    {
+        $cursor = $definition->next_due_on?->startOfDay();
+        $endDate = $definition->end_date?->startOfDay();
+        $generated = 0;
+        $iterations = 0;
+
+        while ($cursor !== null
+            && $cursor->lessThanOrEqualTo($today)
+            && ($endDate === null || $cursor->lessThanOrEqualTo($endDate))) {
+            if (++$iterations > self::MAX_OCCURRENCES_PER_DEFINITION) {
+                break;
+            }
+
+            $exists = Expense::query()
+                ->where('recurring_expense_id', $definition->getKey())
+                ->whereDate('expense_date', $cursor->toDateString())
+                ->exists();
+
+            if (! $exists) {
+                Expense::create([
+                    'property_id' => $definition->property_id,
+                    'expense_category_id' => $definition->expense_category_id,
+                    'recurring_expense_id' => $definition->getKey(),
+                    'amount' => $definition->amount,
+                    'currency' => $definition->currency,
+                    'expense_date' => $cursor->toDateString(),
+                    'vendor' => $definition->vendor,
+                    'description' => $definition->description,
+                ]);
+
+                $generated++;
+            }
+
+            $nextCursor = $definition->nextOccurrenceAfter($cursor);
+
+            if (! $nextCursor->greaterThan($cursor)) {
+                throw new LogicException('Recurring expense generation cursor did not advance.');
+            }
+
+            $cursor = $nextCursor;
+        }
+
+        $definition->next_due_on = $cursor !== null
+            && ($endDate === null || $cursor->lessThanOrEqualTo($endDate))
+            ? $cursor->toDateString()
+            : null;
+        $definition->saveQuietly();
+
+        return $generated;
+    }
+}

--- a/app/Console/Commands/GenerateRecurringExpensesCommand.php
+++ b/app/Console/Commands/GenerateRecurringExpensesCommand.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Actions\Expenses\GenerateRecurringExpenses;
+use Illuminate\Console\Command;
+
+class GenerateRecurringExpensesCommand extends Command
+{
+    protected $signature = 'expenses:generate-recurring';
+
+    protected $description = 'Generate expenses for due recurring expense schedules';
+
+    public function handle(GenerateRecurringExpenses $action): int
+    {
+        $count = $action->execute();
+
+        $this->info("Generated {$count} recurring expense(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/ExpenseController.php
+++ b/app/Http/Controllers/ExpenseController.php
@@ -113,6 +113,7 @@ class ExpenseController extends Controller
             ->with([
                 'property:id,name',
                 'category:id,slug,label,is_active',
+                'recurringExpense:id,vendor,description,billing_interval,billing_unit',
                 'voidedByUser:id,name',
                 'media' => fn ($mediaQuery) => $mediaQuery
                     ->where('collection', 'receipts')

--- a/app/Http/Controllers/RecurringExpenseController.php
+++ b/app/Http/Controllers/RecurringExpenseController.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Enums\BillingUnit;
+use App\Http\Requests\RecurringExpense\IndexRecurringExpenseRequest;
+use App\Http\Requests\RecurringExpense\StoreRecurringExpenseRequest;
+use App\Http\Requests\RecurringExpense\UpdateRecurringExpenseRequest;
+use App\Models\ExpenseCategory;
+use App\Models\Property;
+use App\Models\RecurringExpense;
+use App\Services\Payments\MoneyConverter;
+use App\Tables\Column;
+use App\Tables\Filter;
+use App\Tables\Table;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class RecurringExpenseController extends Controller
+{
+    public function index(IndexRecurringExpenseRequest $request, MoneyConverter $moneyConverter): Response
+    {
+        $today = CarbonImmutable::today()->toDateString();
+        $table = Table::make()
+            ->columns([
+                Column::make('property_name', 'Property')
+                    ->sortable(fn (Builder $query, string $direction) => $query->orderBy(
+                        Property::select('name')->whereColumn('properties.id', 'recurring_expenses.property_id'),
+                        $direction,
+                    ))
+                    ->searchable(fn (Builder $query, string $search) => $query->orWhereHas(
+                        'property',
+                        fn (Builder $propertyQuery) => $propertyQuery->whereRaw(
+                            'lower(name) like ?',
+                            ['%'.mb_strtolower($search).'%'],
+                        ),
+                    )),
+                Column::make('category_name', 'Category')
+                    ->sortable(fn (Builder $query, string $direction) => $query->orderBy(
+                        ExpenseCategory::select('label')->whereColumn('expense_categories.id', 'recurring_expenses.expense_category_id'),
+                        $direction,
+                    ))
+                    ->searchable(fn (Builder $query, string $search) => $query->orWhereHas(
+                        'category',
+                        fn (Builder $categoryQuery) => $categoryQuery->whereRaw(
+                            'lower(label) like ?',
+                            ['%'.mb_strtolower($search).'%'],
+                        ),
+                    )),
+                Column::make('amount', 'Amount')->sortable(),
+                Column::make('billing_unit', 'Frequency')->sortable(),
+                Column::make('vendor', 'Vendor')->searchable(),
+                Column::make('start_date', 'Start')->sortable(),
+                Column::make('end_date', 'End')->sortable(),
+                Column::make('status', 'Status'),
+                Column::make('_actions', 'Actions'),
+            ])
+            ->filters([
+                Filter::select('status', 'Status', ['active', 'paused', 'ended'])
+                    ->query(function (Builder $query, string $value) use ($today): void {
+                        match ($value) {
+                            'active' => $query
+                                ->where('is_active', true)
+                                ->whereNotNull('next_due_on')
+                                ->where(fn (Builder $query) => $query->whereNull('end_date')->orWhereDate('end_date', '>=', $today)),
+                            'paused' => $query
+                                ->where('is_active', false)
+                                ->whereNotNull('paused_at')
+                                ->whereNotNull('next_due_on')
+                                ->where(fn (Builder $query) => $query->whereNull('end_date')->orWhereDate('end_date', '>=', $today)),
+                            'ended' => $query->whereNotNull('end_date')->where(function (Builder $query) use ($today): void {
+                                $query->whereDate('end_date', '<', $today)
+                                    ->orWhereNull('next_due_on');
+                            }),
+                            default => null,
+                        };
+                    }),
+            ])
+            ->defaultSort('-start_date');
+
+        $query = RecurringExpense::query()
+            ->with(['property:id,name', 'category:id,slug,label,is_active'])
+            ->when(! $request->user()->isOwner(), fn (Builder $query) => $query->whereHas(
+                'property.users',
+                fn (Builder $userQuery) => $userQuery->whereKey($request->user()->id),
+            ));
+
+        $result = $table->paginate($query, $request, 'recurring_expenses');
+
+        foreach ($result['recurring_expenses'] as $recurringExpense) {
+            $recurringExpense->setAttribute('status', $this->status($recurringExpense));
+        }
+
+        $properties = Property::query()
+            ->when(! $request->user()->isOwner(), fn (Builder $query) => $query->whereHas(
+                'users',
+                fn (Builder $userQuery) => $userQuery->whereKey($request->user()->id),
+            ))
+            ->orderBy('name')
+            ->get(['id', 'name']);
+
+        return Inertia::render('expenses/recurring', [
+            ...$result,
+            'properties' => $properties,
+            'categories' => ExpenseCategory::ordered()->get(['id', 'slug', 'label', 'is_active']),
+            'currencies' => array_keys($moneyConverter->scales()),
+            'billing_units' => BillingUnit::values(),
+            'status' => $request->query('status', ''),
+            'can' => [
+                'create' => $request->user()->can('expenses.create'),
+                'update' => $request->user()->can('expenses.update'),
+            ],
+        ]);
+    }
+
+    public function store(StoreRecurringExpenseRequest $request): RedirectResponse
+    {
+        $data = $request->validated();
+        $recurringExpense = new RecurringExpense($data);
+        $recurringExpense->next_due_on = $recurringExpense->firstOccurrence()->toDateString();
+        $recurringExpense->save();
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Recurring expense added.')]);
+
+        return back();
+    }
+
+    public function update(
+        UpdateRecurringExpenseRequest $request,
+        RecurringExpense $recurringExpense,
+    ): RedirectResponse {
+        $data = $request->validated();
+
+        DB::transaction(function () use ($data, $recurringExpense): void {
+            $locked = RecurringExpense::query()->lockForUpdate()->findOrFail($recurringExpense->getKey());
+            $scheduleChanged = collect(['billing_interval', 'billing_unit', 'start_date', 'end_date'])
+                ->contains(fn (string $field): bool => array_key_exists($field, $data)
+                    && (string) $locked->getRawOriginal($field) !== (string) $data[$field]);
+
+            $locked->fill($data);
+
+            if ($scheduleChanged) {
+                $nextDueOn = $locked->nextOccurrenceAfter(CarbonImmutable::today());
+                $locked->next_due_on = $locked->end_date !== null
+                    && $nextDueOn->greaterThan($locked->end_date->startOfDay())
+                    ? null
+                    : $nextDueOn->toDateString();
+            } elseif ($locked->end_date !== null
+                && $locked->next_due_on !== null
+                && $locked->next_due_on->greaterThan($locked->end_date)) {
+                $locked->next_due_on = null;
+            }
+
+            $locked->save();
+        });
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Recurring expense updated.')]);
+
+        return back();
+    }
+
+    public function pause(RecurringExpense $recurringExpense): RedirectResponse
+    {
+        $this->authorize('update', $recurringExpense);
+
+        DB::transaction(function () use ($recurringExpense): void {
+            $locked = RecurringExpense::query()->lockForUpdate()->findOrFail($recurringExpense->getKey());
+
+            if ($locked->is_active && ! $locked->isEnded()) {
+                $locked->is_active = false;
+                $locked->paused_at = now();
+                $locked->save();
+            }
+        });
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Recurring expense paused.')]);
+
+        return back();
+    }
+
+    public function resume(RecurringExpense $recurringExpense): RedirectResponse
+    {
+        $this->authorize('update', $recurringExpense);
+
+        DB::transaction(function () use ($recurringExpense): void {
+            $locked = RecurringExpense::query()->lockForUpdate()->findOrFail($recurringExpense->getKey());
+            $nextDueOn = $locked->nextOccurrenceAfter(CarbonImmutable::today());
+
+            if ($locked->end_date !== null && $nextDueOn->greaterThan($locked->end_date->startOfDay())) {
+                throw ValidationException::withMessages([
+                    'recurring_expense' => __('This schedule has no future occurrence. Edit its end date or cadence before resuming.'),
+                ]);
+            }
+
+            $locked->update([
+                'is_active' => true,
+                'paused_at' => null,
+                'next_due_on' => $nextDueOn->toDateString(),
+            ]);
+        });
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Recurring expense resumed.')]);
+
+        return back();
+    }
+
+    private function status(RecurringExpense $recurringExpense): string
+    {
+        if ($recurringExpense->end_date !== null
+            && ($recurringExpense->end_date->lt(CarbonImmutable::today())
+                || $recurringExpense->next_due_on === null)) {
+            return 'ended';
+        }
+
+        return $recurringExpense->is_active ? 'active' : 'paused';
+    }
+}

--- a/app/Http/Controllers/Settings/ExpenseCategoryController.php
+++ b/app/Http/Controllers/Settings/ExpenseCategoryController.php
@@ -17,7 +17,7 @@ class ExpenseCategoryController extends Controller
     {
         return Inertia::render('settings/expense-categories', [
             'categories' => ExpenseCategory::ordered()
-                ->withCount('expenses')
+                ->withCount(['expenses', 'recurringExpenses'])
                 ->get(['id', 'slug', 'label', 'is_active', 'sort_order']),
         ]);
     }
@@ -49,7 +49,7 @@ class ExpenseCategoryController extends Controller
 
     public function destroy(ExpenseCategory $expenseCategory): RedirectResponse
     {
-        if ($expenseCategory->expenses()->exists()) {
+        if ($expenseCategory->expenses()->exists() || $expenseCategory->recurringExpenses()->exists()) {
             $expenseCategory->update(['is_active' => false]);
             Inertia::flash('toast', ['type' => 'success', 'message' => __('Expense category archived.')]);
 

--- a/app/Http/Requests/RecurringExpense/IndexRecurringExpenseRequest.php
+++ b/app/Http/Requests/RecurringExpense/IndexRecurringExpenseRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests\RecurringExpense;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class IndexRecurringExpenseRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()?->can('expenses.view') ?? false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'status' => ['nullable', 'in:active,paused,ended'],
+        ];
+    }
+}

--- a/app/Http/Requests/RecurringExpense/StoreRecurringExpenseRequest.php
+++ b/app/Http/Requests/RecurringExpense/StoreRecurringExpenseRequest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Http\Requests\RecurringExpense;
+
+use App\Enums\BillingUnit;
+use App\Models\Property;
+use App\Rules\MoneyAmount;
+use App\Services\Payments\MoneyConverter;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreRecurringExpenseRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()?->can('expenses.create') ?? false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'property_id' => $this->propertyRules(),
+            'expense_category_id' => [
+                'required', 'integer', Rule::exists('expense_categories', 'id')->where('is_active', true),
+            ],
+            'amount' => ['required', new MoneyAmount($this->input('currency'), allowZero: false)],
+            'currency' => [
+                'required', 'string', 'size:3', Rule::in(array_keys(app(MoneyConverter::class)->scales())),
+            ],
+            'vendor' => ['nullable', 'string', 'max:255'],
+            'description' => ['nullable', 'string', 'max:65535'],
+            'billing_interval' => ['required', 'integer', 'min:1', 'max:255'],
+            'billing_unit' => ['required', 'string', Rule::in(BillingUnit::values())],
+            'start_date' => ['required', 'date'],
+            'end_date' => ['nullable', 'date', 'after_or_equal:start_date'],
+        ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        if ($this->filled('currency')) {
+            $this->merge(['currency' => strtoupper((string) $this->input('currency'))]);
+        }
+    }
+
+    /** @return array<int, mixed> */
+    private function propertyRules(): array
+    {
+        return [
+            'required',
+            'integer',
+            Rule::exists('properties', 'id'),
+            function (string $attribute, mixed $value, \Closure $fail): void {
+                if ($this->user()->isOwner()) {
+                    return;
+                }
+
+                if (! Property::query()->whereKey($value)->whereHas(
+                    'users', fn ($query) => $query->whereKey($this->user()->id),
+                )->exists()) {
+                    $fail(__('You do not have access to this property.'));
+                }
+            },
+        ];
+    }
+}

--- a/app/Http/Requests/RecurringExpense/UpdateRecurringExpenseRequest.php
+++ b/app/Http/Requests/RecurringExpense/UpdateRecurringExpenseRequest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Http\Requests\RecurringExpense;
+
+use App\Enums\BillingUnit;
+use App\Models\Property;
+use App\Models\RecurringExpense;
+use App\Rules\MoneyAmount;
+use App\Services\Payments\MoneyConverter;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateRecurringExpenseRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        $recurringExpense = $this->route('recurringExpense');
+
+        return $recurringExpense instanceof RecurringExpense
+            && ($this->user()?->can('update', $recurringExpense) ?? false);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'property_id' => $this->propertyRules(),
+            'expense_category_id' => ['required', 'integer', Rule::exists('expense_categories', 'id')],
+            'amount' => ['required', new MoneyAmount($this->input('currency'), allowZero: false)],
+            'currency' => [
+                'required', 'string', 'size:3', Rule::in(array_keys(app(MoneyConverter::class)->scales())),
+            ],
+            'vendor' => ['nullable', 'string', 'max:255'],
+            'description' => ['nullable', 'string', 'max:65535'],
+            'billing_interval' => ['required', 'integer', 'min:1', 'max:255'],
+            'billing_unit' => ['required', 'string', Rule::in(BillingUnit::values())],
+            'start_date' => ['required', 'date'],
+            'end_date' => ['nullable', 'date', 'after_or_equal:start_date'],
+        ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        if ($this->filled('currency')) {
+            $this->merge(['currency' => strtoupper((string) $this->input('currency'))]);
+        }
+    }
+
+    /** @return array<int, mixed> */
+    private function propertyRules(): array
+    {
+        return [
+            'required',
+            'integer',
+            Rule::exists('properties', 'id'),
+            function (string $attribute, mixed $value, \Closure $fail): void {
+                if ($this->user()->isOwner()) {
+                    return;
+                }
+
+                if (! Property::query()->whereKey($value)->whereHas(
+                    'users', fn ($query) => $query->whereKey($this->user()->id),
+                )->exists()) {
+                    $fail(__('You do not have access to this property.'));
+                }
+            },
+        ];
+    }
+}

--- a/app/Models/Expense.php
+++ b/app/Models/Expense.php
@@ -18,6 +18,7 @@ use LogicException;
 #[Fillable([
     'property_id',
     'expense_category_id',
+    'recurring_expense_id',
     'amount',
     'currency',
     'expense_date',
@@ -66,6 +67,10 @@ class Expense extends Model
                 throw new LogicException('Expense currency snapshots are immutable.');
             }
 
+            if ($expense->isDirty('recurring_expense_id')) {
+                throw new LogicException('Expense recurring source is immutable.');
+            }
+
             if ($expense->isDirty('amount')) {
                 $expense->amount = app(MoneyConverter::class)->normalizeAmount(
                     (string) $expense->amount,
@@ -83,6 +88,11 @@ class Expense extends Model
     public function category(): BelongsTo
     {
         return $this->belongsTo(ExpenseCategory::class, 'expense_category_id');
+    }
+
+    public function recurringExpense(): BelongsTo
+    {
+        return $this->belongsTo(RecurringExpense::class);
     }
 
     public function voidedByUser(): BelongsTo

--- a/app/Models/ExpenseCategory.php
+++ b/app/Models/ExpenseCategory.php
@@ -39,6 +39,11 @@ class ExpenseCategory extends Model
         return $this->hasMany(Expense::class);
     }
 
+    public function recurringExpenses(): HasMany
+    {
+        return $this->hasMany(RecurringExpense::class);
+    }
+
     public function scopeActive(Builder $query): void
     {
         $query->where('is_active', true);

--- a/app/Models/RecurringExpense.php
+++ b/app/Models/RecurringExpense.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\Auditable;
+use App\Concerns\SerializesDatesWithTimezone;
+use App\Enums\BillingUnit;
+use App\Services\Payments\MoneyConverter;
+use Carbon\CarbonImmutable;
+use Carbon\CarbonInterface;
+use Database\Factories\RecurringExpenseFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use LogicException;
+
+#[Fillable([
+    'property_id',
+    'expense_category_id',
+    'amount',
+    'currency',
+    'vendor',
+    'description',
+    'billing_interval',
+    'billing_unit',
+    'start_date',
+    'end_date',
+    'is_active',
+    'next_due_on',
+    'paused_at',
+])]
+class RecurringExpense extends Model
+{
+    /** @use HasFactory<RecurringExpenseFactory> */
+    use Auditable, HasFactory, SerializesDatesWithTimezone;
+
+    protected function casts(): array
+    {
+        return [
+            'amount' => 'decimal:3',
+            'billing_interval' => 'integer',
+            'billing_unit' => BillingUnit::class,
+            'start_date' => 'date:Y-m-d',
+            'end_date' => 'date:Y-m-d',
+            'is_active' => 'boolean',
+            'next_due_on' => 'date:Y-m-d',
+            'paused_at' => 'datetime',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::creating(function (RecurringExpense $recurringExpense): void {
+            $converter = app(MoneyConverter::class);
+            $recurringExpense->currency = $converter->normalizeCurrency($recurringExpense->currency);
+            $recurringExpense->amount = $converter->normalizeAmount(
+                (string) $recurringExpense->amount,
+                $recurringExpense->currency,
+            );
+        });
+
+        static::updating(function (RecurringExpense $recurringExpense): void {
+            if ($recurringExpense->isDirty(['amount', 'currency'])) {
+                $converter = app(MoneyConverter::class);
+                $currency = $converter->normalizeCurrency($recurringExpense->currency);
+                $recurringExpense->currency = $currency;
+                $recurringExpense->amount = $converter->normalizeAmount(
+                    (string) $recurringExpense->amount,
+                    $currency,
+                );
+            }
+        });
+    }
+
+    public function property(): BelongsTo
+    {
+        return $this->belongsTo(Property::class);
+    }
+
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(ExpenseCategory::class, 'expense_category_id');
+    }
+
+    public function expenses(): HasMany
+    {
+        return $this->hasMany(Expense::class);
+    }
+
+    public function scopeActive(Builder $query): void
+    {
+        $query->where('is_active', true);
+    }
+
+    public function firstOccurrence(): CarbonImmutable
+    {
+        return $this->occurrenceAt(0);
+    }
+
+    public function nextOccurrenceAfter(CarbonInterface|string $date): CarbonImmutable
+    {
+        $target = CarbonImmutable::parse($date)->startOfDay();
+        $start = CarbonImmutable::parse($this->start_date)->startOfDay();
+
+        if ($target->lt($start)) {
+            return $start;
+        }
+
+        $index = $this->approximateOccurrenceIndex($start, $target);
+        $occurrence = $this->occurrenceAt($index);
+
+        while ($occurrence->lessThanOrEqualTo($target)) {
+            $nextIndex = $index + 1;
+            $nextOccurrence = $this->occurrenceAt($nextIndex);
+
+            if (! $nextOccurrence->greaterThan($occurrence)) {
+                throw new LogicException('Recurring expense occurrence cursor did not advance.');
+            }
+
+            $index = $nextIndex;
+            $occurrence = $nextOccurrence;
+        }
+
+        return $occurrence;
+    }
+
+    public function isEnded(?CarbonInterface $today = null): bool
+    {
+        return $this->end_date !== null
+            && ($this->end_date->startOfDay()->lt(($today ?? now())->startOfDay())
+                || $this->next_due_on === null);
+    }
+
+    private function occurrenceAt(int $index): CarbonImmutable
+    {
+        $start = CarbonImmutable::parse($this->start_date)->startOfDay();
+        $interval = max(1, (int) $this->billing_interval);
+        $unit = $this->billing_unit ?? BillingUnit::Month;
+
+        return match ($unit) {
+            BillingUnit::Day => $start->addDays($index * $interval),
+            BillingUnit::Week => $start->addWeeks($index * $interval),
+            BillingUnit::Month => $this->monthOccurrence($start, $index * $interval),
+            BillingUnit::Year => $this->yearOccurrence($start, $index * $interval),
+        };
+    }
+
+    private function monthOccurrence(CarbonImmutable $start, int $months): CarbonImmutable
+    {
+        $month = $start->startOfMonth()->addMonthsNoOverflow($months);
+
+        return $month->setDay(min($start->day, $month->daysInMonth));
+    }
+
+    private function yearOccurrence(CarbonImmutable $start, int $years): CarbonImmutable
+    {
+        $year = $start->startOfYear()->addYearsNoOverflow($years)->setMonth($start->month);
+
+        return $year->setDay(min($start->day, $year->daysInMonth));
+    }
+
+    private function approximateOccurrenceIndex(CarbonImmutable $start, CarbonImmutable $target): int
+    {
+        $interval = max(1, (int) $this->billing_interval);
+        $unit = $this->billing_unit ?? BillingUnit::Month;
+
+        return match ($unit) {
+            BillingUnit::Day => intdiv($start->diffInDays($target), $interval),
+            BillingUnit::Week => intdiv(intdiv($start->diffInDays($target), 7), $interval),
+            BillingUnit::Month => intdiv(
+                (($target->year - $start->year) * 12) + $target->month - $start->month,
+                $interval,
+            ),
+            BillingUnit::Year => intdiv($target->year - $start->year, $interval),
+        };
+    }
+}

--- a/app/Policies/RecurringExpensePolicy.php
+++ b/app/Policies/RecurringExpensePolicy.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\RecurringExpense;
+use App\Models\User;
+
+class RecurringExpensePolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return $user->can('expenses.view');
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, RecurringExpense $recurringExpense): bool
+    {
+        return $user->can('expenses.view')
+            && $user->canAccessProperty($recurringExpense->property_id);
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return $user->can('expenses.create');
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, RecurringExpense $recurringExpense): bool
+    {
+        return $user->can('expenses.update')
+            && $user->canAccessProperty($recurringExpense->property_id);
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, RecurringExpense $recurringExpense): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, RecurringExpense $recurringExpense): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, RecurringExpense $recurringExpense): bool
+    {
+        return false;
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -9,6 +9,7 @@ use App\Models\Lease;
 use App\Models\MaintenanceTicket;
 use App\Models\Payment;
 use App\Models\Property;
+use App\Models\RecurringExpense;
 use App\Models\Tenant;
 use App\Models\Unit;
 use App\Models\UnitType;
@@ -18,6 +19,7 @@ use App\Policies\LeasePolicy;
 use App\Policies\MaintenanceTicketPolicy;
 use App\Policies\PaymentPolicy;
 use App\Policies\PropertyPolicy;
+use App\Policies\RecurringExpensePolicy;
 use App\Policies\TenantPolicy;
 use App\Policies\UnitPolicy;
 use App\Policies\UnitTypePolicy;
@@ -35,6 +37,7 @@ class AuthServiceProvider extends ServiceProvider
         Invoice::class => InvoicePolicy::class,
         Payment::class => PaymentPolicy::class,
         Expense::class => ExpensePolicy::class,
+        RecurringExpense::class => RecurringExpensePolicy::class,
         MaintenanceTicket::class => MaintenanceTicketPolicy::class,
     ];
 

--- a/database/factories/RecurringExpenseFactory.php
+++ b/database/factories/RecurringExpenseFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\BillingUnit;
+use App\Models\ExpenseCategory;
+use App\Models\Property;
+use App\Models\RecurringExpense;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<RecurringExpense>
+ */
+class RecurringExpenseFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'property_id' => Property::factory(),
+            'expense_category_id' => ExpenseCategory::factory(),
+            'amount' => '500000.00',
+            'currency' => 'IDR',
+            'vendor' => fake()->company(),
+            'description' => fake()->sentence(),
+            'billing_interval' => 1,
+            'billing_unit' => BillingUnit::Month,
+            'start_date' => now()->startOfMonth()->toDateString(),
+            'end_date' => null,
+            'is_active' => true,
+            'next_due_on' => now()->startOfMonth()->toDateString(),
+            'paused_at' => null,
+        ];
+    }
+
+    public function paused(): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'is_active' => false,
+            'paused_at' => now(),
+        ]);
+    }
+}

--- a/database/migrations/2026_09_11_064319_create_recurring_expenses_table.php
+++ b/database/migrations/2026_09_11_064319_create_recurring_expenses_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('recurring_expenses', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('property_id')->constrained()->restrictOnDelete();
+            $table->foreignId('expense_category_id')->constrained()->restrictOnDelete();
+            $table->decimal('amount', 20, 3);
+            $table->char('currency', 3);
+            $table->string('vendor')->nullable();
+            $table->text('description')->nullable();
+            $table->unsignedSmallInteger('billing_interval');
+            $table->string('billing_unit', 10);
+            $table->date('start_date');
+            $table->date('end_date')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->date('next_due_on')->nullable();
+            $table->timestamp('paused_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['is_active', 'next_due_on']);
+            $table->index(['property_id', 'is_active']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('recurring_expenses');
+    }
+};

--- a/database/migrations/2026_09_11_064320_add_recurring_expense_id_to_expenses_table.php
+++ b/database/migrations/2026_09_11_064320_add_recurring_expense_id_to_expenses_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('expenses', function (Blueprint $table) {
+            $table->foreignId('recurring_expense_id')
+                ->nullable()
+                ->after('expense_category_id')
+                ->constrained('recurring_expenses')
+                ->restrictOnDelete();
+            $table->unique(['recurring_expense_id', 'expense_date'], 'expenses_recurring_expense_date_unique');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('expenses', function (Blueprint $table) {
+            $table->dropUnique('expenses_recurring_expense_date_unique');
+            $table->dropForeign(['recurring_expense_id']);
+            $table->dropColumn('recurring_expense_id');
+        });
+    }
+};

--- a/resources/js/components/features/app/app-sidebar.tsx
+++ b/resources/js/components/features/app/app-sidebar.tsx
@@ -34,6 +34,7 @@ import {
     rent as dashboardRent,
 } from '@/routes/dashboard';
 import expenses from '@/routes/expenses';
+import recurringExpenses from '@/routes/expenses/recurring';
 import leases from '@/routes/leases';
 import maintenanceTickets from '@/routes/maintenance-tickets';
 import { dashboard as portalDashboard } from '@/routes/portal';
@@ -186,6 +187,11 @@ export function AppSidebar() {
                                                   {
                                                       title: 'All Expenses',
                                                       href: expenses.index(),
+                                                      icon: ReceiptText,
+                                                  },
+                                                  {
+                                                      title: 'Recurring Expenses',
+                                                      href: recurringExpenses.index(),
                                                       icon: ReceiptText,
                                                   },
                                                   ...(isOwner

--- a/resources/js/components/features/expenses/expense-detail-sheet.tsx
+++ b/resources/js/components/features/expenses/expense-detail-sheet.tsx
@@ -20,7 +20,12 @@ import {
     SheetHeader,
     SheetTitle,
 } from '@/components/ui/sheet';
-import { formatDate, formatDateTime, formatPrice } from '@/lib/formatters';
+import {
+    formatBillingPeriod,
+    formatDate,
+    formatDateTime,
+    formatPrice,
+} from '@/lib/formatters';
 import { t } from '@/lib/i18n';
 import expenses from '@/routes/expenses';
 import type { Expense } from '@/types';
@@ -120,6 +125,18 @@ export default function ExpenseDetailSheet({
                                     value={expense.vendor ?? '—'}
                                 />
                             </section>
+
+                            {expense.recurring_expense && (
+                                <section className="rounded-lg border border-primary/20 bg-primary/5 p-4 text-sm">
+                                    <p className="font-medium">{t('Recurring expense')}</p>
+                                    <p className="mt-1 text-muted-foreground">
+                                        {formatBillingPeriod(
+                                            expense.recurring_expense.billing_interval,
+                                            expense.recurring_expense.billing_unit,
+                                        )}
+                                    </p>
+                                </section>
+                            )}
 
                             {expense.description && (
                                 <section>

--- a/resources/js/components/features/expenses/index.ts
+++ b/resources/js/components/features/expenses/index.ts
@@ -1,2 +1,3 @@
 export { default as ExpenseDetailSheet } from './expense-detail-sheet';
 export { default as ExpenseFormSheet } from './expense-form-sheet';
+export { default as RecurringExpenseFormSheet } from './recurring-expense-form-sheet';

--- a/resources/js/components/features/expenses/recurring-expense-form-sheet.tsx
+++ b/resources/js/components/features/expenses/recurring-expense-form-sheet.tsx
@@ -1,5 +1,5 @@
 import { useForm, usePage } from '@inertiajs/react';
-import { useMemo } from 'react';
+import { useState } from 'react';
 import { InputError, SearchableSelect } from '@/components/shared';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -24,6 +24,8 @@ import { todayISO } from '@/lib/formatters';
 import { t } from '@/lib/i18n';
 import recurringExpenses from '@/routes/expenses/recurring';
 import type { ExpenseCategory, RecurringExpense } from '@/types';
+
+const OTHER_CURRENCY = '__other__';
 
 type RecurringExpenseFormData = {
     property_id: string;
@@ -54,24 +56,59 @@ export default function RecurringExpenseFormSheet({
     onOpenChange: (open: boolean) => void;
 }) {
     const { setting } = usePage<{
-        setting: { currency: string };
+        setting: { currency: string; supported_currencies: string[] };
     }>().props;
     const isEdit = Boolean(recurringExpense);
+    const currentRecurringCurrency = recurringExpense?.currency?.toUpperCase();
     const defaultCurrency = setting.currency.toUpperCase();
-    const currencyOptions = useMemo(
-        () =>
-            Array.from(
-                new Set([...currencies, defaultCurrency].map((currency) => currency.toUpperCase())),
-            ).sort(),
-        [currencies, defaultCurrency],
+    const allCurrencies = Array.from(
+        new Set(
+            [
+                ...currencies,
+                defaultCurrency,
+                ...(currentRecurringCurrency ? [currentRecurringCurrency] : []),
+            ].map((currency) => currency.toUpperCase()),
+        ),
     );
+    const supportedCurrencies = Array.from(
+        new Set([
+            defaultCurrency,
+            ...setting.supported_currencies.map((currency) =>
+                currency.toUpperCase(),
+            ),
+        ]),
+    ).filter((currency) => allCurrencies.includes(currency));
+    const otherCurrencies = allCurrencies
+        .filter((currency) => !supportedCurrencies.includes(currency))
+        .sort();
+    const supportedCurrencyOptions = supportedCurrencies.map((currency) => ({
+        value: currency,
+        label: currency,
+    }));
+    const otherCurrencyOptions = otherCurrencies.map((currency) => ({
+        value: currency,
+        label: currency,
+    }));
+    const currencyOptions = [
+        ...supportedCurrencyOptions,
+        ...(otherCurrencyOptions.length > 0
+            ? [{ value: OTHER_CURRENCY, label: t('Other currency') }]
+            : []),
+    ];
+    const initialOtherCurrency = Boolean(
+        currentRecurringCurrency &&
+        !supportedCurrencies.includes(currentRecurringCurrency),
+    );
+    const [isOtherCurrency, setIsOtherCurrency] =
+        useState(initialOtherCurrency);
     const propertyOptions = properties.map((property) => ({
         value: String(property.id),
         label: property.name,
     }));
     const availableCategories = categories.filter(
         (category) =>
-            category.is_active || category.id === recurringExpense?.expense_category_id,
+            category.is_active ||
+            category.id === recurringExpense?.expense_category_id,
     );
     const { data, setData, submit, reset, processing, errors } =
         useForm<RecurringExpenseFormData>({
@@ -82,9 +119,11 @@ export default function RecurringExpenseFormSheet({
                   : '',
             expense_category_id: recurringExpense?.expense_category_id
                 ? String(recurringExpense.expense_category_id)
-                : (categories.find((category) => category.is_active)?.id.toString() ?? ''),
+                : (categories
+                      .find((category) => category.is_active)
+                      ?.id.toString() ?? ''),
             amount: recurringExpense?.amount ?? '',
-            currency: recurringExpense?.currency ?? defaultCurrency,
+            currency: currentRecurringCurrency ?? defaultCurrency,
             vendor: recurringExpense?.vendor ?? '',
             description: recurringExpense?.description ?? '',
             billing_interval: String(recurringExpense?.billing_interval ?? 1),
@@ -98,6 +137,7 @@ export default function RecurringExpenseFormSheet({
 
         if (!next) {
             reset();
+            setIsOtherCurrency(initialOtherCurrency);
         }
     }
 
@@ -113,14 +153,24 @@ export default function RecurringExpenseFormSheet({
     }
 
     return (
-        <Sheet key={recurringExpense?.id ?? 'new'} open={open} onOpenChange={close}>
+        <Sheet
+            key={recurringExpense?.id ?? 'new'}
+            open={open}
+            onOpenChange={close}
+        >
             <SheetContent className="sm:max-w-lg">
                 <SheetHeader>
                     <SheetTitle>
-                        {t(isEdit ? 'Edit recurring expense' : 'New recurring expense')}
+                        {t(
+                            isEdit
+                                ? 'Edit recurring expense'
+                                : 'New recurring expense',
+                        )}
                     </SheetTitle>
                     <SheetDescription>
-                        {t('Future expenses use the current schedule values; generated expenses never change.')}
+                        {t(
+                            'Future expenses use the current schedule values; generated expenses never change.',
+                        )}
                     </SheetDescription>
                 </SheetHeader>
 
@@ -135,7 +185,10 @@ export default function RecurringExpenseFormSheet({
                                 options={propertyOptions}
                                 value={data.property_id || null}
                                 onChange={(value) =>
-                                    setData('property_id', value === null ? '' : String(value))
+                                    setData(
+                                        'property_id',
+                                        value === null ? '' : String(value),
+                                    )
                                 }
                                 placeholder={t('Select property...')}
                                 searchPlaceholder={t('Search property...')}
@@ -144,22 +197,33 @@ export default function RecurringExpenseFormSheet({
                             <InputError message={errors.property_id} />
                         </div>
 
-                        <div className="grid gap-2">
+                        <div className="grid w-full gap-2">
                             <Label htmlFor="recurring-expense-category">
                                 {t('Category')}
                             </Label>
                             <Select
                                 value={data.expense_category_id}
-                                onValueChange={(value) => setData('expense_category_id', value)}
+                                onValueChange={(value) =>
+                                    setData('expense_category_id', value)
+                                }
                             >
-                                <SelectTrigger id="recurring-expense-category">
-                                    <SelectValue placeholder={t('Select category')} />
+                                <SelectTrigger
+                                    id="recurring-expense-category"
+                                    className="w-full"
+                                >
+                                    <SelectValue
+                                        placeholder={t('Select category')}
+                                    />
                                 </SelectTrigger>
                                 <SelectContent>
                                     {availableCategories.map((category) => (
-                                        <SelectItem key={category.id} value={String(category.id)}>
+                                        <SelectItem
+                                            key={category.id}
+                                            value={String(category.id)}
+                                        >
                                             {category.label}
-                                            {!category.is_active && ` (${t('archived')})`}
+                                            {!category.is_active &&
+                                                ' (' + t('archived') + ')'}
                                         </SelectItem>
                                     ))}
                                 </SelectContent>
@@ -167,9 +231,11 @@ export default function RecurringExpenseFormSheet({
                             <InputError message={errors.expense_category_id} />
                         </div>
 
-                        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                            <div className="grid gap-2">
-                                <Label htmlFor="recurring-expense-amount">{t('Amount')}</Label>
+                        <div className="grid w-full grid-cols-1 items-start gap-4 sm:grid-cols-[2fr_1fr]">
+                            <div className="grid min-w-0 gap-2">
+                                <Label htmlFor="recurring-expense-amount">
+                                    {t('Amount')}
+                                </Label>
                                 <Input
                                     id="recurring-expense-amount"
                                     type="number"
@@ -178,27 +244,60 @@ export default function RecurringExpenseFormSheet({
                                     inputMode="decimal"
                                     required
                                     value={data.amount}
-                                    onChange={(event) => setData('amount', event.target.value)}
+                                    onChange={(event) =>
+                                        setData('amount', event.target.value)
+                                    }
                                 />
                                 <InputError message={errors.amount} />
                             </div>
-                            <div className="grid gap-2">
+                            <div className="grid min-w-0 gap-2 overflow-hidden">
                                 <Label>{t('Currency')}</Label>
-                                <Select
-                                    value={data.currency}
-                                    onValueChange={(value) => setData('currency', value)}
-                                >
-                                    <SelectTrigger>
-                                        <SelectValue placeholder={t('Select currency')} />
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        {currencyOptions.map((currency) => (
-                                            <SelectItem key={currency} value={currency}>
-                                                {currency}
-                                            </SelectItem>
-                                        ))}
-                                    </SelectContent>
-                                </Select>
+                                <SearchableSelect
+                                    options={currencyOptions}
+                                    value={
+                                        isOtherCurrency
+                                            ? OTHER_CURRENCY
+                                            : data.currency || null
+                                    }
+                                    onChange={(value) => {
+                                        if (value === OTHER_CURRENCY) {
+                                            setIsOtherCurrency(true);
+                                            setData('currency', '');
+
+                                            return;
+                                        }
+
+                                        setIsOtherCurrency(false);
+                                        setData(
+                                            'currency',
+                                            value === null ? '' : String(value),
+                                        );
+                                    }}
+                                    placeholder={t('Select currency...')}
+                                    searchPlaceholder={t('Search currency...')}
+                                    emptyText={t('No currencies found.')}
+                                />
+                                {isOtherCurrency && (
+                                    <SearchableSelect
+                                        options={otherCurrencyOptions}
+                                        value={data.currency || null}
+                                        onChange={(value) =>
+                                            setData(
+                                                'currency',
+                                                value === null
+                                                    ? ''
+                                                    : String(value),
+                                            )
+                                        }
+                                        placeholder={t(
+                                            'Select other currency...',
+                                        )}
+                                        searchPlaceholder={t(
+                                            'Search other currencies...',
+                                        )}
+                                        emptyText={t('No currencies found.')}
+                                    />
+                                )}
                                 <InputError message={errors.currency} />
                             </div>
                         </div>
@@ -213,16 +312,24 @@ export default function RecurringExpenseFormSheet({
                                     required
                                     value={data.billing_interval}
                                     onChange={(event) =>
-                                        setData('billing_interval', event.target.value)
+                                        setData(
+                                            'billing_interval',
+                                            event.target.value,
+                                        )
                                     }
                                 />
                                 <Select
                                     value={data.billing_unit}
                                     onValueChange={(value) =>
-                                        setData('billing_unit', value as RecurringExpense['billing_unit'])
+                                        setData(
+                                            'billing_unit',
+                                            value as RecurringExpense['billing_unit'],
+                                        )
                                     }
                                 >
-                                    <SelectTrigger aria-label={t('Billing unit')}>
+                                    <SelectTrigger
+                                        aria-label={t('Billing unit')}
+                                    >
                                         <SelectValue />
                                     </SelectTrigger>
                                     <SelectContent>
@@ -235,59 +342,86 @@ export default function RecurringExpenseFormSheet({
                                 </Select>
                             </div>
                             <InputError
-                                message={errors.billing_interval ?? errors.billing_unit}
+                                message={
+                                    errors.billing_interval ??
+                                    errors.billing_unit
+                                }
                             />
                         </div>
 
                         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                            <div className="grid gap-2">
-                                <Label htmlFor="recurring-expense-start">{t('Start date')}</Label>
+                            <div className="grid min-w-0 gap-2">
+                                <Label htmlFor="recurring-expense-start">
+                                    {t('Start date')}
+                                </Label>
                                 <Input
                                     id="recurring-expense-start"
                                     type="date"
                                     required
                                     value={data.start_date}
-                                    onChange={(event) => setData('start_date', event.target.value)}
+                                    onChange={(event) =>
+                                        setData(
+                                            'start_date',
+                                            event.target.value,
+                                        )
+                                    }
                                 />
                                 <InputError message={errors.start_date} />
                             </div>
-                            <div className="grid gap-2">
-                                <Label htmlFor="recurring-expense-end">{t('End date')}</Label>
+                            <div className="grid min-w-0 gap-2">
+                                <Label htmlFor="recurring-expense-end">
+                                    {t('End date')}
+                                </Label>
                                 <Input
                                     id="recurring-expense-end"
                                     type="date"
                                     value={data.end_date}
-                                    onChange={(event) => setData('end_date', event.target.value)}
+                                    onChange={(event) =>
+                                        setData('end_date', event.target.value)
+                                    }
                                 />
                                 <InputError message={errors.end_date} />
                             </div>
                         </div>
 
                         <div className="grid gap-2">
-                            <Label htmlFor="recurring-expense-vendor">{t('Vendor / Payee')}</Label>
+                            <Label htmlFor="recurring-expense-vendor">
+                                {t('Vendor / Payee')}
+                            </Label>
                             <Input
                                 id="recurring-expense-vendor"
                                 value={data.vendor}
-                                onChange={(event) => setData('vendor', event.target.value)}
+                                onChange={(event) =>
+                                    setData('vendor', event.target.value)
+                                }
                                 placeholder={t('Optional')}
                             />
                             <InputError message={errors.vendor} />
                         </div>
 
                         <div className="grid gap-2">
-                            <Label htmlFor="recurring-expense-description">{t('Description')}</Label>
+                            <Label htmlFor="recurring-expense-description">
+                                {t('Description')}
+                            </Label>
                             <Textarea
                                 id="recurring-expense-description"
                                 value={data.description}
-                                onChange={(event) => setData('description', event.target.value)}
+                                onChange={(event) =>
+                                    setData('description', event.target.value)
+                                }
                                 placeholder={t('Optional')}
                             />
                             <InputError message={errors.description} />
                         </div>
                     </div>
 
-                    <div className="flex items-center justify-end gap-3 border-t pt-4">
-                        <Button type="button" variant="outline" onClick={() => close(false)} disabled={processing}>
+                    <div className="flex flex-wrap items-center justify-end gap-4 border-t pt-4">
+                        <Button
+                            type="button"
+                            variant="outline"
+                            onClick={() => close(false)}
+                            disabled={processing}
+                        >
                             {t('Cancel')}
                         </Button>
                         <Button type="submit" disabled={processing}>

--- a/resources/js/components/features/expenses/recurring-expense-form-sheet.tsx
+++ b/resources/js/components/features/expenses/recurring-expense-form-sheet.tsx
@@ -1,0 +1,301 @@
+import { useForm, usePage } from '@inertiajs/react';
+import { useMemo } from 'react';
+import { InputError, SearchableSelect } from '@/components/shared';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import {
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetHeader,
+    SheetTitle,
+} from '@/components/ui/sheet';
+import { Textarea } from '@/components/ui/textarea';
+import { BILLING_UNITS } from '@/lib/constants';
+import { todayISO } from '@/lib/formatters';
+import { t } from '@/lib/i18n';
+import recurringExpenses from '@/routes/expenses/recurring';
+import type { ExpenseCategory, RecurringExpense } from '@/types';
+
+type RecurringExpenseFormData = {
+    property_id: string;
+    expense_category_id: string;
+    amount: string;
+    currency: string;
+    vendor: string;
+    description: string;
+    billing_interval: string;
+    billing_unit: RecurringExpense['billing_unit'];
+    start_date: string;
+    end_date: string;
+};
+
+export default function RecurringExpenseFormSheet({
+    recurringExpense,
+    properties,
+    categories,
+    currencies,
+    open,
+    onOpenChange,
+}: {
+    recurringExpense?: RecurringExpense | null;
+    properties: { id: number; name: string }[];
+    categories: ExpenseCategory[];
+    currencies: string[];
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}) {
+    const { setting } = usePage<{
+        setting: { currency: string };
+    }>().props;
+    const isEdit = Boolean(recurringExpense);
+    const defaultCurrency = setting.currency.toUpperCase();
+    const currencyOptions = useMemo(
+        () =>
+            Array.from(
+                new Set([...currencies, defaultCurrency].map((currency) => currency.toUpperCase())),
+            ).sort(),
+        [currencies, defaultCurrency],
+    );
+    const propertyOptions = properties.map((property) => ({
+        value: String(property.id),
+        label: property.name,
+    }));
+    const availableCategories = categories.filter(
+        (category) =>
+            category.is_active || category.id === recurringExpense?.expense_category_id,
+    );
+    const { data, setData, submit, reset, processing, errors } =
+        useForm<RecurringExpenseFormData>({
+            property_id: recurringExpense?.property_id
+                ? String(recurringExpense.property_id)
+                : properties[0]
+                  ? String(properties[0].id)
+                  : '',
+            expense_category_id: recurringExpense?.expense_category_id
+                ? String(recurringExpense.expense_category_id)
+                : (categories.find((category) => category.is_active)?.id.toString() ?? ''),
+            amount: recurringExpense?.amount ?? '',
+            currency: recurringExpense?.currency ?? defaultCurrency,
+            vendor: recurringExpense?.vendor ?? '',
+            description: recurringExpense?.description ?? '',
+            billing_interval: String(recurringExpense?.billing_interval ?? 1),
+            billing_unit: recurringExpense?.billing_unit ?? 'month',
+            start_date: recurringExpense?.start_date ?? todayISO(),
+            end_date: recurringExpense?.end_date ?? '',
+        });
+
+    function close(next: boolean): void {
+        onOpenChange(next);
+
+        if (!next) {
+            reset();
+        }
+    }
+
+    function handleSubmit(event: React.FormEvent): void {
+        event.preventDefault();
+
+        submit(
+            isEdit
+                ? recurringExpenses.update(recurringExpense!)
+                : recurringExpenses.store(),
+            { onSuccess: () => close(false) },
+        );
+    }
+
+    return (
+        <Sheet key={recurringExpense?.id ?? 'new'} open={open} onOpenChange={close}>
+            <SheetContent className="sm:max-w-lg">
+                <SheetHeader>
+                    <SheetTitle>
+                        {t(isEdit ? 'Edit recurring expense' : 'New recurring expense')}
+                    </SheetTitle>
+                    <SheetDescription>
+                        {t('Future expenses use the current schedule values; generated expenses never change.')}
+                    </SheetDescription>
+                </SheetHeader>
+
+                <form
+                    onSubmit={handleSubmit}
+                    className="flex flex-1 flex-col justify-between gap-6 overflow-x-hidden overflow-y-auto px-4 pt-4 pb-6"
+                >
+                    <div className="space-y-6">
+                        <div className="grid gap-2">
+                            <Label>{t('Property')}</Label>
+                            <SearchableSelect
+                                options={propertyOptions}
+                                value={data.property_id || null}
+                                onChange={(value) =>
+                                    setData('property_id', value === null ? '' : String(value))
+                                }
+                                placeholder={t('Select property...')}
+                                searchPlaceholder={t('Search property...')}
+                                emptyText={t('No properties found.')}
+                            />
+                            <InputError message={errors.property_id} />
+                        </div>
+
+                        <div className="grid gap-2">
+                            <Label htmlFor="recurring-expense-category">
+                                {t('Category')}
+                            </Label>
+                            <Select
+                                value={data.expense_category_id}
+                                onValueChange={(value) => setData('expense_category_id', value)}
+                            >
+                                <SelectTrigger id="recurring-expense-category">
+                                    <SelectValue placeholder={t('Select category')} />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {availableCategories.map((category) => (
+                                        <SelectItem key={category.id} value={String(category.id)}>
+                                            {category.label}
+                                            {!category.is_active && ` (${t('archived')})`}
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                            <InputError message={errors.expense_category_id} />
+                        </div>
+
+                        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                            <div className="grid gap-2">
+                                <Label htmlFor="recurring-expense-amount">{t('Amount')}</Label>
+                                <Input
+                                    id="recurring-expense-amount"
+                                    type="number"
+                                    min="0"
+                                    step="any"
+                                    inputMode="decimal"
+                                    required
+                                    value={data.amount}
+                                    onChange={(event) => setData('amount', event.target.value)}
+                                />
+                                <InputError message={errors.amount} />
+                            </div>
+                            <div className="grid gap-2">
+                                <Label>{t('Currency')}</Label>
+                                <Select
+                                    value={data.currency}
+                                    onValueChange={(value) => setData('currency', value)}
+                                >
+                                    <SelectTrigger>
+                                        <SelectValue placeholder={t('Select currency')} />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {currencyOptions.map((currency) => (
+                                            <SelectItem key={currency} value={currency}>
+                                                {currency}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                                <InputError message={errors.currency} />
+                            </div>
+                        </div>
+
+                        <div className="grid gap-2">
+                            <Label>{t('Billing period')}</Label>
+                            <div className="grid grid-cols-[5rem_minmax(0,1fr)] gap-2">
+                                <Input
+                                    aria-label={t('Billing interval')}
+                                    type="number"
+                                    min={1}
+                                    required
+                                    value={data.billing_interval}
+                                    onChange={(event) =>
+                                        setData('billing_interval', event.target.value)
+                                    }
+                                />
+                                <Select
+                                    value={data.billing_unit}
+                                    onValueChange={(value) =>
+                                        setData('billing_unit', value as RecurringExpense['billing_unit'])
+                                    }
+                                >
+                                    <SelectTrigger aria-label={t('Billing unit')}>
+                                        <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {BILLING_UNITS.map((unit) => (
+                                            <SelectItem key={unit} value={unit}>
+                                                {t(unit)}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                            </div>
+                            <InputError
+                                message={errors.billing_interval ?? errors.billing_unit}
+                            />
+                        </div>
+
+                        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                            <div className="grid gap-2">
+                                <Label htmlFor="recurring-expense-start">{t('Start date')}</Label>
+                                <Input
+                                    id="recurring-expense-start"
+                                    type="date"
+                                    required
+                                    value={data.start_date}
+                                    onChange={(event) => setData('start_date', event.target.value)}
+                                />
+                                <InputError message={errors.start_date} />
+                            </div>
+                            <div className="grid gap-2">
+                                <Label htmlFor="recurring-expense-end">{t('End date')}</Label>
+                                <Input
+                                    id="recurring-expense-end"
+                                    type="date"
+                                    value={data.end_date}
+                                    onChange={(event) => setData('end_date', event.target.value)}
+                                />
+                                <InputError message={errors.end_date} />
+                            </div>
+                        </div>
+
+                        <div className="grid gap-2">
+                            <Label htmlFor="recurring-expense-vendor">{t('Vendor / Payee')}</Label>
+                            <Input
+                                id="recurring-expense-vendor"
+                                value={data.vendor}
+                                onChange={(event) => setData('vendor', event.target.value)}
+                                placeholder={t('Optional')}
+                            />
+                            <InputError message={errors.vendor} />
+                        </div>
+
+                        <div className="grid gap-2">
+                            <Label htmlFor="recurring-expense-description">{t('Description')}</Label>
+                            <Textarea
+                                id="recurring-expense-description"
+                                value={data.description}
+                                onChange={(event) => setData('description', event.target.value)}
+                                placeholder={t('Optional')}
+                            />
+                            <InputError message={errors.description} />
+                        </div>
+                    </div>
+
+                    <div className="flex items-center justify-end gap-3 border-t pt-4">
+                        <Button type="button" variant="outline" onClick={() => close(false)} disabled={processing}>
+                            {t('Cancel')}
+                        </Button>
+                        <Button type="submit" disabled={processing}>
+                            {t(processing ? 'Saving...' : 'Save')}
+                        </Button>
+                    </div>
+                </form>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/resources/js/pages/expenses/recurring.tsx
+++ b/resources/js/pages/expenses/recurring.tsx
@@ -141,7 +141,7 @@ export default function Recurring({
                         </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end" onClick={(event) => event.stopPropagation()}>
-                        {can.update && item.status !== 'ended' && (
+                        {can.update && (
                             <DropdownMenuItem onClick={() => openEdit(item)}>
                                 <Pencil className="size-4" />
                                 {t('Edit')}
@@ -220,6 +220,7 @@ export default function Recurring({
             </div>
 
             <RecurringExpenseFormSheet
+                key={editing?.id ?? 'new'}
                 recurringExpense={editing}
                 properties={properties}
                 categories={categories}

--- a/resources/js/pages/expenses/recurring.tsx
+++ b/resources/js/pages/expenses/recurring.tsx
@@ -1,0 +1,236 @@
+import { Head, router } from '@inertiajs/react';
+import { EllipsisVertical, Pause, Pencil, Play, Plus } from 'lucide-react';
+import { useState } from 'react';
+import { DataTable } from '@/components/data-table';
+import type { TableColumn } from '@/components/data-table';
+import { FilterBar } from '@/components/data-table/filter-bar';
+import { SearchInput } from '@/components/data-table/search-input';
+import { RecurringExpenseFormSheet } from '@/components/features';
+import { Heading } from '@/components/shared';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { useTable } from '@/hooks/use-table';
+import { formatBillingPeriod, formatDate, formatPrice } from '@/lib/formatters';
+import { t } from '@/lib/i18n';
+import recurringExpenses from '@/routes/expenses/recurring';
+import type { ExpenseCategory, PaginatedData, RecurringExpense, TableMeta } from '@/types';
+
+type PageProps = {
+    recurring_expenses: PaginatedData<RecurringExpense>;
+    properties: { id: number; name: string }[];
+    categories: ExpenseCategory[];
+    currencies: string[];
+    can: { create: boolean; update: boolean };
+    table: TableMeta;
+    sort?: string;
+    search?: string;
+    per_page?: number | string;
+    status?: string;
+};
+
+function statusBadge(status: string) {
+    const labels: Record<string, string> = {
+        active: 'Active',
+        paused: 'Paused',
+        ended: 'Ended',
+    };
+
+    return <Badge variant={status === 'active' ? 'default' : 'secondary'}>{t(labels[status] ?? status)}</Badge>;
+}
+
+export default function Recurring({
+    recurring_expenses: data,
+    properties,
+    categories,
+    currencies,
+    can,
+    table: tableMeta,
+    sort: currentSort = '-start_date',
+    search: currentSearch = '',
+    per_page: currentPerPage = 15,
+    status: currentStatus = '',
+}: PageProps) {
+    const [formOpen, setFormOpen] = useState(false);
+    const [editing, setEditing] = useState<RecurringExpense | null>(null);
+    const table = useTable({
+        routeFn: () => recurringExpenses.index(),
+        params: {
+            sort: currentSort,
+            search: currentSearch,
+            per_page: String(currentPerPage),
+            status: currentStatus,
+        },
+        defaults: { sort: '-start_date', per_page: '15' },
+    });
+
+    function openCreate(): void {
+        setEditing(null);
+        setFormOpen(true);
+    }
+
+    function openEdit(recurringExpense: RecurringExpense): void {
+        setEditing(recurringExpense);
+        setFormOpen(true);
+    }
+
+    function pause(recurringExpense: RecurringExpense): void {
+        router.post(recurringExpenses.pause.url(recurringExpense));
+    }
+
+    function resume(recurringExpense: RecurringExpense): void {
+        router.post(recurringExpenses.resume.url(recurringExpense));
+    }
+
+    const columns: TableColumn<RecurringExpense>[] = [
+        {
+            key: 'property_name',
+            label: t('Property'),
+            sortable: true,
+            render: (item) => item.property?.name ?? '—',
+        },
+        {
+            key: 'category_name',
+            label: t('Category'),
+            sortable: true,
+            render: (item) => item.category?.label ?? '—',
+        },
+        {
+            key: 'amount',
+            label: t('Amount'),
+            sortable: true,
+            className: 'text-right tabular-nums',
+            render: (item) => formatPrice(item.amount, item.currency),
+        },
+        {
+            key: 'billing_unit',
+            label: t('Frequency'),
+            sortable: true,
+            render: (item) => formatBillingPeriod(item.billing_interval, item.billing_unit),
+        },
+        {
+            key: 'start_date',
+            label: t('Start'),
+            sortable: true,
+            render: (item) => formatDate(item.start_date),
+        },
+        {
+            key: 'end_date',
+            label: t('End'),
+            sortable: true,
+            render: (item) => formatDate(item.end_date),
+        },
+        {
+            key: 'status',
+            label: t('Status'),
+            render: (item) => statusBadge(item.status),
+        },
+        {
+            key: '_actions',
+            label: '',
+            render: (item) => (
+                <DropdownMenu>
+                    <DropdownMenuTrigger asChild onClick={(event) => event.stopPropagation()}>
+                        <Button variant="ghost" size="icon" className="size-8">
+                            <EllipsisVertical className="size-4" />
+                        </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" onClick={(event) => event.stopPropagation()}>
+                        {can.update && item.status !== 'ended' && (
+                            <DropdownMenuItem onClick={() => openEdit(item)}>
+                                <Pencil className="size-4" />
+                                {t('Edit')}
+                            </DropdownMenuItem>
+                        )}
+                        {can.update && item.status === 'active' && (
+                            <DropdownMenuItem onClick={() => pause(item)}>
+                                <Pause className="size-4" />
+                                {t('Pause')}
+                            </DropdownMenuItem>
+                        )}
+                        {can.update && item.status === 'paused' && (
+                            <DropdownMenuItem onClick={() => resume(item)}>
+                                <Play className="size-4" />
+                                {t('Resume')}
+                            </DropdownMenuItem>
+                        )}
+                    </DropdownMenuContent>
+                </DropdownMenu>
+            ),
+        },
+    ];
+
+    const activeFilters = table.activeFilters;
+
+    return (
+        <>
+            <Head title={t('Recurring Expenses')} />
+
+            <div className="flex h-full flex-1 flex-col gap-4 overflow-x-auto rounded-xl p-4">
+                <div className="flex flex-wrap items-center justify-between gap-4">
+                    <Heading
+                        title={t('Recurring Expenses')}
+                        description={t('Automatically generate operating expenses on a schedule.')}
+                    />
+                    {can.create && (
+                        <Button onClick={openCreate}>
+                            <Plus className="size-4" />
+                            {t('New recurring expense')}
+                        </Button>
+                    )}
+                </div>
+
+                <FilterBar
+                    filters={tableMeta.filters}
+                    activeFilters={activeFilters}
+                    activeFilterCount={table.activeFilterCount}
+                    onToggleOption={table.toggleFilterOption}
+                    onClearAll={table.clearAllFilters}
+                    searchInput={
+                        <SearchInput
+                            value={table.searchValue}
+                            onChange={table.onSearchChange}
+                            onClear={table.clearSearch}
+                            placeholder={t('Search by property, category, or vendor...')}
+                        />
+                    }
+                />
+
+                <DataTable
+                    columns={columns}
+                    rows={data.data}
+                    currentSort={currentSort}
+                    onSort={table.toggleSort}
+                    paginator={data}
+                    perPage={Number(currentPerPage)}
+                    onPageChange={table.goToPage}
+                    onPerPageChange={table.setPerPage}
+                    noun={t('recurring expenses')}
+                    empty={{
+                        message: t('No recurring expenses yet.'),
+                        createLabel: can.create ? t('Add a recurring expense') : undefined,
+                        onCreate: can.create ? openCreate : undefined,
+                    }}
+                />
+            </div>
+
+            <RecurringExpenseFormSheet
+                recurringExpense={editing}
+                properties={properties}
+                categories={categories}
+                currencies={currencies}
+                open={formOpen}
+                onOpenChange={setFormOpen}
+            />
+        </>
+    );
+}
+
+Recurring.layout = {
+    breadcrumbs: [{ title: 'Recurring Expenses', href: recurringExpenses.index() }],
+};

--- a/resources/js/pages/settings/expense-categories.tsx
+++ b/resources/js/pages/settings/expense-categories.tsx
@@ -207,7 +207,8 @@ export default function ExpenseCategories({
                                 <tbody>
                                     {categories.map((category) => {
                                         const inUse =
-                                            (category.expenses_count ?? 0) > 0;
+                                            (category.expenses_count ?? 0) > 0 ||
+                                            (category.recurring_expenses_count ?? 0) > 0;
 
                                         return (
                                             <tr
@@ -218,8 +219,9 @@ export default function ExpenseCategories({
                                                     {category.label}
                                                 </td>
                                                 <td className="px-4 py-3 text-muted-foreground tabular-nums">
-                                                    {category.expenses_count ??
-                                                        0}
+                                                    {(category.expenses_count ?? 0) +
+                                                        (category.recurring_expenses_count ??
+                                                            0)}
                                                 </td>
                                                 <td className="px-4 py-3">
                                                     <Switch

--- a/resources/js/types/models.ts
+++ b/resources/js/types/models.ts
@@ -63,6 +63,7 @@ export type ExpenseCategory = {
     is_active: boolean;
     sort_order?: number;
     expenses_count?: number;
+    recurring_expenses_count?: number;
 };
 
 export type ExpenseReceipt = {
@@ -77,6 +78,7 @@ export type Expense = {
     id: number;
     property_id: number;
     expense_category_id: number;
+    recurring_expense_id: number | null;
     amount: string;
     currency: string;
     expense_date: string;
@@ -92,8 +94,37 @@ export type Expense = {
     updated_at: string;
     property?: { id: number; name: string } | null;
     category?: ExpenseCategory | null;
+    recurring_expense?: {
+        id: number;
+        vendor: string | null;
+        description: string | null;
+        billing_interval: number;
+        billing_unit: 'day' | 'week' | 'month' | 'year';
+    } | null;
     voided_by_user?: { id: number; name: string } | null;
     receipt?: ExpenseReceipt | null;
+};
+
+export type RecurringExpense = {
+    id: number;
+    property_id: number;
+    expense_category_id: number;
+    amount: string;
+    currency: string;
+    vendor: string | null;
+    description: string | null;
+    billing_interval: number;
+    billing_unit: 'day' | 'week' | 'month' | 'year';
+    start_date: string;
+    end_date: string | null;
+    is_active: boolean;
+    next_due_on: string | null;
+    paused_at: string | null;
+    status: 'active' | 'paused' | 'ended' | string;
+    created_at: string;
+    updated_at: string;
+    property?: { id: number; name: string } | null;
+    category?: ExpenseCategory | null;
 };
 
 export type Property = {

--- a/routes/console.php
+++ b/routes/console.php
@@ -12,6 +12,11 @@ Schedule::command('invoices:generate')
     ->dailyAt('01:00')
     ->withoutOverlapping(60);
 
+Schedule::command('expenses:generate-recurring')
+    ->dailyAt('01:05')
+    ->withoutOverlapping(60)
+    ->onOneServer();
+
 Schedule::command('payments:reconcile')
     ->everyFiveMinutes()
     ->withoutOverlapping(15);

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,6 +17,7 @@ use App\Http\Controllers\PropertyDocumentsController;
 use App\Http\Controllers\PropertyLeasesController;
 use App\Http\Controllers\PropertyMediaController;
 use App\Http\Controllers\PropertyUnitTypeController;
+use App\Http\Controllers\RecurringExpenseController;
 use App\Http\Controllers\RoleController;
 use App\Http\Controllers\SignedPaymentController;
 use App\Http\Controllers\TenantController;
@@ -324,6 +325,17 @@ Route::middleware(['auth', 'verified', 'permission:dashboard.view'])->group(func
             ->defaults('dataset', 'expenses')
             ->name('transfer.export')
             ->middleware('permission:expenses.export');
+
+        Route::prefix('recurring')->name('recurring.')->group(function () {
+            Route::get('/', [RecurringExpenseController::class, 'index'])->name('index')->middleware('permission:expenses.view');
+            Route::post('/', [RecurringExpenseController::class, 'store'])->name('store')->middleware('permission:expenses.create');
+
+            Route::prefix('{recurringExpense}')->whereNumber('recurringExpense')->group(function () {
+                Route::put('/', [RecurringExpenseController::class, 'update'])->name('update')->middleware('permission:expenses.update');
+                Route::post('pause', [RecurringExpenseController::class, 'pause'])->name('pause')->middleware('permission:expenses.update');
+                Route::post('resume', [RecurringExpenseController::class, 'resume'])->name('resume')->middleware('permission:expenses.update');
+            });
+        });
 
         Route::prefix('{expense}')->whereNumber('expense')->group(function () {
             Route::put('/', [ExpenseController::class, 'update'])->name('update')->middleware('permission:expenses.update');

--- a/tests/Feature/RecurringExpenseTest.php
+++ b/tests/Feature/RecurringExpenseTest.php
@@ -67,6 +67,20 @@ it('catches up active schedules after scheduler downtime', function (): void {
         ->and($recurringExpense->refresh()->next_due_on->toDateString())->toBe('2026-10-01');
 });
 
+it('does not generate occurrences while paused', function (): void {
+    $this->travelTo('2026-09-20');
+    $recurringExpense = makeRecurringExpense([
+        'start_date' => '2026-09-01',
+        'next_due_on' => '2026-09-01',
+        'is_active' => false,
+        'paused_at' => now(),
+    ]);
+
+    expect(app(GenerateRecurringExpenses::class)->execute())->toBe(0)
+        ->and($recurringExpense->expenses()->count())->toBe(0)
+        ->and($recurringExpense->refresh()->next_due_on->toDateString())->toBe('2026-09-01');
+});
+
 it('limits a large catch-up batch while continuing to advance the cursor', function (): void {
     $this->travelTo('2029-01-01');
     $recurringExpense = makeRecurringExpense([

--- a/tests/Feature/RecurringExpenseTest.php
+++ b/tests/Feature/RecurringExpenseTest.php
@@ -1,0 +1,258 @@
+<?php
+
+use App\Actions\Expenses\GenerateRecurringExpenses;
+use App\Enums\ExpenseStatus;
+use App\Models\Expense;
+use App\Models\ExpenseCategory;
+use App\Models\Property;
+use App\Models\RecurringExpense;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Database\Seeders\RoleAndPermissionSeeder;
+
+uses()->beforeEach(function (): void {
+    $this->seed(RoleAndPermissionSeeder::class);
+});
+
+function makeRecurringExpense(array $overrides = []): RecurringExpense
+{
+    $startDate = $overrides['start_date'] ?? '2026-01-01';
+
+    return RecurringExpense::factory()->create(array_merge([
+        'start_date' => $startDate,
+        'next_due_on' => $startDate,
+    ], $overrides));
+}
+
+it('anchors monthly recurrence to the original day and clamps January 31 in February', function (): void {
+    $recurringExpense = makeRecurringExpense([
+        'start_date' => '2024-01-31',
+        'next_due_on' => '2024-01-31',
+        'billing_unit' => 'month',
+    ]);
+
+    expect($recurringExpense->nextOccurrenceAfter('2024-01-31')->toDateString())
+        ->toBe('2024-02-29')
+        ->and($recurringExpense->nextOccurrenceAfter('2024-02-29')->toDateString())
+        ->toBe('2024-03-31')
+        ->and($recurringExpense->nextOccurrenceAfter('2025-02-28')->toDateString())
+        ->toBe('2025-03-31');
+});
+
+it('recovers February 29 on the next leap year for yearly recurrence', function (): void {
+    $recurringExpense = makeRecurringExpense([
+        'start_date' => '2024-02-29',
+        'next_due_on' => '2024-02-29',
+        'billing_unit' => 'year',
+    ]);
+
+    expect($recurringExpense->nextOccurrenceAfter('2024-02-29')->toDateString())
+        ->toBe('2025-02-28')
+        ->and($recurringExpense->nextOccurrenceAfter('2027-02-28')->toDateString())
+        ->toBe('2028-02-29');
+});
+
+it('catches up active schedules after scheduler downtime', function (): void {
+    $this->travelTo('2026-09-20');
+    $recurringExpense = makeRecurringExpense([
+        'start_date' => '2026-06-01',
+        'next_due_on' => '2026-06-01',
+        'billing_unit' => 'month',
+    ]);
+
+    $count = app(GenerateRecurringExpenses::class)->execute();
+
+    expect($count)->toBe(4)
+        ->and($recurringExpense->expenses()->count())->toBe(4)
+        ->and($recurringExpense->refresh()->next_due_on->toDateString())->toBe('2026-10-01');
+});
+
+it('limits a large catch-up batch while continuing to advance the cursor', function (): void {
+    $this->travelTo('2029-01-01');
+    $recurringExpense = makeRecurringExpense([
+        'start_date' => '2026-01-01',
+        'next_due_on' => '2026-01-01',
+        'billing_unit' => 'day',
+    ]);
+
+    expect(app(GenerateRecurringExpenses::class)->execute())->toBe(1000)
+        ->and($recurringExpense->expenses()->count())->toBe(1000)
+        ->and($recurringExpense->refresh()->next_due_on->toDateString())
+        ->toBe(CarbonImmutable::parse('2026-01-01')->addDays(1000)->toDateString());
+});
+
+it('skips paused occurrences and resumes strictly from the next future occurrence', function (): void {
+    $owner = User::factory()->owner()->create();
+    $this->travelTo('2026-06-10');
+    $recurringExpense = makeRecurringExpense([
+        'start_date' => '2026-06-01',
+        'next_due_on' => '2026-06-01',
+        'billing_unit' => 'month',
+    ]);
+
+    $this->actingAs($owner)
+        ->post(route('expenses.recurring.pause', $recurringExpense))
+        ->assertRedirect();
+
+    $this->travelTo('2026-08-20');
+
+    $this->actingAs($owner)
+        ->post(route('expenses.recurring.resume', $recurringExpense->fresh()))
+        ->assertRedirect();
+
+    expect($recurringExpense->refresh()->next_due_on->toDateString())->toBe('2026-09-01')
+        ->and($recurringExpense->expenses()->count())->toBe(0);
+
+    app(GenerateRecurringExpenses::class)->execute();
+
+    expect($recurringExpense->expenses()->count())->toBe(0);
+
+    $this->travelTo('2026-09-02');
+    app(GenerateRecurringExpenses::class)->execute();
+
+    expect($recurringExpense->expenses()->whereDate('expense_date', '2026-09-01')->exists())->toBeTrue();
+});
+
+it('does not backfill historical occurrences after a cadence or start-date edit', function (): void {
+    $owner = User::factory()->owner()->create();
+    $newProperty = Property::factory()->create();
+    $newCategory = ExpenseCategory::factory()->create();
+    $this->travelTo('2026-01-02');
+    $recurringExpense = makeRecurringExpense([
+        'start_date' => '2026-01-01',
+        'next_due_on' => '2026-01-01',
+        'amount' => '500000.00',
+    ]);
+
+    app(GenerateRecurringExpenses::class)->execute();
+    $generated = $recurringExpense->expenses()->firstOrFail();
+
+    $this->travelTo('2026-02-02');
+    $this->actingAs($owner)
+        ->put(route('expenses.recurring.update', $recurringExpense), [
+            'property_id' => $newProperty->id,
+            'expense_category_id' => $newCategory->id,
+            'amount' => '750000.00',
+            'currency' => 'USD',
+            'vendor' => 'New vendor',
+            'description' => 'Updated description',
+            'billing_interval' => 1,
+            'billing_unit' => 'month',
+            'start_date' => '2026-02-15',
+            'end_date' => null,
+        ])
+        ->assertRedirect();
+
+    expect($generated->refresh()->amount)->toBe('500000.000')
+        ->and($generated->property_id)->toBe($recurringExpense->getRawOriginal('property_id'))
+        ->and($generated->expense_category_id)->toBe($recurringExpense->getRawOriginal('expense_category_id'))
+        ->and($generated->currency)->toBe('IDR')
+        ->and($generated->vendor)->not->toBe('New vendor')
+        ->and($generated->description)->not->toBe('Updated description')
+        ->and($recurringExpense->refresh()->next_due_on->toDateString())->toBe('2026-02-15');
+
+    $this->travelTo('2026-02-20');
+    app(GenerateRecurringExpenses::class)->execute();
+
+    $futureExpense = $recurringExpense->expenses()->whereDate('expense_date', '2026-02-15')->firstOrFail();
+
+    expect($futureExpense->amount)->toBe('750000.000')
+        ->and($futureExpense->property_id)->toBe($newProperty->id)
+        ->and($futureExpense->expense_category_id)->toBe($newCategory->id)
+        ->and($futureExpense->currency)->toBe('USD')
+        ->and($futureExpense->vendor)->toBe('New vendor')
+        ->and($futureExpense->description)->toBe('Updated description');
+});
+
+it('generates an occurrence on the inclusive end date and then ends', function (): void {
+    $this->travelTo('2026-03-15');
+    $recurringExpense = makeRecurringExpense([
+        'start_date' => '2026-03-01',
+        'end_date' => '2026-03-01',
+        'next_due_on' => '2026-03-01',
+    ]);
+
+    expect(app(GenerateRecurringExpenses::class)->execute())->toBe(1)
+        ->and($recurringExpense->expenses()->whereDate('expense_date', '2026-03-01')->exists())->toBeTrue()
+        ->and($recurringExpense->refresh()->next_due_on)->toBeNull();
+});
+
+it('clears the cursor when an edited end date leaves no future occurrence', function (): void {
+    $owner = User::factory()->owner()->create();
+    $this->travelTo('2026-09-20');
+    $recurringExpense = makeRecurringExpense([
+        'start_date' => '2026-01-01',
+        'next_due_on' => '2026-10-01',
+        'end_date' => null,
+    ]);
+
+    $this->actingAs($owner)
+        ->put(route('expenses.recurring.update', $recurringExpense), [
+            'property_id' => $recurringExpense->property_id,
+            'expense_category_id' => $recurringExpense->expense_category_id,
+            'amount' => $recurringExpense->amount,
+            'currency' => $recurringExpense->currency,
+            'vendor' => $recurringExpense->vendor,
+            'description' => $recurringExpense->description,
+            'billing_interval' => $recurringExpense->billing_interval,
+            'billing_unit' => $recurringExpense->billing_unit->value,
+            'start_date' => $recurringExpense->start_date->toDateString(),
+            'end_date' => '2026-09-10',
+        ])
+        ->assertRedirect();
+
+    expect($recurringExpense->refresh()->next_due_on)->toBeNull();
+});
+
+it('rejects resuming a schedule with no future occurrence', function (): void {
+    $owner = User::factory()->owner()->create();
+    $this->travelTo('2026-09-20');
+    $recurringExpense = makeRecurringExpense([
+        'start_date' => '2026-01-01',
+        'end_date' => '2026-09-10',
+    ]);
+    $recurringExpense->update([
+        'is_active' => false,
+        'paused_at' => now(),
+        'next_due_on' => null,
+    ]);
+
+    $this->actingAs($owner)
+        ->post(route('expenses.recurring.resume', $recurringExpense))
+        ->assertSessionHasErrors('recurring_expense');
+
+    expect($recurringExpense->refresh()->is_active)->toBeFalse();
+});
+
+it('keeps a voided generated expense from being regenerated', function (): void {
+    $this->travelTo('2026-09-02');
+    $recurringExpense = makeRecurringExpense([
+        'start_date' => '2026-09-01',
+        'next_due_on' => '2026-09-01',
+    ]);
+    $expense = Expense::factory()->voided()->create([
+        'recurring_expense_id' => $recurringExpense->id,
+        'property_id' => $recurringExpense->property_id,
+        'expense_category_id' => $recurringExpense->expense_category_id,
+        'expense_date' => '2026-09-01',
+    ]);
+
+    expect(app(GenerateRecurringExpenses::class)->execute())->toBe(0)
+        ->and($recurringExpense->expenses()->count())->toBe(1)
+        ->and($expense->refresh()->status)->toBe(ExpenseStatus::Voided);
+});
+
+it('shows recurring expense definitions only for accessible properties', function (): void {
+    $admin = User::factory()->admin()->create();
+    $assigned = Property::factory()->create();
+    $unassigned = Property::factory()->create();
+    $assigned->users()->attach($admin);
+    $category = ExpenseCategory::factory()->create();
+    makeRecurringExpense(['property_id' => $assigned->id, 'expense_category_id' => $category->id]);
+    makeRecurringExpense(['property_id' => $unassigned->id, 'expense_category_id' => $category->id]);
+
+    $this->actingAs($admin)
+        ->get(route('expenses.recurring.index'))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page->has('recurring_expenses.data', 1));
+});

--- a/tests/Feature/Settings/ExpenseCategoryTest.php
+++ b/tests/Feature/Settings/ExpenseCategoryTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\Expense;
 use App\Models\ExpenseCategory;
+use App\Models\RecurringExpense;
 use App\Models\User;
 use Database\Seeders\RoleAndPermissionSeeder;
 
@@ -67,6 +68,18 @@ it('archives a category referenced by an expense', function (): void {
 
     expect($category->refresh()->is_active)->toBeFalse()
         ->and($expense->refresh()->expense_category_id)->toBe($category->id);
+});
+
+it('archives a category referenced by a recurring expense', function (): void {
+    $owner = User::factory()->owner()->create();
+    $category = ExpenseCategory::factory()->create();
+    RecurringExpense::factory()->create(['expense_category_id' => $category->id]);
+
+    $this->actingAs($owner)
+        ->delete(route('settings.expense-categories.destroy', $category))
+        ->assertRedirect();
+
+    expect($category->refresh()->is_active)->toBeFalse();
 });
 
 it('deletes an unused category', function (): void {


### PR DESCRIPTION
## Summary

- Add date-based recurring expense schedules with daily generation.
- Skip occurrences while paused and resume from the next strictly future occurrence.
- Catch up active schedules after scheduler downtime without backfilling after edits.
- Preserve immutable expense snapshots and recurring/date idempotency.
- Add explicit lifecycle UI plus January 31 and February 29 coverage.

## Verification

- `php artisan test --compact tests/Feature/RecurringExpenseTest.php tests/Feature/ExpenseTest.php tests/Feature/Settings/ExpenseCategoryTest.php`
- `vendor/bin/pint --dirty --format agent`
- `php artisan route:list --path=expenses --except-vendor`
- `php artisan schedule:list`
- `npm run types:check`
- `npm run lint:check`
- `npm run build`

The full suite had 1,197 passing tests out of 1,209; remaining failures/errors are unrelated existing plugin, branding, payment-upload, and runtime-plugin issues, including missing GD.