### PR TITLE
feat: make platform package the plugin compatibility contract

### DIFF
--- a/app/Services/Marketplace/MarketplaceClient.php
+++ b/app/Services/Marketplace/MarketplaceClient.php
@@ -55,7 +55,6 @@ final class MarketplaceClient
     /** @return array<string, mixed>|null */
     public function resolveVersion(
         string $pluginId,
-        string $coreVersion,
         string $platformVersion,
         string $phpVersion,
     ): ?array {
@@ -63,7 +62,6 @@ final class MarketplaceClient
             $data = $this->getJson(
                 'plugins/'.rawurlencode($this->pluginId($pluginId)).'/versions/resolve',
                 [
-                    'core_version' => $coreVersion,
                     'platform_version' => $platformVersion,
                     'php_version' => $phpVersion,
                 ],
@@ -350,12 +348,6 @@ final class MarketplaceClient
             throw new MarketplaceException('Marketplace returned malformed plugin version metadata.');
         }
 
-        $coreCompatibility = $data['compatibility']['core'] ?? $data['compatibility']['openkos'] ?? null;
-
-        if (! is_string($coreCompatibility) || trim($coreCompatibility) === '') {
-            throw new MarketplaceException('Marketplace returned malformed compatibility metadata.');
-        }
-
         foreach (['platform', 'php'] as $key) {
             if (! is_string($data['compatibility'][$key] ?? null) || trim($data['compatibility'][$key]) === '') {
                 throw new MarketplaceException('Marketplace returned malformed compatibility metadata.');
@@ -366,7 +358,6 @@ final class MarketplaceClient
             'version' => $data['version'],
             'entry_class' => $data['entry_class'],
             'compatibility' => [
-                'core' => $coreCompatibility,
                 'platform' => $data['compatibility']['platform'],
                 'php' => $data['compatibility']['php'],
             ],
@@ -410,23 +401,27 @@ final class MarketplaceClient
     /** @param array<string, mixed> $manifest @param array<string, mixed> $compatibility @return array<string, mixed> */
     private function validateManifest(array $manifest, string $pluginId, string $version, string $entryClass, array $compatibility): array
     {
-        foreach (['id', 'name', 'version', 'description', 'entry_class', 'core_version', 'php', 'dependencies'] as $key) {
+        foreach (['id', 'name', 'version', 'description', 'entry_class', 'php', 'dependencies'] as $key) {
             if (! array_key_exists($key, $manifest)) {
                 throw new MarketplaceException('Marketplace returned an incomplete plugin manifest.');
             }
         }
 
-        foreach (['id', 'name', 'version', 'description', 'entry_class', 'core_version', 'php'] as $key) {
+        foreach (['id', 'name', 'version', 'description', 'entry_class', 'php'] as $key) {
             if (! is_string($manifest[$key]) || ($key !== 'description' && trim($manifest[$key]) === '')) {
                 throw new MarketplaceException('Marketplace returned an invalid plugin manifest.');
             }
+        }
+
+        if (array_key_exists('core_version', $manifest)
+            && (! is_string($manifest['core_version']) || trim($manifest['core_version']) === '')) {
+            throw new MarketplaceException('Marketplace returned an invalid legacy plugin manifest.');
         }
 
         if (
             $manifest['id'] !== $pluginId
             || $manifest['version'] !== $version
             || $manifest['entry_class'] !== $entryClass
-            || $manifest['core_version'] !== $compatibility['core']
             || $manifest['php'] !== $compatibility['php']
         ) {
             throw new MarketplaceException('Marketplace version metadata does not match its manifest.');
@@ -438,7 +433,9 @@ final class MarketplaceClient
             'version' => $manifest['version'],
             'description' => $manifest['description'],
             'entry_class' => $manifest['entry_class'],
-            'core_version' => $manifest['core_version'],
+            ...(is_string($manifest['core_version'] ?? null)
+                ? ['core_version' => $manifest['core_version']]
+                : []),
             'php' => $manifest['php'],
             'dependencies' => $this->validateDependencies($manifest['dependencies']),
         ];

--- a/app/Services/Platform/PluginInstaller.php
+++ b/app/Services/Platform/PluginInstaller.php
@@ -26,7 +26,7 @@ final class PluginInstaller
      *     version: string,
      *     description: string,
      *     entry_class: class-string<Plugin>,
-     *     core_version: string,
+     *     platform_constraint: string|null,
      *     php: string,
      *     dependencies: array<int, string>
      * }
@@ -144,7 +144,7 @@ final class PluginInstaller
      *     version: string,
      *     description: string,
      *     entry_class: class-string<Plugin>,
-     *     core_version: string,
+     *     platform_constraint: string|null,
      *     php: string,
      *     dependencies: array<int, string>
      * }
@@ -396,7 +396,6 @@ final class PluginInstaller
             'version' => $metadata['version'] ?? null,
             'description' => $metadata['description'] ?? null,
             'entry_class' => $metadata['entry_class'] ?? null,
-            'core_version' => $metadata['core_version'] ?? null,
             'php' => $metadata['php'] ?? null,
             'dependencies' => $metadata['dependencies'] ?? null,
             'platform_constraint' => $metadata['platform_constraint'] ?? null,
@@ -407,7 +406,6 @@ final class PluginInstaller
             'version' => $manifest['version'] ?? null,
             'description' => $manifest['description'] ?? null,
             'entry_class' => $manifest['entry_class'] ?? null,
-            'core_version' => $manifest['core_version'] ?? null,
             'php' => $manifest['php'] ?? null,
             'dependencies' => $manifest['dependencies'] ?? null,
             'platform_constraint' => $expected['platform_constraint'] ?? null,
@@ -416,7 +414,6 @@ final class PluginInstaller
         if (
             $actual !== $expectedManifest
             || ($expected['entry_class'] ?? null) !== $actual['entry_class']
-            || ($expected['core_version'] ?? null) !== $actual['core_version']
             || ($expected['php'] ?? null) !== $actual['php']
             || ($expected['dependencies'] ?? null) !== $actual['dependencies']
         ) {

--- a/app/Services/Platform/PluginManagementService.php
+++ b/app/Services/Platform/PluginManagementService.php
@@ -55,7 +55,7 @@ class PluginManagementService
      *     version: string,
      *     description: string,
      *     entry_class: class-string<Plugin>,
-     *     core_version: string,
+     *     platform_constraint: string|null,
      *     php: string,
      *     dependencies: array<int, string>
      * }
@@ -314,7 +314,7 @@ class PluginManagementService
         return __('The plugin artifact was rejected. Check that it is a valid prepared runtime plugin ZIP.');
     }
 
-    /** @return array{0: string, 1: string, 2: string}|null */
+    /** @return array{0: string, 1: string}|null */
     private function marketplaceHostVersions(): ?array
     {
         $versions = [config('platform.version'), PHP_VERSION];
@@ -329,7 +329,7 @@ class PluginManagementService
             }
         }
 
-        return [$versions[0], $versions[0], $versions[1]];
+        return [$versions[0], $versions[1]];
     }
 
     /** @param array<string, mixed> $record @param array<string, mixed>|null $compatible @param array<string, mixed>|null $local @return array<string, mixed> */
@@ -379,7 +379,6 @@ class PluginManagementService
             || ! is_string($versionMetadata['entry_class'] ?? null)
             || ! is_array($versionMetadata['dependencies'] ?? null)
             || ! is_array($versionMetadata['manifest'] ?? null)
-            || ! is_string($compatibility['core'] ?? null)
             || ! is_string($compatibility['platform'] ?? null)
             || ! is_string($compatibility['php'] ?? null)
         ) {
@@ -408,7 +407,6 @@ class PluginManagementService
                 expectedCurrentState: $expectedCurrentState,
                 expectedMetadata: [
                     'entry_class' => $versionMetadata['entry_class'],
-                    'core_version' => $compatibility['core'],
                     'platform_constraint' => $compatibility['platform'],
                     'php' => $compatibility['php'],
                     'dependencies' => $versionMetadata['dependencies'],
@@ -649,7 +647,7 @@ class PluginManagementService
                 'version' => null,
                 'description' => '',
                 'entry_class' => null,
-                'core_version' => null,
+                'platform_constraint' => null,
                 'php' => null,
                 'dependencies' => [],
                 ...$this->runtimeProvenance($entry),
@@ -859,7 +857,7 @@ class PluginManagementService
                     'version' => $manifest->version,
                     'description' => $manifest->description,
                     'entry_class' => $class,
-                    'core_version' => $manifest->coreVersion,
+                    'platform_constraint' => null,
                     'php' => null,
                     'dependencies' => $manifest->dependencies,
                     'provenance' => null,
@@ -959,7 +957,7 @@ class PluginManagementService
                 ? __('Runtime recovery metadata exists, but its package identity cannot be trusted.')
                 : __('No runtime package is installed, but lifecycle metadata still requires recovery.'),
             'entry_class' => null,
-            'core_version' => null,
+            'platform_constraint' => null,
             'php' => null,
             'dependencies' => [],
             'provenance' => null,
@@ -991,7 +989,7 @@ class PluginManagementService
             'version' => null,
             'description' => __('Recovery metadata exists for a package that is not installed.'),
             'entry_class' => null,
-            'core_version' => null,
+            'platform_constraint' => null,
             'php' => null,
             'dependencies' => [],
             'provenance' => null,
@@ -1032,7 +1030,7 @@ class PluginManagementService
                 ? __('A managed runtime path is a symlink and was not followed.')
                 : __('A managed runtime path has an unexpected filesystem type.'),
             'entry_class' => null,
-            'core_version' => null,
+            'platform_constraint' => null,
             'php' => null,
             'dependencies' => [],
             'provenance' => null,
@@ -1093,7 +1091,7 @@ class PluginManagementService
             'version' => null,
             'description' => '',
             'entry_class' => null,
-            'core_version' => null,
+            'platform_constraint' => null,
             'php' => null,
             'dependencies' => [],
         ];
@@ -1124,7 +1122,7 @@ class PluginManagementService
             return $preview;
         }
 
-        foreach (['id', 'name', 'version', 'description', 'entry_class', 'core_version', 'php'] as $key) {
+        foreach (['id', 'name', 'version', 'description', 'entry_class', 'php'] as $key) {
             if (is_string($manifest[$key] ?? null) && $manifest[$key] !== '') {
                 if ($key === 'id') {
                     $preview['declared_id'] = $manifest[$key];
@@ -1136,6 +1134,19 @@ class PluginManagementService
 
         if (is_array($manifest['dependencies'] ?? null)) {
             $preview['dependencies'] = array_values(array_filter($manifest['dependencies'], 'is_string'));
+        }
+
+        $composerPath = $path.'/composer.json';
+        if (is_file($composerPath) && ! is_link($composerPath)) {
+            try {
+                $composer = json_decode(file_get_contents($composerPath) ?: '', true, 512, JSON_THROW_ON_ERROR);
+                $constraint = is_array($composer) ? data_get($composer, 'require.openkos/platform') : null;
+                if (is_string($constraint) && $constraint !== '') {
+                    $preview['platform_constraint'] = $constraint;
+                }
+            } catch (Throwable) {
+                // The runtime validator reports malformed Composer metadata.
+            }
         }
 
         return $preview;

--- a/app/Services/Platform/RuntimePluginArtifactValidator.php
+++ b/app/Services/Platform/RuntimePluginArtifactValidator.php
@@ -18,9 +18,10 @@ final class RuntimePluginArtifactValidator
      *     version: string,
      *     description: string,
      *     entry_class: class-string<Plugin>,
-     *     core_version: string,
+     *     core_version?: string,
      *     php: string,
-     *     dependencies: array<int, string>
+     *     dependencies: array<int, string>,
+     *     platform_constraint: string
      * }
      */
     public function validate(string $directory, ?string $expectedId = null): array
@@ -35,7 +36,10 @@ final class RuntimePluginArtifactValidator
         $composer = $this->readJsonFile($directory.'/composer.json', 'composer.json');
         $lock = $this->readJsonFile($directory.'/composer.lock', 'composer.lock');
 
-        $metadata = $this->validateManifest($manifest);
+        $metadata = [
+            ...$this->validateManifest($manifest),
+            'platform_constraint' => $this->platformConstraint($composer),
+        ];
 
         if ($expectedId !== null && $metadata['id'] !== $expectedId) {
             throw new InvalidArgumentException(
@@ -99,7 +103,7 @@ final class RuntimePluginArtifactValidator
             $pluginManifest->name !== $metadata['name'] ||
             $pluginManifest->version !== $metadata['version'] ||
             $pluginManifest->description !== $metadata['description'] ||
-            $pluginManifest->coreVersion !== $metadata['core_version'] ||
+            (isset($metadata['core_version']) && $pluginManifest->coreVersion !== $metadata['core_version']) ||
             $pluginManifest->dependencies !== $metadata['dependencies']
         ) {
             throw new InvalidArgumentException(
@@ -119,10 +123,10 @@ final class RuntimePluginArtifactValidator
      *     version: string,
      *     description: string,
      *     entry_class: class-string<Plugin>,
-     *     core_version: string,
+     *     core_version?: string,
      *     php: string,
      *     dependencies: array<int, string>,
-     *     platform_constraint: string|null
+     *     platform_constraint: string
      * }
      */
     public function inspectStaticMetadata(string $directory, ?string $expectedId = null): array
@@ -160,11 +164,9 @@ final class RuntimePluginArtifactValidator
             throw new InvalidArgumentException('Runtime plugin artifact must include vendor/autoload.php.');
         }
 
-        $platformConstraint = data_get($composer, 'require.openkos/platform');
-
         return [
             ...$metadata,
-            'platform_constraint' => is_string($platformConstraint) ? $platformConstraint : null,
+            'platform_constraint' => $this->platformConstraint($composer),
         ];
     }
 
@@ -175,9 +177,10 @@ final class RuntimePluginArtifactValidator
      *     version: string,
      *     description: string,
      *     entry_class: class-string<Plugin>,
-     *     core_version: string,
+     *     core_version?: string,
      *     php: string,
-     *     dependencies: array<int, string>
+     *     dependencies: array<int, string>,
+     *     platform_constraint: string
      * }
      */
     public function validateInFreshProcess(string $directory, ?string $expectedId = null): array
@@ -221,12 +224,25 @@ final class RuntimePluginArtifactValidator
          *     version: string,
          *     description: string,
          *     entry_class: class-string<Plugin>,
-         *     core_version: string,
+         *     core_version?: string,
          *     php: string,
-         *     dependencies: array<int, string>
+         *     dependencies: array<int, string>,
+         *     platform_constraint: string
          * } $metadata
          */
         return $metadata;
+    }
+
+    /** @param array<string, mixed> $composer */
+    private function platformConstraint(array $composer): string
+    {
+        $constraint = data_get($composer, 'require.openkos/platform');
+
+        if (! is_string($constraint) || trim($constraint) === '') {
+            throw new InvalidArgumentException('Runtime plugin Composer requirements must declare openkos/platform.');
+        }
+
+        return $constraint;
     }
 
     /**
@@ -237,14 +253,14 @@ final class RuntimePluginArtifactValidator
      *     version: string,
      *     description: string,
      *     entry_class: class-string<Plugin>,
-     *     core_version: string,
+     *     core_version?: string,
      *     php: string,
      *     dependencies: array<int, string>
      * }
      */
     private function validateManifest(array $manifest): array
     {
-        $required = ['id', 'name', 'version', 'entry_class', 'core_version', 'php', 'dependencies'];
+        $required = ['id', 'name', 'version', 'entry_class', 'php', 'dependencies'];
 
         foreach ($required as $key) {
             if (! array_key_exists($key, $manifest)) {
@@ -252,10 +268,15 @@ final class RuntimePluginArtifactValidator
             }
         }
 
-        foreach (['id', 'name', 'version', 'entry_class', 'core_version', 'php'] as $key) {
+        foreach (['id', 'name', 'version', 'entry_class', 'php'] as $key) {
             if (! is_string($manifest[$key]) || trim($manifest[$key]) === '') {
                 throw new InvalidArgumentException("Runtime plugin manifest field [{$key}] must be a non-empty string.");
             }
+        }
+
+        $coreVersion = $manifest['core_version'] ?? null;
+        if ($coreVersion !== null && (! is_string($coreVersion) || trim($coreVersion) === '')) {
+            throw new InvalidArgumentException('Runtime plugin legacy compatibility metadata is invalid.');
         }
 
         if (preg_match('/^(?:[A-Za-z_][A-Za-z0-9_]*\\\\)*[A-Za-z_][A-Za-z0-9_]*$/', $manifest['entry_class']) !== 1) {
@@ -282,7 +303,7 @@ final class RuntimePluginArtifactValidator
          *     version: string,
          *     description?: string,
          *     entry_class: class-string<Plugin>,
-         *     core_version: string,
+         *     core_version?: string,
          *     php: string,
          *     dependencies: array<int, string>
          * } $manifest
@@ -293,7 +314,7 @@ final class RuntimePluginArtifactValidator
             'version' => $manifest['version'],
             'description' => is_string($manifest['description'] ?? '') ? $manifest['description'] : '',
             'entry_class' => $manifest['entry_class'],
-            'core_version' => $manifest['core_version'],
+            ...($coreVersion !== null ? ['core_version' => $coreVersion] : []),
             'php' => $manifest['php'],
             'dependencies' => array_values($manifest['dependencies']),
         ];

--- a/app/Services/Platform/RuntimePluginGraphValidator.php
+++ b/app/Services/Platform/RuntimePluginGraphValidator.php
@@ -3,7 +3,6 @@
 namespace App\Services\Platform;
 
 use OpenKOS\Platform\Plugin\Plugin;
-use OpenKOS\Platform\Plugin\PluginLoader;
 use Throwable;
 
 final class RuntimePluginGraphValidator
@@ -67,26 +66,6 @@ final class RuntimePluginGraphValidator
                 continue;
             }
 
-            try {
-                if (! (new PluginLoader)->satisfies(
-                    (string) config('platform.version', '0.2.0'),
-                    (string) ($metadata['core_version'] ?? '*'),
-                )) {
-                    $this->addIssue(
-                        $issues,
-                        $id,
-                        'incompatible',
-                        "Runtime plugin [{$id}] is incompatible with the current OpenKOS version.",
-                    );
-                }
-            } catch (Throwable) {
-                $this->addIssue(
-                    $issues,
-                    $id,
-                    'incompatible',
-                    "Runtime plugin [{$id}] declares an invalid OpenKOS version constraint.",
-                );
-            }
         }
 
         foreach ($entryClasses as $entryClass => $ids) {

--- a/config/platform.php
+++ b/config/platform.php
@@ -14,8 +14,8 @@ return [
     | Platform version
     |--------------------------------------------------------------------------
     |
-    | Plugins declare a `coreVersion` constraint in their manifest; it is
-    | checked against this value at boot (see PluginLoader).
+    | Plugin compatibility is declared by the Composer requirement for
+    | openkos/platform and validated when the plugin is installed.
     |
     */
 

--- a/docs/architecture/adr/005-plugin-philosophy.md
+++ b/docs/architecture/adr/005-plugin-philosophy.md
@@ -15,10 +15,10 @@ OpenKOS must be extensible (navigation, dashboards, workspace tabs, settings pag
 
 We will treat plugins as **trusted, in-process extensions registering into typed platform registries** — the trust boundary is installation, not a runtime sandbox.
 
-- A plugin extends `OpenKOS\Platform\Plugin\Plugin`, declares a `PluginManifest` (id, version, `coreVersion` constraint, dependencies), and registers into container-singleton registries via the `OpenKOSManager`. In-repo plugins are listed explicitly in `config/platform.php`; trusted Composer plugins may be discovered by the host.
+- A plugin extends `OpenKOS\Platform\Plugin\Plugin`, declares a `PluginManifest` (id, version, dependencies), and declares `openkos/platform` and PHP requirements in Composer. Plugins register into container-singleton registries via the `OpenKOSManager`. In-repo plugins are listed explicitly in `config/platform.php`; trusted Composer plugins may be discovered by the host.
 - Extension is **additive only**: plugins own their tables via their own migrations, declare their own permissions, and must not alter core schema or behavior.
 - Plugins react to core through **platform-level domain events** (`OpenKOS\Core\Events`, see [docs/domain-events.md](../../domain-events.md)) — the stable plugin API — never by patching core code. Application events remain a compatibility surface for host-only subscribers.
-- The loader fail-fasts on incompatible core versions, missing dependencies, and cycles; a broken plugin never half-boots.
+- Composer validation owns platform compatibility; the loader fail-fasts on missing dependencies and cycles, so a broken plugin never half-boots.
 - Dormant seams are interface-only until a real consumer forces their shape (e.g. `PaymentGateway` waits for the first real gateway).
 
 Full mechanics: [docs/platform.md](../../platform.md).

--- a/docs/platform.md
+++ b/docs/platform.md
@@ -138,14 +138,13 @@ use OpenKOS\Platform\Plugin\PluginManifest;
 
 class MyPlugin extends Plugin
 {
-    // Identity + compatibility. Required.
+    // Identity and dependencies. Compatibility is declared in composer.json.
     public function manifest(): PluginManifest
     {
         return new PluginManifest(
             id: 'acme/my-plugin',      // unique, vendor-namespaced
             name: 'My Plugin',
             version: '1.0.0',
-            coreVersion: '^0.2',        // constraint against config('platform.version')
             dependencies: [],           // ids of plugins that must load first
         );
     }
@@ -213,10 +212,10 @@ The package `PlatformServiceProvider::boot()`:
    removes duplicate class names.
 2. Resolves and validates **every** class before loading any plugin resources or
    running lifecycle methods. Each class must extend `Plugin`.
-3. **Validates & orders** them with `PluginLoader`: checks each `coreVersion`
-   against `config('platform.version')`, verifies declared `dependencies` exist,
-   and topologically sorts so each plugin loads after its dependencies. Throws on
-   an incompatible version, missing dependency, dependency cycle, or duplicate id.
+3. **Validates & orders** them with `PluginLoader`: verifies declared
+   `dependencies` exist and topologically sorts so each plugin loads after its
+   dependencies. Composer validates `openkos/platform` compatibility before
+   runtime loading.
 4. **Loads resources** — each plugin's `routes/web.php` and `database/migrations/`.
 5. Runs **two passes**: every plugin's `register()`, then every plugin's `boot()`
    (so `boot()` can rely on all plugins having registered).
@@ -225,12 +224,12 @@ The package `PlatformServiceProvider::boot()`:
 ### Manifest, versioning & dependencies
 
 - **Manifest** (`PluginManifest`): `id`, `name`, `version`, `description`,
-  `coreVersion`, `dependencies`. It's a PHP value object, not a JSON file — type-safe
+  `dependencies`. It's a PHP value object, not a JSON file — type-safe
   and IDE-navigable; a JSON manifest can wrap it later if external discovery needs one.
-- **Version compatibility**: `coreVersion` is checked against `config('platform.version')`
-  (currently `0.2.0`). Supported constraints: any Composer semver constraint supported by `composer/semver`
-  (`*`, `^`, `~`, ranges, wildcards like `1.*`, `||`, …). Incompatible plugins fail fast at boot rather than
-  half-loading.
+- **Version compatibility**: plugin `composer.json` must require `openkos/platform`
+  and declare its PHP requirement. The host validates both constraints before loading.
+- **Legacy compatibility**: `coreVersion` remains accepted by the SDK for old
+  artifacts but is deprecated and never gates loading.
 - **Dependencies**: a plugin lists other plugin **ids**; the loader guarantees they're
   present and loaded first. Missing deps and cycles are hard errors.
 

--- a/resources/js/pages/settings/plugins.tsx
+++ b/resources/js/pages/settings/plugins.tsx
@@ -1079,16 +1079,16 @@ export default function Plugins({
                                                             </dd>
                                                         </div>
                                                     )}
-                                                {plugin.core_version && (
+                                                {plugin.platform_constraint && (
                                                     <div>
                                                         <dt className="text-muted-foreground">
                                                             {t(
-                                                                'OpenKOS requirement',
+                                                                'OpenKOS platform requirement',
                                                             )}
                                                         </dt>
                                                         <dd className="font-mono">
                                                             {
-                                                                plugin.core_version
+                                                                plugin.platform_constraint
                                                             }
                                                         </dd>
                                                     </div>

--- a/resources/js/types/platform.ts
+++ b/resources/js/types/platform.ts
@@ -33,7 +33,7 @@ export type PlatformPlugin = {
     version: string | null;
     description: string;
     entry_class: string | null;
-    core_version: string | null;
+    platform_constraint: string | null;
     php: string | null;
     dependencies: string[];
     provenance: 'marketplace' | 'manual' | null;
@@ -69,7 +69,6 @@ export type MarketplaceVersion = {
     version: string;
     entry_class: string;
     compatibility: {
-        core: string;
         platform: string;
         php: string;
     };

--- a/src/Plugins/Example/ExamplePlugin.php
+++ b/src/Plugins/Example/ExamplePlugin.php
@@ -13,7 +13,7 @@ use OpenKOS\Plugins\Example\Listeners\LogPaymentRecorded;
 
 /**
  * Reference plugin demonstrating every extension point:
- *  - a manifest (id, version, core-version constraint)
+ *  - a manifest (id, version, dependencies)
  *  - registry registrations: a sidebar nav item, a Dashboard sub-page,
  *    a settings page (+ a workspace-header badge, client side)
  *  - a domain-event subscription via listens()
@@ -29,7 +29,6 @@ class ExamplePlugin extends Plugin
             name: 'Example Plugin',
             version: '1.0.0',
             description: 'Reference plugin demonstrating every extension point.',
-            coreVersion: '^0.2',
         );
     }
 

--- a/src/Plugins/Mail/MailPlugin.php
+++ b/src/Plugins/Mail/MailPlugin.php
@@ -18,7 +18,6 @@ class MailPlugin extends Plugin
             name: 'Mail Notifications',
             version: '1.0.0',
             description: 'Registers built-in SMTP and Log mail drivers.',
-            coreVersion: '^0.2',
         );
     }
 

--- a/src/Plugins/WhatsApp/WhatsAppPlugin.php
+++ b/src/Plugins/WhatsApp/WhatsAppPlugin.php
@@ -25,7 +25,6 @@ class WhatsAppPlugin extends Plugin
             name: 'WhatsApp Notifications',
             version: '1.0.0',
             description: 'Registers the built-in WhatsApp drivers as notification channels.',
-            coreVersion: '^0.2',
         );
     }
 

--- a/tests/Feature/Platform/RuntimePluginTest.php
+++ b/tests/Feature/Platform/RuntimePluginTest.php
@@ -696,7 +696,6 @@ function makeRuntimePluginArtifact(
         'version' => '1.0.0',
         'description' => 'Runtime fixture plugin.',
         'entry_class' => $entryClass,
-        'core_version' => '^0.2',
         'php' => '>=8.4 <8.6',
         'dependencies' => [],
         ...$overrides,
@@ -713,8 +712,10 @@ function makeRuntimePluginArtifact(
         'extra' => ['openkos' => ['plugin' => $entryClass]],
     ];
     $dependencies = var_export($manifest['dependencies'], true);
-    $source = "<?php\n\nnamespace RuntimeArtifact;\n\nuse OpenKOS\\Platform\\OpenKOSManager;\nuse OpenKOS\\Platform\\Plugin\\Plugin;\nuse OpenKOS\\Platform\\Plugin\\PluginManifest;\n\nfinal class {$classShort} extends Plugin\n{\n    public function manifest(): PluginManifest\n    {\n        return new PluginManifest(\n            id: '{$manifest['id']}',\n            name: '{$manifest['name']}',\n            version: '{$manifest['version']}',\n            description: '{$manifest['description']}',\n            coreVersion: '{$manifest['core_version']}',\n            dependencies: [],\n        );\n    }\n\n    public function register(OpenKOSManager \$platform): void\n    {\n        \$platform->permissions()->register('runtime-fixture.view', 'Runtime Fixture');\n    }\n}\n";
-    $source = str_replace('dependencies: [],', "dependencies: {$dependencies},", $source);
+    $coreVersion = isset($manifest['core_version'])
+        ? "            coreVersion: '{$manifest['core_version']}',\n"
+        : '';
+    $source = "<?php\n\nnamespace RuntimeArtifact;\n\nuse OpenKOS\\Platform\\OpenKOSManager;\nuse OpenKOS\\Platform\\Plugin\\Plugin;\nuse OpenKOS\\Platform\\Plugin\\PluginManifest;\n\nfinal class {$classShort} extends Plugin\n{\n    public function manifest(): PluginManifest\n    {\n        return new PluginManifest(\n            id: '{$manifest['id']}',\n            name: '{$manifest['name']}',\n            version: '{$manifest['version']}',\n            description: '{$manifest['description']}',\n{$coreVersion}            dependencies: {$dependencies},\n        );\n    }\n\n    public function register(OpenKOSManager \$platform): void\n    {\n        \$platform->permissions()->register('runtime-fixture.view', 'Runtime Fixture');\n    }\n}\n";
 
     $installedPackages = [
         ...array_map(

--- a/tests/Feature/PluginSettingsTest.php
+++ b/tests/Feature/PluginSettingsTest.php
@@ -414,7 +414,7 @@ it('keeps the plugins page available when a runtime dependency is missing or dis
         ->toContain("disabled plugin [{$dependency['id']}]");
 });
 
-it('surfaces a runtime plugin that is incompatible with the current core', function (): void {
+it('does not gate legacy core metadata during runtime discovery', function (): void {
     $artifact = makePluginSettingsArtifact(['core_version' => '^9.0']);
     $path = $this->runtimePluginPath.'/'.$artifact['id'];
     File::makeDirectory($path, 0750, true);
@@ -432,7 +432,7 @@ it('surfaces a runtime plugin that is incompatible with the current core', funct
         ->inertiaProps('plugins');
 
     expect(collect($plugins)->firstWhere('id', $artifact['id']))->toMatchArray([
-        'status' => 'incompatible',
+        'status' => 'enabled',
         'can_enable' => false,
         'can_disable' => true,
         'can_remove' => true,
@@ -861,8 +861,9 @@ it('lists marketplace plugins with the latest compatible version', function (): 
 
         parse_str((string) parse_url($request->url(), PHP_URL_QUERY), $query);
 
-        return ($query['core_version'] ?? null) === '0.2.5'
-            && ($query['platform_version'] ?? null) === '0.2.5';
+        return ! isset($query['core_version'])
+            && ($query['platform_version'] ?? null) === '0.2.5'
+            && ($query['php_version'] ?? null) === PHP_VERSION;
     });
 });
 
@@ -870,8 +871,7 @@ it('accepts legacy marketplace compatibility metadata', function (): void {
     configureMarketplaceForTests();
     $artifact = makePluginSettingsArtifact(['version' => '1.0.0']);
     $metadata = marketplaceVersionMetadata($artifact, '1.0.0');
-    $metadata['compatibility']['core'] = $metadata['compatibility']['openkos'];
-    unset($metadata['compatibility']['openkos']);
+    $metadata['compatibility']['openkos'] = '^9';
     fakeMarketplace($artifact, ['1.0.0' => $metadata], '1.0.0');
 
     $this->actingAs(User::factory()->owner()->create())
@@ -1252,15 +1252,16 @@ function makePluginSettingsArtifact(array $overrides = []): array
         'version' => '1.0.0',
         'description' => 'Settings runtime fixture.',
         'entry_class' => $entryClass,
-        'core_version' => '^0.2',
         'php' => '>=8.4 <8.6',
         'dependencies' => [],
         ...$overrides,
     ];
     $dependencies = var_export($manifest['dependencies'], true);
-    $source = "<?php\n\nnamespace SettingsRuntime;\n\nuse OpenKOS\\Platform\\OpenKOSManager;\nuse OpenKOS\\Platform\\Plugin\\Plugin;\nuse OpenKOS\\Platform\\Plugin\\PluginManifest;\n\nfinal class {$classShort} extends Plugin\n{\n    public function manifest(): PluginManifest\n    {\n        return new PluginManifest(\n            id: '{$id}',\n            name: 'Settings Runtime Fixture',\n            version: '1.0.0',\n            description: 'Settings runtime fixture.',\n            coreVersion: '^0.2',\n        );\n    }\n\n    public function register(OpenKOSManager \$platform): void {}\n}\n";
+    $coreVersion = isset($manifest['core_version'])
+        ? "            coreVersion: '{$manifest['core_version']}',\n"
+        : '';
+    $source = "<?php\n\nnamespace SettingsRuntime;\n\nuse OpenKOS\\Platform\\OpenKOSManager;\nuse OpenKOS\\Platform\\Plugin\\Plugin;\nuse OpenKOS\\Platform\\Plugin\\PluginManifest;\n\nfinal class {$classShort} extends Plugin\n{\n    public function manifest(): PluginManifest\n    {\n        return new PluginManifest(\n            id: '{$id}',\n            name: 'Settings Runtime Fixture',\n            version: '1.0.0',\n            description: 'Settings runtime fixture.',\n{$coreVersion}            dependencies: {$dependencies},\n        );\n    }\n\n    public function register(OpenKOSManager \$platform): void {}\n}\n";
     $source = str_replace("version: '1.0.0',", "version: '{$manifest['version']}',", $source);
-    $source = str_replace("coreVersion: '^0.2',", "coreVersion: '{$manifest['core_version']}',\n            dependencies: {$dependencies},", $source);
 
     $directory = sys_get_temp_dir().'/openkos-settings-zip-'.bin2hex(random_bytes(8));
     mkdir($directory, 0750, true);


### PR DESCRIPTION
## Summary

- use openkos/platform Composer requirements and PHP as the runtime compatibility contract
- retain legacy coreVersion/core_version data without gating plugin loading
- update Marketplace client, runtime validation, built-ins, UI, docs, and fixtures

## Validation

- composer test
- composer run lint:check
- npm run build
- npm run types:check
- targeted runtime and plugin settings tests