### PR TITLE
feat(leases): add deposit settlement

### DIFF
--- a/app/Actions/Leases/MoveOutLease.php
+++ b/app/Actions/Leases/MoveOutLease.php
@@ -24,6 +24,7 @@ class MoveOutLease
         private GenerateInvoices $generateInvoices,
         private MoneyConverter $money,
         private ReferenceAllocationRetry $referenceAllocationRetry,
+        private SettleLeaseDeposit $settleLeaseDeposit,
     ) {}
 
     private function cancelFutureInvoices(Lease $lease): void
@@ -93,9 +94,12 @@ class MoveOutLease
 
         $this->leaseStatusValidator->validate($oldLeaseStatus, LeaseStatus::Terminated);
 
-        $depositRefundAmount = $data->depositReturned
-            ? ($data->depositRefundAmount ?? $lease->deposit_amount)
-            : null;
+        $depositRefundAmount = $data->depositSettlement !== null
+            ? $lease->deposit_refund_amount
+            : ($data->depositReturned ? ($data->depositRefundAmount ?? $lease->deposit_amount) : null);
+        $depositRefundedAt = $data->depositSettlement !== null
+            ? $lease->deposit_refunded_at
+            : ($data->depositReturned ? now() : null);
 
         $lease->update([
             'end_date' => $data->endDate,
@@ -103,9 +107,13 @@ class MoveOutLease
             'termination_date' => $data->terminationDate,
             'termination_reason' => $data->reason,
             'deposit_refund_amount' => $depositRefundAmount,
-            'deposit_refunded_at' => $data->depositReturned ? now() : null,
+            'deposit_refunded_at' => $depositRefundedAt,
             'notes' => $data->notes ?? $lease->notes,
         ]);
+
+        if ($data->depositSettlement !== null) {
+            $this->settleLeaseDeposit->execute($lease, $data->depositSettlement);
+        }
 
         $this->cancelFutureInvoices($lease);
 
@@ -124,6 +132,8 @@ class MoveOutLease
 
     private function transfer(Lease $lease, Unit $oldUnit, Unit $targetUnit, MoveOutLeaseData $data): MoveOutLeaseResult
     {
+        abort_if($data->depositSettlement !== null, 422, __('A deposit cannot be settled while moving to another unit.'));
+
         $oldLeaseStatus = $lease->status;
         $oldSourceStatus = $oldUnit->status;
         $oldTargetStatus = $targetUnit->status;

--- a/app/Actions/Leases/SettleLeaseDeposit.php
+++ b/app/Actions/Leases/SettleLeaseDeposit.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace App\Actions\Leases;
+
+use App\Data\Lease\DepositDeductionData;
+use App\Data\Lease\DepositSettlementData;
+use App\Enums\DepositSettlementStatus;
+use App\Enums\LeaseStatus;
+use App\Models\DepositSettlement;
+use App\Models\Lease;
+use App\Services\Payments\MoneyConverter;
+use Brick\Math\BigDecimal;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+use Throwable;
+
+class SettleLeaseDeposit
+{
+    public function __construct(private readonly MoneyConverter $money) {}
+
+    public function execute(Lease $lease, DepositSettlementData $data): DepositSettlement
+    {
+        try {
+            return DB::transaction(function () use ($lease, $data): DepositSettlement {
+                $lockedLease = Lease::query()
+                    ->whereKey($lease->getKey())
+                    ->lockForUpdate()
+                    ->firstOrFail();
+
+                abort_unless(
+                    $lockedLease->status === LeaseStatus::Terminated,
+                    422,
+                    __('Only terminated leases can have a deposit settlement.'),
+                );
+
+                $settlement = DepositSettlement::query()
+                    ->where('lease_id', $lockedLease->getKey())
+                    ->lockForUpdate()
+                    ->first();
+
+                if ($settlement?->status === DepositSettlementStatus::Settled) {
+                    throw ValidationException::withMessages([
+                        'settlement' => __('This deposit settlement is already settled and cannot be changed.'),
+                    ]);
+                }
+
+                if ($settlement) {
+                    $settlement->deductions()->lockForUpdate()->get();
+                    $currency = $this->money->normalizeCurrency((string) $settlement->currency);
+                    $originalAmount = $this->money->normalizeAmount(
+                        (string) $settlement->original_amount,
+                        $currency,
+                    );
+                } else {
+                    $currency = $this->money->normalizeCurrency($lockedLease->currency);
+
+                    if ($lockedLease->deposit_amount === null || trim((string) $lockedLease->deposit_amount) === '') {
+                        throw ValidationException::withMessages([
+                            'settlement' => __('A lease with no security deposit cannot be settled.'),
+                        ]);
+                    }
+
+                    $originalAmount = $this->money->normalizeAmount(
+                        (string) $lockedLease->deposit_amount,
+                        $currency,
+                    );
+
+                    if ($this->money->compare($originalAmount, '0') === 0) {
+                        throw ValidationException::withMessages([
+                            'settlement' => __('A lease with no security deposit cannot be settled.'),
+                        ]);
+                    }
+                }
+
+                $refundAmount = $this->normalizeAmount($data->refundAmount, $currency, 'refund_amount');
+                $deductions = array_map(
+                    fn (DepositDeductionData $deduction): array => [
+                        'amount' => $this->normalizeAmount($deduction->amount, $currency, 'deductions'),
+                        'reason' => trim($deduction->reason),
+                        'description' => $deduction->description,
+                    ],
+                    $data->deductions,
+                );
+
+                foreach ($deductions as $deduction) {
+                    if ($deduction['reason'] === '') {
+                        throw ValidationException::withMessages([
+                            'deductions' => __('Each deduction must include a reason.'),
+                        ]);
+                    }
+                }
+
+                $deductionsTotal = array_reduce(
+                    $deductions,
+                    fn (BigDecimal $total, array $deduction): BigDecimal => $total->plus($deduction['amount']),
+                    BigDecimal::zero(),
+                );
+                $allocatedAmount = BigDecimal::of($refundAmount)->plus($deductionsTotal);
+                $original = BigDecimal::of($originalAmount);
+
+                if ($allocatedAmount->compareTo($original) > 0) {
+                    throw ValidationException::withMessages([
+                        'settlement' => __('The refund and deductions cannot exceed the original deposit.'),
+                    ]);
+                }
+
+                if ($data->status === DepositSettlementStatus::Settled && $allocatedAmount->compareTo($original) !== 0) {
+                    throw ValidationException::withMessages([
+                        'settlement' => __('A settled deposit must allocate the full original deposit as a refund or deduction.'),
+                    ]);
+                }
+
+                $settlement ??= DepositSettlement::create([
+                    'lease_id' => $lockedLease->getKey(),
+                    'original_amount' => $originalAmount,
+                    'currency' => $currency,
+                    'status' => $data->status,
+                    'settlement_date' => $data->settlementDate,
+                    'refund_amount' => $refundAmount,
+                    'refund_reference' => $data->refundReference,
+                    'notes' => $data->notes,
+                ]);
+
+                $settlement->update([
+                    'status' => $data->status,
+                    'settlement_date' => $data->settlementDate,
+                    'refund_amount' => $refundAmount,
+                    'refund_reference' => $data->refundReference,
+                    'notes' => $data->notes,
+                ]);
+
+                $settlement->deductions()
+                    ->lockForUpdate()
+                    ->get()
+                    ->each
+                    ->delete();
+
+                foreach ($deductions as $deduction) {
+                    $settlement->deductions()->create($deduction);
+                }
+
+                return $settlement->load('deductions');
+            }, attempts: 3);
+        } catch (QueryException $exception) {
+            if ($this->isSettlementUniqueViolation($exception)) {
+                throw ValidationException::withMessages([
+                    'settlement' => __('A deposit settlement already exists for this lease.'),
+                ]);
+            }
+
+            throw $exception;
+        }
+    }
+
+    private function normalizeAmount(string $amount, string $currency, string $attribute): string
+    {
+        try {
+            return $this->money->normalizeAmount($amount, $currency);
+        } catch (Throwable) {
+            throw ValidationException::withMessages([
+                $attribute => __('The :attribute is invalid for the settlement currency.', ['attribute' => $attribute]),
+            ]);
+        }
+    }
+
+    private function isSettlementUniqueViolation(QueryException $exception): bool
+    {
+        $errorInfo = $exception->errorInfo ?? [];
+        $isUniqueViolation = match (DB::getDriverName()) {
+            'pgsql' => (string) ($errorInfo[0] ?? $exception->getCode()) === '23505',
+            'mysql', 'mariadb' => (int) ($errorInfo[1] ?? 0) === 1062,
+            'sqlite' => (int) ($errorInfo[1] ?? 0) === 19,
+            default => false,
+        };
+
+        $message = strtolower($exception->getMessage());
+
+        return $isUniqueViolation && (
+            str_contains($message, 'deposit_settlements_lease_id_unique')
+            || (DB::getDriverName() === 'sqlite' && str_contains($message, 'deposit_settlements.lease_id'))
+        );
+    }
+}

--- a/app/Actions/Leases/SettleLeaseDeposit.php
+++ b/app/Actions/Leases/SettleLeaseDeposit.php
@@ -115,7 +115,7 @@ class SettleLeaseDeposit
                     'lease_id' => $lockedLease->getKey(),
                     'original_amount' => $originalAmount,
                     'currency' => $currency,
-                    'status' => $data->status,
+                    'status' => DepositSettlementStatus::Draft,
                     'settlement_date' => $data->settlementDate,
                     'refund_amount' => $refundAmount,
                     'refund_reference' => $data->refundReference,
@@ -123,7 +123,6 @@ class SettleLeaseDeposit
                 ]);
 
                 $settlement->update([
-                    'status' => $data->status,
                     'settlement_date' => $data->settlementDate,
                     'refund_amount' => $refundAmount,
                     'refund_reference' => $data->refundReference,
@@ -139,6 +138,8 @@ class SettleLeaseDeposit
                 foreach ($deductions as $deduction) {
                     $settlement->deductions()->create($deduction);
                 }
+
+                $settlement->update(['status' => $data->status]);
 
                 return $settlement->load('deductions');
             }, attempts: 3);

--- a/app/Data/Lease/DepositDeductionData.php
+++ b/app/Data/Lease/DepositDeductionData.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Data\Lease;
+
+final readonly class DepositDeductionData
+{
+    public function __construct(
+        public string $amount,
+        public string $reason,
+        public ?string $description = null,
+    ) {}
+
+    /**
+     * @param  array{amount: string|int, reason: string, description?: string|null}  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            amount: (string) $data['amount'],
+            reason: $data['reason'],
+            description: $data['description'] ?? null,
+        );
+    }
+}

--- a/app/Data/Lease/DepositSettlementData.php
+++ b/app/Data/Lease/DepositSettlementData.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Data\Lease;
+
+use App\Enums\DepositSettlementStatus;
+use Carbon\CarbonImmutable;
+
+final readonly class DepositSettlementData
+{
+    /**
+     * @param  array<int, DepositDeductionData>  $deductions
+     */
+    public function __construct(
+        public DepositSettlementStatus $status,
+        public CarbonImmutable $settlementDate,
+        public string $refundAmount,
+        public array $deductions = [],
+        public ?string $refundReference = null,
+        public ?string $notes = null,
+    ) {}
+
+    /**
+     * @param  array{status: string, settlement_date?: string|null, refund_amount?: string|int|null, deductions?: array<int, array{amount: string|int, reason: string, description?: string|null}>, refund_reference?: string|null, notes?: string|null}  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            status: DepositSettlementStatus::from($data['status']),
+            settlementDate: CarbonImmutable::parse($data['settlement_date'] ?? now()->toDateString()),
+            refundAmount: (string) ($data['refund_amount'] ?? '0'),
+            deductions: array_map(
+                fn (array $deduction): DepositDeductionData => DepositDeductionData::fromArray($deduction),
+                $data['deductions'] ?? [],
+            ),
+            refundReference: $data['refund_reference'] ?? null,
+            notes: $data['notes'] ?? null,
+        );
+    }
+}

--- a/app/Data/Lease/MoveOutLeaseData.php
+++ b/app/Data/Lease/MoveOutLeaseData.php
@@ -14,5 +14,6 @@ final readonly class MoveOutLeaseData
         public bool $moveToAnotherUnit = false,
         public ?int $targetUnitId = null,
         public bool $carryDepositRefund = false,
+        public ?DepositSettlementData $depositSettlement = null,
     ) {}
 }

--- a/app/Enums/DepositSettlementStatus.php
+++ b/app/Enums/DepositSettlementStatus.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Enums;
+
+enum DepositSettlementStatus: string
+{
+    case Draft = 'draft';
+    case Settled = 'settled';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Draft => 'Draft',
+            self::Settled => 'Settled',
+        };
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+}

--- a/app/Http/Controllers/LeaseController.php
+++ b/app/Http/Controllers/LeaseController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Actions\Leases\CreateLease;
 use App\Actions\Leases\MoveOutLease;
 use App\Actions\Leases\RenewLease;
+use App\Actions\Leases\SettleLeaseDeposit;
 use App\Actions\Reminders\ForceSendReminder;
 use App\Business\Leases\LeaseStatusValidator;
 use App\Data\Lease\CreateLeaseData;
@@ -17,6 +18,7 @@ use App\Enums\UnitStatus;
 use App\Events\Lease\LeaseCreated;
 use App\Events\Lease\LeaseStatusChanged;
 use App\Events\Unit\UnitStatusChanged;
+use App\Http\Requests\Lease\DepositSettlementRequest;
 use App\Http\Requests\Lease\MoveLeaseRequest;
 use App\Http\Requests\Lease\MoveOutRequest;
 use App\Http\Requests\Lease\RenewLeaseRequest;
@@ -60,6 +62,7 @@ class LeaseController extends Controller
             'payments.proofs.media',
             'payments.invoice:id,period_start,period_end,reference,status',
             'unitHistories.transferredBy:id,name',
+            'depositSettlement.deductions',
         ]);
 
         return Inertia::render('leases/show', [
@@ -153,7 +156,7 @@ class LeaseController extends Controller
         $unit->load('property.city');
 
         $leases = $unit->leases()
-            ->with(['tenants:id,name,phone', 'primaryTenant:id,name,phone', 'payments.confirmedBy:id,name', 'payments.proofs.media', 'payments.invoice:id,period_start,period_end,reference,status'])
+            ->with(['tenants:id,name,phone', 'primaryTenant:id,name,phone', 'payments.confirmedBy:id,name', 'payments.proofs.media', 'payments.invoice:id,period_start,period_end,reference,status', 'depositSettlement.deductions'])
             ->withTrashed()
             ->orderBy('created_at', 'desc')
             ->get()
@@ -224,7 +227,7 @@ class LeaseController extends Controller
             ->defaultSort('status,-start_date');
 
         $query = Lease::query()
-            ->with(['primaryTenant:id,name,phone', 'tenants:id,name,phone', 'unit:id,slug,name,property_id', 'unit.property:id,slug,name'])
+            ->with(['primaryTenant:id,name,phone', 'tenants:id,name,phone', 'unit:id,slug,name,property_id', 'unit.property:id,slug,name', 'depositSettlement.deductions'])
             ->addSelect(['payment_status' => Invoice::query()
                 ->selectRaw("CASE WHEN COUNT(*) > 0 THEN 'overdue' ELSE 'paid' END")
                 ->whereColumn('lease_id', 'leases.id')
@@ -423,6 +426,7 @@ class LeaseController extends Controller
             notes: $validated['notes'] ?? null,
             moveToAnotherUnit: $validated['move_to_another_unit'] ?? false,
             targetUnitId: $validated['target_unit_id'] ?? null,
+            depositSettlement: $request->settlementData(),
         );
 
         $result = $action->execute($lease, $data);
@@ -445,14 +449,28 @@ class LeaseController extends Controller
 
         Inertia::flash('toast', [
             'type' => 'success',
-            'message' => $validated['move_to_another_unit']
+            'message' => ($validated['move_to_another_unit'] ?? false)
                 ? __('Tenant moved to new unit.')
                 : __('Tenant moved out.'),
         ]);
 
-        if ($validated['move_to_another_unit']) {
+        if ($validated['move_to_another_unit'] ?? false) {
             return back();
         }
+
+        return back();
+    }
+
+    public function saveDepositSettlement(
+        DepositSettlementRequest $request,
+        Lease $lease,
+        SettleLeaseDeposit $action,
+    ): RedirectResponse {
+        $this->authorize('moveOut', $lease);
+
+        $action->execute($lease, $request->toData());
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Deposit settlement saved.')]);
 
         return back();
     }

--- a/app/Http/Requests/Lease/DepositSettlementRequest.php
+++ b/app/Http/Requests/Lease/DepositSettlementRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Requests\Lease;
+
+use App\Data\Lease\DepositSettlementData;
+use App\Enums\DepositSettlementStatus;
+use App\Models\Lease;
+use App\Rules\MoneyAmount;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class DepositSettlementRequest extends FormRequest
+{
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        $lease = $this->route('lease');
+        $currency = $lease instanceof Lease
+            ? ($lease->depositSettlement?->currency ?? $lease->currency)
+            : null;
+
+        return [
+            'status' => ['required', Rule::in(DepositSettlementStatus::values())],
+            'settlement_date' => ['nullable', 'date'],
+            'refund_amount' => ['nullable', new MoneyAmount($currency)],
+            'deductions' => ['nullable', 'array'],
+            'deductions.*.amount' => ['required', new MoneyAmount($currency)],
+            'deductions.*.reason' => ['required', 'string', 'max:255'],
+            'deductions.*.description' => ['nullable', 'string', 'max:65535'],
+            'refund_reference' => ['nullable', 'string', 'max:255'],
+            'notes' => ['nullable', 'string', 'max:65535'],
+        ];
+    }
+
+    public function toData(): DepositSettlementData
+    {
+        return DepositSettlementData::fromArray($this->validated());
+    }
+}

--- a/app/Http/Requests/Lease/MoveOutRequest.php
+++ b/app/Http/Requests/Lease/MoveOutRequest.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Requests\Lease;
 
+use App\Data\Lease\DepositSettlementData;
+use App\Enums\DepositSettlementStatus;
 use App\Models\Lease;
 use App\Rules\MoneyAmount;
 use Illuminate\Contracts\Validation\ValidationRule;
@@ -17,6 +19,7 @@ class MoveOutRequest extends FormRequest
     {
         $lease = $this->route('lease');
         $sourceUnitId = $lease instanceof Lease ? $lease->unit_id : null;
+        $settlementPresent = is_array($this->input('settlement'));
 
         return [
             'move_out_date' => ['required', 'date'],
@@ -26,6 +29,23 @@ class MoveOutRequest extends FormRequest
             'notes' => ['nullable', 'string', 'max:65535'],
             'move_to_another_unit' => ['nullable', 'boolean'],
             'target_unit_id' => ['nullable', 'integer', Rule::notIn([$sourceUnitId]), 'exists:units,id'],
+            'settlement' => ['nullable', 'array'],
+            'settlement.status' => [Rule::requiredIf($settlementPresent), Rule::in(DepositSettlementStatus::values())],
+            'settlement.settlement_date' => ['nullable', 'date'],
+            'settlement.refund_amount' => ['nullable', new MoneyAmount($lease instanceof Lease ? $lease->currency : null)],
+            'settlement.deductions' => ['nullable', 'array'],
+            'settlement.deductions.*.amount' => ['required', new MoneyAmount($lease instanceof Lease ? $lease->currency : null)],
+            'settlement.deductions.*.reason' => ['required', 'string', 'max:255'],
+            'settlement.deductions.*.description' => ['nullable', 'string', 'max:65535'],
+            'settlement.refund_reference' => ['nullable', 'string', 'max:255'],
+            'settlement.notes' => ['nullable', 'string', 'max:65535'],
         ];
+    }
+
+    public function settlementData(): ?DepositSettlementData
+    {
+        $settlement = $this->validated('settlement');
+
+        return is_array($settlement) ? DepositSettlementData::fromArray($settlement) : null;
     }
 }

--- a/app/Models/DepositDeduction.php
+++ b/app/Models/DepositDeduction.php
@@ -4,11 +4,13 @@ namespace App\Models;
 
 use App\Concerns\Auditable;
 use App\Concerns\SerializesDatesWithTimezone;
+use App\Enums\DepositSettlementStatus;
 use Database\Factories\DepositDeductionFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use LogicException;
 
 #[Fillable([
     'deposit_settlement_id',
@@ -21,6 +23,21 @@ class DepositDeduction extends Model
     /** @use HasFactory<DepositDeductionFactory> */
     use Auditable, HasFactory, SerializesDatesWithTimezone;
 
+    protected static function booted(): void
+    {
+        static::creating(function (DepositDeduction $deduction): void {
+            $deduction->guardMutable();
+        });
+
+        static::updating(function (DepositDeduction $deduction): void {
+            $deduction->guardMutable();
+        });
+
+        static::deleting(function (DepositDeduction $deduction): void {
+            $deduction->guardMutable();
+        });
+    }
+
     protected function casts(): array
     {
         return [
@@ -31,5 +48,12 @@ class DepositDeduction extends Model
     public function settlement(): BelongsTo
     {
         return $this->belongsTo(DepositSettlement::class, 'deposit_settlement_id');
+    }
+
+    private function guardMutable(): void
+    {
+        if ($this->settlement()->where('status', DepositSettlementStatus::Settled->value)->exists()) {
+            throw new LogicException('Deduction lines for settled deposit settlements are immutable.');
+        }
     }
 }

--- a/app/Models/DepositDeduction.php
+++ b/app/Models/DepositDeduction.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\Auditable;
+use App\Concerns\SerializesDatesWithTimezone;
+use Database\Factories\DepositDeductionFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+#[Fillable([
+    'deposit_settlement_id',
+    'amount',
+    'reason',
+    'description',
+])]
+class DepositDeduction extends Model
+{
+    /** @use HasFactory<DepositDeductionFactory> */
+    use Auditable, HasFactory, SerializesDatesWithTimezone;
+
+    protected function casts(): array
+    {
+        return [
+            'amount' => 'decimal:3',
+        ];
+    }
+
+    public function settlement(): BelongsTo
+    {
+        return $this->belongsTo(DepositSettlement::class, 'deposit_settlement_id');
+    }
+}

--- a/app/Models/DepositSettlement.php
+++ b/app/Models/DepositSettlement.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use LogicException;
 
 #[Fillable([
     'lease_id',
@@ -29,6 +30,25 @@ class DepositSettlement extends Model
     use Auditable, HasFactory, SerializesDatesWithTimezone;
 
     protected $appends = ['deductions_total'];
+
+    protected static function booted(): void
+    {
+        static::updating(function (DepositSettlement $settlement): void {
+            if ($settlement->getRawOriginal('status') === DepositSettlementStatus::Settled->value) {
+                throw new LogicException('Settled deposit settlements are immutable.');
+            }
+
+            if ($settlement->isDirty(['lease_id', 'original_amount', 'currency'])) {
+                throw new LogicException('Deposit settlement snapshots are immutable.');
+            }
+        });
+
+        static::deleting(function (DepositSettlement $settlement): void {
+            if ($settlement->status === DepositSettlementStatus::Settled) {
+                throw new LogicException('Settled deposit settlements are immutable.');
+            }
+        });
+    }
 
     protected function casts(): array
     {

--- a/app/Models/DepositSettlement.php
+++ b/app/Models/DepositSettlement.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\Auditable;
+use App\Concerns\SerializesDatesWithTimezone;
+use App\Enums\DepositSettlementStatus;
+use Brick\Math\BigDecimal;
+use Database\Factories\DepositSettlementFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+#[Fillable([
+    'lease_id',
+    'original_amount',
+    'currency',
+    'status',
+    'settlement_date',
+    'refund_amount',
+    'refund_reference',
+    'notes',
+])]
+class DepositSettlement extends Model
+{
+    /** @use HasFactory<DepositSettlementFactory> */
+    use Auditable, HasFactory, SerializesDatesWithTimezone;
+
+    protected $appends = ['deductions_total'];
+
+    protected function casts(): array
+    {
+        return [
+            'original_amount' => 'decimal:3',
+            'refund_amount' => 'decimal:3',
+            'settlement_date' => 'date:Y-m-d',
+            'status' => DepositSettlementStatus::class,
+        ];
+    }
+
+    public function lease(): BelongsTo
+    {
+        return $this->belongsTo(Lease::class);
+    }
+
+    public function deductions(): HasMany
+    {
+        return $this->hasMany(DepositDeduction::class);
+    }
+
+    public function getDeductionsTotalAttribute(): string
+    {
+        $sum = $this->getAttribute('deductions_sum_amount');
+
+        if ($sum !== null) {
+            return (string) $sum;
+        }
+
+        if (! $this->relationLoaded('deductions')) {
+            return '0';
+        }
+
+        return $this->deductions->reduce(
+            fn (BigDecimal $total, DepositDeduction $deduction): BigDecimal => $total->plus((string) $deduction->amount),
+            BigDecimal::zero(),
+        )->toString();
+    }
+}

--- a/app/Models/Lease.php
+++ b/app/Models/Lease.php
@@ -138,6 +138,11 @@ class Lease extends Model
         return $this->hasMany(Invoice::class);
     }
 
+    public function depositSettlement(): HasOne
+    {
+        return $this->hasOne(DepositSettlement::class);
+    }
+
     public function payments(): HasManyThrough
     {
         return $this->hasManyThrough(Payment::class, Invoice::class);

--- a/database/factories/DepositDeductionFactory.php
+++ b/database/factories/DepositDeductionFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\DepositDeduction;
+use App\Models\DepositSettlement;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<DepositDeduction>
+ */
+class DepositDeductionFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'deposit_settlement_id' => DepositSettlement::factory(),
+            'amount' => '100000',
+            'reason' => 'Cleaning',
+            'description' => null,
+        ];
+    }
+}

--- a/database/factories/DepositSettlementFactory.php
+++ b/database/factories/DepositSettlementFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\DepositSettlementStatus;
+use App\Models\DepositSettlement;
+use App\Models\Lease;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<DepositSettlement>
+ */
+class DepositSettlementFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'lease_id' => Lease::factory(),
+            'original_amount' => '1000000',
+            'currency' => 'IDR',
+            'status' => DepositSettlementStatus::Draft,
+            'settlement_date' => now()->toDateString(),
+            'refund_amount' => '1000000',
+            'refund_reference' => null,
+            'notes' => null,
+        ];
+    }
+}

--- a/database/migrations/2026_09_11_064836_create_deposit_settlements_table.php
+++ b/database/migrations/2026_09_11_064836_create_deposit_settlements_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('deposit_settlements', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('lease_id')->unique()->constrained()->cascadeOnDelete();
+            $table->decimal('original_amount', 20, 3);
+            $table->char('currency', 3);
+            $table->string('status')->default('draft');
+            $table->date('settlement_date');
+            $table->decimal('refund_amount', 20, 3)->default(0);
+            $table->string('refund_reference')->nullable();
+            $table->text('notes')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('deposit_settlements');
+    }
+};

--- a/database/migrations/2026_09_11_064840_create_deposit_deductions_table.php
+++ b/database/migrations/2026_09_11_064840_create_deposit_deductions_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('deposit_deductions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('deposit_settlement_id')->constrained()->cascadeOnDelete();
+            $table->decimal('amount', 20, 3);
+            $table->string('reason');
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('deposit_deductions');
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
                 "eslint-plugin-import": "^2.32.0",
                 "eslint-plugin-react": "^7.37.3",
                 "eslint-plugin-react-hooks": "^7.0.0",
+                "playwright": "^1.63.0",
                 "prettier": "^3.4.2",
                 "prettier-plugin-tailwindcss": "^0.6.11",
                 "typescript-eslint": "^8.23.0"
@@ -9224,6 +9225,35 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/playwright": {
+            "version": "1.63.0",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+            "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright-core": "1.63.0"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/playwright-core": {
+            "version": "1.63.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+            "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "playwright-core": "cli.js"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-react": "^7.37.3",
         "eslint-plugin-react-hooks": "^7.0.0",
+        "playwright": "^1.63.0",
         "prettier": "^3.4.2",
         "prettier-plugin-tailwindcss": "^0.6.11",
         "typescript-eslint": "^8.23.0"

--- a/resources/js/components/features/leases/deposit-settlement-fields.tsx
+++ b/resources/js/components/features/leases/deposit-settlement-fields.tsx
@@ -1,0 +1,291 @@
+import { Plus, Trash2 } from 'lucide-react';
+import { InputError } from '@/components/shared';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { formatPrice, todayISO } from '@/lib/formatters';
+import { t } from '@/lib/i18n';
+
+export type DepositSettlementFormData = {
+    status: 'draft' | 'settled';
+    settlement_date: string;
+    refund_amount: string;
+    deductions: {
+        amount: string;
+        reason: string;
+        description: string;
+    }[];
+    refund_reference: string;
+    notes: string;
+};
+
+type Props = {
+    value: DepositSettlementFormData;
+    originalAmount: string;
+    currency: string;
+    errors?: Record<string, string | undefined>;
+    readOnly?: boolean;
+    onChange: (value: DepositSettlementFormData) => void;
+};
+
+export function emptyDepositSettlementForm(
+    originalAmount: string,
+): DepositSettlementFormData {
+    return {
+        status: 'draft',
+        settlement_date: todayISO(),
+        refund_amount: originalAmount,
+        deductions: [],
+        refund_reference: '',
+        notes: '',
+    };
+}
+
+export default function DepositSettlementFields({
+    value,
+    originalAmount,
+    currency,
+    errors = {},
+    readOnly = false,
+    onChange,
+}: Props) {
+    const update = <K extends keyof DepositSettlementFormData>(
+        key: K,
+        nextValue: DepositSettlementFormData[K],
+    ) => onChange({ ...value, [key]: nextValue });
+
+    const updateDeduction = (
+        index: number,
+        field: keyof DepositSettlementFormData['deductions'][number],
+        fieldValue: string,
+    ) => {
+        const deductions = value.deductions.map((deduction, deductionIndex) =>
+            deductionIndex === index
+                ? { ...deduction, [field]: fieldValue }
+                : deduction,
+        );
+
+        update('deductions', deductions);
+    };
+
+    const error = (field: string): string | undefined => errors[field];
+
+    return (
+        <div className="space-y-4 rounded-md border bg-muted/20 p-3">
+            <div className="flex items-start justify-between gap-4">
+                <div>
+                    <p className="text-xs font-medium text-muted-foreground">
+                        {t('Original deposit')}
+                    </p>
+                    <p className="font-medium tabular-nums">
+                        {formatPrice(originalAmount, currency)}
+                    </p>
+                </div>
+                <p className="max-w-56 text-right text-xs text-muted-foreground">
+                    {t(
+                        'Refund and deductions must account for the full deposit when settled.',
+                    )}
+                </p>
+            </div>
+
+            <div className="grid gap-2">
+                <Label htmlFor="settlement_date">{t('Settlement Date')}</Label>
+                <Input
+                    id="settlement_date"
+                    type="date"
+                    value={value.settlement_date}
+                    onChange={(event) =>
+                        update('settlement_date', event.target.value)
+                    }
+                    disabled={readOnly}
+                    required={value.status === 'settled'}
+                />
+                <InputError message={error('settlement_date')} />
+            </div>
+
+            <div className="grid gap-2">
+                <Label htmlFor="settlement_refund_amount">
+                    {t('Refund Amount')} ({currency})
+                </Label>
+                <Input
+                    id="settlement_refund_amount"
+                    type="number"
+                    min={0}
+                    value={value.refund_amount}
+                    onChange={(event) =>
+                        update('refund_amount', event.target.value)
+                    }
+                    disabled={readOnly}
+                />
+                <InputError message={error('refund_amount')} />
+            </div>
+
+            <div className="space-y-3">
+                <div className="flex items-center justify-between gap-3">
+                    <div>
+                        <Label>{t('Deductions')}</Label>
+                        <p className="text-xs text-muted-foreground">
+                            {t('Record each withheld amount with a reason.')}
+                        </p>
+                    </div>
+                    {!readOnly && (
+                        <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            onClick={() =>
+                                update('deductions', [
+                                    ...value.deductions,
+                                    {
+                                        amount: '',
+                                        reason: '',
+                                        description: '',
+                                    },
+                                ])
+                            }
+                        >
+                            <Plus />
+                            {t('Add deduction')}
+                        </Button>
+                    )}
+                </div>
+
+                {value.deductions.length === 0 ? (
+                    <p className="rounded-md border border-dashed p-3 text-sm text-muted-foreground">
+                        {t('No deductions recorded.')}
+                    </p>
+                ) : (
+                    value.deductions.map((deduction, index) => (
+                        <div
+                            key={index}
+                            className="space-y-3 rounded-md border p-3"
+                        >
+                            <div className="grid gap-3 sm:grid-cols-[9rem_1fr_auto] sm:items-end">
+                                <div className="grid gap-2">
+                                    <Label
+                                        htmlFor={`deduction-${index}-amount`}
+                                    >
+                                        {t('Amount')} ({currency})
+                                    </Label>
+                                    <Input
+                                        id={`deduction-${index}-amount`}
+                                        type="number"
+                                        min={0}
+                                        value={deduction.amount}
+                                        onChange={(event) =>
+                                            updateDeduction(
+                                                index,
+                                                'amount',
+                                                event.target.value,
+                                            )
+                                        }
+                                        disabled={readOnly}
+                                    />
+                                </div>
+                                <div className="grid gap-2">
+                                    <Label
+                                        htmlFor={`deduction-${index}-reason`}
+                                    >
+                                        {t('Reason')}
+                                    </Label>
+                                    <Input
+                                        id={`deduction-${index}-reason`}
+                                        value={deduction.reason}
+                                        onChange={(event) =>
+                                            updateDeduction(
+                                                index,
+                                                'reason',
+                                                event.target.value,
+                                            )
+                                        }
+                                        disabled={readOnly}
+                                        required
+                                    />
+                                </div>
+                                {!readOnly && (
+                                    <Button
+                                        type="button"
+                                        variant="ghost"
+                                        size="icon-sm"
+                                        className="text-muted-foreground hover:text-destructive"
+                                        onClick={() =>
+                                            update(
+                                                'deductions',
+                                                value.deductions.filter(
+                                                    (_, deductionIndex) =>
+                                                        deductionIndex !==
+                                                        index,
+                                                ),
+                                            )
+                                        }
+                                        aria-label={t('Remove deduction')}
+                                    >
+                                        <Trash2 />
+                                    </Button>
+                                )}
+                            </div>
+                            <div className="grid gap-2">
+                                <Label
+                                    htmlFor={`deduction-${index}-description`}
+                                >
+                                    {t('Description')}
+                                </Label>
+                                <Textarea
+                                    id={`deduction-${index}-description`}
+                                    value={deduction.description}
+                                    onChange={(event) =>
+                                        updateDeduction(
+                                            index,
+                                            'description',
+                                            event.target.value,
+                                        )
+                                    }
+                                    disabled={readOnly}
+                                />
+                            </div>
+                            <InputError
+                                message={
+                                    error(`deductions.${index}.amount`) ??
+                                    error(`deductions.${index}.reason`) ??
+                                    error(`deductions.${index}.description`)
+                                }
+                            />
+                        </div>
+                    ))
+                )}
+                <InputError message={error('deductions')} />
+            </div>
+
+            <div className="grid gap-2">
+                <Label htmlFor="refund_reference">
+                    {t('Refund Reference')} ({t('Optional')})
+                </Label>
+                <Input
+                    id="refund_reference"
+                    value={value.refund_reference}
+                    onChange={(event) =>
+                        update('refund_reference', event.target.value)
+                    }
+                    disabled={readOnly}
+                />
+                <InputError message={error('refund_reference')} />
+            </div>
+
+            <div className="grid gap-2">
+                <Label htmlFor="settlement_notes">
+                    {t('Settlement Notes')} ({t('Optional')})
+                </Label>
+                <Textarea
+                    id="settlement_notes"
+                    value={value.notes}
+                    onChange={(event) => update('notes', event.target.value)}
+                    disabled={readOnly}
+                />
+                <InputError message={error('notes')} />
+            </div>
+
+            <InputError message={error('settlement')} />
+        </div>
+    );
+}

--- a/resources/js/components/features/leases/deposit-settlement-sheet.tsx
+++ b/resources/js/components/features/leases/deposit-settlement-sheet.tsx
@@ -1,0 +1,138 @@
+import { useForm } from '@inertiajs/react';
+import { useEffect, useMemo } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetHeader,
+    SheetTitle,
+} from '@/components/ui/sheet';
+import { t } from '@/lib/i18n';
+import leases from '@/routes/leases';
+import type { Lease } from '@/types';
+import DepositSettlementFields, {
+    emptyDepositSettlementForm,
+} from './deposit-settlement-fields';
+import type { DepositSettlementFormData } from './deposit-settlement-fields';
+
+export default function DepositSettlementSheet({
+    lease,
+    open,
+    onOpenChange,
+}: {
+    lease?: Lease | null;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}) {
+    const initialData = useMemo<DepositSettlementFormData>(() => {
+        if (!lease?.deposit_settlement) {
+            return emptyDepositSettlementForm(lease?.deposit_amount ?? '0');
+        }
+
+        return {
+            status:
+                lease.deposit_settlement.status === 'settled'
+                    ? 'settled'
+                    : 'draft',
+            settlement_date: lease.deposit_settlement.settlement_date,
+            refund_amount: lease.deposit_settlement.refund_amount,
+            deductions: lease.deposit_settlement.deductions.map(
+                (deduction) => ({
+                    amount: deduction.amount,
+                    reason: deduction.reason,
+                    description: deduction.description ?? '',
+                }),
+            ),
+            refund_reference: lease.deposit_settlement.refund_reference ?? '',
+            notes: lease.deposit_settlement.notes ?? '',
+        };
+    }, [lease]);
+
+    const { data, setData, transform, submit, processing, errors } =
+        useForm<DepositSettlementFormData>(initialData);
+
+    useEffect(() => {
+        if (open) {
+            setData(initialData);
+        }
+    }, [initialData, open, setData]);
+
+    if (!lease) {
+        return null;
+    }
+
+    const currentLease = lease;
+    const settlement = currentLease.deposit_settlement;
+    const isReadOnly = settlement?.status === 'settled';
+
+    function save(status: 'draft' | 'settled') {
+        transform((current) => ({ ...current, status }));
+        submit(leases.depositSettlement({ lease: currentLease.id }), {
+            onSuccess: () => onOpenChange(false),
+        });
+    }
+
+    return (
+        <Sheet open={open} onOpenChange={onOpenChange}>
+            <SheetContent className="sm:max-w-lg">
+                <SheetHeader>
+                    <SheetTitle>
+                        {isReadOnly
+                            ? t('Deposit Settlement')
+                            : settlement
+                              ? t('Edit Deposit Settlement')
+                              : t('Settle Deposit')}
+                    </SheetTitle>
+                    <SheetDescription>
+                        {lease.reference ?? `#${lease.id}`} ·{' '}
+                        {lease.primary_tenant?.name ?? t('Lease')}
+                    </SheetDescription>
+                </SheetHeader>
+
+                <div className="flex flex-1 flex-col justify-between gap-6 overflow-y-auto px-4 pt-4 pb-6">
+                    <DepositSettlementFields
+                        value={data}
+                        originalAmount={
+                            settlement?.original_amount ?? lease.deposit_amount
+                        }
+                        currency={settlement?.currency ?? lease.currency}
+                        errors={errors as Record<string, string | undefined>}
+                        readOnly={isReadOnly}
+                        onChange={setData}
+                    />
+
+                    <div className="flex flex-wrap items-center justify-end gap-3">
+                        <Button
+                            variant="outline"
+                            type="button"
+                            onClick={() => onOpenChange(false)}
+                            disabled={processing}
+                        >
+                            {t('Close')}
+                        </Button>
+                        {!isReadOnly && (
+                            <>
+                                <Button
+                                    variant="outline"
+                                    type="button"
+                                    onClick={() => save('draft')}
+                                    disabled={processing}
+                                >
+                                    {t('Save Draft')}
+                                </Button>
+                                <Button
+                                    type="button"
+                                    onClick={() => save('settled')}
+                                    disabled={processing}
+                                >
+                                    {t('Settle Deposit')}
+                                </Button>
+                            </>
+                        )}
+                    </div>
+                </div>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/resources/js/components/features/leases/index.ts
+++ b/resources/js/components/features/leases/index.ts
@@ -1,5 +1,6 @@
 export { default as LeaseDetailSheet } from './lease-detail-sheet';
 export { default as LeaseEditSheet } from './lease-edit-sheet';
+export { default as DepositSettlementSheet } from './deposit-settlement-sheet';
 export { default as MoveOutSheet } from './move-out-sheet';
 export { default as MoveUnitSheet } from './move-unit-sheet';
 export { default as RenewLeaseSheet } from './renew-lease-sheet';

--- a/resources/js/components/features/leases/lease-detail-sheet.tsx
+++ b/resources/js/components/features/leases/lease-detail-sheet.tsx
@@ -1,7 +1,10 @@
 import { router, usePage } from '@inertiajs/react';
 import { Banknote, ChevronDown, FileText } from 'lucide-react';
 import { useState } from 'react';
-import { RecordPaymentSheet } from '@/components/features';
+import {
+    DepositSettlementSheet,
+    RecordPaymentSheet,
+} from '@/components/features';
 import { DocumentPreview } from '@/components/shared';
 import { StatusBadge } from '@/components/shared/status-badge';
 import { Badge } from '@/components/ui/badge';
@@ -42,6 +45,7 @@ export default function LeaseDetailSheet({
 }) {
     const { auth } = usePage<{ auth: { permissions: string[] } }>().props;
     const [recordPaymentOpen, setRecordPaymentOpen] = useState(false);
+    const [settlementOpen, setSettlementOpen] = useState(false);
     const [verifyingId, setVerifyingId] = useState<number | null>(null);
     const [previewProof, setPreviewProof] = useState<{
         src: string;
@@ -52,6 +56,7 @@ export default function LeaseDetailSheet({
     const payments = (lease?.payments ?? []) as Payment[];
     const canVerify = auth.permissions.includes('payments.verify');
     const canSendReminder = auth.permissions.includes('reminders.send');
+    const depositSettlement = lease?.deposit_settlement;
 
     function handleVerify(payment: Payment, action: 'confirm' | 'reject') {
         setVerifyingId(payment.id);
@@ -342,8 +347,10 @@ export default function LeaseDetailSheet({
                                                 </span>
                                                 <span className="tabular-nums">
                                                     {formatPrice(
-                                                        lease.deposit_amount,
-                                                        lease.currency,
+                                                        depositSettlement?.original_amount ??
+                                                            lease.deposit_amount,
+                                                        depositSettlement?.currency ??
+                                                            lease.currency,
                                                     )}
                                                 </span>
                                             </div>
@@ -359,30 +366,128 @@ export default function LeaseDetailSheet({
                                                     </span>
                                                 </div>
                                             )}
-                                            {lease.deposit_refund_amount && (
-                                                <div className="flex items-center justify-between text-sm">
-                                                    <span className="text-muted-foreground">
-                                                        {t('Refund')}
-                                                    </span>
-                                                    <span className="tabular-nums">
-                                                        {formatPrice(
-                                                            lease.deposit_refund_amount,
-                                                            lease.currency,
-                                                        )}
-                                                    </span>
-                                                </div>
-                                            )}
-                                            {lease.deposit_refunded_at && (
-                                                <div className="flex items-center justify-between text-sm">
-                                                    <span className="text-muted-foreground">
-                                                        {t('Refunded at')}
-                                                    </span>
-                                                    <span className="tabular-nums">
-                                                        {formatDate(
-                                                            lease.deposit_refunded_at,
-                                                        )}
-                                                    </span>
-                                                </div>
+                                            {depositSettlement ? (
+                                                <>
+                                                    <div className="flex items-center justify-between text-sm">
+                                                        <span className="text-muted-foreground">
+                                                            {t('Settlement')}
+                                                        </span>
+                                                        <span className="font-medium capitalize">
+                                                            {
+                                                                depositSettlement.status
+                                                            }
+                                                        </span>
+                                                    </div>
+                                                    <div className="flex items-center justify-between text-sm">
+                                                        <span className="text-muted-foreground">
+                                                            {t(
+                                                                'Settlement date',
+                                                            )}
+                                                        </span>
+                                                        <span className="tabular-nums">
+                                                            {formatDate(
+                                                                depositSettlement.settlement_date,
+                                                            )}
+                                                        </span>
+                                                    </div>
+                                                    <div className="flex items-center justify-between text-sm">
+                                                        <span className="text-muted-foreground">
+                                                            {t('Refund')}
+                                                        </span>
+                                                        <span className="tabular-nums">
+                                                            {formatPrice(
+                                                                depositSettlement.refund_amount,
+                                                                depositSettlement.currency,
+                                                            )}
+                                                        </span>
+                                                    </div>
+                                                    <div className="flex items-center justify-between text-sm">
+                                                        <span className="text-muted-foreground">
+                                                            {t('Deductions')}
+                                                        </span>
+                                                        <span className="tabular-nums">
+                                                            {formatPrice(
+                                                                depositSettlement.deductions_total,
+                                                                depositSettlement.currency,
+                                                            )}
+                                                        </span>
+                                                    </div>
+                                                    {depositSettlement.deductions.map(
+                                                        (deduction) => (
+                                                            <div
+                                                                key={
+                                                                    deduction.id
+                                                                }
+                                                                className="rounded-md bg-muted/30 p-2 text-xs"
+                                                            >
+                                                                <div className="flex items-center justify-between gap-3">
+                                                                    <span>
+                                                                        {
+                                                                            deduction.reason
+                                                                        }
+                                                                    </span>
+                                                                    <span className="tabular-nums">
+                                                                        {formatPrice(
+                                                                            deduction.amount,
+                                                                            depositSettlement.currency,
+                                                                        )}
+                                                                    </span>
+                                                                </div>
+                                                                {deduction.description && (
+                                                                    <p className="mt-1 text-muted-foreground">
+                                                                        {
+                                                                            deduction.description
+                                                                        }
+                                                                    </p>
+                                                                )}
+                                                            </div>
+                                                        ),
+                                                    )}
+                                                    {depositSettlement.refund_reference && (
+                                                        <div className="flex items-center justify-between text-sm">
+                                                            <span className="text-muted-foreground">
+                                                                {t(
+                                                                    'Refund reference',
+                                                                )}
+                                                            </span>
+                                                            <span className="text-right">
+                                                                {
+                                                                    depositSettlement.refund_reference
+                                                                }
+                                                            </span>
+                                                        </div>
+                                                    )}
+                                                </>
+                                            ) : (
+                                                <>
+                                                    {lease.deposit_refund_amount && (
+                                                        <div className="flex items-center justify-between text-sm">
+                                                            <span className="text-muted-foreground">
+                                                                {t('Refund')}
+                                                            </span>
+                                                            <span className="tabular-nums">
+                                                                {formatPrice(
+                                                                    lease.deposit_refund_amount,
+                                                                    lease.currency,
+                                                                )}
+                                                            </span>
+                                                        </div>
+                                                    )}
+                                                    {lease.deposit_refunded_at && (
+                                                        <div className="flex items-center justify-between text-sm">
+                                                            <span className="text-muted-foreground">
+                                                                {t(
+                                                                    'Refunded at',
+                                                                )}
+                                                            </span>
+                                                            <span className="tabular-nums">
+                                                                {formatDate(
+                                                                    lease.deposit_refunded_at,
+                                                                )}
+                                                            </span>
+                                                        </div>
+                                                    )}
+                                                </>
                                             )}
                                         </div>
                                     </CollapsibleContent>
@@ -674,6 +779,19 @@ export default function LeaseDetailSheet({
                                     {t('Move Unit')}
                                 </Button>
                             )}
+                            {lease?.status === 'terminated' && (
+                                <Button
+                                    variant="outline"
+                                    onClick={() => {
+                                        onOpenChange(false);
+                                        setSettlementOpen(true);
+                                    }}
+                                >
+                                    {depositSettlement
+                                        ? t('View Deposit Settlement')
+                                        : t('Settle Deposit')}
+                                </Button>
+                            )}
                             {isActive && canSendReminder && (
                                 <Button
                                     variant="outline"
@@ -701,6 +819,12 @@ export default function LeaseDetailSheet({
                 lease={lease}
                 open={recordPaymentOpen}
                 onOpenChange={setRecordPaymentOpen}
+            />
+
+            <DepositSettlementSheet
+                lease={lease}
+                open={settlementOpen}
+                onOpenChange={setSettlementOpen}
             />
 
             {previewProof && (

--- a/resources/js/components/features/leases/lease-overview.tsx
+++ b/resources/js/components/features/leases/lease-overview.tsx
@@ -1,5 +1,7 @@
 import { ChevronDown } from 'lucide-react';
+import { useState } from 'react';
 import { StatusBadge } from '@/components/shared/status-badge';
+import { Button } from '@/components/ui/button';
 import {
     Collapsible,
     CollapsibleContent,
@@ -10,13 +12,16 @@ import { BILLING_STRATEGIES } from '@/lib/constants/billing';
 import { formatDate, formatPrice } from '@/lib/formatters';
 import { t } from '@/lib/i18n';
 import type { Lease } from '@/types';
+import DepositSettlementSheet from './deposit-settlement-sheet';
 
 export default function LeaseOverview({ lease }: { lease: Lease }) {
+    const [settlementOpen, setSettlementOpen] = useState(false);
     const unitLabel = lease.unit?.name ?? '—';
     const propertyName = lease.unit?.property?.name ?? '—';
     const city = lease.unit?.property?.city;
     const propertyCity =
         city && typeof city === 'object' ? city.name : (city ?? '');
+    const depositSettlement = lease.deposit_settlement;
     const billingStrategy =
         BILLING_STRATEGIES.find((s) => s.value === lease.billing_strategy)
             ?.label ?? 'Advance (due within period)';
@@ -234,8 +239,10 @@ export default function LeaseOverview({ lease }: { lease: Lease }) {
                                 </span>
                                 <span className="tabular-nums">
                                     {formatPrice(
-                                        lease.deposit_amount,
-                                        lease.currency,
+                                        depositSettlement?.original_amount ??
+                                            lease.deposit_amount,
+                                        depositSettlement?.currency ??
+                                            lease.currency,
                                     )}
                                 </span>
                             </div>
@@ -249,28 +256,126 @@ export default function LeaseOverview({ lease }: { lease: Lease }) {
                                     </span>
                                 </div>
                             )}
-                            {lease.deposit_refund_amount && (
-                                <div className="flex items-center justify-between text-sm">
-                                    <span className="text-muted-foreground">
-                                        {t('Refund')}
-                                    </span>
-                                    <span className="tabular-nums">
-                                        {formatPrice(
-                                            lease.deposit_refund_amount,
-                                            lease.currency,
-                                        )}
-                                    </span>
-                                </div>
+                            {depositSettlement ? (
+                                <>
+                                    <div className="flex items-center justify-between text-sm">
+                                        <span className="text-muted-foreground">
+                                            {t('Settlement')}
+                                        </span>
+                                        <span className="font-medium capitalize">
+                                            {depositSettlement.status}
+                                        </span>
+                                    </div>
+                                    <div className="flex items-center justify-between text-sm">
+                                        <span className="text-muted-foreground">
+                                            {t('Settlement date')}
+                                        </span>
+                                        <span className="tabular-nums">
+                                            {formatDate(
+                                                depositSettlement.settlement_date,
+                                            )}
+                                        </span>
+                                    </div>
+                                    <div className="flex items-center justify-between text-sm">
+                                        <span className="text-muted-foreground">
+                                            {t('Refund')}
+                                        </span>
+                                        <span className="tabular-nums">
+                                            {formatPrice(
+                                                depositSettlement.refund_amount,
+                                                depositSettlement.currency,
+                                            )}
+                                        </span>
+                                    </div>
+                                    <div className="flex items-center justify-between text-sm">
+                                        <span className="text-muted-foreground">
+                                            {t('Deductions')}
+                                        </span>
+                                        <span className="tabular-nums">
+                                            {formatPrice(
+                                                depositSettlement.deductions_total,
+                                                depositSettlement.currency,
+                                            )}
+                                        </span>
+                                    </div>
+                                    {depositSettlement.deductions.map(
+                                        (deduction) => (
+                                            <div
+                                                key={deduction.id}
+                                                className="rounded-md bg-muted/30 p-2 text-xs"
+                                            >
+                                                <div className="flex items-center justify-between gap-3">
+                                                    <span>
+                                                        {deduction.reason}
+                                                    </span>
+                                                    <span className="tabular-nums">
+                                                        {formatPrice(
+                                                            deduction.amount,
+                                                            depositSettlement.currency,
+                                                        )}
+                                                    </span>
+                                                </div>
+                                                {deduction.description && (
+                                                    <p className="mt-1 text-muted-foreground">
+                                                        {deduction.description}
+                                                    </p>
+                                                )}
+                                            </div>
+                                        ),
+                                    )}
+                                    {depositSettlement.refund_reference && (
+                                        <div className="flex items-center justify-between text-sm">
+                                            <span className="text-muted-foreground">
+                                                {t('Refund reference')}
+                                            </span>
+                                            <span className="text-right">
+                                                {
+                                                    depositSettlement.refund_reference
+                                                }
+                                            </span>
+                                        </div>
+                                    )}
+                                </>
+                            ) : (
+                                <>
+                                    {lease.deposit_refund_amount && (
+                                        <div className="flex items-center justify-between text-sm">
+                                            <span className="text-muted-foreground">
+                                                {t('Refund')}
+                                            </span>
+                                            <span className="tabular-nums">
+                                                {formatPrice(
+                                                    lease.deposit_refund_amount,
+                                                    lease.currency,
+                                                )}
+                                            </span>
+                                        </div>
+                                    )}
+                                    {lease.deposit_refunded_at && (
+                                        <div className="flex items-center justify-between text-sm">
+                                            <span className="text-muted-foreground">
+                                                {t('Refunded at')}
+                                            </span>
+                                            <span className="tabular-nums">
+                                                {formatDate(
+                                                    lease.deposit_refunded_at,
+                                                )}
+                                            </span>
+                                        </div>
+                                    )}
+                                </>
                             )}
-                            {lease.deposit_refunded_at && (
-                                <div className="flex items-center justify-between text-sm">
-                                    <span className="text-muted-foreground">
-                                        {t('Refunded at')}
-                                    </span>
-                                    <span className="tabular-nums">
-                                        {formatDate(lease.deposit_refunded_at)}
-                                    </span>
-                                </div>
+                            {lease.status === 'terminated' && (
+                                <Button
+                                    type="button"
+                                    variant="outline"
+                                    className="mt-2 w-full"
+                                    onClick={() => setSettlementOpen(true)}
+                                >
+                                    {depositSettlement
+                                        ? t('View Deposit Settlement')
+                                        : t('Settle Deposit')}
+                                </Button>
                             )}
                         </div>
                     </CollapsibleContent>
@@ -287,6 +392,12 @@ export default function LeaseOverview({ lease }: { lease: Lease }) {
                     </p>
                 </div>
             )}
+
+            <DepositSettlementSheet
+                lease={lease}
+                open={settlementOpen}
+                onOpenChange={setSettlementOpen}
+            />
         </div>
     );
 }

--- a/resources/js/components/features/leases/move-out-sheet.tsx
+++ b/resources/js/components/features/leases/move-out-sheet.tsx
@@ -23,6 +23,18 @@ import { todayISO } from '@/lib/formatters';
 import { t } from '@/lib/i18n';
 import leases from '@/routes/leases';
 import type { AvailableUnit, LeaseData } from '@/types';
+import DepositSettlementFields, {
+    emptyDepositSettlementForm,
+} from './deposit-settlement-fields';
+import type { DepositSettlementFormData } from './deposit-settlement-fields';
+
+type MoveOutFormData = {
+    move_out_date: string;
+    reason: string;
+    deposit_refund_amount: string;
+    notes: string;
+    settlement: DepositSettlementFormData | null;
+};
 
 const REASONS = [
     { value: 'contract_ended', label: 'Contract ended' },
@@ -48,14 +60,16 @@ export default function MoveOutSheet({
     const { setting } = usePage<{ setting: { currency: string } }>().props;
     const currency = lease?.currency ?? setting.currency;
     const { data, setData, transform, submit, reset, processing, errors } =
-        useForm({
+        useForm<MoveOutFormData>({
             move_out_date: todayISO(),
             reason: '',
             deposit_refund_amount: '',
             notes: '',
+            settlement: null,
         });
 
     const [depositReturned, setDepositReturned] = useState<string | null>(null);
+    const [settlementEnabled, setSettlementEnabled] = useState(false);
     const [moveToAnotherUnit, setMoveToAnotherUnit] = useState(false);
     const [selectedPropertyId, setSelectedPropertyId] = useState<number | null>(
         null,
@@ -73,7 +87,11 @@ export default function MoveOutSheet({
                 move_to_another_unit: moveToAnotherUnit ? '1' : '0',
             };
 
-            if (depositReturned !== 'yes') {
+            if (settlementEnabled && d.settlement) {
+                payload.settlement = d.settlement;
+                delete payload.deposit_returned;
+                delete payload.deposit_refund_amount;
+            } else if (depositReturned !== 'yes') {
                 delete payload.deposit_refund_amount;
             }
 
@@ -143,6 +161,7 @@ export default function MoveOutSheet({
         if (!next) {
             reset();
             setDepositReturned(null);
+            setSettlementEnabled(false);
             setMoveToAnotherUnit(false);
             setSelectedPropertyId(null);
             setSelectedTargetUnitId(null);
@@ -163,6 +182,8 @@ export default function MoveOutSheet({
     if (!isCurrentlyOccupied) {
         return null;
     }
+
+    const currentLease = lease!;
 
     return (
         <Sheet open={open} onOpenChange={handleOpenChange}>
@@ -253,64 +274,157 @@ export default function MoveOutSheet({
                             <InputError message={errors.reason} />
                         </div>
 
-                        <div className="grid gap-2">
-                            <Label>{t('Deposit Returned?')}</Label>
-                            <div className="flex items-center gap-4">
-                                <label className="flex items-center gap-2 text-sm">
-                                    <input
-                                        type="radio"
-                                        name="deposit_returned_radio"
-                                        checked={depositReturned === 'yes'}
-                                        onChange={() =>
-                                            setDepositReturned('yes')
+                        {!settlementEnabled && (
+                            <>
+                                <div className="grid gap-2">
+                                    <Label>{t('Deposit Returned?')}</Label>
+                                    <div className="flex items-center gap-4">
+                                        <label className="flex items-center gap-2 text-sm">
+                                            <input
+                                                type="radio"
+                                                name="deposit_returned_radio"
+                                                checked={
+                                                    depositReturned === 'yes'
+                                                }
+                                                onChange={() =>
+                                                    setDepositReturned('yes')
+                                                }
+                                                className="size-4"
+                                            />
+                                            {t('Yes')}
+                                        </label>
+                                        <label className="flex items-center gap-2 text-sm">
+                                            <input
+                                                type="radio"
+                                                name="deposit_returned_radio"
+                                                checked={
+                                                    depositReturned === 'no'
+                                                }
+                                                onChange={() =>
+                                                    setDepositReturned('no')
+                                                }
+                                                className="size-4"
+                                            />
+                                            {t('No')}
+                                        </label>
+                                    </div>
+                                    <InputError
+                                        message={
+                                            (errors as Record<string, string>)
+                                                .deposit_returned
                                         }
-                                        className="size-4"
                                     />
-                                    {t('Yes')}
-                                </label>
-                                <label className="flex items-center gap-2 text-sm">
-                                    <input
-                                        type="radio"
-                                        name="deposit_returned_radio"
-                                        checked={depositReturned === 'no'}
-                                        onChange={() =>
-                                            setDepositReturned('no')
-                                        }
-                                        className="size-4"
-                                    />
-                                    {t('No')}
-                                </label>
-                            </div>
-                            <InputError
-                                message={
-                                    (errors as Record<string, string>)
-                                        .deposit_returned
-                                }
-                            />
-                        </div>
+                                </div>
 
-                        {depositReturned === 'yes' && (
-                            <div className="grid gap-2">
-                                <Label htmlFor="deposit_refund_amount">
-                                    {t('Refund Amount')} ({currency})
-                                </Label>
-                                <Input
-                                    id="deposit_refund_amount"
-                                    type="number"
-                                    min={0}
-                                    value={data.deposit_refund_amount}
-                                    onChange={(e) =>
-                                        setData(
-                                            'deposit_refund_amount',
-                                            e.target.value,
-                                        )
-                                    }
-                                    placeholder={t(
-                                        'Leave empty for full deposit',
+                                {depositReturned === 'yes' && (
+                                    <div className="grid gap-2">
+                                        <Label htmlFor="deposit_refund_amount">
+                                            {t('Refund Amount')} ({currency})
+                                        </Label>
+                                        <Input
+                                            id="deposit_refund_amount"
+                                            type="number"
+                                            min={0}
+                                            value={data.deposit_refund_amount}
+                                            onChange={(e) =>
+                                                setData(
+                                                    'deposit_refund_amount',
+                                                    e.target.value,
+                                                )
+                                            }
+                                            placeholder={t(
+                                                'Leave empty for full deposit',
+                                            )}
+                                        />
+                                        <InputError
+                                            message={
+                                                errors.deposit_refund_amount
+                                            }
+                                        />
+                                    </div>
+                                )}
+                            </>
+                        )}
+
+                        <label className="flex items-start gap-3 rounded-md border p-3 text-sm">
+                            <input
+                                type="checkbox"
+                                checked={settlementEnabled}
+                                disabled={moveToAnotherUnit}
+                                onChange={(event) => {
+                                    const enabled = event.target.checked;
+                                    setSettlementEnabled(enabled);
+                                    setData(
+                                        'settlement',
+                                        enabled
+                                            ? emptyDepositSettlementForm(
+                                                  currentLease.deposit_amount,
+                                              )
+                                            : null,
+                                    );
+                                }}
+                                className="mt-0.5 size-4"
+                            />
+                            <div>
+                                <span className="font-medium">
+                                    {t('Create deposit settlement now?')}
+                                </span>
+                                <p className="text-xs text-muted-foreground">
+                                    {t(
+                                        'Optional. Save a draft or settle the deposit as part of move-out.',
                                     )}
-                                />
-                                <InputError
-                                    message={errors.deposit_refund_amount}
+                                </p>
+                            </div>
+                        </label>
+
+                        {settlementEnabled && data.settlement && (
+                            <div className="space-y-3">
+                                <div className="grid gap-2">
+                                    <Label>{t('Settlement Status')}</Label>
+                                    <Select
+                                        value={data.settlement.status}
+                                        onValueChange={(value) =>
+                                            setData('settlement', {
+                                                ...data.settlement!,
+                                                status: value as
+                                                    | 'draft'
+                                                    | 'settled',
+                                            })
+                                        }
+                                    >
+                                        <SelectTrigger>
+                                            <SelectValue />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            <SelectItem value="draft">
+                                                {t('Draft')}
+                                            </SelectItem>
+                                            <SelectItem value="settled">
+                                                {t('Settled')}
+                                            </SelectItem>
+                                        </SelectContent>
+                                    </Select>
+                                    <InputError
+                                        message={
+                                            (errors as Record<string, string>)[
+                                                'settlement.status'
+                                            ]
+                                        }
+                                    />
+                                </div>
+                                <DepositSettlementFields
+                                    value={data.settlement}
+                                    originalAmount={currentLease.deposit_amount}
+                                    currency={currency}
+                                    errors={
+                                        errors as Record<
+                                            string,
+                                            string | undefined
+                                        >
+                                    }
+                                    onChange={(settlement) =>
+                                        setData('settlement', settlement)
+                                    }
                                 />
                             </div>
                         )}
@@ -321,6 +435,11 @@ export default function MoveOutSheet({
                                 checked={moveToAnotherUnit}
                                 onChange={(e) => {
                                     setMoveToAnotherUnit(e.target.checked);
+
+                                    if (e.target.checked) {
+                                        setSettlementEnabled(false);
+                                        setData('settlement', null);
+                                    }
 
                                     if (!e.target.checked) {
                                         setSelectedPropertyId(null);

--- a/resources/js/pages/leases/index.tsx
+++ b/resources/js/pages/leases/index.tsx
@@ -407,16 +407,7 @@ export default function Index({
             />
 
             <MoveOutSheet
-                lease={
-                    detailLease
-                        ? {
-                              id: detailLease.id,
-                              tenants: detailLease.tenants,
-                              primary_tenant: detailLease.primary_tenant,
-                              unit: detailLease.unit,
-                          }
-                        : null
-                }
+                lease={detailLease}
                 availableUnits={_availableUnits}
                 open={moveOutOpen}
                 onOpenChange={setMoveOutOpen}

--- a/resources/js/pages/properties/units/index.tsx
+++ b/resources/js/pages/properties/units/index.tsx
@@ -105,6 +105,8 @@ export default function Index({
 
     const [moveOutLeaseData, setMoveOutLeaseData] = useState<{
         id: number;
+        currency: string;
+        deposit_amount: string;
         tenants: { id: number; name: string; phone: string | null }[];
         primary_tenant: {
             id: number;
@@ -208,6 +210,8 @@ export default function Index({
 
         setMoveOutLeaseData({
             id: lease.id,
+            currency: lease.currency,
+            deposit_amount: lease.deposit_amount,
             tenants: lease.tenants ?? [],
             primary_tenant: lease.primary_tenant ?? null,
             unit: {

--- a/resources/js/pages/properties/units/leases/index.tsx
+++ b/resources/js/pages/properties/units/leases/index.tsx
@@ -171,11 +171,25 @@ export default function Index({
                                         <td className="px-4 py-3 tabular-nums">
                                             <div>
                                                 {formatPrice(
-                                                    lease.deposit_amount,
-                                                    lease.currency,
+                                                    lease.deposit_settlement
+                                                        ?.original_amount ??
+                                                        lease.deposit_amount,
+                                                    lease.deposit_settlement
+                                                        ?.currency ??
+                                                        lease.currency,
                                                 )}
                                             </div>
-                                            {lease.deposit_refund_amount && (
+                                            {lease.deposit_settlement ? (
+                                                <div className="text-xs text-muted-foreground">
+                                                    {t('Refund')}:{' '}
+                                                    {formatPrice(
+                                                        lease.deposit_settlement
+                                                            .refund_amount,
+                                                        lease.deposit_settlement
+                                                            .currency,
+                                                    )}
+                                                </div>
+                                            ) : lease.deposit_refund_amount ? (
                                                 <div className="text-xs text-muted-foreground">
                                                     Refund:{' '}
                                                     {formatPrice(
@@ -183,7 +197,7 @@ export default function Index({
                                                         lease.currency,
                                                     )}
                                                 </div>
-                                            )}
+                                            ) : null}
                                         </td>
                                         <td className="px-4 py-3 tabular-nums">
                                             {lease.rent_due_day}
@@ -236,16 +250,7 @@ export default function Index({
             />
 
             <MoveOutSheet
-                lease={
-                    detailLease
-                        ? {
-                              id: detailLease.id,
-                              tenants: detailLease.tenants,
-                              primary_tenant: detailLease.primary_tenant,
-                              unit: detailLease.unit,
-                          }
-                        : null
-                }
+                lease={detailLease}
                 availableUnits={_availableUnits}
                 open={moveOutOpen}
                 onOpenChange={setMoveOutOpen}

--- a/resources/js/pages/tenants/index.tsx
+++ b/resources/js/pages/tenants/index.tsx
@@ -380,6 +380,10 @@ export default function Index({
         },
     ];
 
+    const tenantMoveOutLease = moveOutTenant
+        ? (moveOutTenant as WorkspaceTenant & { leases?: Lease[] }).leases?.[0]
+        : null;
+
     return (
         <>
             <Head title={t('Tenants')} />
@@ -508,14 +512,11 @@ export default function Index({
 
             <MoveOutSheet
                 lease={
-                    moveOutTenant
+                    moveOutTenant && tenantMoveOutLease
                         ? {
-                              id:
-                                  (
-                                      moveOutTenant as WorkspaceTenant & {
-                                          leases?: Lease[];
-                                      }
-                                  ).leases?.[0]?.id ?? 0,
+                              id: tenantMoveOutLease.id,
+                              currency: tenantMoveOutLease.currency,
+                              deposit_amount: tenantMoveOutLease.deposit_amount,
                               tenants: [
                                   {
                                       id: moveOutTenant.id,
@@ -529,12 +530,7 @@ export default function Index({
                                   name: moveOutTenant.name,
                                   phone: moveOutTenant.phone,
                               },
-                              unit:
-                                  (
-                                      moveOutTenant as WorkspaceTenant & {
-                                          leases?: Lease[];
-                                      }
-                                  ).leases?.[0]?.unit ?? null,
+                              unit: tenantMoveOutLease.unit ?? null,
                           }
                         : null
                 }

--- a/resources/js/types/models.ts
+++ b/resources/js/types/models.ts
@@ -251,6 +251,26 @@ export type TenantLease = {
     primary_tenant: TenantInfo | null;
 };
 
+export type DepositDeduction = {
+    id: number;
+    amount: string;
+    reason: string;
+    description: string | null;
+};
+
+export type DepositSettlement = {
+    id: number;
+    original_amount: string;
+    currency: string;
+    status: 'draft' | 'settled' | string;
+    settlement_date: string;
+    refund_amount: string;
+    deductions_total: string;
+    refund_reference: string | null;
+    notes: string | null;
+    deductions: DepositDeduction[];
+};
+
 export type LeaseInfo = {
     id: number;
     reference: string | null;
@@ -268,6 +288,7 @@ export type LeaseInfo = {
     deposit_paid_at: string | null;
     deposit_refund_amount: string | null;
     deposit_refunded_at: string | null;
+    deposit_settlement?: DepositSettlement | null;
     rent_due_day: number;
     status: string;
     notes: string | null;
@@ -294,6 +315,7 @@ export type Lease = {
     deposit_paid_at: string | null;
     deposit_refund_amount: string | null;
     deposit_refunded_at: string | null;
+    deposit_settlement?: DepositSettlement | null;
     rent_due_day: number;
     status: string;
     termination_date: string | null;
@@ -334,7 +356,8 @@ export type TenantLeaseContext = {
 
 export type LeaseData = {
     id: number;
-    currency?: string;
+    currency: string;
+    deposit_amount: string;
     tenants: TenantInfo[];
     primary_tenant: TenantInfo | null;
     unit: { id: number; name: string } | null;

--- a/routes/web.php
+++ b/routes/web.php
@@ -286,6 +286,7 @@ Route::middleware(['auth', 'verified', 'permission:dashboard.view'])->group(func
             Route::get('invoices/{invoice}/download', [LeaseInvoiceController::class, 'download'])->name('workspace.invoices.download')->middleware('permission:leases.view');
             Route::get('rent-schedule', LeaseRentScheduleController::class)->name('rent-schedule')->middleware('permission:leases.view');
             Route::post('move-out', [LeaseController::class, 'moveOut'])->name('move-out')->middleware('permission:leases.move_out');
+            Route::post('deposit-settlement', [LeaseController::class, 'saveDepositSettlement'])->name('deposit-settlement')->middleware('permission:leases.move_out');
             Route::post('renew', [LeaseController::class, 'renew'])->name('renew')->middleware('permission:leases.renew');
 
             Route::prefix('payments')->group(function () {

--- a/tests/Feature/DepositSettlementTest.php
+++ b/tests/Feature/DepositSettlementTest.php
@@ -1,19 +1,23 @@
 <?php
 
+use App\Actions\Leases\MoveOutLease;
 use App\Actions\Leases\SettleLeaseDeposit;
 use App\Data\Lease\DepositDeductionData;
 use App\Data\Lease\DepositSettlementData;
+use App\Data\Lease\MoveOutLeaseData;
 use App\Enums\DepositSettlementStatus;
 use App\Enums\LeaseStatus;
 use App\Models\AuditLog;
 use App\Models\DepositSettlement;
 use App\Models\Lease;
+use App\Models\Unit;
 use App\Models\User;
 use Carbon\CarbonImmutable;
 use Database\Seeders\RegionAndCitySeeder;
 use Database\Seeders\RoleAndPermissionSeeder;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 uses()->beforeEach(function () {
     $this->seed(RoleAndPermissionSeeder::class);
@@ -202,6 +206,24 @@ it('keeps one settlement when a draft is saved more than once', function () {
     expect(DepositSettlement::where('lease_id', $lease->id)->count())->toBe(1);
 });
 
+it('keeps the original snapshot when lease deposit data later changes', function () {
+    $lease = terminatedDepositLease();
+    $action = app(SettleLeaseDeposit::class);
+
+    $action->execute($lease, depositSettlementData());
+    DB::table('leases')->whereKey($lease->id)->update([
+        'deposit_amount' => '2000',
+        'currency' => 'EUR',
+    ]);
+
+    $settlement = $action->execute($lease, depositSettlementData(refundAmount: '600'));
+
+    expect($settlement)
+        ->original_amount->toBe('1000.000')
+        ->currency->toBe('USD')
+        ->refund_amount->toBe('600.000');
+});
+
 it('translates concurrent settlement creation conflicts into validation errors', function () {
     $lease = terminatedDepositLease();
     $dispatcher = DepositSettlement::getEventDispatcher();
@@ -237,6 +259,28 @@ it('translates concurrent settlement creation conflicts into validation errors',
     }
 
     expect(DepositSettlement::count())->toBe(0);
+});
+
+it('does not settle a deposit while transferring a lease to another unit', function () {
+    $sourceUnit = Unit::factory()->withRate('1000', 'USD')->create();
+    $targetUnit = Unit::factory()->withRate('1000', 'USD')->create();
+    $lease = Lease::factory()->create([
+        'unit_id' => $sourceUnit->id,
+        'deposit_amount' => '1000',
+        'currency' => 'USD',
+    ]);
+
+    expect(fn () => app(MoveOutLease::class)->execute($lease, new MoveOutLeaseData(
+        terminationDate: '2026-09-11',
+        endDate: '2026-09-11',
+        reason: 'Moved unit',
+        moveToAnotherUnit: true,
+        targetUnitId: $targetUnit->id,
+        depositSettlement: depositSettlementData(DepositSettlementStatus::Settled, refundAmount: '1000'),
+    )))->toThrow(HttpException::class);
+
+    expect($lease->fresh()->status)->toBe(LeaseStatus::Active)
+        ->and(DepositSettlement::count())->toBe(0);
 });
 
 it('rejects zero-deposit settlements', function () {

--- a/tests/Feature/DepositSettlementTest.php
+++ b/tests/Feature/DepositSettlementTest.php
@@ -1,0 +1,295 @@
+<?php
+
+use App\Actions\Leases\SettleLeaseDeposit;
+use App\Data\Lease\DepositDeductionData;
+use App\Data\Lease\DepositSettlementData;
+use App\Enums\DepositSettlementStatus;
+use App\Enums\LeaseStatus;
+use App\Models\AuditLog;
+use App\Models\DepositSettlement;
+use App\Models\Lease;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Database\Seeders\RegionAndCitySeeder;
+use Database\Seeders\RoleAndPermissionSeeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+uses()->beforeEach(function () {
+    $this->seed(RoleAndPermissionSeeder::class);
+    $this->seed(RegionAndCitySeeder::class);
+});
+
+function depositSettlementData(
+    DepositSettlementStatus $status = DepositSettlementStatus::Draft,
+    string $refundAmount = '700',
+    array $deductions = [],
+): DepositSettlementData {
+    return new DepositSettlementData(
+        status: $status,
+        settlementDate: CarbonImmutable::parse('2026-09-11'),
+        refundAmount: $refundAmount,
+        deductions: array_map(
+            fn (array $deduction): DepositDeductionData => new DepositDeductionData(...$deduction),
+            $deductions,
+        ),
+    );
+}
+
+function terminatedDepositLease(array $attributes = []): Lease
+{
+    return Lease::factory()->terminated()->create([
+        'deposit_amount' => '1000',
+        'currency' => 'USD',
+        ...$attributes,
+    ]);
+}
+
+it('creates a draft with a deposit snapshot and deduction lines', function () {
+    $lease = terminatedDepositLease();
+    $auditCount = AuditLog::count();
+
+    $settlement = app(SettleLeaseDeposit::class)->execute(
+        $lease,
+        depositSettlementData(deductions: [
+            ['amount' => '300', 'reason' => 'Repairs', 'description' => 'Broken door'],
+        ]),
+    );
+
+    expect($settlement)
+        ->original_amount->toBe('1000.000')
+        ->currency->toBe('USD')
+        ->status->toBe(DepositSettlementStatus::Draft)
+        ->refund_amount->toBe('700.000')
+        ->deductions_total->toBe('300.000');
+    expect($settlement->deductions)->toHaveCount(1);
+    expect(AuditLog::where('created_at', '>=', now()->subMinute())->count())->toBeGreaterThan($auditCount);
+});
+
+it('allows drafts to be edited and replaces deduction rows with audit events', function () {
+    $lease = terminatedDepositLease();
+    $action = app(SettleLeaseDeposit::class);
+
+    $draft = $action->execute($lease, depositSettlementData());
+    $oldDeduction = $draft->deductions()->create([
+        'amount' => '300',
+        'reason' => 'Repairs',
+    ]);
+
+    $action->execute($lease, depositSettlementData(
+        refundAmount: '500',
+        deductions: [
+            ['amount' => '500', 'reason' => 'Cleaning', 'description' => null],
+        ],
+    ));
+
+    expect($draft->fresh()->deductions)->toHaveCount(1)
+        ->and($draft->fresh()->deductions->first()->reason)->toBe('Cleaning');
+    expect(AuditLog::where('auditable_type', $oldDeduction->getMorphClass())
+        ->where('auditable_id', $oldDeduction->id)
+        ->where('operation', 'delete')
+        ->exists())->toBeTrue();
+});
+
+it('rejects allocations above the original deposit', function () {
+    $lease = terminatedDepositLease();
+
+    expect(fn () => app(SettleLeaseDeposit::class)->execute(
+        $lease,
+        depositSettlementData(
+            refundAmount: '701',
+            deductions: [['amount' => '300', 'reason' => 'Repairs']],
+        ),
+    ))->toThrow(ValidationException::class);
+
+    expect(DepositSettlement::count())->toBe(0);
+});
+
+it('requires exact reconciliation when settling', function () {
+    $lease = terminatedDepositLease();
+
+    expect(fn () => app(SettleLeaseDeposit::class)->execute(
+        $lease,
+        depositSettlementData(DepositSettlementStatus::Settled, refundAmount: '700'),
+    ))->toThrow(ValidationException::class);
+
+    expect(DepositSettlement::count())->toBe(0);
+});
+
+it('supports full refunds and full forfeiture through deductions', function () {
+    $action = app(SettleLeaseDeposit::class);
+    $refundSettlement = $action->execute(
+        terminatedDepositLease(),
+        depositSettlementData(DepositSettlementStatus::Settled, refundAmount: '1000'),
+    );
+    $forfeitSettlement = $action->execute(
+        terminatedDepositLease(),
+        depositSettlementData(
+            DepositSettlementStatus::Settled,
+            refundAmount: '0',
+            deductions: [['amount' => '1000', 'reason' => 'Full forfeiture']],
+        ),
+    );
+
+    expect($refundSettlement->status)->toBe(DepositSettlementStatus::Settled)
+        ->and($refundSettlement->deductions)->toBeEmpty()
+        ->and($forfeitSettlement->refund_amount)->toBe('0.000')
+        ->and($forfeitSettlement->deductions_total)->toBe('1000.000');
+});
+
+it('does not allow settled settlements to be changed', function () {
+    $lease = terminatedDepositLease();
+    $action = app(SettleLeaseDeposit::class);
+
+    $action->execute($lease, depositSettlementData(DepositSettlementStatus::Settled, refundAmount: '1000'));
+
+    expect(fn () => $action->execute($lease, depositSettlementData()))
+        ->toThrow(ValidationException::class);
+});
+
+it('saves a post-move-out draft through the lease endpoint', function () {
+    $user = User::factory()->owner()->create();
+    $lease = terminatedDepositLease();
+
+    $this->actingAs($user)
+        ->post(route('leases.deposit-settlement', $lease), [
+            'status' => 'draft',
+            'refund_amount' => '500',
+            'deductions' => [
+                ['amount' => '100', 'reason' => 'Cleaning'],
+            ],
+        ])
+        ->assertRedirect();
+
+    expect($lease->fresh()->depositSettlement)
+        ->status->toBe(DepositSettlementStatus::Draft)
+        ->refund_amount->toBe('500.000');
+});
+
+it('keeps one settlement when a draft is saved more than once', function () {
+    $lease = terminatedDepositLease();
+    $action = app(SettleLeaseDeposit::class);
+
+    $action->execute($lease, depositSettlementData());
+    $action->execute($lease, depositSettlementData(refundAmount: '600'));
+
+    expect(DepositSettlement::where('lease_id', $lease->id)->count())->toBe(1);
+});
+
+it('translates concurrent settlement creation conflicts into validation errors', function () {
+    $lease = terminatedDepositLease();
+    $dispatcher = DepositSettlement::getEventDispatcher();
+    $testDispatcher = clone $dispatcher;
+    $injected = false;
+
+    DepositSettlement::setEventDispatcher($testDispatcher);
+    DepositSettlement::creating(function (DepositSettlement $settlement) use (&$injected): void {
+        if ($injected) {
+            return;
+        }
+
+        $injected = true;
+        DB::table('deposit_settlements')->insert([
+            'lease_id' => $settlement->lease_id,
+            'original_amount' => $settlement->original_amount,
+            'currency' => $settlement->currency,
+            'status' => DepositSettlementStatus::Draft->value,
+            'settlement_date' => $settlement->settlement_date,
+            'refund_amount' => $settlement->refund_amount,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    });
+
+    try {
+        expect(fn () => app(SettleLeaseDeposit::class)->execute(
+            $lease,
+            depositSettlementData(),
+        ))->toThrow(ValidationException::class);
+    } finally {
+        DepositSettlement::setEventDispatcher($dispatcher);
+    }
+
+    expect(DepositSettlement::count())->toBe(0);
+});
+
+it('rejects zero-deposit settlements', function () {
+    $lease = terminatedDepositLease(['deposit_amount' => '0']);
+
+    expect(fn () => app(SettleLeaseDeposit::class)->execute($lease, depositSettlementData()))
+        ->toThrow(ValidationException::class);
+});
+
+it('settles an active lease atomically with move-out', function () {
+    $user = User::factory()->owner()->create();
+    $lease = Lease::factory()->create([
+        'deposit_amount' => '1000',
+        'currency' => 'USD',
+    ]);
+
+    $this->actingAs($user)
+        ->post(route('leases.move-out', $lease), [
+            'move_out_date' => '2026-09-11',
+            'reason' => 'Moved out',
+            'settlement' => [
+                'status' => 'settled',
+                'settlement_date' => '2026-09-11',
+                'refund_amount' => '800',
+                'deductions' => [
+                    ['amount' => '200', 'reason' => 'Cleaning'],
+                ],
+            ],
+        ])
+        ->assertRedirect();
+
+    expect($lease->fresh()->status)->toBe(LeaseStatus::Terminated);
+    expect($lease->fresh()->depositSettlement)
+        ->status->toBe(DepositSettlementStatus::Settled)
+        ->refund_amount->toBe('800.000');
+});
+
+it('rolls back move-out when its settlement is invalid', function () {
+    $user = User::factory()->owner()->create();
+    $lease = Lease::factory()->create([
+        'deposit_amount' => '1000',
+        'currency' => 'USD',
+    ]);
+
+    $this->actingAs($user)
+        ->from(route('leases.show', $lease))
+        ->post(route('leases.move-out', $lease), [
+            'move_out_date' => '2026-09-11',
+            'settlement' => [
+                'status' => 'settled',
+                'refund_amount' => '500',
+            ],
+        ])
+        ->assertRedirect(route('leases.show', $lease))
+        ->assertSessionHasErrors('settlement');
+
+    expect($lease->fresh()->status)->toBe(LeaseStatus::Active)
+        ->and(DepositSettlement::count())->toBe(0);
+});
+
+it('keeps legacy refund fields separate from a new settlement', function () {
+    $user = User::factory()->owner()->create();
+    $lease = Lease::factory()->create([
+        'deposit_amount' => '1000',
+        'deposit_refund_amount' => '600',
+        'deposit_refunded_at' => '2026-09-01 10:00:00',
+        'currency' => 'USD',
+    ]);
+
+    $this->actingAs($user)->post(route('leases.move-out', $lease), [
+        'move_out_date' => '2026-09-11',
+        'settlement' => [
+            'status' => 'settled',
+            'refund_amount' => '1000',
+            'settlement_date' => '2026-09-11',
+        ],
+    ])->assertRedirect();
+
+    expect($lease->fresh())
+        ->deposit_refund_amount->toBe('600.000')
+        ->deposit_refunded_at->not->toBeNull();
+});

--- a/tests/Feature/DepositSettlementTest.php
+++ b/tests/Feature/DepositSettlementTest.php
@@ -147,6 +147,32 @@ it('does not allow settled settlements to be changed', function () {
         ->toThrow(ValidationException::class);
 });
 
+it('keeps settled settlements and deduction lines immutable at the model boundary', function () {
+    $lease = terminatedDepositLease();
+    $settlement = app(SettleLeaseDeposit::class)->execute(
+        $lease,
+        depositSettlementData(
+            DepositSettlementStatus::Settled,
+            refundAmount: '700',
+            deductions: [['amount' => '300', 'reason' => 'Repairs']],
+        ),
+    );
+    $deduction = $settlement->deductions->firstOrFail();
+
+    expect(fn () => $settlement->update(['notes' => 'Changed']))
+        ->toThrow(LogicException::class);
+    expect(fn () => $settlement->delete())
+        ->toThrow(LogicException::class);
+    expect(fn () => $deduction->update(['amount' => '200']))
+        ->toThrow(LogicException::class);
+    expect(fn () => $deduction->delete())
+        ->toThrow(LogicException::class);
+    expect(fn () => $settlement->deductions()->create([
+        'amount' => '100',
+        'reason' => 'Additional repairs',
+    ]))->toThrow(LogicException::class);
+});
+
 it('saves a post-move-out draft through the lease endpoint', function () {
     $user = User::factory()->owner()->create();
     $lease = terminatedDepositLease();


### PR DESCRIPTION
## Summary
- Add one draft/settled deposit settlement per lease with immutable snapshots and deduction line items.
- Support optional settlement during move-out and later from terminated lease details.
- Preserve legacy refund fields as fallback without historical backfill.

## Verification
- 76 focused Pest tests passed.
- ESLint and Pint passed.
- TypeScript/build remain blocked by the pre-existing missing `recharts` dashboard dependency.

Refs OPE-191